### PR TITLE
[CIT-178] Example GH Actions workflows based on the proposal [Do not merge]

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -1,0 +1,36 @@
+name: tedge-commit
+
+# triggering manually for test purpose
+on: workflow_dispatch
+#  push:
+#    branches: [ main ]
+#  pull_request:
+#    branches: [ main ]
+
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint and format check
+        shell: bash
+        run: ./scripts/pre_build.sh
+      - name: Install Mosquitto
+        shell: bash
+        run: ./scripts/install_mosquitto.sh
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose
+      - name: Build release
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,60 @@
+name: tedge-nightly
+
+# triggering manually for test purpose
+on: workflow_dispatch
+#  schedule:
+#    - cron: '0 0 * * *' # Run at 0:00 every day
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - armv7-unknown-linux-gnueabihf
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+      - name: Build an Artifact
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+          args: --release --target=${{ matrix.target }}
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: tedge
+          path: target/armv7-unknown-linux-gnueabihf/release/tedge
+          retention-days: 5
+
+
+  test:
+    name: system-test
+    needs: build # Run after the first job
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: Raspbian32
+    steps:
+      - name: Download a Build Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: tedge
+          path: ~/Downloads
+      - name: Add executable permission
+        shell: bash
+        run: chmod +x ~/Downloads/tedge
+      - name: Run tedge
+        shell: bash
+        run: ~/Downloads/tedge
+

--- a/scripts/install_mosquitto.sh
+++ b/scripts/install_mosquitto.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install Mosquitto
+if ! sudo apt install -y mosquitto;
+then
+   exit 1
+fi

--- a/scripts/pre_build.sh
+++ b/scripts/pre_build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#check the format of the rust code
+if ! cargo fmt -- --check;
+then
+   exit 1
+fi
+# Lint Checking
+if ! cargo clippy;
+then
+   exit 1
+fi


### PR DESCRIPTION
This pull request is an example of the proposal on iWiki page. Please do not merge.

**commit.yml**
Quite similar to the existing hosted.yml workflow. The difference is to add installing mosquitto step.

**nightly.yml**
The workflow is consists of two jobs: 
1) Build on GH hosted runner and upload the build artifact.
2) Download the build artifact and run `tedge` command on RPi self-hosted runner.
Uploading/downloading artifacts use the actions introduced in [the GH Actions doc](https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts).