### PR TITLE
Extract common mosquitto configurations to separate file

### DIFF
--- a/tedge/src/cli/connect/az.rs
+++ b/tedge/src/cli/connect/az.rs
@@ -34,7 +34,6 @@ impl Azure {
 
         Ok(BridgeConfig {
             common_mosquitto_config: CommonMosquittoConfig::default(),
-            common_bridge_config: CommonBridgeConfig::default(),
             cloud_name: "az".into(),
             config_file: AZURE_CONFIG_FILENAME.to_string(),
             connection: "edge_to_az".into(),
@@ -45,6 +44,11 @@ impl Azure {
             local_clientid: "Azure".into(),
             bridge_certfile: config::get_config_value(&config, DEVICE_CERT_PATH)?,
             bridge_keyfile: config::get_config_value(&config, DEVICE_KEY_PATH)?,
+            try_private: false,
+            start_type: "automatic".into(),
+            clean_session: true,
+            notifications: false,
+            bridge_attempt_unsubscribe: false,
             topics: vec![
                 pub_msg_topic,
                 sub_msg_topic,

--- a/tedge/src/cli/connect/c8y.rs
+++ b/tedge/src/cli/connect/c8y.rs
@@ -32,7 +32,6 @@ impl C8y {
 
         Ok(BridgeConfig {
             common_mosquitto_config: CommonMosquittoConfig::default(),
-            common_bridge_config: CommonBridgeConfig::default(),
             cloud_name: "c8y".into(),
             config_file: C8Y_CONFIG_FILENAME.to_string(),
             connection: "edge_to_c8y".into(),
@@ -43,6 +42,11 @@ impl C8y {
             local_clientid: "Cumulocity".into(),
             bridge_certfile: config::get_config_value(&config, DEVICE_CERT_PATH)?,
             bridge_keyfile: config::get_config_value(&config, DEVICE_KEY_PATH)?,
+            try_private: false,
+            start_type: "automatic".into(),
+            clean_session: true,
+            notifications: false,
+            bridge_attempt_unsubscribe: false,
             topics: vec![
                 // Registration
                 r#"s/dcr in 2 c8y/ """#.into(),

--- a/tedge/src/cli/connect/mod.rs
+++ b/tedge/src/cli/connect/mod.rs
@@ -93,15 +93,6 @@ struct CommonMosquittoConfig {
     log_types: Vec<String>,
 }
 
-#[derive(Debug, PartialEq)]
-struct CommonBridgeConfig {
-    try_private: bool,
-    start_type: String,
-    clean_session: bool,
-    notifications: bool,
-    bridge_attempt_unsubscribe: bool,
-}
-
 impl Default for CommonMosquittoConfig {
     fn default() -> Self {
         CommonMosquittoConfig {
@@ -120,22 +111,9 @@ impl Default for CommonMosquittoConfig {
     }
 }
 
-impl Default for CommonBridgeConfig {
-    fn default() -> Self {
-        CommonBridgeConfig {
-            try_private: false,
-            start_type: "automatic".into(),
-            clean_session: true,
-            notifications: false,
-            bridge_attempt_unsubscribe: false,
-        }
-    }
-}
-
 #[derive(Debug, PartialEq)]
 pub struct BridgeConfig {
     common_mosquitto_config: CommonMosquittoConfig,
-    common_bridge_config: CommonBridgeConfig,
     cloud_name: String,
     config_file: String,
     connection: String,
@@ -146,6 +124,11 @@ pub struct BridgeConfig {
     local_clientid: String,
     bridge_certfile: String,
     bridge_keyfile: String,
+    try_private: bool,
+    start_type: String,
+    clean_session: bool,
+    notifications: bool,
+    bridge_attempt_unsubscribe: bool,
     topics: Vec<String>,
 }
 
@@ -272,30 +255,14 @@ impl BridgeConfig {
         writeln!(writer, "local_clientid {}", self.local_clientid)?;
         writeln!(writer, "bridge_certfile {}", self.bridge_certfile)?;
         writeln!(writer, "bridge_keyfile {}", self.bridge_keyfile)?;
-        writeln!(
-            writer,
-            "try_private {}",
-            self.common_bridge_config.try_private
-        )?;
-        writeln!(
-            writer,
-            "start_type {}",
-            self.common_bridge_config.start_type
-        )?;
-        writeln!(
-            writer,
-            "cleansession {}",
-            self.common_bridge_config.clean_session
-        )?;
-        writeln!(
-            writer,
-            "notifications {}",
-            self.common_bridge_config.notifications
-        )?;
+        writeln!(writer, "try_private {}", self.try_private)?;
+        writeln!(writer, "start_type {}", self.start_type)?;
+        writeln!(writer, "cleansession {}", self.clean_session)?;
+        writeln!(writer, "notifications {}", self.notifications)?;
         writeln!(
             writer,
             "bridge_attempt_unsubscribe {}",
-            self.common_bridge_config.bridge_attempt_unsubscribe
+            self.bridge_attempt_unsubscribe
         )?;
 
         writeln!(writer, "\n### Topics",)?;


### PR DESCRIPTION
The mosquitto configurations like `bind_address` and `log_type` are global configurations affecting the whole of MQTT and not a bridge specific configuration. So, the idea here is to capture all the bridge configs to their own dedicated files which are cloud specific and the common configs to a separate file.