### PR TITLE
[CIT-308] Create single commit when versioning

### DIFF
--- a/.github/workflows/hosted-post-merge_version_update.yml
+++ b/.github/workflows/hosted-post-merge_version_update.yml
@@ -1,6 +1,7 @@
 name: hosted-post-merge_version_update
 on:
   pull_request:
+    branches: [main]
     types: [closed]
 
 env:

--- a/.github/workflows/hosted-post-merge_version_update.yml
+++ b/.github/workflows/hosted-post-merge_version_update.yml
@@ -29,4 +29,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: release
-          args: patch --skip-publish -vv --no-dev-version --no-confirm
+          args: patch -vv --no-confirm

--- a/.github/workflows/hosted-post-merge_version_update.yml
+++ b/.github/workflows/hosted-post-merge_version_update.yml
@@ -1,0 +1,31 @@
+name: hosted-post-merge_version_update
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  versioning:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - run: |
+          git config --global user.email "versioneer@actions.io"
+          git config --global user.name "Versioneer"
+
+      - name: Install cargo-release
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-release
+
+      - name: Increment version and tag
+        uses: actions-rs/cargo@v1
+        with:
+          command: release
+          args: patch --skip-publish -vv --no-dev-version --no-confirm

--- a/.github/workflows/hosted-post-merge_version_update.yml
+++ b/.github/workflows/hosted-post-merge_version_update.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - run: |
-          git config --global user.email "versioneer@actions.io"
+          git config --global user.email "info@thin-edge.io"
           git config --global user.name "Versioneer"
 
       - name: Install cargo-release

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,3 @@
+disable-publish = true
+no-dev-version = true
+tag-name = "{{prefix}}{{version}}"

--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,4 @@
+consolidate-commits = true
 disable-publish = true
 no-dev-version = true
 tag-name = "{{prefix}}{{version}}"


### PR DESCRIPTION
This will create single commit for each version bump instead of for each crate.