### PR TITLE
[CIT-181] Improve JSON translator error messages

### DIFF
--- a/mapper/cumulocity/c8y_translator_lib/src/lib.rs
+++ b/mapper/cumulocity/c8y_translator_lib/src/lib.rs
@@ -309,7 +309,7 @@ pub enum ThinEdgeJsonError {
     #[error("Not a number: the {name:?} value must be a number, not {actual_type}.")]
     InvalidThinEdgeJsonValue { name: String, actual_type: String },
 
-    #[error("Not a timestamp: the time value must be a timestamp string, not {actual_type}.")]
+    #[error("Not a timestamp: the time value must be an ISO8601 timestamp string in the YYYY-MM-DDThh:mm:ss.sss.±hh:mm format, not {actual_type}.")]
     InvalidThinEdgeJsonTime { actual_type: String },
 
     #[error(
@@ -711,8 +711,7 @@ mod tests {
            "pressure": 220
           }"#;
 
-        let expected_output =
-            r#"Not a timestamp: the time value must be a timestamp string, not a number."#;
+        let expected_output = r#"Not a timestamp: the time value must be an ISO8601 timestamp string in the YYYY-MM-DDThh:mm:ss.sss.±hh:mm format, not a number."#;
         let output = CumulocityJson::from_thin_edge_json(
             &String::from(string_value_thin_edge_json).into_bytes(),
         );


### PR DESCRIPTION
The error messages have been improved with a root cause and a context.

* See the tests for various example of error messages.
* When the context is unbounded (a byte string for UTF8 conversion, a string for JSON parsing), the error message retain only a prefix of that input. A better approach could have been to display an excerpt around the error. This has not been done because of the extra complexity (as for getting the last ten valid utf8 chars and transforming line:column error information into an index in the json string).