### PR TITLE
[CIT-208] In case of connection failure, delay for 1s before retrying

### DIFF
--- a/mqtt/mqtt_client/src/lib.rs
+++ b/mqtt/mqtt_client/src/lib.rs
@@ -303,7 +303,11 @@ impl Client {
 
                 Err(err) => {
                     let delay = match err {
-                        rumqttc::ConnectionError::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::ConnectionRefused => true,
+                        rumqttc::ConnectionError::Io(ref io_err)
+                            if io_err.kind() == std::io::ErrorKind::ConnectionRefused =>
+                        {
+                            true
+                        }
                         _ => false,
                     };
 


### PR DESCRIPTION
A short PR to fix the high cpu issue on the mapper when there is no broker for a while.

* See [CIT-208](https://cumulocity.atlassian.net/browse/CIT-208)
* This is a rebased copy of https://github.com/mneumann/thin-edge/tree/CIT-208.
* This has been manually tested on `ubuntu/x64` and `rasp/armv7`.
* Later, when the CI/CD pipeline will be setup for system testing, we will have to automate this check of the behavior of the mapper under missing requirements. 