### PR TITLE
[CIT-234] Add a special error message for `tedge config set device.id`

### DIFF
--- a/tedge/src/config.rs
+++ b/tedge/src/config.rs
@@ -67,11 +67,23 @@ impl std::str::FromStr for WritableConfigKey {
                 mode: ConfigKeyMode::ReadWrite,
                 ..
             }) => Ok(WritableConfigKey(key.into())),
-            _ => Err(format!(
-                "Invalid key `{}'. Valid keys are: [{}].",
-                key,
-                TEdgeConfig::valid_writable_keys().join(", ")
-            )),
+            _ => {
+                if key == DEVICE_ID {
+                    Err(format!(
+                        "Invalid key `{}'. Valid keys are: [{}].\n\
+                Setting the device id is only allowed with tedge cert create. \
+                To set 'device.id', use `tedge cert create --device-id <id>`.",
+                        key,
+                        TEdgeConfig::valid_writable_keys().join(", ")
+                    ))
+                } else {
+                    Err(format!(
+                        "Invalid key `{}'. Valid keys are: [{}].",
+                        key,
+                        TEdgeConfig::valid_writable_keys().join(", ")
+                    ))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
After the UX review with Sebastian. Now output is following.

```
> ./tedge config set device.id aaaa
error: Invalid value for '<key>': Invalid key `device.id'. Valid keys are: [device.key.path, device.cert.path, c8y.url, c8y.root.cert.path, azure.url, azure.root.cert.path].
Setting the device id is only allowed with tedge cert create. To set 'device.id', use `tedge cert create --device-id <id>`.
```