### PR TITLE
Add config keys module

### DIFF
--- a/tedge/src/certificate.rs
+++ b/tedge/src/certificate.rs
@@ -1,7 +1,4 @@
-use crate::config::{
-    keys::{C8Y_URL, DEVICE_CERT_PATH, DEVICE_ID, DEVICE_KEY_PATH},
-    ConfigError, TEdgeConfig,
-};
+use crate::config::{keys, ConfigError, TEdgeConfig};
 use crate::utils::{paths, paths::PathsError};
 use crate::{
     command::{BuildCommand, Command},
@@ -84,19 +81,19 @@ impl BuildCommand for UploadCertOpt {
         match self {
             UploadCertOpt::C8y { username } => {
                 let device_id = config.device.id.ok_or_else(|| ConfigError::ConfigNotSet {
-                    key: String::from(DEVICE_ID),
+                    key: String::from(keys::DEVICE_ID),
                 })?;
 
                 let path = PathBuf::try_from(config.device.cert_path.ok_or_else(|| {
                     ConfigError::ConfigNotSet {
-                        key: String::from(DEVICE_CERT_PATH),
+                        key: String::from(keys::DEVICE_CERT_PATH),
                     }
                 })?)
                 .expect("Path conversion failed unexpectedly!"); // This is Infallible that means it should never happen.
 
                 let host = utils::config::parse_user_provided_address(config.c8y.url.ok_or_else(
                     || ConfigError::ConfigNotSet {
-                        key: String::from(C8Y_URL),
+                        key: String::from(keys::C8Y_URL),
                     },
                 )?)?;
 
@@ -329,12 +326,12 @@ impl BuildCommand for TEdgeCertOpt {
                         id,
                         cert_path: config.device.cert_path.ok_or_else(|| {
                             ConfigError::ConfigNotSet {
-                                key: String::from(DEVICE_CERT_PATH),
+                                key: String::from(keys::DEVICE_CERT_PATH),
                             }
                         })?,
                         key_path: config.device.key_path.ok_or_else(|| {
                             ConfigError::ConfigNotSet {
-                                key: String::from(DEVICE_KEY_PATH),
+                                key: String::from(keys::DEVICE_KEY_PATH),
                             }
                         })?,
                     };
@@ -345,7 +342,7 @@ impl BuildCommand for TEdgeCertOpt {
                     let cmd = ShowCertCmd {
                         cert_path: config.device.cert_path.ok_or_else(|| {
                             ConfigError::ConfigNotSet {
-                                key: String::from(DEVICE_CERT_PATH),
+                                key: String::from(keys::DEVICE_CERT_PATH),
                             }
                         })?,
                     };
@@ -356,12 +353,12 @@ impl BuildCommand for TEdgeCertOpt {
                     let cmd = RemoveCertCmd {
                         cert_path: config.device.cert_path.ok_or_else(|| {
                             ConfigError::ConfigNotSet {
-                                key: String::from(DEVICE_CERT_PATH),
+                                key: String::from(keys::DEVICE_CERT_PATH),
                             }
                         })?,
                         key_path: config.device.key_path.ok_or_else(|| {
                             ConfigError::ConfigNotSet {
-                                key: String::from(DEVICE_KEY_PATH),
+                                key: String::from(keys::DEVICE_KEY_PATH),
                             }
                         })?,
                     };

--- a/tedge/src/cli/connect/az.rs
+++ b/tedge/src/cli/connect/az.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::config::ConfigError;
+use crate::config::{keys, ConfigError};
 use crate::utils::config;
 use mqtt_client::{Client, Message, Topic, TopicFilter};
 use std::time::Duration;
@@ -12,10 +12,12 @@ pub struct Azure {}
 
 impl Azure {
     pub fn azure_bridge_config(config: TEdgeConfig) -> Result<BridgeConfig, ConfigError> {
-        let az_url =
-            config::parse_user_provided_address(config::get_config_value(&config, AZURE_URL)?)?;
+        let az_url = config::parse_user_provided_address(config::get_config_value(
+            &config,
+            keys::AZURE_URL,
+        )?)?;
         let address = format!("{}:{}", az_url, MQTT_TLS_PORT);
-        let clientid = config::get_config_value(&config, DEVICE_ID)?;
+        let clientid = config::get_config_value(&config, keys::DEVICE_ID)?;
         let user_name = format!("{}/{}/?api-version=2018-06-30", az_url, &clientid);
         let pub_msg_topic = format!("messages/events/ out 1 az/ devices/{}/", clientid);
         let sub_msg_topic = format!("messages/devicebound/# out 1 az/ devices/{}/", clientid);
@@ -26,11 +28,11 @@ impl Azure {
             connection: "edge_to_az".into(),
             address,
             remote_username: Some(user_name),
-            bridge_cafile: config::get_config_value(&config, AZURE_ROOT_CERT_PATH)?,
+            bridge_cafile: config::get_config_value(&config, keys::AZURE_ROOT_CERT_PATH)?,
             remote_clientid: clientid,
             local_clientid: "Azure".into(),
-            bridge_certfile: config::get_config_value(&config, DEVICE_CERT_PATH)?,
-            bridge_keyfile: config::get_config_value(&config, DEVICE_KEY_PATH)?,
+            bridge_certfile: config::get_config_value(&config, keys::DEVICE_CERT_PATH)?,
+            bridge_keyfile: config::get_config_value(&config, keys::DEVICE_KEY_PATH)?,
             try_private: false,
             start_type: "automatic".into(),
             cleansession: true,

--- a/tedge/src/cli/connect/c8y.rs
+++ b/tedge/src/cli/connect/c8y.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::config::ConfigError;
+use crate::config::{keys, ConfigError};
 use crate::utils::config;
 use mqtt_client::{Client, Message, Topic};
 use std::time::Duration;
@@ -14,7 +14,7 @@ impl C8y {
     pub fn c8y_bridge_config(config: TEdgeConfig) -> Result<BridgeConfig, ConfigError> {
         let address = format!(
             "{}:{}",
-            config::parse_user_provided_address(config::get_config_value(&config, C8Y_URL)?)?,
+            config::parse_user_provided_address(config::get_config_value(&config, keys::C8Y_URL)?)?,
             MQTT_TLS_PORT
         );
 
@@ -24,11 +24,11 @@ impl C8y {
             connection: "edge_to_c8y".into(),
             address,
             remote_username: None,
-            bridge_cafile: config::get_config_value(&config, C8Y_ROOT_CERT_PATH)?,
-            remote_clientid: config::get_config_value(&config, DEVICE_ID)?,
+            bridge_cafile: config::get_config_value(&config, keys::C8Y_ROOT_CERT_PATH)?,
+            remote_clientid: config::get_config_value(&config, keys::DEVICE_ID)?,
             local_clientid: "Cumulocity".into(),
-            bridge_certfile: config::get_config_value(&config, DEVICE_CERT_PATH)?,
-            bridge_keyfile: config::get_config_value(&config, DEVICE_KEY_PATH)?,
+            bridge_certfile: config::get_config_value(&config, keys::DEVICE_CERT_PATH)?,
+            bridge_keyfile: config::get_config_value(&config, keys::DEVICE_KEY_PATH)?,
             try_private: false,
             start_type: "automatic".into(),
             cleansession: true,

--- a/tedge/src/cli/connect/mod.rs
+++ b/tedge/src/cli/connect/mod.rs
@@ -1,12 +1,6 @@
 use crate::cli::connect::{az::Azure, c8y::C8y};
 use crate::command::{BuildCommand, Command};
-use crate::config::{
-    keys::{
-        AZURE_ROOT_CERT_PATH, AZURE_URL, C8Y_ROOT_CERT_PATH, C8Y_URL, DEVICE_CERT_PATH, DEVICE_ID,
-        DEVICE_KEY_PATH,
-    },
-    ConfigError, TEdgeConfig, TEDGE_HOME_DIR,
-};
+use crate::config::{ConfigError, TEdgeConfig, TEDGE_HOME_DIR};
 
 use crate::utils::{paths, services};
 use std::path::Path;

--- a/tedge/src/config.rs
+++ b/tedge/src/config.rs
@@ -601,13 +601,7 @@ impl TEdgeConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        keys::{
-            AZURE_ROOT_CERT_PATH, AZURE_URL, C8Y_ROOT_CERT_PATH, C8Y_URL, DEVICE_CERT_PATH,
-            DEVICE_ID, DEVICE_KEY_PATH,
-        },
-        *,
-    };
+    use super::{keys, *};
     use assert_matches::assert_matches;
 
     #[test]
@@ -954,27 +948,33 @@ root_cert_path = "/path/to/azure/root/cert"
         let original_device_key_path = "/path/to/key".to_string();
         let original_device_cert_path = "/path/to/cert".to_string();
         assert_eq!(
-            config.get_config_value(DEVICE_ID).unwrap().unwrap(),
+            config.get_config_value(keys::DEVICE_ID).unwrap().unwrap(),
             original_device_id
         );
         assert_eq!(
-            config.get_config_value(DEVICE_KEY_PATH).unwrap().unwrap(),
+            config
+                .get_config_value(keys::DEVICE_KEY_PATH)
+                .unwrap()
+                .unwrap(),
             original_device_key_path
         );
         assert_eq!(
-            config.get_config_value(DEVICE_CERT_PATH).unwrap().unwrap(),
+            config
+                .get_config_value(keys::DEVICE_CERT_PATH)
+                .unwrap()
+                .unwrap(),
             original_device_cert_path
         );
 
         let original_c8y_url = "your-tenant.cumulocity.com".to_string();
         let original_c8y_root_cert_path = "/path/to/c8y/root/cert".to_string();
         assert_eq!(
-            config.get_config_value(C8Y_URL).unwrap().unwrap(),
+            config.get_config_value(keys::C8Y_URL).unwrap().unwrap(),
             original_c8y_url
         );
         assert_eq!(
             config
-                .get_config_value(C8Y_ROOT_CERT_PATH)
+                .get_config_value(keys::C8Y_ROOT_CERT_PATH)
                 .unwrap()
                 .unwrap(),
             original_c8y_root_cert_path
@@ -984,32 +984,38 @@ root_cert_path = "/path/to/azure/root/cert"
         let updated_c8y_url = "other-tenant.cumulocity.com".to_string();
 
         config
-            .set_config_value(DEVICE_ID, updated_device_id.clone())
+            .set_config_value(keys::DEVICE_ID, updated_device_id.clone())
             .unwrap();
         config
-            .set_config_value(C8Y_URL, updated_c8y_url.clone())
+            .set_config_value(keys::C8Y_URL, updated_c8y_url.clone())
             .unwrap();
-        config.unset_config_value(C8Y_ROOT_CERT_PATH).unwrap();
+        config.unset_config_value(keys::C8Y_ROOT_CERT_PATH).unwrap();
 
         assert_eq!(
-            config.get_config_value(DEVICE_ID).unwrap().unwrap(),
+            config.get_config_value(keys::DEVICE_ID).unwrap().unwrap(),
             updated_device_id
         );
         assert_eq!(
-            config.get_config_value(DEVICE_KEY_PATH).unwrap().unwrap(),
+            config
+                .get_config_value(keys::DEVICE_KEY_PATH)
+                .unwrap()
+                .unwrap(),
             original_device_key_path
         );
         assert_eq!(
-            config.get_config_value(DEVICE_CERT_PATH).unwrap().unwrap(),
+            config
+                .get_config_value(keys::DEVICE_CERT_PATH)
+                .unwrap()
+                .unwrap(),
             original_device_cert_path
         );
 
         assert_eq!(
-            config.get_config_value(C8Y_URL).unwrap().unwrap(),
+            config.get_config_value(keys::C8Y_URL).unwrap().unwrap(),
             updated_c8y_url
         );
         assert!(config
-            .get_config_value(C8Y_ROOT_CERT_PATH)
+            .get_config_value(keys::C8Y_ROOT_CERT_PATH)
             .unwrap()
             .is_none());
     }
@@ -1039,12 +1045,12 @@ root_cert_path = "/path/to/azure/root/cert"
 
         // read
         assert_eq!(
-            config.get_config_value(AZURE_URL).unwrap().unwrap(),
+            config.get_config_value(keys::AZURE_URL).unwrap().unwrap(),
             original_azure_url
         );
         assert_eq!(
             config
-                .get_config_value(AZURE_ROOT_CERT_PATH)
+                .get_config_value(keys::AZURE_ROOT_CERT_PATH)
                 .unwrap()
                 .unwrap(),
             original_azure_root_cert_path
@@ -1053,17 +1059,19 @@ root_cert_path = "/path/to/azure/root/cert"
         // set
         let updated_azure_url = "OtherAzure.azure-devices.net".to_string();
         config
-            .set_config_value(AZURE_URL, updated_azure_url.clone())
+            .set_config_value(keys::AZURE_URL, updated_azure_url.clone())
             .unwrap();
         assert_eq!(
-            config.get_config_value(AZURE_URL).unwrap().unwrap(),
+            config.get_config_value(keys::AZURE_URL).unwrap().unwrap(),
             updated_azure_url
         );
 
         // unset
-        config.unset_config_value(AZURE_ROOT_CERT_PATH).unwrap();
+        config
+            .unset_config_value(keys::AZURE_ROOT_CERT_PATH)
+            .unwrap();
         assert!(config
-            .get_config_value(AZURE_ROOT_CERT_PATH)
+            .get_config_value(keys::AZURE_ROOT_CERT_PATH)
             .unwrap()
             .is_none());
     }


### PR DESCRIPTION
As per suggestion from a reviewer in #98 names of the config keys are not explicit.
This code adds keys module in config module such that the config keys are more obvious when reading the code.

Ways to use:
Import all required keys explicitly and use it was till now
```rust
use config::keys::{C8Y_URL, DEVICE_CERT_PATH, DEVICE_ID, DEVICE_KEY_PATH};
...
PathBuf::try_from(config.device.cert_path.ok_or_else(|| {
                    ConfigError::ConfigNotSet {
                        key: String::from(DEVICE_CERT_PATH),
                    }
```  
or use with `keys::KEY_NAME`:
```rust
use config::keys;
...

if key == keys::DEVICE_ID ...
```

