### PR TITLE
[CIT-210] Fixed the permission of the generated private key

### DIFF
--- a/tedge/src/certificate.rs
+++ b/tedge/src/certificate.rs
@@ -220,8 +220,13 @@ fn create_test_certificate(
 ) -> Result<(), CertError> {
     check_identifier(id)?;
 
+    // Creating files with permission 644
     let mut cert_file = create_new_file(cert_path).map_err(|err| err.cert_context(cert_path))?;
     let mut key_file = create_new_file(key_path).map_err(|err| err.key_context(key_path))?;
+
+    let mut key_perm = key_file.metadata()?.permissions();
+    key_perm.set_mode(0o600);
+    key_file.set_permissions(key_perm)?;
 
     let cert = new_selfsigned_certificate(&config, id)?;
 
@@ -239,7 +244,7 @@ fn create_test_certificate(
         key_file.write_all(cert_key.as_bytes())?;
         key_file.sync_all()?;
 
-        let mut key_perm = key_file.metadata()?.permissions();
+        key_perm = key_file.metadata()?.permissions();
         key_perm.set_mode(0o400);
         key_file.set_permissions(key_perm)?;
     }


### PR DESCRIPTION
Change the file permission of private key to **600**.
```
-rw-r--r--  1 rina rina      614 Feb  4 17:51 tedge-certificate.pem
-rw-------  1 rina rina      246 Feb  4 17:51 tedge-private-key.pem
```