### PR TITLE
Simplify signature of mqtt_client::Client#publish_with_ack

### DIFF
--- a/tedge/src/mqtt.rs
+++ b/tedge/src/mqtt.rs
@@ -85,8 +85,7 @@ async fn publish(topic: &str, message: &str, qos: QoS) -> Result<(), MqttError> 
         .await?;
     let tpc = Topic::new(topic)?;
     let msg = Message::new(&tpc, message).qos(qos);
-    let ack = mqtt.publish_with_ack(msg).await?;
-    ack.await?;
+    let () = mqtt.publish_with_ack(msg).await?;
     mqtt.disconnect().await?;
 
     Ok(())


### PR DESCRIPTION
* Do not return a `Future` that returns a `Future`. This causes trouble
  in actual code (@makr11st).

* `publish_with_ack` has now same signature as `publish`.

* Message ordering of two or more `publish_with_ack` calls is no longer
  guarateed when `select!`ing them concurrently. To guaratee message
  ordering, await each of the `publish_with_ack` calls sequentially.