### PR TITLE
[CIT-308] Add simple automated version bumper

### DIFF
--- a/.github/workflows/hosted-post-merge_version_update.yml
+++ b/.github/workflows/hosted-post-merge_version_update.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - run: |
-          git config --global user.email "versioneer@actions.io"
+          git config --global user.email "info@thin-edge.io"
           git config --global user.name "Versioneer"
 
       - name: Install cargo-release


### PR DESCRIPTION
This will automatically bump version of all crates in the workspace by patch, create tag with `crate_name-vx.x.x` and push it back to the main.
This will be triggered only on merged pull request to main.

TODO: Bump version of only the changed crate.