### PR TITLE
Refactor TEdge config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,6 +1746,7 @@ dependencies = [
  "serde",
  "sha-1",
  "structopt",
+ "tedge_config",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1755,6 +1756,17 @@ dependencies = [
  "which",
  "x509-parser",
  "zeroize",
+]
+
+[[package]]
+name = "tedge_config"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "serde",
+ "tempfile",
+ "thiserror",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "common/mqtt_client",
     "tedge",
+    "tedge_config",
     "mapper/tedge_mapper",
     "mapper/cumulocity/c8y_translator_lib",
 ]

--- a/tedge/Cargo.toml
+++ b/tedge/Cargo.toml
@@ -30,6 +30,7 @@ which = "4.0"
 x509-parser = "0.9"
 zeroize = "1.2"
 sha-1 = "0.9"
+tedge_config = { path = "../tedge_config" }
 
 [target.'cfg(unix)'.dependencies]
 users = "0.11.0"

--- a/tedge_config/Cargo.toml
+++ b/tedge_config/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tedge_config"
+version = "0.1.0"
+authors = ["Software AG <thin-edge-team@softwareag.com>"]
+edition = "2018"
+
+[dependencies]
+toml = "0.5"
+thiserror = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+tempfile = "3.2"
+
+[dev-dependencies]
+assert_matches = "1.4"

--- a/tedge_config/src/config_setting.rs
+++ b/tedge_config/src/config_setting.rs
@@ -37,16 +37,6 @@ pub enum ConfigSettingError {
     )]
     ConfigNotSet { key: &'static str },
 
-    // XXX
-    #[error(
-        r#"Provided URL: '{0}' contains scheme or port.
-    Provided URL should contain only domain, eg: 'subdomain.cumulocity.com'."#
-    )]
-    InvalidConfigUrl(String),
-
     #[error("Readonly setting")]
     ReadonlySetting,
-
-    #[error("Infallible Error")]
-    Infallible(#[from] std::convert::Infallible),
 }

--- a/tedge_config/src/config_setting.rs
+++ b/tedge_config/src/config_setting.rs
@@ -1,0 +1,52 @@
+pub trait ConfigSetting {
+    /// This is something like `device.id`.
+    const KEY: &'static str;
+
+    const DESCRIPTION: &'static str;
+
+    /// The underlying value type of the configuration setting.
+    type Value;
+}
+
+pub trait ConfigSettingAccessor<T: ConfigSetting> {
+    /// Read a configuration setting
+    fn query(&self, setting: T) -> ConfigSettingResult<T::Value>;
+
+    fn query_optional(&self, setting: T) -> ConfigSettingResult<Option<T::Value>> {
+        match self.query(setting) {
+            Ok(value) => Ok(Some(value)),
+            Err(ConfigSettingError::ConfigNotSet { .. }) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Update a configuration setting
+    fn update(&mut self, _setting: T, _value: T::Value) -> ConfigSettingResult<()>;
+
+    /// Unset a configuration setting / reset to default
+    fn unset(&mut self, _setting: T) -> ConfigSettingResult<()>;
+}
+
+pub type ConfigSettingResult<T> = Result<T, ConfigSettingError>;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ConfigSettingError {
+    #[error(
+        r#"A value for `{key}` is missing.
+    A value can be set with `tedge config set {key} <value>`"#
+    )]
+    ConfigNotSet { key: &'static str },
+
+    // XXX
+    #[error(
+        r#"Provided URL: '{0}' contains scheme or port.
+    Provided URL should contain only domain, eg: 'subdomain.cumulocity.com'."#
+    )]
+    InvalidConfigUrl(String),
+
+    #[error("Readonly setting")]
+    ReadonlySetting,
+
+    #[error("Infallible Error")]
+    Infallible(#[from] std::convert::Infallible),
+}

--- a/tedge_config/src/error.rs
+++ b/tedge_config/src/error.rs
@@ -18,6 +18,9 @@ pub enum TEdgeConfigError {
     #[error(transparent)]
     ConfigSettingError(#[from] crate::ConfigSettingError),
 
+    #[error(transparent)]
+    InvalidConfigUrl(#[from] crate::models::InvalidConnectUrl),
+
     #[error("Config file not found: {0}")]
     ConfigFileNotFound(std::path::PathBuf),
 }

--- a/tedge_config/src/error.rs
+++ b/tedge_config/src/error.rs
@@ -1,0 +1,23 @@
+#[derive(thiserror::Error, Debug)]
+pub enum TEdgeConfigError {
+    #[error("TOML parse error")]
+    TOMLParseError(#[from] toml::de::Error),
+
+    #[error("TOML serialization error")]
+    InvalidTOMLError(#[from] toml::ser::Error),
+
+    #[error("I/O error")]
+    IOError(#[from] std::io::Error),
+
+    #[error("Home directory not found")]
+    HomeDirectoryNotFound,
+
+    #[error("Invalid characters found in home directory path")]
+    InvalidCharacterInHomeDirectoryPath,
+
+    #[error(transparent)]
+    ConfigSettingError(#[from] crate::ConfigSettingError),
+
+    #[error("Config file not found: {0}")]
+    ConfigFileNotFound(std::path::PathBuf),
+}

--- a/tedge_config/src/lib.rs
+++ b/tedge_config/src/lib.rs
@@ -4,12 +4,9 @@ mod models;
 mod settings;
 mod tedge_config;
 mod tedge_config_dto;
+mod tedge_config_location;
 mod tedge_config_repository;
 
-pub use self::config_setting::*;
-pub use self::error::*;
-pub use self::models::*;
-pub use self::settings::*;
-pub use self::tedge_config::*;
 use self::tedge_config_dto::*;
-pub use self::tedge_config_repository::*;
+pub use self::{config_setting::*, error::*, models::*, settings::*};
+pub use self::{tedge_config::*, tedge_config_location::*, tedge_config_repository::*};

--- a/tedge_config/src/lib.rs
+++ b/tedge_config/src/lib.rs
@@ -1,0 +1,15 @@
+mod config_setting;
+mod error;
+mod models;
+mod settings;
+mod tedge_config;
+mod tedge_config_dto;
+mod tedge_config_repository;
+
+pub use self::config_setting::*;
+pub use self::error::*;
+pub use self::models::*;
+pub use self::settings::*;
+pub use self::tedge_config::*;
+use self::tedge_config_dto::*;
+pub use self::tedge_config_repository::*;

--- a/tedge_config/src/models/connect_url.rs
+++ b/tedge_config/src/models/connect_url.rs
@@ -1,4 +1,3 @@
-use crate::*;
 use std::convert::TryFrom;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
@@ -11,12 +10,6 @@ pub struct ConnectUrl(String);
          Provided URL should contain only domain, eg: 'subdomain.cumulocity.com'."
 )]
 pub struct InvalidConnectUrl(pub String);
-
-impl Into<ConfigSettingError> for InvalidConnectUrl {
-    fn into(self) -> ConfigSettingError {
-        ConfigSettingError::InvalidConfigUrl(self.0)
-    }
-}
 
 impl TryFrom<String> for ConnectUrl {
     type Error = InvalidConnectUrl;
@@ -54,30 +47,28 @@ impl Into<String> for ConnectUrl {
 fn connect_url_from_string_should_return_err_provided_address_with_port() {
     let input = "test.address.com:8883";
 
-    assert!(ConnectUrl::try_from(input.to_string()).is_err());
+    assert!(ConnectUrl::try_from(input).is_err());
 }
 
 #[test]
 fn connect_url_from_string_should_return_err_provided_address_with_scheme_http() {
     let input = "http://test.address.com";
 
-    assert!(ConnectUrl::try_from(input.to_string()).is_err());
+    assert!(ConnectUrl::try_from(input).is_err());
 }
 
 #[test]
 fn connect_url_from_string_should_return_err_provided_address_with_port_and_http() {
     let input = "http://test.address.com:8883";
 
-    assert!(ConnectUrl::try_from(input.to_string()).is_err());
+    assert!(ConnectUrl::try_from(input).is_err());
 }
 
 #[test]
-fn connect_url_from_string_should_return_string() {
+fn connect_url_from_string_should_return_string() -> Result<(), crate::TEdgeConfigError> {
     let input = "test.address.com";
     let expected = "test.address.com";
 
-    assert_eq!(
-        &ConnectUrl::try_from(input.to_string()).unwrap().as_str(),
-        &expected
-    );
+    assert_eq!(&ConnectUrl::try_from(input)?.as_str(), &expected);
+    Ok(())
 }

--- a/tedge_config/src/models/connect_url.rs
+++ b/tedge_config/src/models/connect_url.rs
@@ -1,0 +1,83 @@
+use crate::*;
+use std::convert::TryFrom;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+#[serde(try_from = "String", into = "String")]
+pub struct ConnectUrl(String);
+
+#[derive(thiserror::Error, Debug)]
+#[error(
+    "Provided URL: '{0}' contains scheme or port.
+         Provided URL should contain only domain, eg: 'subdomain.cumulocity.com'."
+)]
+pub struct InvalidConnectUrl(pub String);
+
+impl Into<ConfigSettingError> for InvalidConnectUrl {
+    fn into(self) -> ConfigSettingError {
+        ConfigSettingError::InvalidConfigUrl(self.0)
+    }
+}
+
+impl TryFrom<String> for ConnectUrl {
+    type Error = InvalidConnectUrl;
+
+    fn try_from(input: String) -> Result<Self, Self::Error> {
+        if input.contains(':') {
+            Err(InvalidConnectUrl(input))
+        } else {
+            Ok(Self(input))
+        }
+    }
+}
+
+impl TryFrom<&str> for ConnectUrl {
+    type Error = InvalidConnectUrl;
+
+    fn try_from(input: &str) -> Result<Self, Self::Error> {
+        ConnectUrl::try_from(input.to_string())
+    }
+}
+
+impl ConnectUrl {
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Into<String> for ConnectUrl {
+    fn into(self) -> String {
+        self.0
+    }
+}
+
+#[test]
+fn connect_url_from_string_should_return_err_provided_address_with_port() {
+    let input = "test.address.com:8883";
+
+    assert!(ConnectUrl::try_from(input.to_string()).is_err());
+}
+
+#[test]
+fn connect_url_from_string_should_return_err_provided_address_with_scheme_http() {
+    let input = "http://test.address.com";
+
+    assert!(ConnectUrl::try_from(input.to_string()).is_err());
+}
+
+#[test]
+fn connect_url_from_string_should_return_err_provided_address_with_port_and_http() {
+    let input = "http://test.address.com:8883";
+
+    assert!(ConnectUrl::try_from(input.to_string()).is_err());
+}
+
+#[test]
+fn connect_url_from_string_should_return_string() {
+    let input = "test.address.com";
+    let expected = "test.address.com";
+
+    assert_eq!(
+        &ConnectUrl::try_from(input.to_string()).unwrap().as_str(),
+        &expected
+    );
+}

--- a/tedge_config/src/models/mod.rs
+++ b/tedge_config/src/models/mod.rs
@@ -1,0 +1,3 @@
+pub mod connect_url;
+
+pub use self::connect_url::*;

--- a/tedge_config/src/settings.rs
+++ b/tedge_config/src/settings.rs
@@ -1,4 +1,5 @@
 use crate::{config_setting::*, models::*};
+use std::path::PathBuf;
 
 ///
 /// Identifier of the device within the fleet. It must be globally
@@ -33,7 +34,7 @@ impl ConfigSetting for DeviceKeyPathSetting {
     const DESCRIPTION: &'static str =
         "Path to the private key file. Example: /home/user/.tedge/tedge-private-key.pem";
 
-    type Value = String;
+    type Value = PathBuf;
 }
 
 ///
@@ -50,7 +51,7 @@ impl ConfigSetting for DeviceCertPathSetting {
     const DESCRIPTION: &'static str =
         "Path to the certificate file. Example: /home/user/.tedge/tedge-certificate.crt";
 
-    type Value = String;
+    type Value = PathBuf;
 }
 
 ///
@@ -85,7 +86,7 @@ impl ConfigSetting for C8yRootCertPathSetting {
         "Example: /home/user/.tedge/c8y-trusted-root-certificates.pem"
     );
 
-    type Value = String;
+    type Value = PathBuf;
 }
 
 ///
@@ -123,5 +124,5 @@ impl ConfigSetting for AzureRootCertPathSetting {
         "Example: /home/user/.tedge/azure-trusted-root-certificates.pem"
     );
 
-    type Value = String;
+    type Value = PathBuf;
 }

--- a/tedge_config/src/settings.rs
+++ b/tedge_config/src/settings.rs
@@ -1,0 +1,127 @@
+use crate::{config_setting::*, models::*};
+
+///
+/// Identifier of the device within the fleet. It must be globally
+/// unique and the same one used in the device certificate.
+///
+/// Example: Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665")
+///
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct DeviceIdSetting;
+
+impl ConfigSetting for DeviceIdSetting {
+    const KEY: &'static str = "device.id";
+
+    const DESCRIPTION: &'static str = concat!(
+        "Identifier of the device within the fleet. It must be ",
+        "globally unique and the same one used in the device certificate. ",
+        "Example: Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665"
+    );
+
+    type Value = String;
+}
+
+///
+/// Path to the private key file. Example: /home/user/.tedge/tedge-private-key.pem
+///
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct DeviceKeyPathSetting;
+
+impl ConfigSetting for DeviceKeyPathSetting {
+    const KEY: &'static str = "device.key.path";
+
+    const DESCRIPTION: &'static str =
+        "Path to the private key file. Example: /home/user/.tedge/tedge-private-key.pem";
+
+    type Value = String;
+}
+
+///
+/// Path to the certificate file.
+///
+/// Example: /home/user/.tedge/tedge-certificate.crt
+///
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct DeviceCertPathSetting;
+
+impl ConfigSetting for DeviceCertPathSetting {
+    const KEY: &'static str = "device.cert.path";
+
+    const DESCRIPTION: &'static str =
+        "Path to the certificate file. Example: /home/user/.tedge/tedge-certificate.crt";
+
+    type Value = String;
+}
+
+///
+/// Tenant endpoint URL of Cumulocity tenant.
+///
+/// Example: your-tenant.cumulocity.com
+///
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct C8yUrlSetting;
+
+impl ConfigSetting for C8yUrlSetting {
+    const KEY: &'static str = "c8y.url";
+
+    const DESCRIPTION: &'static str =
+        "Tenant endpoint URL of Cumulocity tenant. Example: your-tenant.cumulocity.com";
+    type Value = ConnectUrl;
+}
+
+///
+/// Path where Cumulocity root certificate(s) are located.
+///
+/// Example: /home/user/.tedge/c8y-trusted-root-certificates.pem
+///
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct C8yRootCertPathSetting;
+
+impl ConfigSetting for C8yRootCertPathSetting {
+    const KEY: &'static str = "c8y.root_cert_path";
+
+    const DESCRIPTION: &'static str = concat!(
+        "Path where Cumulocity root certificate(s) are located. ",
+        "Example: /home/user/.tedge/c8y-trusted-root-certificates.pem"
+    );
+
+    type Value = String;
+}
+
+///
+/// Tenant endpoint URL of Azure IoT tenant.
+///
+/// Example: MyAzure.azure-devices.net
+///
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct AzureUrlSetting;
+
+impl ConfigSetting for AzureUrlSetting {
+    const KEY: &'static str = "device.id";
+
+    const DESCRIPTION: &'static str = concat!(
+        "Tenant endpoint URL of Azure IoT tenant. ",
+        "Example:  MyAzure.azure-devices.net"
+    );
+
+    type Value = ConnectUrl;
+}
+
+///
+/// Path where Azure IoT root certificate(s) are located.
+///
+/// Example: /home/user/.tedge/azure-trusted-root-certificates.pem
+///
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct AzureRootCertPathSetting;
+
+impl ConfigSetting for AzureRootCertPathSetting {
+    const KEY: &'static str = "azure.root_cert_path";
+
+    const DESCRIPTION: &'static str = concat!(
+        "Path where Azure IoT root certificate(s) are located. ",
+        "Example: /home/user/.tedge/azure-trusted-root-certificates.pem"
+    );
+
+    type Value = String;
+}

--- a/tedge_config/src/tedge_config.rs
+++ b/tedge_config/src/tedge_config.rs
@@ -1,0 +1,194 @@
+use crate::*;
+
+const DEFAULT_ROOT_CERT_PATH: &str = "/etc/ssl/certs";
+
+/// Represents the complete configuration of a thin edge device.
+/// This configuration is a wrapper over the device specific configurations
+/// as well as the IoT cloud provider specific configurations.
+///
+#[derive(Debug)]
+pub struct TEdgeConfig {
+    pub(crate) data: TEdgeConfigDto,
+}
+
+impl TEdgeConfig {
+    pub fn update_if_not_set<T: ConfigSetting + Copy>(
+        &mut self,
+        setting: T,
+        value: T::Value,
+    ) -> Result<(), TEdgeConfigError>
+    where
+        Self: ConfigSettingAccessor<T>,
+    {
+        match self.query(setting) {
+            Err(ConfigSettingError::ConfigNotSet { .. }) => {
+                self.update(setting, value)?;
+                Ok(())
+            }
+            Err(other) => Err(other.into()),
+            Ok(_ok) => Ok(()),
+        }
+    }
+}
+
+impl ConfigSettingAccessor<DeviceIdSetting> for TEdgeConfig {
+    fn query(&self, _setting: DeviceIdSetting) -> ConfigSettingResult<String> {
+        self.data
+            .device
+            .id
+            .clone()
+            .ok_or(ConfigSettingError::ConfigNotSet {
+                key: DeviceIdSetting::KEY,
+            })
+    }
+
+    fn update(&mut self, _setting: DeviceIdSetting, _value: String) -> ConfigSettingResult<()> {
+        Err(ConfigSettingError::ReadonlySetting)
+    }
+
+    fn unset(&mut self, _setting: DeviceIdSetting) -> ConfigSettingResult<()> {
+        Err(ConfigSettingError::ReadonlySetting)
+    }
+}
+
+impl ConfigSettingAccessor<AzureUrlSetting> for TEdgeConfig {
+    fn query(&self, _setting: AzureUrlSetting) -> ConfigSettingResult<ConnectUrl> {
+        self.data
+            .azure
+            .url
+            .clone()
+            .ok_or(ConfigSettingError::ConfigNotSet {
+                key: AzureUrlSetting::KEY,
+            })
+    }
+
+    fn update(&mut self, _setting: AzureUrlSetting, value: ConnectUrl) -> ConfigSettingResult<()> {
+        self.data.azure.url = Some(value);
+        Ok(())
+    }
+
+    fn unset(&mut self, _setting: AzureUrlSetting) -> ConfigSettingResult<()> {
+        self.data.azure.url = None;
+        Ok(())
+    }
+}
+
+impl ConfigSettingAccessor<C8yUrlSetting> for TEdgeConfig {
+    fn query(&self, _setting: C8yUrlSetting) -> ConfigSettingResult<ConnectUrl> {
+        self.data
+            .c8y
+            .url
+            .clone()
+            .ok_or(ConfigSettingError::ConfigNotSet {
+                key: C8yUrlSetting::KEY,
+            })
+    }
+
+    fn update(&mut self, _setting: C8yUrlSetting, value: ConnectUrl) -> ConfigSettingResult<()> {
+        self.data.c8y.url = Some(value);
+        Ok(())
+    }
+
+    fn unset(&mut self, _setting: C8yUrlSetting) -> ConfigSettingResult<()> {
+        self.data.c8y.url = None;
+        Ok(())
+    }
+}
+
+impl ConfigSettingAccessor<DeviceCertPathSetting> for TEdgeConfig {
+    fn query(&self, _setting: DeviceCertPathSetting) -> ConfigSettingResult<String> {
+        self.data
+            .device
+            .cert_path
+            .clone()
+            .ok_or(ConfigSettingError::ConfigNotSet {
+                key: DeviceCertPathSetting::KEY,
+            })
+    }
+
+    fn update(
+        &mut self,
+        _setting: DeviceCertPathSetting,
+        value: String,
+    ) -> ConfigSettingResult<()> {
+        self.data.device.cert_path = Some(value);
+        Ok(())
+    }
+
+    fn unset(&mut self, _setting: DeviceCertPathSetting) -> ConfigSettingResult<()> {
+        self.data.device.cert_path = None;
+        Ok(())
+    }
+}
+
+impl ConfigSettingAccessor<DeviceKeyPathSetting> for TEdgeConfig {
+    fn query(&self, _setting: DeviceKeyPathSetting) -> ConfigSettingResult<String> {
+        self.data
+            .device
+            .key_path
+            .clone()
+            .ok_or(ConfigSettingError::ConfigNotSet {
+                key: DeviceKeyPathSetting::KEY,
+            })
+    }
+
+    fn update(&mut self, _setting: DeviceKeyPathSetting, value: String) -> ConfigSettingResult<()> {
+        self.data.device.key_path = Some(value);
+        Ok(())
+    }
+
+    fn unset(&mut self, _setting: DeviceKeyPathSetting) -> ConfigSettingResult<()> {
+        self.data.device.key_path = None;
+        Ok(())
+    }
+}
+
+impl ConfigSettingAccessor<AzureRootCertPathSetting> for TEdgeConfig {
+    fn query(&self, _setting: AzureRootCertPathSetting) -> ConfigSettingResult<String> {
+        Ok(self
+            .data
+            .azure
+            .root_cert_path
+            .clone()
+            .unwrap_or_else(|| DEFAULT_ROOT_CERT_PATH.into()))
+    }
+
+    fn update(
+        &mut self,
+        _setting: AzureRootCertPathSetting,
+        value: String,
+    ) -> ConfigSettingResult<()> {
+        self.data.azure.root_cert_path = Some(value);
+        Ok(())
+    }
+
+    fn unset(&mut self, _setting: AzureRootCertPathSetting) -> ConfigSettingResult<()> {
+        self.data.azure.root_cert_path = None;
+        Ok(())
+    }
+}
+
+impl ConfigSettingAccessor<C8yRootCertPathSetting> for TEdgeConfig {
+    fn query(&self, _setting: C8yRootCertPathSetting) -> ConfigSettingResult<String> {
+        Ok(self
+            .data
+            .c8y
+            .root_cert_path
+            .clone()
+            .unwrap_or_else(|| DEFAULT_ROOT_CERT_PATH.into()))
+    }
+
+    fn update(
+        &mut self,
+        _setting: C8yRootCertPathSetting,
+        value: String,
+    ) -> ConfigSettingResult<()> {
+        self.data.c8y.root_cert_path = Some(value);
+        Ok(())
+    }
+
+    fn unset(&mut self, _setting: C8yRootCertPathSetting) -> ConfigSettingResult<()> {
+        self.data.c8y.root_cert_path = None;
+        Ok(())
+    }
+}

--- a/tedge_config/src/tedge_config.rs
+++ b/tedge_config/src/tedge_config.rs
@@ -82,7 +82,7 @@ impl ConfigSettingAccessor<DeviceCertPathSetting> for TEdgeConfig {
             .device
             .cert_path
             .clone()
-            .unwrap_or_else(|| self.config_location.default_device_cert_path()))
+            .unwrap_or_else(|| self.config_location.default_device_cert_path.clone()))
     }
 
     fn update(
@@ -107,7 +107,7 @@ impl ConfigSettingAccessor<DeviceKeyPathSetting> for TEdgeConfig {
             .device
             .key_path
             .clone()
-            .unwrap_or_else(|| self.config_location.default_device_key_path()))
+            .unwrap_or_else(|| self.config_location.default_device_key_path.clone()))
     }
 
     fn update(
@@ -132,7 +132,7 @@ impl ConfigSettingAccessor<AzureRootCertPathSetting> for TEdgeConfig {
             .azure
             .root_cert_path
             .clone()
-            .unwrap_or_else(|| self.config_location.default_azure_root_cert_path()))
+            .unwrap_or_else(|| self.config_location.default_azure_root_cert_path.clone()))
     }
 
     fn update(
@@ -157,7 +157,7 @@ impl ConfigSettingAccessor<C8yRootCertPathSetting> for TEdgeConfig {
             .c8y
             .root_cert_path
             .clone()
-            .unwrap_or_else(|| self.config_location.default_c8y_root_cert_path()))
+            .unwrap_or_else(|| self.config_location.default_c8y_root_cert_path.clone()))
     }
 
     fn update(

--- a/tedge_config/src/tedge_config.rs
+++ b/tedge_config/src/tedge_config.rs
@@ -1,9 +1,5 @@
 use crate::*;
-
-const DEFAULT_DEVICE_CERT_PATH: &str = "/etc/ssl/certs/tedge-certificate.pem";
-const DEFAULT_DEVICE_KEY_PATH: &str = "/etc/ssl/certs/tedge-private-key.pem";
-const DEFAULT_AZURE_ROOT_CERT_PATH: &str = "/etc/ssl/certs";
-const DEFAULT_C8Y_ROOT_CERT_PATH: &str = "/etc/ssl/certs";
+use std::path::PathBuf;
 
 /// Represents the complete configuration of a thin edge device.
 /// This configuration is a wrapper over the device specific configurations
@@ -12,6 +8,7 @@ const DEFAULT_C8Y_ROOT_CERT_PATH: &str = "/etc/ssl/certs";
 #[derive(Debug)]
 pub struct TEdgeConfig {
     pub(crate) data: TEdgeConfigDto,
+    pub(crate) config_location: TEdgeConfigLocation,
 }
 
 impl ConfigSettingAccessor<DeviceIdSetting> for TEdgeConfig {
@@ -79,19 +76,19 @@ impl ConfigSettingAccessor<C8yUrlSetting> for TEdgeConfig {
 }
 
 impl ConfigSettingAccessor<DeviceCertPathSetting> for TEdgeConfig {
-    fn query(&self, _setting: DeviceCertPathSetting) -> ConfigSettingResult<String> {
+    fn query(&self, _setting: DeviceCertPathSetting) -> ConfigSettingResult<PathBuf> {
         Ok(self
             .data
             .device
             .cert_path
             .clone()
-            .unwrap_or_else(|| DEFAULT_DEVICE_CERT_PATH.into()))
+            .unwrap_or_else(|| self.config_location.default_device_cert_path()))
     }
 
     fn update(
         &mut self,
         _setting: DeviceCertPathSetting,
-        value: String,
+        value: PathBuf,
     ) -> ConfigSettingResult<()> {
         self.data.device.cert_path = Some(value);
         Ok(())
@@ -104,16 +101,20 @@ impl ConfigSettingAccessor<DeviceCertPathSetting> for TEdgeConfig {
 }
 
 impl ConfigSettingAccessor<DeviceKeyPathSetting> for TEdgeConfig {
-    fn query(&self, _setting: DeviceKeyPathSetting) -> ConfigSettingResult<String> {
+    fn query(&self, _setting: DeviceKeyPathSetting) -> ConfigSettingResult<PathBuf> {
         Ok(self
             .data
             .device
             .key_path
             .clone()
-            .unwrap_or_else(|| DEFAULT_DEVICE_KEY_PATH.into()))
+            .unwrap_or_else(|| self.config_location.default_device_key_path()))
     }
 
-    fn update(&mut self, _setting: DeviceKeyPathSetting, value: String) -> ConfigSettingResult<()> {
+    fn update(
+        &mut self,
+        _setting: DeviceKeyPathSetting,
+        value: PathBuf,
+    ) -> ConfigSettingResult<()> {
         self.data.device.key_path = Some(value);
         Ok(())
     }
@@ -125,19 +126,19 @@ impl ConfigSettingAccessor<DeviceKeyPathSetting> for TEdgeConfig {
 }
 
 impl ConfigSettingAccessor<AzureRootCertPathSetting> for TEdgeConfig {
-    fn query(&self, _setting: AzureRootCertPathSetting) -> ConfigSettingResult<String> {
+    fn query(&self, _setting: AzureRootCertPathSetting) -> ConfigSettingResult<PathBuf> {
         Ok(self
             .data
             .azure
             .root_cert_path
             .clone()
-            .unwrap_or_else(|| DEFAULT_AZURE_ROOT_CERT_PATH.into()))
+            .unwrap_or_else(|| self.config_location.default_azure_root_cert_path()))
     }
 
     fn update(
         &mut self,
         _setting: AzureRootCertPathSetting,
-        value: String,
+        value: PathBuf,
     ) -> ConfigSettingResult<()> {
         self.data.azure.root_cert_path = Some(value);
         Ok(())
@@ -150,19 +151,19 @@ impl ConfigSettingAccessor<AzureRootCertPathSetting> for TEdgeConfig {
 }
 
 impl ConfigSettingAccessor<C8yRootCertPathSetting> for TEdgeConfig {
-    fn query(&self, _setting: C8yRootCertPathSetting) -> ConfigSettingResult<String> {
+    fn query(&self, _setting: C8yRootCertPathSetting) -> ConfigSettingResult<PathBuf> {
         Ok(self
             .data
             .c8y
             .root_cert_path
             .clone()
-            .unwrap_or_else(|| DEFAULT_C8Y_ROOT_CERT_PATH.into()))
+            .unwrap_or_else(|| self.config_location.default_c8y_root_cert_path()))
     }
 
     fn update(
         &mut self,
         _setting: C8yRootCertPathSetting,
-        value: String,
+        value: PathBuf,
     ) -> ConfigSettingResult<()> {
         self.data.c8y.root_cert_path = Some(value);
         Ok(())

--- a/tedge_config/src/tedge_config_dto.rs
+++ b/tedge_config/src/tedge_config_dto.rs
@@ -1,0 +1,59 @@
+//! Crate-private plain-old data-type used for serialization.
+
+use crate::*;
+use serde::{Deserialize, Serialize};
+
+#[serde(deny_unknown_fields)]
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub(crate) struct TEdgeConfigDto {
+    /// Captures the device specific configurations
+    #[serde(default)]
+    pub(crate) device: DeviceConfigDto,
+
+    /// Captures the configurations required to connect to Cumulocity
+    #[serde(default)]
+    pub(crate) c8y: CumulocityConfigDto,
+    #[serde(default)]
+    pub(crate) azure: AzureConfigDto,
+}
+
+/// Represents the device specific configurations defined in the [device] section
+/// of the thin edge configuration TOML file
+#[serde(deny_unknown_fields)]
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub(crate) struct DeviceConfigDto {
+    /// The unique id of the device
+    pub(crate) id: Option<String>,
+
+    /// Path where the device's private key is stored.
+    /// Defaults to $HOME/.tedge/tedge-private.pem
+    pub(crate) key_path: Option<String>,
+
+    /// Path where the device's certificate is stored.
+    /// Defaults to $HOME/.tedge/tedge-certificate.crt
+    pub(crate) cert_path: Option<String>,
+}
+
+/// Represents the Cumulocity specific configurations defined in the
+/// [c8y] section of the thin edge configuration TOML file
+#[serde(deny_unknown_fields)]
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub(crate) struct CumulocityConfigDto {
+    /// Preserves the current status of the connection
+    pub(crate) connect: Option<String>,
+
+    /// Endpoint URL of the Cumulocity tenant
+    pub(crate) url: Option<ConnectUrl>,
+
+    /// The path where Cumulocity root certificate(s) are stored.
+    /// The value can be a directory path as well as the path of the direct certificate file.
+    pub(crate) root_cert_path: Option<String>,
+}
+
+#[serde(deny_unknown_fields)]
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub(crate) struct AzureConfigDto {
+    pub(crate) connect: Option<String>,
+    pub(crate) url: Option<ConnectUrl>,
+    pub(crate) root_cert_path: Option<String>,
+}

--- a/tedge_config/src/tedge_config_dto.rs
+++ b/tedge_config/src/tedge_config_dto.rs
@@ -2,6 +2,7 @@
 
 use crate::*;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[serde(deny_unknown_fields)]
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -27,11 +28,11 @@ pub(crate) struct DeviceConfigDto {
 
     /// Path where the device's private key is stored.
     /// Defaults to $HOME/.tedge/tedge-private.pem
-    pub(crate) key_path: Option<String>,
+    pub(crate) key_path: Option<PathBuf>,
 
     /// Path where the device's certificate is stored.
     /// Defaults to $HOME/.tedge/tedge-certificate.crt
-    pub(crate) cert_path: Option<String>,
+    pub(crate) cert_path: Option<PathBuf>,
 }
 
 /// Represents the Cumulocity specific configurations defined in the
@@ -47,7 +48,7 @@ pub(crate) struct CumulocityConfigDto {
 
     /// The path where Cumulocity root certificate(s) are stored.
     /// The value can be a directory path as well as the path of the direct certificate file.
-    pub(crate) root_cert_path: Option<String>,
+    pub(crate) root_cert_path: Option<PathBuf>,
 }
 
 #[serde(deny_unknown_fields)]
@@ -55,5 +56,5 @@ pub(crate) struct CumulocityConfigDto {
 pub(crate) struct AzureConfigDto {
     pub(crate) connect: Option<String>,
     pub(crate) url: Option<ConnectUrl>,
-    pub(crate) root_cert_path: Option<String>,
+    pub(crate) root_cert_path: Option<PathBuf>,
 }

--- a/tedge_config/src/tedge_config_location.rs
+++ b/tedge_config/src/tedge_config_location.rs
@@ -54,8 +54,12 @@ impl TEdgeConfigLocation {
         let tedge_path = etc_path.join("tedge");
         Self {
             tedge_config_path: tedge_path.join(TEDGE_CONFIG_FILE),
-            default_device_cert_path: tedge_path.join("certs").join("tedge-certificate.pem"),
-            default_device_key_path: tedge_path.join("certs").join("tedge-private-key.pem"),
+            default_device_cert_path: tedge_path
+                .join("device-certs")
+                .join("tedge-certificate.pem"),
+            default_device_key_path: tedge_path
+                .join("device-certs")
+                .join("tedge-private-key.pem"),
             default_azure_root_cert_path: etc_path.join("ssl").join("certs"),
             default_c8y_root_cert_path: etc_path.join("ssl").join("certs"),
         }
@@ -68,8 +72,12 @@ impl TEdgeConfigLocation {
         let tedge_path = home_path.as_ref().join(".tedge");
         Self {
             tedge_config_path: tedge_path.join(TEDGE_CONFIG_FILE),
-            default_device_cert_path: tedge_path.join("certs").join("tedge-certificate.pem"),
-            default_device_key_path: tedge_path.join("certs").join("tedge-private-key.pem"),
+            default_device_cert_path: tedge_path
+                .join("device-certs")
+                .join("tedge-certificate.pem"),
+            default_device_key_path: tedge_path
+                .join("device-certs")
+                .join("tedge-private-key.pem"),
             default_azure_root_cert_path: etc_path.join("ssl").join("certs"),
             default_c8y_root_cert_path: etc_path.join("ssl").join("certs"),
         }
@@ -85,11 +93,11 @@ fn test_from_default_system_location() {
     );
     assert_eq!(
         config_location.default_device_cert_path,
-        PathBuf::from("/etc/tedge/certs/tedge-certificate.pem")
+        PathBuf::from("/etc/tedge/device-certs/tedge-certificate.pem")
     );
     assert_eq!(
         config_location.default_device_key_path,
-        PathBuf::from("/etc/tedge/certs/tedge-private-key.pem")
+        PathBuf::from("/etc/tedge/device-certs/tedge-private-key.pem")
     );
     assert_eq!(
         config_location.default_azure_root_cert_path,
@@ -111,11 +119,11 @@ fn test_from_system_location() {
     );
     assert_eq!(
         config_location.default_device_cert_path,
-        PathBuf::from("/usr/local/etc/tedge/certs/tedge-certificate.pem")
+        PathBuf::from("/usr/local/etc/tedge/device-certs/tedge-certificate.pem")
     );
     assert_eq!(
         config_location.default_device_key_path,
-        PathBuf::from("/usr/local/etc/tedge/certs/tedge-private-key.pem")
+        PathBuf::from("/usr/local/etc/tedge/device-certs/tedge-private-key.pem")
     );
     // XXX: This should actually be "/etc/ssl/certs".
     assert_eq!(
@@ -138,11 +146,11 @@ fn test_from_users_home_location() {
     );
     assert_eq!(
         config_location.default_device_cert_path,
-        PathBuf::from("/home/user/.tedge/certs/tedge-certificate.pem")
+        PathBuf::from("/home/user/.tedge/device-certs/tedge-certificate.pem")
     );
     assert_eq!(
         config_location.default_device_key_path,
-        PathBuf::from("/home/user/.tedge/certs/tedge-private-key.pem")
+        PathBuf::from("/home/user/.tedge/device-certs/tedge-private-key.pem")
     );
     assert_eq!(
         config_location.default_azure_root_cert_path,

--- a/tedge_config/src/tedge_config_location.rs
+++ b/tedge_config/src/tedge_config_location.rs
@@ -24,74 +24,56 @@ const TEDGE_CONFIG_FILE: &str = "tedge.toml";
 /// But once we have found `tedge.toml`, we never ever have to care about the executing user
 /// (except when `chown`ing files...).
 ///
-/// # NOTES
-///
-/// Why this is no trait? We need to `clone` a config location, and cloning a `Box<dyn>` is
-/// difficult (you can use `dyn_clone` or have your own function `clone() -> Box<dyn ...>` of
-/// course).
-///
 #[derive(Debug, Clone)]
-pub enum TEdgeConfigLocation {
-    /// `tedge.toml` is located in `/etc/tedge`. All defaults are based on system locations.
-    SystemLocation { etc_path: PathBuf },
-
-    /// `tedge.toml` is located in `$HOME/.tedge/tedge.toml`. All defaults are relative to the
-    /// `$HOME/.tedge` directory.
-    UserLocation { home_path: PathBuf },
-}
-
-impl TEdgeConfigLocation {
-    pub fn default_system_location() -> Self {
-        Self::SystemLocation {
-            etc_path: DEFAULT_ETC_PATH.into(),
-        }
-    }
-}
-
-impl TEdgeConfigLocation {
+pub struct TEdgeConfigLocation {
     /// Full path to `tedge.toml`.
-    pub(crate) fn tedge_config_path(&self) -> PathBuf {
-        match self {
-            Self::SystemLocation { etc_path } => etc_path.join("tedge").join(TEDGE_CONFIG_FILE),
-            Self::UserLocation { home_path } => home_path.join(".tedge").join(TEDGE_CONFIG_FILE),
-        }
-    }
+    pub tedge_config_path: PathBuf,
 
     /// Default device cert path
-    pub(crate) fn default_device_cert_path(&self) -> PathBuf {
-        match self {
-            Self::SystemLocation { etc_path } => etc_path
+    pub default_device_cert_path: PathBuf,
+
+    /// Default device key path
+    pub default_device_key_path: PathBuf,
+
+    /// Default path for azure root certificates
+    pub default_azure_root_cert_path: PathBuf,
+
+    /// Default path for c8y root certificates
+    pub default_c8y_root_cert_path: PathBuf,
+}
+
+impl TEdgeConfigLocation {
+    /// `tedge.toml` is located in `/etc/tedge`. All defaults are based on system locations.
+    pub fn from_default_system_location() -> Self {
+        Self::from_system_location(DEFAULT_ETC_PATH.into())
+    }
+
+    /// `tedge.toml` is located in `${etc_path}/tedge`. All defaults are based on system locations.
+    pub fn from_system_location(etc_path: PathBuf) -> Self {
+        Self {
+            tedge_config_path: etc_path.join("tedge").join(TEDGE_CONFIG_FILE),
+            default_device_cert_path: etc_path
                 .join("ssl")
                 .join("certs")
                 .join("tedge-certificate.pem"),
-            Self::UserLocation { home_path: _ } => unimplemented!(),
-        }
-    }
-
-    /// Default device key path
-    pub(crate) fn default_device_key_path(&self) -> PathBuf {
-        match self {
-            Self::SystemLocation { etc_path } => etc_path
+            default_device_key_path: etc_path
                 .join("ssl")
                 .join("certs")
                 .join("tedge-private-key.pem"),
-            Self::UserLocation { home_path: _ } => unimplemented!(),
+            default_azure_root_cert_path: etc_path.join("ssl").join("certs"),
+            default_c8y_root_cert_path: etc_path.join("ssl").join("certs"),
         }
     }
 
-    /// Default path for azure root certificates
-    pub(crate) fn default_azure_root_cert_path(&self) -> PathBuf {
-        match self {
-            Self::SystemLocation { etc_path } => etc_path.join("ssl").join("certs"),
-            Self::UserLocation { home_path: _ } => unimplemented!(),
-        }
-    }
-
-    /// Default path for c8y root certificates
-    pub(crate) fn default_c8y_root_cert_path(&self) -> PathBuf {
-        match self {
-            Self::SystemLocation { etc_path } => etc_path.join("ssl").join("certs"),
-            Self::UserLocation { home_path: _ } => unimplemented!(),
+    /// `tedge.toml` is located in `$HOME/.tedge/tedge.toml`. All defaults are relative to the
+    /// `$HOME/.tedge` directory.
+    pub fn from_user_home_location(home_path: PathBuf) -> Self {
+        Self {
+            tedge_config_path: home_path.join(".tedge").join(TEDGE_CONFIG_FILE),
+            default_device_cert_path: unimplemented!(),
+            default_device_key_path: unimplemented!(),
+            default_azure_root_cert_path: unimplemented!(),
+            default_c8y_root_cert_path: unimplemented!(),
         }
     }
 }

--- a/tedge_config/src/tedge_config_location.rs
+++ b/tedge_config/src/tedge_config_location.rs
@@ -1,0 +1,97 @@
+use std::path::PathBuf;
+
+const DEFAULT_ETC_PATH: &str = "/etc";
+const TEDGE_CONFIG_FILE: &str = "tedge.toml";
+
+/// Information about where `tedge.toml` is located and the defaults that are based
+/// on that location.
+///
+/// Broadly speaking, we distinguish two different locations:
+///
+/// - System-wide locations under `/etc/tedge`
+/// - User-local locations under `$HOME/.tedge`
+///
+/// We DO NOT base the defaults on the currently executing user. Instead, we base
+/// the defaults on the location of the `tedge.toml` file. If it is located in
+/// `/etc`, regardless of the executing user, we use defaults that use system-wide
+/// locations (e.g. `/etc/ssl/certs`). Whereas if `tedge.toml` is located in a users
+/// home directory, we base the defaults on locations within the users home directory.
+///
+/// This allows run `sudo tedge -c '$HOME/.tedge/tedge.toml ...` where the defaults are picked up
+/// correctly.
+///
+/// The choice, where we find `tedge.toml` OTOH is based on the executing user AND the env `$HOME`.
+/// But once we have found `tedge.toml`, we never ever have to care about the executing user
+/// (except when `chown`ing files...).
+///
+/// # NOTES
+///
+/// Why this is no trait? We need to `clone` a config location, and cloning a `Box<dyn>` is
+/// difficult (you can use `dyn_clone` or have your own function `clone() -> Box<dyn ...>` of
+/// course).
+///
+#[derive(Debug, Clone)]
+pub enum TEdgeConfigLocation {
+    /// `tedge.toml` is located in `/etc/tedge`. All defaults are based on system locations.
+    SystemLocation { etc_path: PathBuf },
+
+    /// `tedge.toml` is located in `$HOME/.tedge/tedge.toml`. All defaults are relative to the
+    /// `$HOME/.tedge` directory.
+    UserLocation { home_path: PathBuf },
+}
+
+impl TEdgeConfigLocation {
+    pub fn default_system_location() -> Self {
+        Self::SystemLocation {
+            etc_path: DEFAULT_ETC_PATH.into(),
+        }
+    }
+}
+
+impl TEdgeConfigLocation {
+    /// Full path to `tedge.toml`.
+    pub(crate) fn tedge_config_path(&self) -> PathBuf {
+        match self {
+            Self::SystemLocation { etc_path } => etc_path.join("tedge").join(TEDGE_CONFIG_FILE),
+            Self::UserLocation { home_path } => home_path.join(".tedge").join(TEDGE_CONFIG_FILE),
+        }
+    }
+
+    /// Default device cert path
+    pub(crate) fn default_device_cert_path(&self) -> PathBuf {
+        match self {
+            Self::SystemLocation { etc_path } => etc_path
+                .join("ssl")
+                .join("certs")
+                .join("tedge-certificate.pem"),
+            Self::UserLocation { home_path: _ } => unimplemented!(),
+        }
+    }
+
+    /// Default device key path
+    pub(crate) fn default_device_key_path(&self) -> PathBuf {
+        match self {
+            Self::SystemLocation { etc_path } => etc_path
+                .join("ssl")
+                .join("certs")
+                .join("tedge-private-key.pem"),
+            Self::UserLocation { home_path: _ } => unimplemented!(),
+        }
+    }
+
+    /// Default path for azure root certificates
+    pub(crate) fn default_azure_root_cert_path(&self) -> PathBuf {
+        match self {
+            Self::SystemLocation { etc_path } => etc_path.join("ssl").join("certs"),
+            Self::UserLocation { home_path: _ } => unimplemented!(),
+        }
+    }
+
+    /// Default path for c8y root certificates
+    pub(crate) fn default_c8y_root_cert_path(&self) -> PathBuf {
+        match self {
+            Self::SystemLocation { etc_path } => etc_path.join("ssl").join("certs"),
+            Self::UserLocation { home_path: _ } => unimplemented!(),
+        }
+    }
+}

--- a/tedge_config/src/tedge_config_location.rs
+++ b/tedge_config/src/tedge_config_location.rs
@@ -20,9 +20,9 @@ const TEDGE_CONFIG_FILE: &str = "tedge.toml";
 /// This allows run `sudo tedge -c '$HOME/.tedge/tedge.toml ...` where the defaults are picked up
 /// correctly.
 ///
-/// The choice, where we find `tedge.toml` OTOH is based on the executing user AND the env `$HOME`.
-/// But once we have found `tedge.toml`, we never ever have to care about the executing user
-/// (except when `chown`ing files...).
+/// The choice, where to find `tedge.toml` on the other hand is based on the executing user AND the
+/// env `$HOME`.  But once we have found `tedge.toml`, we never again have to care about the
+/// executing user (except when `chown`ing files...).
 ///
 #[derive(Debug, Clone)]
 pub struct TEdgeConfigLocation {
@@ -67,7 +67,8 @@ impl TEdgeConfigLocation {
 
     /// `tedge.toml` is located in `$HOME/.tedge/tedge.toml`. All defaults are relative to the
     /// `$HOME/.tedge` directory.
-    pub fn from_user_home_location(home_path: PathBuf) -> Self {
+    /// XXX: @didier-wenzek What should be the defaults in this case?
+    pub fn from_users_home_location(home_path: PathBuf) -> Self {
         Self {
             tedge_config_path: home_path.join(".tedge").join(TEDGE_CONFIG_FILE),
             default_device_cert_path: unimplemented!(),

--- a/tedge_config/src/tedge_config_location.rs
+++ b/tedge_config/src/tedge_config_location.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 const DEFAULT_ETC_PATH: &str = "/etc";
 const TEDGE_CONFIG_FILE: &str = "tedge.toml";
@@ -45,21 +45,17 @@ pub struct TEdgeConfigLocation {
 impl TEdgeConfigLocation {
     /// `tedge.toml` is located in `/etc/tedge`. All defaults are based on system locations.
     pub fn from_default_system_location() -> Self {
-        Self::from_system_location(DEFAULT_ETC_PATH.into())
+        Self::from_system_location(DEFAULT_ETC_PATH)
     }
 
     /// `tedge.toml` is located in `${etc_path}/tedge`. All defaults are based on system locations.
-    pub fn from_system_location(etc_path: PathBuf) -> Self {
+    pub fn from_system_location(etc_path: impl AsRef<Path>) -> Self {
+        let etc_path = etc_path.as_ref();
+        let tedge_path = etc_path.join("tedge");
         Self {
-            tedge_config_path: etc_path.join("tedge").join(TEDGE_CONFIG_FILE),
-            default_device_cert_path: etc_path
-                .join("ssl")
-                .join("certs")
-                .join("tedge-certificate.pem"),
-            default_device_key_path: etc_path
-                .join("ssl")
-                .join("certs")
-                .join("tedge-private-key.pem"),
+            tedge_config_path: tedge_path.join(TEDGE_CONFIG_FILE),
+            default_device_cert_path: tedge_path.join("certs").join("tedge-certificate.pem"),
+            default_device_key_path: tedge_path.join("certs").join("tedge-private-key.pem"),
             default_azure_root_cert_path: etc_path.join("ssl").join("certs"),
             default_c8y_root_cert_path: etc_path.join("ssl").join("certs"),
         }
@@ -67,14 +63,93 @@ impl TEdgeConfigLocation {
 
     /// `tedge.toml` is located in `$HOME/.tedge/tedge.toml`. All defaults are relative to the
     /// `$HOME/.tedge` directory.
-    /// XXX: @didier-wenzek What should be the defaults in this case?
-    pub fn from_users_home_location(home_path: PathBuf) -> Self {
+    pub fn from_users_home_location(home_path: impl AsRef<Path>) -> Self {
+        let etc_path = Path::new(DEFAULT_ETC_PATH);
+        let tedge_path = home_path.as_ref().join(".tedge");
         Self {
-            tedge_config_path: home_path.join(".tedge").join(TEDGE_CONFIG_FILE),
-            default_device_cert_path: unimplemented!(),
-            default_device_key_path: unimplemented!(),
-            default_azure_root_cert_path: unimplemented!(),
-            default_c8y_root_cert_path: unimplemented!(),
+            tedge_config_path: tedge_path.join(TEDGE_CONFIG_FILE),
+            default_device_cert_path: tedge_path.join("certs").join("tedge-certificate.pem"),
+            default_device_key_path: tedge_path.join("certs").join("tedge-private-key.pem"),
+            default_azure_root_cert_path: etc_path.join("ssl").join("certs"),
+            default_c8y_root_cert_path: etc_path.join("ssl").join("certs"),
         }
     }
+}
+
+#[test]
+fn test_from_default_system_location() {
+    let config_location = TEdgeConfigLocation::from_default_system_location();
+    assert_eq!(
+        config_location.tedge_config_path,
+        PathBuf::from("/etc/tedge/tedge.toml")
+    );
+    assert_eq!(
+        config_location.default_device_cert_path,
+        PathBuf::from("/etc/tedge/certs/tedge-certificate.pem")
+    );
+    assert_eq!(
+        config_location.default_device_key_path,
+        PathBuf::from("/etc/tedge/certs/tedge-private-key.pem")
+    );
+    assert_eq!(
+        config_location.default_azure_root_cert_path,
+        PathBuf::from("/etc/ssl/certs")
+    );
+    assert_eq!(
+        config_location.default_c8y_root_cert_path,
+        PathBuf::from("/etc/ssl/certs")
+    );
+}
+
+#[test]
+fn test_from_system_location() {
+    // "/usr/local/etc" is often used for installed services on FreeBSD
+    let config_location = TEdgeConfigLocation::from_system_location("/usr/local/etc");
+    assert_eq!(
+        config_location.tedge_config_path,
+        PathBuf::from("/usr/local/etc/tedge/tedge.toml")
+    );
+    assert_eq!(
+        config_location.default_device_cert_path,
+        PathBuf::from("/usr/local/etc/tedge/certs/tedge-certificate.pem")
+    );
+    assert_eq!(
+        config_location.default_device_key_path,
+        PathBuf::from("/usr/local/etc/tedge/certs/tedge-private-key.pem")
+    );
+    // XXX: This should actually be "/etc/ssl/certs".
+    assert_eq!(
+        config_location.default_azure_root_cert_path,
+        PathBuf::from("/usr/local/etc/ssl/certs")
+    );
+    // XXX: This should actually be "/etc/ssl/certs".
+    assert_eq!(
+        config_location.default_c8y_root_cert_path,
+        PathBuf::from("/usr/local/etc/ssl/certs")
+    );
+}
+
+#[test]
+fn test_from_users_home_location() {
+    let config_location = TEdgeConfigLocation::from_users_home_location("/home/user");
+    assert_eq!(
+        config_location.tedge_config_path,
+        PathBuf::from("/home/user/.tedge/tedge.toml")
+    );
+    assert_eq!(
+        config_location.default_device_cert_path,
+        PathBuf::from("/home/user/.tedge/certs/tedge-certificate.pem")
+    );
+    assert_eq!(
+        config_location.default_device_key_path,
+        PathBuf::from("/home/user/.tedge/certs/tedge-private-key.pem")
+    );
+    assert_eq!(
+        config_location.default_azure_root_cert_path,
+        PathBuf::from("/etc/ssl/certs")
+    );
+    assert_eq!(
+        config_location.default_c8y_root_cert_path,
+        PathBuf::from("/etc/ssl/certs")
+    );
 }

--- a/tedge_config/src/tedge_config_repository.rs
+++ b/tedge_config/src/tedge_config_repository.rs
@@ -15,13 +15,15 @@ pub struct TEdgeConfigRepository {
     tedge_home: PathBuf,
 }
 
-/// XXX: Hard coding a concrete error type in a generic trait is aweful.
 pub trait ConfigRepository<T> {
-    fn load(&self) -> Result<T, TEdgeConfigError>;
-    fn store(&self, config: T) -> Result<(), TEdgeConfigError>;
+    type Error;
+    fn load(&self) -> Result<T, Self::Error>;
+    fn store(&self, config: T) -> Result<(), Self::Error>;
 }
 
 impl ConfigRepository<TEdgeConfig> for TEdgeConfigRepository {
+    type Error = TEdgeConfigError;
+
     fn load(&self) -> Result<TEdgeConfig, TEdgeConfigError> {
         let config = self.read_file_or_default(self.config_file_name().into())?;
         Ok(self.fixup_config(config)?)

--- a/tedge_config/src/tedge_config_repository.rs
+++ b/tedge_config/src/tedge_config_repository.rs
@@ -1,0 +1,110 @@
+use crate::*;
+use std::fs::create_dir_all;
+use std::io::Write;
+use std::path::PathBuf;
+use tempfile::NamedTempFile;
+
+const TEDGE_DEFAULT_LOCATION: &str = "/etc/tedge";
+const TEDGE_CONFIG_FILE: &str = "tedge.toml";
+const DEVICE_KEY_FILE: &str = "tedge-private-key.pem";
+const DEVICE_CERT_FILE: &str = "tedge-certificate.pem";
+
+/// TEdgeConfigRepository is resposible for loading and storing TEdgeConfig entities.
+///
+pub struct TEdgeConfigRepository {
+    tedge_home: PathBuf,
+}
+
+/// XXX: Hard coding a concrete error type in a generic trait is aweful.
+pub trait ConfigRepository<T> {
+    fn load(&self) -> Result<T, TEdgeConfigError>;
+    fn store(&self, config: T) -> Result<(), TEdgeConfigError>;
+}
+
+impl ConfigRepository<TEdgeConfig> for TEdgeConfigRepository {
+    fn load(&self) -> Result<TEdgeConfig, TEdgeConfigError> {
+        let config = self.read_file_or_default(self.config_file_name().into())?;
+        Ok(self.fixup_config(config)?)
+    }
+
+    fn store(&self, config: TEdgeConfig) -> Result<(), TEdgeConfigError> {
+        let toml = toml::to_string_pretty(&config.data)?;
+        let mut file = NamedTempFile::new()?;
+        file.write_all(toml.as_bytes())?;
+        let path = self.config_file_name();
+        if !path.exists() {
+            create_dir_all(path.parent().unwrap())?;
+        }
+        match file.persist(path) {
+            Ok(_) => Ok(()),
+            Err(err) => Err(err.error.into()),
+        }
+    }
+}
+
+impl TEdgeConfigRepository {
+    pub fn from_default_location() -> Result<Self, TEdgeConfigError> {
+        Ok(Self::from_dir(TEDGE_DEFAULT_LOCATION))
+    }
+
+    pub fn from_dir(tedge_home: impl Into<PathBuf>) -> Self {
+        Self {
+            tedge_home: tedge_home.into(),
+        }
+    }
+
+    fn config_file_name(&self) -> PathBuf {
+        self.tedge_home.join(TEDGE_CONFIG_FILE)
+    }
+
+    fn fixup_config(&self, mut config: TEdgeConfig) -> Result<TEdgeConfig, TEdgeConfigError> {
+        config.update_if_not_set(DeviceKeyPathSetting, self.default_device_key_path()?)?;
+        config.update_if_not_set(DeviceCertPathSetting, self.default_device_cert_path()?)?;
+        Ok(config)
+    }
+
+    /// Parse the configuration file at the provided `path` and create a `TEdgeConfig` out of it
+    ///
+    /// #Arguments
+    ///
+    /// * `path` - Path to a thin edge configuration TOML file
+    ///
+    fn read_file(&self, path: PathBuf) -> Result<TEdgeConfig, TEdgeConfigError> {
+        match std::fs::read(&path) {
+            Ok(bytes) => {
+                let data = toml::from_slice::<TEdgeConfigDto>(bytes.as_slice())?;
+                Ok(TEdgeConfig { data })
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                Err(TEdgeConfigError::ConfigFileNotFound(path))
+            }
+            Err(err) => Err(TEdgeConfigError::IOError(err)),
+        }
+    }
+
+    fn read_file_or_default(&self, path: PathBuf) -> Result<TEdgeConfig, TEdgeConfigError> {
+        match self.read_file(path.clone()) {
+            Ok(file) => Ok(file),
+            Err(TEdgeConfigError::ConfigFileNotFound(..)) => Ok(TEdgeConfig {
+                data: TEdgeConfigDto::default(),
+            }),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn default_device_key_path(&self) -> Result<String, TEdgeConfigError> {
+        self.path_in_cert_directory(DEVICE_KEY_FILE)
+    }
+
+    fn default_device_cert_path(&self) -> Result<String, TEdgeConfigError> {
+        self.path_in_cert_directory(DEVICE_CERT_FILE)
+    }
+
+    fn path_in_cert_directory(&self, file_name: &str) -> Result<String, TEdgeConfigError> {
+        self.tedge_home
+            .join(file_name)
+            .to_str()
+            .map(|s| s.into())
+            .ok_or(TEdgeConfigError::InvalidCharacterInHomeDirectoryPath)
+    }
+}

--- a/tedge_config/src/tedge_config_repository.rs
+++ b/tedge_config/src/tedge_config_repository.rs
@@ -53,16 +53,6 @@ impl TEdgeConfigRepository {
         self.tedge_home.join(TEDGE_CONFIG_FILE)
     }
 
-    /*
-    fn fixup_config(&self, mut config: TEdgeConfig) -> Result<TEdgeConfig, TEdgeConfigError> {
-        config.update_if_not_set(DeviceKeyPathSetting, self.default_device_key_path()?)?;
-        config.update_if_not_set(DeviceCertPathSetting, self.default_device_cert_path()?)?;
-        config.update_if_not_set(AzureRootCertPathSetting, DEFAULT_ROOT_CERT_PATH.into())?;
-        config.update_if_not_set(C8yRootCertPathSetting, DEFAULT_ROOT_CERT_PATH.into())?;
-        Ok(config)
-    }
-    */
-
     /// Parse the configuration file at the provided `path` and create a `TEdgeConfig` out of it
     ///
     /// #Arguments

--- a/tedge_config/src/tedge_config_repository.rs
+++ b/tedge_config/src/tedge_config_repository.rs
@@ -1,5 +1,4 @@
 use crate::*;
-use std::fs::create_dir_all;
 use std::io::Write;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
@@ -29,13 +28,11 @@ impl ConfigRepository<TEdgeConfig> for TEdgeConfigRepository {
         Ok(self.fixup_config(config)?)
     }
 
+    // XXX: Explicitly set the file permissions in this function and file ownership!
     fn store(&self, config: TEdgeConfig) -> Result<(), TEdgeConfigError> {
         let toml = toml::to_string_pretty(&config.data)?;
         let mut file = NamedTempFile::new()?;
         file.write_all(toml.as_bytes())?;
-        if !self.tedge_home.exists() {
-            create_dir_all(&self.tedge_home)?;
-        }
         match file.persist(self.config_file_name()) {
             Ok(_) => Ok(()),
             Err(err) => Err(err.error.into()),

--- a/tedge_config/src/tedge_config_repository.rs
+++ b/tedge_config/src/tedge_config_repository.rs
@@ -31,11 +31,10 @@ impl ConfigRepository<TEdgeConfig> for TEdgeConfigRepository {
         let toml = toml::to_string_pretty(&config.data)?;
         let mut file = NamedTempFile::new()?;
         file.write_all(toml.as_bytes())?;
-        let path = self.config_file_name();
-        if !path.exists() {
-            create_dir_all(path.parent().unwrap())?;
+        if !self.tedge_home.exists() {
+            create_dir_all(&self.tedge_home)?;
         }
-        match file.persist(path) {
+        match file.persist(self.config_file_name()) {
             Ok(_) => Ok(()),
             Err(err) => Err(err.error.into()),
         }

--- a/tedge_config/src/tedge_config_repository.rs
+++ b/tedge_config/src/tedge_config_repository.rs
@@ -5,8 +5,6 @@ use tempfile::NamedTempFile;
 
 const TEDGE_DEFAULT_LOCATION: &str = "/etc/tedge";
 const TEDGE_CONFIG_FILE: &str = "tedge.toml";
-const DEVICE_KEY_FILE: &str = "tedge-private-key.pem";
-const DEVICE_CERT_FILE: &str = "tedge-certificate.pem";
 
 /// TEdgeConfigRepository is resposible for loading and storing TEdgeConfig entities.
 ///
@@ -25,7 +23,7 @@ impl ConfigRepository<TEdgeConfig> for TEdgeConfigRepository {
 
     fn load(&self) -> Result<TEdgeConfig, TEdgeConfigError> {
         let config = self.read_file_or_default(self.config_file_name().into())?;
-        Ok(self.fixup_config(config)?)
+        Ok(config)
     }
 
     // XXX: Explicitly set the file permissions in this function and file ownership!
@@ -55,11 +53,15 @@ impl TEdgeConfigRepository {
         self.tedge_home.join(TEDGE_CONFIG_FILE)
     }
 
+    /*
     fn fixup_config(&self, mut config: TEdgeConfig) -> Result<TEdgeConfig, TEdgeConfigError> {
         config.update_if_not_set(DeviceKeyPathSetting, self.default_device_key_path()?)?;
         config.update_if_not_set(DeviceCertPathSetting, self.default_device_cert_path()?)?;
+        config.update_if_not_set(AzureRootCertPathSetting, DEFAULT_ROOT_CERT_PATH.into())?;
+        config.update_if_not_set(C8yRootCertPathSetting, DEFAULT_ROOT_CERT_PATH.into())?;
         Ok(config)
     }
+    */
 
     /// Parse the configuration file at the provided `path` and create a `TEdgeConfig` out of it
     ///
@@ -88,21 +90,5 @@ impl TEdgeConfigRepository {
             }),
             Err(err) => Err(err),
         }
-    }
-
-    fn default_device_key_path(&self) -> Result<String, TEdgeConfigError> {
-        self.path_in_cert_directory(DEVICE_KEY_FILE)
-    }
-
-    fn default_device_cert_path(&self) -> Result<String, TEdgeConfigError> {
-        self.path_in_cert_directory(DEVICE_CERT_FILE)
-    }
-
-    fn path_in_cert_directory(&self, file_name: &str) -> Result<String, TEdgeConfigError> {
-        self.tedge_home
-            .join(file_name)
-            .to_str()
-            .map(|s| s.into())
-            .ok_or(TEdgeConfigError::InvalidCharacterInHomeDirectoryPath)
     }
 }

--- a/tedge_config/src/tedge_config_repository.rs
+++ b/tedge_config/src/tedge_config_repository.rs
@@ -19,7 +19,7 @@ impl ConfigRepository<TEdgeConfig> for TEdgeConfigRepository {
     type Error = TEdgeConfigError;
 
     fn load(&self) -> Result<TEdgeConfig, TEdgeConfigError> {
-        let config = self.read_file_or_default(self.config_location.tedge_config_path())?;
+        let config = self.read_file_or_default(self.config_location.tedge_config_path.clone())?;
         Ok(config)
     }
 
@@ -28,7 +28,7 @@ impl ConfigRepository<TEdgeConfig> for TEdgeConfigRepository {
         let toml = toml::to_string_pretty(&config.data)?;
         let mut file = NamedTempFile::new()?;
         file.write_all(toml.as_bytes())?;
-        match file.persist(self.config_location.tedge_config_path()) {
+        match file.persist(self.config_location.tedge_config_path.clone()) {
             Ok(_) => Ok(()),
             Err(err) => Err(err.error.into()),
         }

--- a/tedge_config/tests/test_tedge_config.rs
+++ b/tedge_config/tests/test_tedge_config.rs
@@ -1,0 +1,389 @@
+use assert_matches::assert_matches;
+use std::convert::TryFrom;
+use std::io::Write;
+use std::path::PathBuf;
+use tedge_config::*;
+use tempfile::TempDir;
+
+#[test]
+fn test_parse_config_with_all_values() -> Result<(), TEdgeConfigError> {
+    let toml_conf = r#"
+[device]
+id = "ABCD1234"
+key_path = "/path/to/key"
+cert_path = "/path/to/cert"
+
+[c8y]
+url = "your-tenant.cumulocity.com"
+root_cert_path = "/path/to/c8y/root/cert"
+connect = "true"
+
+[azure]
+url = "MyAzure.azure-devices.net"
+root_cert_path = "/path/to/azure/root/cert"
+connect = "false"
+"#;
+
+    let tempdir = create_temp_tedge_config(toml_conf)?;
+    let config = TEdgeConfigRepository::from_dir(tempdir.path()).load()?;
+
+    assert_eq!(config.query(DeviceIdSetting)?, "ABCD1234");
+    assert_eq!(config.query(DeviceKeyPathSetting)?, "/path/to/key");
+    assert_eq!(config.query(DeviceCertPathSetting)?, "/path/to/cert");
+
+    assert_eq!(
+        config.query(C8yUrlSetting)?.as_str(),
+        "your-tenant.cumulocity.com"
+    );
+    assert_eq!(
+        config.query(C8yRootCertPathSetting)?,
+        "/path/to/c8y/root/cert"
+    );
+
+    assert_eq!(
+        config.query(AzureUrlSetting)?.as_str(),
+        "MyAzure.azure-devices.net"
+    );
+    assert_eq!(
+        config.query(AzureRootCertPathSetting)?,
+        "/path/to/azure/root/cert"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_store_config() -> Result<(), TEdgeConfigError> {
+    let toml_conf = r#"
+[device]
+id = "ABCD1234"
+key_path = "/path/to/key"
+cert_path = "/path/to/cert"
+
+[c8y]
+url = "your-tenant.cumulocity.com"
+root_cert_path = "/path/to/c8y/root/cert"
+
+[azure]
+url = "MyAzure.azure-devices.net"
+root_cert_path = "/path/to/azure/root/cert"
+"#;
+
+    let tempdir = create_temp_tedge_config(toml_conf)?;
+    let config_repo = TEdgeConfigRepository::from_dir(tempdir.path());
+
+    let updated_c8y_url = "other-tenant.cumulocity.com";
+    let updated_azure_url = "OtherAzure.azure-devices.net";
+
+    {
+        let mut config = config_repo.load()?;
+        assert_eq!(config.query(DeviceIdSetting)?, "ABCD1234");
+        assert_eq!(config.query(DeviceKeyPathSetting)?, "/path/to/key");
+        assert_eq!(config.query(DeviceCertPathSetting)?, "/path/to/cert");
+
+        assert_eq!(
+            config.query(C8yUrlSetting)?.as_str(),
+            "your-tenant.cumulocity.com"
+        );
+        assert_eq!(
+            config.query(C8yRootCertPathSetting)?,
+            "/path/to/c8y/root/cert"
+        );
+
+        assert_eq!(
+            config.query(AzureUrlSetting)?.as_str(),
+            "MyAzure.azure-devices.net"
+        );
+        assert_eq!(
+            config.query(AzureRootCertPathSetting)?,
+            "/path/to/azure/root/cert"
+        );
+
+        config.update(
+            C8yUrlSetting,
+            ConnectUrl::try_from(updated_c8y_url.to_string()).unwrap(),
+        )?;
+        config.unset(C8yRootCertPathSetting)?;
+        config.update(
+            AzureUrlSetting,
+            ConnectUrl::try_from(updated_azure_url.to_string()).unwrap(),
+        )?;
+        config.unset(AzureRootCertPathSetting)?;
+        config_repo.store(config)?;
+    }
+
+    {
+        let config = config_repo.load()?;
+
+        assert_eq!(config.query(DeviceIdSetting)?, "ABCD1234");
+        assert_eq!(config.query(DeviceKeyPathSetting)?, "/path/to/key");
+        assert_eq!(config.query(DeviceCertPathSetting)?, "/path/to/cert");
+
+        assert_eq!(config.query(C8yUrlSetting)?.as_str(), updated_c8y_url);
+        assert_eq!(config.query(C8yRootCertPathSetting)?, "/etc/ssl/certs");
+
+        assert_eq!(config.query(AzureUrlSetting)?.as_str(), updated_azure_url);
+        assert_eq!(config.query(AzureRootCertPathSetting)?, "/etc/ssl/certs");
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_parse_config_missing_c8y_configuration() -> Result<(), TEdgeConfigError> {
+    let toml_conf = r#"
+[device]
+id = "ABCD1234"
+"#;
+
+    let tempdir = create_temp_tedge_config(toml_conf)?;
+    let config = TEdgeConfigRepository::from_dir(tempdir.path()).load()?;
+
+    assert_eq!(config.query(DeviceIdSetting)?, "ABCD1234");
+    assert_eq!(
+        PathBuf::from(config.query(DeviceCertPathSetting)?),
+        tempdir.path().join("tedge-certificate.pem")
+    );
+    assert_eq!(
+        PathBuf::from(config.query(DeviceKeyPathSetting)?),
+        tempdir.path().join("tedge-private-key.pem")
+    );
+
+    assert!(config.query_optional(C8yUrlSetting)?.is_none());
+    assert_eq!(config.query(C8yRootCertPathSetting)?, "/etc/ssl/certs");
+    Ok(())
+}
+
+#[test]
+fn test_parse_config_missing_azure_configuration() -> Result<(), TEdgeConfigError> {
+    let toml_conf = r#"
+[device]
+id = "ABCD1234"
+"#;
+
+    let tempdir = create_temp_tedge_config(toml_conf)?;
+    let config = TEdgeConfigRepository::from_dir(tempdir.path()).load()?;
+
+    assert_eq!(config.query(DeviceIdSetting)?, "ABCD1234");
+    assert_eq!(
+        PathBuf::from(config.query(DeviceCertPathSetting)?),
+        tempdir.path().join("tedge-certificate.pem")
+    );
+    assert_eq!(
+        PathBuf::from(config.query(DeviceKeyPathSetting)?),
+        tempdir.path().join("tedge-private-key.pem")
+    );
+
+    assert!(config.query_optional(AzureUrlSetting).unwrap().is_none());
+    assert_eq!(config.query(C8yRootCertPathSetting)?, "/etc/ssl/certs");
+    Ok(())
+}
+
+#[test]
+fn test_parse_config_missing_device_configuration() -> Result<(), TEdgeConfigError> {
+    let toml_conf = r#"
+[c8y]
+url = "your-tenant.cumulocity.com"
+"#;
+
+    let tempdir = create_temp_tedge_config(toml_conf)?;
+    let config = TEdgeConfigRepository::from_dir(tempdir.path()).load()?;
+
+    assert_eq!(
+        config.query(C8yUrlSetting)?.as_str(),
+        "your-tenant.cumulocity.com"
+    );
+
+    assert!(config.query_optional(DeviceIdSetting)?.is_none());
+    assert_eq!(
+        PathBuf::from(config.query(DeviceCertPathSetting)?),
+        tempdir.path().join("tedge-certificate.pem")
+    );
+    assert_eq!(
+        PathBuf::from(config.query(DeviceKeyPathSetting)?),
+        tempdir.path().join("tedge-private-key.pem")
+    );
+    Ok(())
+}
+
+#[test]
+fn test_parse_config_empty_file() -> Result<(), TEdgeConfigError> {
+    let tempdir = create_temp_tedge_config("")?;
+    let config = TEdgeConfigRepository::from_dir(tempdir.path()).load()?;
+
+    assert!(config.query_optional(DeviceIdSetting)?.is_none());
+
+    assert_eq!(
+        PathBuf::from(config.query(DeviceCertPathSetting)?),
+        tempdir.path().join("tedge-certificate.pem")
+    );
+    assert_eq!(
+        PathBuf::from(config.query(DeviceKeyPathSetting)?),
+        tempdir.path().join("tedge-private-key.pem")
+    );
+
+    assert!(config.query_optional(C8yUrlSetting)?.is_none());
+    assert_eq!(config.query(C8yRootCertPathSetting)?, "/etc/ssl/certs");
+
+    assert!(config.query_optional(AzureUrlSetting).unwrap().is_none());
+    assert_eq!(config.query(AzureRootCertPathSetting)?, "/etc/ssl/certs");
+    Ok(())
+}
+
+#[test]
+fn test_parse_config_no_config_file() -> Result<(), TEdgeConfigError> {
+    let config = TEdgeConfigRepository::from_dir("/non/existent/path").load()?;
+
+    assert!(config.query_optional(DeviceIdSetting)?.is_none());
+    assert!(config.query_optional(C8yUrlSetting)?.is_none());
+    Ok(())
+}
+
+#[test]
+fn test_parse_unsupported_keys() -> Result<(), TEdgeConfigError> {
+    let toml_conf = r#"
+hey="tedge"
+[c8y]
+hello="tedge"
+"#;
+
+    let tempdir = create_temp_tedge_config(toml_conf)?;
+    let result = TEdgeConfigRepository::from_dir(tempdir.path()).load();
+
+    assert_matches!(
+        result,
+        Err(TEdgeConfigError::TOMLParseError(_)),
+        "Expected the parsing to fail with TOMLParseError"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_parse_invalid_toml_file() -> Result<(), TEdgeConfigError> {
+    let toml_conf = r#"
+        <abcde>
+        "#;
+
+    let tempdir = create_temp_tedge_config(toml_conf)?;
+    let result = TEdgeConfigRepository::from_dir(tempdir.path()).load();
+
+    assert_matches!(
+        result,
+        Err(TEdgeConfigError::TOMLParseError(_)),
+        "Expected the parsing to fail with TOMLParseError"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_crud_config_value() -> Result<(), TEdgeConfigError> {
+    let toml_conf = r#"
+[device]
+id = "ABCD1234"
+key_path = "/path/to/key"
+cert_path = "/path/to/cert"
+
+[c8y]
+url = "your-tenant.cumulocity.com"
+root_cert_path = "/path/to/c8y/root/cert"
+
+[azure]
+url = "MyAzure.azure-devices.net"
+root_cert_path = "/path/to/azure/root/cert"
+"#;
+
+    let tempdir = create_temp_tedge_config(toml_conf)?;
+    let mut config = TEdgeConfigRepository::from_dir(tempdir.path()).load()?;
+
+    let original_device_id = "ABCD1234".to_string();
+    let original_device_key_path = "/path/to/key".to_string();
+    let original_device_cert_path = "/path/to/cert".to_string();
+
+    assert_eq!(config.query(DeviceIdSetting)?, original_device_id);
+    assert_eq!(
+        config.query(DeviceKeyPathSetting)?,
+        original_device_key_path
+    );
+    assert_eq!(
+        config.query(DeviceCertPathSetting)?,
+        original_device_cert_path
+    );
+
+    let original_c8y_url = ConnectUrl::try_from("your-tenant.cumulocity.com").unwrap();
+    let original_c8y_root_cert_path = "/path/to/c8y/root/cert".to_string();
+    assert_eq!(config.query(C8yUrlSetting)?, original_c8y_url);
+    assert_eq!(
+        config.query(C8yRootCertPathSetting)?,
+        original_c8y_root_cert_path
+    );
+
+    let updated_c8y_url = ConnectUrl::try_from("other-tenant.cumulocity.com").unwrap();
+
+    config.update(C8yUrlSetting, updated_c8y_url.clone())?;
+
+    config.unset(C8yRootCertPathSetting)?;
+
+    assert_eq!(
+        config.query(DeviceKeyPathSetting)?,
+        original_device_key_path
+    );
+    assert_eq!(
+        config.query(DeviceCertPathSetting)?,
+        original_device_cert_path
+    );
+
+    assert_eq!(config.query(C8yUrlSetting)?, updated_c8y_url);
+    assert_eq!(config.query(C8yRootCertPathSetting)?, "/etc/ssl/certs");
+    Ok(())
+}
+
+#[test]
+fn test_crud_config_value_azure() -> Result<(), TEdgeConfigError> {
+    let toml_conf = r#"
+[device]
+id = "ABCD1234"
+key_path = "/path/to/key"
+cert_path = "/path/to/cert"
+
+[c8y]
+url = "your-tenant.cumulocity.com"
+root_cert_path = "/path/to/c8y/root/cert"
+
+[azure]
+url = "MyAzure.azure-devices.net"
+root_cert_path = "/path/to/azure/root/cert"
+"#;
+
+    let tempdir = create_temp_tedge_config(toml_conf)?;
+    let mut config = TEdgeConfigRepository::from_dir(tempdir.path()).load()?;
+
+    let original_azure_url = ConnectUrl::try_from("MyAzure.azure-devices.net").unwrap();
+    let original_azure_root_cert_path = "/path/to/azure/root/cert".to_string();
+
+    // read
+    assert_eq!(config.query(AzureUrlSetting)?, original_azure_url);
+    assert_eq!(
+        config.query(AzureRootCertPathSetting)?,
+        original_azure_root_cert_path
+    );
+
+    // set
+    let updated_azure_url = ConnectUrl::try_from("OtherAzure.azure-devices.net").unwrap();
+    config.update(AzureUrlSetting, updated_azure_url.clone())?;
+
+    assert_eq!(config.query(AzureUrlSetting)?, updated_azure_url);
+
+    // unset
+    config.unset(AzureRootCertPathSetting)?;
+
+    assert_eq!(config.query(AzureRootCertPathSetting)?, "/etc/ssl/certs");
+    Ok(())
+}
+
+fn create_temp_tedge_config(content: &str) -> std::io::Result<TempDir> {
+    let dir = TempDir::new()?;
+    let file_path = dir.path().join("tedge.toml");
+    let mut file = std::fs::File::create(file_path)?;
+    file.write_all(content.as_bytes())?;
+    Ok(dir)
+}

--- a/tedge_config/tests/test_tedge_config.rs
+++ b/tedge_config/tests/test_tedge_config.rs
@@ -1,7 +1,6 @@
 use assert_matches::assert_matches;
 use std::convert::TryFrom;
 use std::io::Write;
-use std::path::PathBuf;
 use tedge_config::*;
 use tempfile::TempDir;
 
@@ -135,12 +134,12 @@ id = "ABCD1234"
 
     assert_eq!(config.query(DeviceIdSetting)?, "ABCD1234");
     assert_eq!(
-        PathBuf::from(config.query(DeviceCertPathSetting)?),
-        tempdir.path().join("tedge-certificate.pem")
+        config.query(DeviceCertPathSetting)?,
+        "/etc/ssl/certs/tedge-certificate.pem"
     );
     assert_eq!(
-        PathBuf::from(config.query(DeviceKeyPathSetting)?),
-        tempdir.path().join("tedge-private-key.pem")
+        config.query(DeviceKeyPathSetting)?,
+        "/etc/ssl/certs/tedge-private-key.pem"
     );
 
     assert!(config.query_optional(C8yUrlSetting)?.is_none());
@@ -160,12 +159,12 @@ id = "ABCD1234"
 
     assert_eq!(config.query(DeviceIdSetting)?, "ABCD1234");
     assert_eq!(
-        PathBuf::from(config.query(DeviceCertPathSetting)?),
-        tempdir.path().join("tedge-certificate.pem")
+        config.query(DeviceCertPathSetting)?,
+        "/etc/ssl/certs/tedge-certificate.pem"
     );
     assert_eq!(
-        PathBuf::from(config.query(DeviceKeyPathSetting)?),
-        tempdir.path().join("tedge-private-key.pem")
+        config.query(DeviceKeyPathSetting)?,
+        "/etc/ssl/certs/tedge-private-key.pem"
     );
 
     assert_matches!(config.query_optional(AzureUrlSetting), Ok(None));
@@ -190,12 +189,12 @@ url = "your-tenant.cumulocity.com"
 
     assert!(config.query_optional(DeviceIdSetting)?.is_none());
     assert_eq!(
-        PathBuf::from(config.query(DeviceCertPathSetting)?),
-        tempdir.path().join("tedge-certificate.pem")
+        config.query(DeviceCertPathSetting)?,
+        "/etc/ssl/certs/tedge-certificate.pem"
     );
     assert_eq!(
-        PathBuf::from(config.query(DeviceKeyPathSetting)?),
-        tempdir.path().join("tedge-private-key.pem")
+        config.query(DeviceKeyPathSetting)?,
+        "/etc/ssl/certs/tedge-private-key.pem",
     );
     Ok(())
 }
@@ -208,12 +207,12 @@ fn test_parse_config_empty_file() -> Result<(), TEdgeConfigError> {
     assert!(config.query_optional(DeviceIdSetting)?.is_none());
 
     assert_eq!(
-        PathBuf::from(config.query(DeviceCertPathSetting)?),
-        tempdir.path().join("tedge-certificate.pem")
+        config.query(DeviceCertPathSetting)?,
+        "/etc/ssl/certs/tedge-certificate.pem"
     );
     assert_eq!(
-        PathBuf::from(config.query(DeviceKeyPathSetting)?),
-        tempdir.path().join("tedge-private-key.pem")
+        config.query(DeviceKeyPathSetting)?,
+        "/etc/ssl/certs/tedge-private-key.pem",
     );
 
     assert!(config.query_optional(C8yUrlSetting)?.is_none());

--- a/tedge_config/tests/test_tedge_config.rs
+++ b/tedge_config/tests/test_tedge_config.rs
@@ -99,15 +99,9 @@ root_cert_path = "/path/to/azure/root/cert"
             "/path/to/azure/root/cert"
         );
 
-        config.update(
-            C8yUrlSetting,
-            ConnectUrl::try_from(updated_c8y_url.to_string()).unwrap(),
-        )?;
+        config.update(C8yUrlSetting, ConnectUrl::try_from(updated_c8y_url)?)?;
         config.unset(C8yRootCertPathSetting)?;
-        config.update(
-            AzureUrlSetting,
-            ConnectUrl::try_from(updated_azure_url.to_string()).unwrap(),
-        )?;
+        config.update(AzureUrlSetting, ConnectUrl::try_from(updated_azure_url)?)?;
         config.unset(AzureRootCertPathSetting)?;
         config_repo.store(config)?;
     }
@@ -174,7 +168,7 @@ id = "ABCD1234"
         tempdir.path().join("tedge-private-key.pem")
     );
 
-    assert!(config.query_optional(AzureUrlSetting).unwrap().is_none());
+    assert_matches!(config.query_optional(AzureUrlSetting), Ok(None));
     assert_eq!(config.query(C8yRootCertPathSetting)?, "/etc/ssl/certs");
     Ok(())
 }
@@ -225,7 +219,7 @@ fn test_parse_config_empty_file() -> Result<(), TEdgeConfigError> {
     assert!(config.query_optional(C8yUrlSetting)?.is_none());
     assert_eq!(config.query(C8yRootCertPathSetting)?, "/etc/ssl/certs");
 
-    assert!(config.query_optional(AzureUrlSetting).unwrap().is_none());
+    assert_matches!(config.query_optional(AzureUrlSetting), Ok(None));
     assert_eq!(config.query(AzureRootCertPathSetting)?, "/etc/ssl/certs");
     Ok(())
 }
@@ -309,7 +303,7 @@ root_cert_path = "/path/to/azure/root/cert"
         original_device_cert_path
     );
 
-    let original_c8y_url = ConnectUrl::try_from("your-tenant.cumulocity.com").unwrap();
+    let original_c8y_url = ConnectUrl::try_from("your-tenant.cumulocity.com")?;
     let original_c8y_root_cert_path = "/path/to/c8y/root/cert".to_string();
     assert_eq!(config.query(C8yUrlSetting)?, original_c8y_url);
     assert_eq!(
@@ -317,7 +311,7 @@ root_cert_path = "/path/to/azure/root/cert"
         original_c8y_root_cert_path
     );
 
-    let updated_c8y_url = ConnectUrl::try_from("other-tenant.cumulocity.com").unwrap();
+    let updated_c8y_url = ConnectUrl::try_from("other-tenant.cumulocity.com")?;
 
     config.update(C8yUrlSetting, updated_c8y_url.clone())?;
 
@@ -357,7 +351,7 @@ root_cert_path = "/path/to/azure/root/cert"
     let tempdir = create_temp_tedge_config(toml_conf)?;
     let mut config = TEdgeConfigRepository::from_dir(tempdir.path()).load()?;
 
-    let original_azure_url = ConnectUrl::try_from("MyAzure.azure-devices.net").unwrap();
+    let original_azure_url = ConnectUrl::try_from("MyAzure.azure-devices.net")?;
     let original_azure_root_cert_path = "/path/to/azure/root/cert".to_string();
 
     // read
@@ -368,7 +362,7 @@ root_cert_path = "/path/to/azure/root/cert"
     );
 
     // set
-    let updated_azure_url = ConnectUrl::try_from("OtherAzure.azure-devices.net").unwrap();
+    let updated_azure_url = ConnectUrl::try_from("OtherAzure.azure-devices.net")?;
     config.update(AzureUrlSetting, updated_azure_url.clone())?;
 
     assert_eq!(config.query(AzureUrlSetting)?, updated_azure_url);


### PR DESCRIPTION
- Move configuration into `tedge_config` crate.

- Add `ConfigSetting` trait. Each "thing" that we want to make
  configurable will have it's own struct-type. For example `struct
  DeviceIdSetting` or `C8yUrlSetting`.

- The `ConfigSetting` trait does not provide any means of how to
  read/write/unset a configuration setting. It only provides the key,
  description and the value type of the setting, but no implementation. It's just "meta-data".

- Use trait `ConfigSettingAccessor` to implemenent `query`, `update` and
  `unset`. TODO: rename to `ConfigSettingAccess`, `ConfigSettingImpl`?

- `TEdgeConfigRepository` implements functionality to read/write a
  `TEdgeConfig`. The `TEdgeConfig` struct itself just holds data. Note that it wraps around `TEdgeConfigDto` to make a clear distinction between the type that we use for serialization and the type that we use as in-memory representation. You can add fields to `TEdgeConfig` without breaking serialization

- Only add the `tedge_config` crate. `tedge` is currently not modified
  to use the new API. This can happen piece by piece once this gets merged.

- TODO: I am happy to rename `query` to `get`, `update` to `set` if you prefer.