### PR TITLE
Rename the keys of `tedge config` by replacing `-` by `.`

### DIFF
--- a/tedge/src/config.rs
+++ b/tedge/src/config.rs
@@ -13,13 +13,13 @@ const DEVICE_CERT_DIR: &str = "certificate";
 const DEVICE_KEY_FILE: &str = "tedge-private-key.pem";
 const DEVICE_CERT_FILE: &str = "tedge-certificate.pem";
 
-pub const DEVICE_ID: &str = "device-id";
-pub const DEVICE_CERT_PATH: &str = "device-cert-path";
-pub const DEVICE_KEY_PATH: &str = "device-key-path";
+pub const DEVICE_ID: &str = "device.id";
+pub const DEVICE_CERT_PATH: &str = "device.cert.path";
+pub const DEVICE_KEY_PATH: &str = "device.key.path";
 
-pub const C8Y_CONNECT: &str = "c8y-connect";
-pub const C8Y_URL: &str = "c8y-url";
-pub const C8Y_ROOT_CERT_PATH: &str = "c8y-root-cert-path";
+pub const C8Y_CONNECT: &str = "c8y.connect";
+pub const C8Y_URL: &str = "c8y.url";
+pub const C8Y_ROOT_CERT_PATH: &str = "c8y.root.cert.path";
 
 /// Wrapper type for Configuration keys.
 #[derive(Debug)]
@@ -256,12 +256,12 @@ macro_rules! config_keys {
 
 config_keys! {
     TEdgeConfig {
-        "device-id"          => (device.id, "Identifier of the device within the fleet. It must be globally unique. Example: Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665")
-        "device-key-path"    => (device.key_path, "Path to the private key file. Example: /home/user/certificate/tedge-private-key.pem")
-        "device-cert-path"   => (device.cert_path, "Path to the certificate file. Example: /home/user/certificate/tedge-certificate.crt")
-        "c8y-url"            => (c8y.url, "Tenant endpoint URL of Cumulocity tenant. Example: your-tenant.cumulocity.com")
-        "c8y-root-cert-path" => (c8y.root_cert_path, "Path where Cumulocity root certificate(s) are located. Example: /home/user/certificate/c8y-trusted-root-certificates.pem")
-        "c8y-connect"        => (c8y.connect, "Connection status to the provided Cumulocity tenant. Example: true")
+        "device.id"          => (device.id, "Identifier of the device within the fleet. It must be globally unique. Example: Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665")
+        "device.key.path"    => (device.key_path, "Path to the private key file. Example: /home/user/certificate/tedge-private-key.pem")
+        "device.cert.path"   => (device.cert_path, "Path to the certificate file. Example: /home/user/certificate/tedge-certificate.crt")
+        "c8y.url"            => (c8y.url, "Tenant endpoint URL of Cumulocity tenant. Example: your-tenant.cumulocity.com")
+        "c8y.root.cert.path" => (c8y.root_cert_path, "Path where Cumulocity root certificate(s) are located. Example: /home/user/certificate/c8y-trusted-root-certificates.pem")
+        "c8y.connect"        => (c8y.connect, "Connection status to the provided Cumulocity tenant. Example: true")
     }
 }
 
@@ -452,8 +452,8 @@ mod tests {
 
     #[test]
     fn test_macro_creates_valid_keys_correctly() {
-        assert_eq!(TEdgeConfig::valid_keys().contains(&"device-id"), true);
-        assert_eq!(TEdgeConfig::valid_keys().contains(&"device.id"), false);
+        assert_eq!(TEdgeConfig::valid_keys().contains(&"device.id"), true);
+        assert_eq!(TEdgeConfig::valid_keys().contains(&"device-id"), false);
     }
 
     #[test]

--- a/tedge/tests/main.rs
+++ b/tedge/tests/main.rs
@@ -108,18 +108,18 @@ mod tests {
         let device_id = "test";
 
         let mut get_device_id_cmd =
-            tedge_command_with_test_home(test_home_str, &["config", "get", "device-id"])?;
+            tedge_command_with_test_home(test_home_str, &["config", "get", "device.id"])?;
 
         get_device_id_cmd
             .assert()
             .failure()
             .stderr(predicate::str::contains(
-                "The provided config key: device-id is not set",
+                "The provided config key: device.id is not set",
             ));
 
         let mut set_device_id_cmd = tedge_command_with_test_home(
             test_home_str,
-            &["config", "set", "device-id", device_id],
+            &["config", "set", "device.id", device_id],
         )?;
 
         set_device_id_cmd.assert().success();
@@ -130,7 +130,7 @@ mod tests {
             .stdout(predicate::str::contains(device_id));
 
         let mut unset_device_id_cmd =
-            tedge_command_with_test_home(test_home_str, &["config", "unset", "device-id"])?;
+            tedge_command_with_test_home(test_home_str, &["config", "unset", "device.id"])?;
 
         unset_device_id_cmd.assert().success();
 
@@ -138,7 +138,7 @@ mod tests {
             .assert()
             .failure()
             .stderr(predicate::str::contains(
-                "The provided config key: device-id is not set",
+                "The provided config key: device.id is not set",
             ));
 
         Ok(())
@@ -154,17 +154,17 @@ mod tests {
         let key_path = temp_path(&temp_dir, "certificate/tedge-private-key.pem");
 
         let mut get_device_id_cmd =
-            tedge_command_with_test_home(test_home_str, &["config", "get", "device-id"])?;
+            tedge_command_with_test_home(test_home_str, &["config", "get", "device.id"])?;
 
         get_device_id_cmd
             .assert()
             .failure()
             .stderr(predicate::str::contains(
-                "The provided config key: device-id is not set",
+                "The provided config key: device.id is not set",
             ));
 
         let mut get_cert_path_cmd =
-            tedge_command_with_test_home(test_home_str, &["config", "get", "device-cert-path"])?;
+            tedge_command_with_test_home(test_home_str, &["config", "get", "device.cert.path"])?;
 
         get_cert_path_cmd
             .assert()
@@ -172,7 +172,7 @@ mod tests {
             .stdout(predicate::str::contains(&cert_path));
 
         let mut get_key_path_cmd =
-            tedge_command_with_test_home(test_home_str, &["config", "get", "device-key-path"])?;
+            tedge_command_with_test_home(test_home_str, &["config", "get", "device.key.path"])?;
 
         get_key_path_cmd
             .assert()
@@ -180,23 +180,23 @@ mod tests {
             .stdout(predicate::str::contains(&key_path));
 
         let mut get_c8y_url_cmd =
-            tedge_command_with_test_home(test_home_str, &["config", "get", "c8y-url"])?;
+            tedge_command_with_test_home(test_home_str, &["config", "get", "c8y.url"])?;
 
         get_c8y_url_cmd
             .assert()
             .failure()
             .stderr(predicate::str::contains(
-                "The provided config key: c8y-url is not set",
+                "The provided config key: c8y.url is not set",
             ));
 
         let mut get_c8y_root_cert_path_cmd =
-            tedge_command_with_test_home(test_home_str, &["config", "get", "c8y-root-cert-path"])?;
+            tedge_command_with_test_home(test_home_str, &["config", "get", "c8y.root.cert.path"])?;
 
         get_c8y_root_cert_path_cmd
             .assert()
             .failure()
             .stderr(predicate::str::contains(
-                "The provided config key: c8y-root-cert-path is not set",
+                "The provided config key: c8y.root.cert.path is not set",
             ));
 
         Ok(())
@@ -207,8 +207,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let test_home_str = temp_dir.path().to_str().unwrap();
 
-        let key_regex = r#"device-key-path=[\w/.]*certificate/tedge-private-key.pem"#;
-        let cert_regex = r#"device-cert-path=[\w/.]*certificate/tedge-certificate.pem"#;
+        let key_regex = r#"device.key.path=[\w/.]*certificate/tedge-private-key.pem"#;
+        let cert_regex = r#"device.cert.path=[\w/.]*certificate/tedge-certificate.pem"#;
 
         let key_predicate_fn = predicate::str::is_match(key_regex).unwrap();
         let cert_predicate_fn = predicate::str::is_match(cert_regex).unwrap();
@@ -217,10 +217,10 @@ mod tests {
             tedge_command_with_test_home(test_home_str, &["config", "list"]).unwrap();
         let assert = list_cmd.assert().success();
         let output = assert.get_output().clone();
-        let str = String::from_utf8(output.clone().stdout).unwrap();
+        let output_str = String::from_utf8(output.clone().stdout).unwrap();
 
-        assert_eq!(true, key_predicate_fn.eval(&str));
-        assert_eq!(true, cert_predicate_fn.eval(&str));
+        assert_eq!(true, key_predicate_fn.eval(&output_str));
+        assert_eq!(true, cert_predicate_fn.eval(&output_str));
     }
 
     #[test]
@@ -241,8 +241,8 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let test_home_str = temp_dir.path().to_str().unwrap();
 
-        let key_regex = r#"device-key-path=[\w/.]*certificate/tedge-private-key.pem"#;
-        let cert_regex = r#"device-cert-path=[\w/.]*certificate/tedge-certificate.pem"#;
+        let key_regex = r#"device.key.path=[\w/.]*certificate/tedge-private-key.pem"#;
+        let cert_regex = r#"device.cert.path=[\w/.]*certificate/tedge-certificate.pem"#;
 
         let key_predicate_fn = predicate::str::is_match(key_regex).unwrap();
         let cert_predicate_fn = predicate::str::is_match(cert_regex).unwrap();
@@ -251,12 +251,12 @@ mod tests {
             tedge_command_with_test_home(test_home_str, &["config", "list", "--all"]).unwrap();
         let assert = list_cmd.assert().success();
         let output = assert.get_output().clone();
-        let str = String::from_utf8(output.clone().stdout).unwrap();
+        let output_str = String::from_utf8(output.clone().stdout).unwrap();
 
-        assert_eq!(true, key_predicate_fn.eval(&str));
-        assert_eq!(true, cert_predicate_fn.eval(&str));
+        assert_eq!(true, key_predicate_fn.eval(&output_str));
+        assert_eq!(true, cert_predicate_fn.eval(&output_str));
         for key in get_tedge_config_keys() {
-            assert_eq!(true, str.contains(key));
+            assert_eq!(true, output_str.contains(key));
         }
     }
 
@@ -269,12 +269,12 @@ mod tests {
             tedge_command_with_test_home(test_home_str, &["config", "list", "--doc"]).unwrap();
         let assert = list_cmd.assert().success();
         let output = assert.get_output().clone();
-        let str = String::from_utf8(output.clone().stdout).unwrap();
+        let output_str = String::from_utf8(output.clone().stdout).unwrap();
 
         for key in get_tedge_config_keys() {
-            assert_eq!(true, str.contains(key));
+            assert_eq!(true, output_str.contains(key));
         }
-        assert_eq!(true, str.contains("Example"));
+        assert_eq!(true, output_str.contains("Example"));
     }
 
     fn tedge_command_with_test_home<I, S>(
@@ -296,12 +296,12 @@ mod tests {
 
     fn get_tedge_config_keys() -> Vec<&'static str> {
         let vec = vec![
-            "device-id",
-            "device-key-path",
-            "device-cert-path",
-            "c8y-url",
-            "c8y-root-cert-path",
-            "c8y-connect",
+            "device.id",
+            "device.key.path",
+            "device.cert.path",
+            "c8y.url",
+            "c8y.root.cert.path",
+            "c8y.connect",
         ];
         return vec;
     }


### PR DESCRIPTION
Change the looking of user-facing keys.
```
> ./tedge config list --all
device.id=AAAAAA
device.key.path=/home/rina/certificate/tedge-private-key.pem
device.cert.path=/home/rina/certificate/tedge-certificate.pem
c8y.url=mytenant.cumulocity.com

c8y.root.cert.path=
c8y.connect=
```