### PR TITLE
[CIT-144] Fix broken dependencies

### DIFF
--- a/mqtt/mqtt_client/Cargo.toml
+++ b/mqtt/mqtt_client/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "0.3", features = ["sync"] }
-rumqttc = "0.3.0"
+tokio = { version = "1.0", features = ["sync"] }
+rumqttc = { git = "https://github.com/bytebeamio/rumqtt" }
 
 [dev-dependencies]
 futures = "0.3"
 futures-timer = "3.0"
-tokio-test = "0.3.0"
+tokio-test = "0.4"
 log = "0.4.11"
 env_logger = "0.8.2"
 async-log = "2.0.0"


### PR DESCRIPTION
Fix [the CI/CD pipeline which is broken due to broken crate dependencies](https://cumulocity.atlassian.net/browse/CIT-144).

This is a *temporary* workaround with a direct dependency to the source code of rumqttc.
