### PR TITLE
[CIT-280] Remove inadvertent dev-dependency to openssl

### DIFF
--- a/tedge/Cargo.toml
+++ b/tedge/Cargo.toml
@@ -38,7 +38,6 @@ assert_matches = "1.4.0"
 mockito = "0.29.0"
 pem = "0.8.2"
 predicates = "1.0.6"
-crypto-hash = "0.3.4"
 base64 = "0.13.0"
 
 [features]

--- a/tedge/src/certificate.rs
+++ b/tedge/src/certificate.rs
@@ -663,8 +663,6 @@ mod tests {
 
     extern crate base64;
 
-    use crypto_hash::{digest, Algorithm};
-
     #[test]
     fn basic_usage() {
         let dir = tempdir().unwrap();
@@ -769,11 +767,10 @@ mod tests {
         //just decode the key contents
         let b64_bytes =
             base64::decode(&cert_cont[header_len..cert_cont.len() - footer_len]).unwrap();
-        let result = digest(Algorithm::SHA1, b64_bytes.as_ref());
-        let thumbprint_crypto: Vec<String> = result.iter().map(|b| format!("{:02X}", b)).collect();
+        let thumbprint_crypto = format!("{:x}", sha1::Sha1::digest(b64_bytes.as_ref()));
 
         //compare the two thumbprints
-        assert_eq!(thumbprint_sha1, thumbprint_crypto.concat());
+        assert_eq!(thumbprint_sha1, thumbprint_crypto.to_uppercase());
     }
 
     #[test]


### PR DESCRIPTION
Without that fix, the tests are broken on windows and don't build on WSL.

The crate `crypto-hash` is a wrapper over openssl on unix and uses other libraries for mac and windows.