### PR TITLE
WIP - Use privilege separation for `tedge`

### DIFF
--- a/tedge/src/bin/tedge_priv.rs
+++ b/tedge/src/bin/tedge_priv.rs
@@ -1,0 +1,27 @@
+fn main() -> anyhow::Result<()> {
+    eprintln!("Privileged tedge process");
+    // assert!(users::get_current_uid() == 0);
+
+    loop {
+        let mut line = String::new();
+        let _ = std::io::stdin().read_line(&mut line)?;
+
+        eprintln!("Received command: {}", line);
+
+        match line.trim() {
+            "command1" => {
+                // ...
+                // if you need to run command1 as different user, switch to that user now.
+                eprintln!("Running command1");
+                println!("OK");
+            }
+            "quit" => {
+                eprintln!("Terminating");
+                return Ok(());
+            }
+            _ => {
+                anyhow::bail!("Invalid command");
+            }
+        }
+    }
+}

--- a/tedge/src/command.rs
+++ b/tedge/src/command.rs
@@ -175,7 +175,8 @@ pub trait BuildCommand {
 ///     }
 /// ```
 pub struct ExecutionContext {
-    pub user_manager: UserManager,
+    pub user_manager: UserManager, // XXX
+    pub privileged_executor: Box<dyn crate::privsep::PrivilegedCommandExecutor>,
 }
 
 impl ExecutionContext {
@@ -183,9 +184,12 @@ impl ExecutionContext {
     ///
     /// Such a context MUST be created only once,
     /// in practice in the `main()` function.
-    pub fn new() -> ExecutionContext {
+    pub fn new(
+        privileged_executor: Box<dyn crate::privsep::PrivilegedCommandExecutor>,
+    ) -> ExecutionContext {
         ExecutionContext {
-            user_manager: UserManager::new(),
+            privileged_executor,
+            user_manager: UserManager::new(), // XXX
         }
     }
 }

--- a/tedge/src/main.rs
+++ b/tedge/src/main.rs
@@ -9,6 +9,7 @@ mod cli;
 mod command;
 mod config;
 mod mqtt;
+mod privsep;
 mod services;
 mod utils;
 
@@ -16,8 +17,28 @@ use command::BuildCommand;
 use command::ExecutionContext;
 
 fn main() -> anyhow::Result<()> {
-    let context = ExecutionContext::new();
-    let _user_guard = context.user_manager.become_user(utils::users::TEDGE_USER)?;
+    let mut privileged_executor: Box<dyn privsep::PrivilegedCommandExecutor> =
+        if users::get_current_uid() == 0 {
+            Box::new(privsep::PrivilegeSeparatedCommandExecutor::new(
+                "/home/mneumann/tedge_priv",
+            ))
+        } else {
+            Box::new(privsep::UnprivilegedDummyCommandExecutor::new())
+        };
+
+    // from now on running as unprivileged user
+    assert!(users::get_current_uid() != 0);
+
+    // Use this code deep inside the Commands to execute a privileged command.
+    privileged_executor
+        .execute(privsep::PrivilegedCommand::Command1)
+        .expect("Command succeeded");
+
+    // ...
+
+    let context = ExecutionContext::new(privileged_executor);
+
+    // let _user_guard = context.user_manager.become_user(utils::users::TEDGE_USER)?;
 
     let opt = cli::Opt::from_args();
 

--- a/tedge/src/privsep.rs
+++ b/tedge/src/privsep.rs
@@ -1,0 +1,92 @@
+use std::io::{BufRead, BufReader, Read, Write};
+
+#[derive(Debug)]
+pub enum PrivilegedCommand {
+    Command1,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PrivilegedCommandError {
+    #[error("Insufficient privileges: Try running with `sudo`")]
+    InsufficientPrivileges,
+
+    #[error("Command execution failed")]
+    CommandFailed,
+}
+
+pub trait PrivilegedCommandExecutor {
+    fn execute(&mut self, command: PrivilegedCommand) -> Result<(), PrivilegedCommandError>;
+}
+
+/// We use this executor when not running as `root`. It will always fail with an error.
+pub struct UnprivilegedDummyCommandExecutor;
+
+impl PrivilegedCommandExecutor for UnprivilegedDummyCommandExecutor {
+    fn execute(&mut self, command: PrivilegedCommand) -> Result<(), PrivilegedCommandError> {
+        eprintln!(
+            "Trying to execute a privileged command as non-root: {:?}",
+            command
+        );
+        Err(PrivilegedCommandError::InsufficientPrivileges)
+    }
+}
+
+impl UnprivilegedDummyCommandExecutor {
+    pub fn new() -> Self {
+        // assert!(users::get_current_uid() != 0);
+        Self {}
+    }
+}
+
+/// When `tedge` is started as `root`, spawn `tedge_priv` which runs all code that
+/// need `root` privileges. Immediately drop privileges for the rest of `tedge`.
+///
+pub struct PrivilegeSeparatedCommandExecutor {
+    child: std::process::Child,
+    child_stdin: std::process::ChildStdin,
+    child_stdout: BufReader<std::process::ChildStdout>,
+}
+
+impl PrivilegeSeparatedCommandExecutor {
+    pub fn new(path_to_tedge_priv: &str) -> Self {
+        //assert!(users::get_current_uid() == 0);
+
+        let mut child = std::process::Command::new(path_to_tedge_priv)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit())
+            .spawn()
+            .expect("Failed to spawn tedge_priv");
+
+        // TODO: Switch to unprivileged user tedge/tedge
+        //
+        // users::switch::switch_user_group("tedge", "tedge")
+
+        let child_stdin = child.stdin.take().unwrap();
+        let child_stdout = BufReader::new(child.stdout.take().unwrap());
+
+        Self {
+            child,
+            child_stdin,
+            child_stdout,
+        }
+    }
+}
+
+impl PrivilegedCommandExecutor for PrivilegeSeparatedCommandExecutor {
+    fn execute(&mut self, command: PrivilegedCommand) -> Result<(), PrivilegedCommandError> {
+        match command {
+            PrivilegedCommand::Command1 => {
+                self.child_stdin.write_all(b"command1\n").unwrap();
+                self.child_stdin.flush().unwrap();
+                let mut result = String::new();
+                self.child_stdout.read_line(&mut result).unwrap();
+
+                match result.trim() {
+                    "OK" => Ok(()),
+                    _ => Err(PrivilegedCommandError::CommandFailed),
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- OpenBSD folks will love you!!! :)

- IF security is not the primary objective, read SECTION BELOW.

- https://en.wikipedia.org/wiki/Privilege_separation

- This makes running `sudo tedge` much more secure!

- We should get rid of UserManager. It's a good idea in the first place, but turned out to be too
  complicated and is not really "thread-safe".

- Running `tedge` as root will immediatly lower privileges to
  `tedge:tedge`, right after forking the privleged process `tedge_priv`.

- `tedge_priv` will continue running as `root`.

- Any privleged command will be executed from the very stripped down
  `tedge_priv` binary. Communication is done via a pipe.

- We will only fork when running as `root`. If not running as root, we
  do not need to fork `tedge_priv` and instead use a dummy privileged
  command executor which will always fail with InsufficientPermissions.
  That means that there are zero performance penalties when running
  not as root.

- This is a **much more secure** approach, as the code that runs as `root`
  is very much limited. You only have to audit `tedge_priv` for
  vulnerabilities and the first lines of `tedge` up to the point where
  it irrecoverably gives up root permissions.

- `tedge` can really drop root permissions permanently. There is no way
  to recover `root` permissions. `UserManager` instead only switches the
  effective uid/gid, which is NOT SECURE.

- Much much easier to test, as you can really mock things that need root
  privileges.

- This is just an example implementation to show the general concept.
  There are crates like `privsep-rs` or `sandbox-ipc` that do similar
  things, but are way more complex.

- It's also possible to `fork(2)` the `tedge` executable in the
  beginning. I just went with a separate binary because it was easier to
  implement. Having a separate binary (ideally as a completely separate
  crate with almost no dependencies) has a lot of advantages. Mainly the
  reduced dependencies required to build it which reduces the potential
  for exploits.

-----------------------------------------
IF security is not the primary objective:
-----------------------------------------

- To run a command as a different user, just use:

  "su -m mosquitto -c systemctl  ..."

  See `su(1)` for details.

- To change file permissions, `chown(2)` is your friend.

- Both of them work as you are running as `root`.

- You do not need to switch the effective user permissions of the
  running process! Only change the user permissions of the command
  that you want to execute!

- If you don't like `su(1)`, just write your own `Process::spawn`, that
  will call `setuid(2)` between `fork(2)` and `execl(3)`.