### PR TITLE
[CIT-231] Change the logic of check_connection() in tedge connect c8y.

### DIFF
--- a/tedge/src/cli/connect/c8y.rs
+++ b/tedge/src/cli/connect/c8y.rs
@@ -104,7 +104,7 @@ impl Connect {
 
         println!(
             "Sending packets to check connection.\n\
-            Also, registering the device if the device is not yet registered.\n\
+            Registering the device in Cumulocity if the device is not yet registered.\n\
             This may take up to {} seconds per try.\n",
             RESPONSE_TIMEOUT.as_secs(),
         );


### PR DESCRIPTION
- Use SmartREST static template 100 (device creation) instead of template existence check.

- 100 returns '41,100,Device already existing' error when the device is already created in c8y. We can use it to check the connection establishment.

- If the device is new, 100 creates the device's managed object in c8y. The external ID is the one used in certificate.