### PR TITLE
DO NOT MERGE - Measure memory statistics

### DIFF
--- a/mapper/tedge_mapper/Cargo.toml
+++ b/mapper/tedge_mapper/Cargo.toml
@@ -26,3 +26,7 @@ mqtt_client = {version = "0.1.0", path = "../../common/mqtt_client" }
 tokio = { version = "1.1.0", features = ["full"] }
 tracing = { version = "0.1.25", features = ["attributes", "log"] }
 tracing-subscriber = "0.2.17"
+stats_alloc = { version = "0.1.8", optional = true }
+
+[features]
+memory-statistics = ["stats_alloc"]

--- a/mapper/tedge_mapper/README.md
+++ b/mapper/tedge_mapper/README.md
@@ -1,0 +1,20 @@
+## Memory statistics
+
+Run mapper:
+
+```sh
+env MAPPER_MQTT_HOST=test.mosquitto.org cargo run --release --features memory-statistics
+```
+
+Produce load:
+
+```sh
+mosquitto_pub -h test.mosquitto.org -t tedge/measurements --repeat 10000 -q 2 -m '{"time": "2020-10-15T05:30:47+00:00", "temperature": 25, "coordinate": {"x": 32.54,"y": -117.67,"z": 98.6},"pressure": 98 }'
+```
+
+Measure memory:
+
+```sh
+mosquitto_sub -h test.mosquitto.org -t 'SYS/mapper/bytes/allocated'
+```
+

--- a/mapper/tedge_mapper/src/main.rs
+++ b/mapper/tedge_mapper/src/main.rs
@@ -7,21 +7,21 @@ const APP_NAME: &str = "tedge-mapper";
 const DEFAULT_LOG_LEVEL: &str = "warn";
 const TIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3f%:z";
 
+#[cfg(feature = "memory-statistics")]
+#[global_allocator]
+static GLOBAL: &stats_alloc::StatsAlloc<std::alloc::System> = &stats_alloc::INSTRUMENTED_SYSTEM;
+
 #[tokio::main]
 async fn main() -> Result<(), mqtt_client::Error> {
-    let filter = std::env::var("RUST_LOG").unwrap_or_else(|_| DEFAULT_LOG_LEVEL.into());
-    tracing_subscriber::fmt()
-        .with_timer(tracing_subscriber::fmt::time::ChronoUtc::with_format(
-            TIME_FORMAT.into(),
-        ))
-        .with_env_filter(filter)
-        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
-        .init();
-
+    setup_tracing();
     info!("{} starting!", APP_NAME);
 
-    let config = mqtt_client::Config::default();
-    let mqtt = Client::connect(APP_NAME, &config).await?;
+    let mut config = mqtt_client::Config::default();
+    config.host = std::env::var("MAPPER_MQTT_HOST").unwrap_or_else(|_| "localhost".into());
+    let mqtt = std::sync::Arc::new(Client::connect(APP_NAME, &config).await?);
+
+    #[cfg(feature = "memory-statistics")]
+    start_statistics_task(mqtt.clone(), std::time::Duration::from_secs(1));
 
     let mapper = mapper::Mapper::new_from_string(
         mqtt,
@@ -33,4 +33,31 @@ async fn main() -> Result<(), mqtt_client::Error> {
     mapper.run().instrument(debug_span!(APP_NAME)).await?;
 
     Ok(())
+}
+
+fn setup_tracing() {
+    tracing_subscriber::fmt()
+        .with_timer(tracing_subscriber::fmt::time::ChronoUtc::with_format(
+            TIME_FORMAT.into(),
+        ))
+        // WARNING: `with_env_filter` accounts for ~800 KiB
+        .with_env_filter(std::env::var("RUST_LOG").unwrap_or_else(|_| DEFAULT_LOG_LEVEL.into()))
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+        .init();
+}
+
+#[cfg(feature = "memory-statistics")]
+fn start_statistics_task(mqtt: std::sync::Arc<mqtt_client::Client>, interval: std::time::Duration) {
+    let topic_allocated_bytes = mqtt_client::Topic::new("SYS/mapper/bytes/allocated").unwrap();
+    let _ = tokio::spawn(async move {
+        loop {
+            let stats = GLOBAL.stats();
+            let active = (stats.bytes_allocated - stats.bytes_deallocated) / 1024;
+            let msg = format!("{} KiB", active);
+            let _ = mqtt
+                .publish(mqtt_client::Message::new(&topic_allocated_bytes, msg))
+                .await;
+            tokio::time::sleep(interval).await;
+        }
+    });
 }

--- a/mapper/tedge_mapper/src/mapper.rs
+++ b/mapper/tedge_mapper/src/mapper.rs
@@ -9,7 +9,7 @@ pub const ERRORS_TOPIC: &str = "tedge/errors";
 
 #[derive(Debug)]
 pub struct Mapper {
-    client: mqtt_client::Client,
+    client: std::sync::Arc<mqtt_client::Client>,
     in_topic: mqtt_client::Topic,
     out_topic: mqtt_client::Topic,
     err_topic: mqtt_client::Topic,
@@ -17,7 +17,7 @@ pub struct Mapper {
 
 impl Mapper {
     pub fn new_from_string(
-        client: mqtt_client::Client,
+        client: std::sync::Arc<mqtt_client::Client>,
         in_topic: &str,
         out_topic: &str,
         err_topic: &str,
@@ -31,7 +31,7 @@ impl Mapper {
     }
 
     fn new(
-        client: mqtt_client::Client,
+        client: std::sync::Arc<mqtt_client::Client>,
         in_topic: mqtt_client::Topic,
         out_topic: mqtt_client::Topic,
         err_topic: mqtt_client::Topic,


### PR DESCRIPTION
Obtain live memory statistics for mapper and post it to MQTT topic `SYS/mapper/bytes/allocated`. Behind feature gate `memory-statistics`.

We could also obtain memory statistics directly from the kernel via `procfs`... it's just not working well cross-platform :/

For CI, I think it's easier to use Python's `psutil` 