### PR TITLE
[CIT-98] deb package building for tedge

### DIFF
--- a/tedge/Cargo.toml
+++ b/tedge/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0"
 readme = "README.md"
 description = "tedge is the cli tool for thin-edge.io"
 
+[package.metadata.deb]
+depends = "mosquitto"
+
 [dependencies]
 anyhow = "1.0.38"
 chrono = "0.4.19"


### PR DESCRIPTION
This adds some details to the Cargo.toml of tedge command that are needed for debian package building.

With an installed version of [cargo-deb](https://github.com/mmstick/cargo-deb ) on the build system, it possible now to build  tedge.deb with the command "cargo deb" executed in the folder tedge.
It is also possible to use "cargo deb --target=" option for cross-compilation.

The built debian package has a dependency on mosquitto. When installed via dpkg, this has to be installed prior, as dpkg cannot resolve dependencies. This will be resolved automatically when we have an apt repository.

The command "cargo deb --target=armv7-unknown-linux-gnueabihf" needs to be added to our new CI/CD workflow to build the deb package for our target system.