### PR TITLE
Fixing formatting issues

### DIFF
--- a/tedge/src/certificate.rs
+++ b/tedge/src/certificate.rs
@@ -502,10 +502,7 @@ mod tests {
 
         let error = cmd.execute(verbose).unwrap_err();
         let cert_error = error.downcast_ref::<CertError>().unwrap();
-        assert_matches!(
-            cert_error,
-            CertError::CertPathError { .. }
-        );
+        assert_matches!(cert_error, CertError::CertPathError { .. });
     }
 
     #[test]
@@ -522,10 +519,7 @@ mod tests {
 
         let error = cmd.execute(verbose).unwrap_err();
         let cert_error = error.downcast_ref::<CertError>().unwrap();
-        assert_matches!(
-            cert_error,
-            CertError::KeyPathError { .. }
-        );
+        assert_matches!(cert_error, CertError::KeyPathError { .. });
     }
 
     fn temp_file_path(dir: &TempDir, filename: &str) -> String {

--- a/tedge/src/utils/paths.rs
+++ b/tedge/src/utils/paths.rs
@@ -155,19 +155,13 @@ mod tests {
     #[test]
     fn validate_path_non_existent() {
         let result = validate_parent_dir_exists(Path::new("/non/existent/path"));
-        assert_matches!(
-            result.unwrap_err(),
-            PathsError::DirNotFound { .. }
-        );
+        assert_matches!(result.unwrap_err(), PathsError::DirNotFound { .. });
     }
 
     #[test]
     fn validate_parent_dir_non_existent() {
         let result = validate_parent_dir_exists(Path::new("/"));
-        assert_matches!(
-            result.unwrap_err(),
-            PathsError::ParentDirNotFound { .. }
-        );
+        assert_matches!(result.unwrap_err(), PathsError::ParentDirNotFound { .. });
     }
 
     #[test]


### PR DESCRIPTION
This is just a temporary symptomatic fix. But there's some sort of inconsistency between the `cargo fmt` behavior on developer machines and the hosted runner, as the previous formatting was completely acceptable to my local cargo installation.