### PR TITLE
No error while fetching unset keys with tedge config get

### DIFF
--- a/tedge/src/config.rs
+++ b/tedge/src/config.rs
@@ -108,15 +108,10 @@ impl Command for ConfigCmd {
         let mut config_updated = false;
 
         match self {
-            ConfigCmd::Get { key } => {
-                let value =
-                    config
-                        .get_config_value(key.as_str())?
-                        .ok_or(ConfigError::ConfigNotSet {
-                            key: key.as_str().to_string(),
-                        })?;
-                println!("{}", value)
-            }
+            ConfigCmd::Get { key } => match config.get_config_value(key.as_str())? {
+                None => println!("The provided config key: '{}' is not set", key.as_str()),
+                Some(value) => println!("{}", value),
+            },
             ConfigCmd::Set { key, value } => {
                 config.set_config_value(key.as_str(), value.to_string())?;
                 config_updated = true;
@@ -391,9 +386,6 @@ pub enum ConfigError {
 
     #[error("The provided config key: {key} is not a valid Thin Edge configuration key")]
     InvalidConfigKey { key: String },
-
-    #[error("The provided config key: {key} is not set")]
-    ConfigNotSet { key: String },
 }
 
 pub fn home_dir() -> Result<PathBuf, ConfigError> {

--- a/tedge/tests/main.rs
+++ b/tedge/tests/main.rs
@@ -112,9 +112,9 @@ mod tests {
 
         get_device_id_cmd
             .assert()
-            .failure()
-            .stderr(predicate::str::contains(
-                "The provided config key: device.id is not set",
+            .success()
+            .stdout(predicate::str::contains(
+                "The provided config key: 'device.id' is not set",
             ));
 
         let mut set_device_id_cmd = tedge_command_with_test_home(
@@ -136,9 +136,9 @@ mod tests {
 
         get_device_id_cmd
             .assert()
-            .failure()
-            .stderr(predicate::str::contains(
-                "The provided config key: device.id is not set",
+            .success()
+            .stdout(predicate::str::contains(
+                "The provided config key: 'device.id' is not set",
             ));
 
         Ok(())
@@ -164,9 +164,9 @@ mod tests {
 
         get_device_id_cmd
             .assert()
-            .failure()
-            .stderr(predicate::str::contains(
-                "The provided config key: device.id is not set",
+            .success()
+            .stdout(predicate::str::contains(
+                "The provided config key: 'device.id' is not set",
             ));
 
         let mut get_cert_path_cmd =
@@ -190,9 +190,9 @@ mod tests {
 
         get_c8y_url_cmd
             .assert()
-            .failure()
-            .stderr(predicate::str::contains(
-                "The provided config key: c8y.url is not set",
+            .success()
+            .stdout(predicate::str::contains(
+                "The provided config key: 'c8y.url' is not set",
             ));
 
         let mut get_c8y_root_cert_path_cmd =
@@ -200,9 +200,9 @@ mod tests {
 
         get_c8y_root_cert_path_cmd
             .assert()
-            .failure()
-            .stderr(predicate::str::contains(
-                "The provided config key: c8y.root.cert.path is not set",
+            .success()
+            .stdout(predicate::str::contains(
+                "The provided config key: 'c8y.root.cert.path' is not set",
             ));
 
         Ok(())


### PR DESCRIPTION
The purpose of this PR is to avoid throwing an error message to the user when he's trying to read the value of a key that's not already set using the `tedge config get` command. The updated logic will just print a message to the stdout that the provided key is not set and exist with exit code 0.