### PR TITLE
[CIT-309] WIP - ThinEdge/C8y mapper/visitor/builder spike 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mapper_visitor"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "thiserror",
+]
+
+[[package]]
 name = "matchers"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "common/mqtt_client",
     "tedge",
     "mapper/tedge_mapper",
+    "mapper_visitor",
     "mapper/cumulocity/c8y_translator_lib",
 ]
 

--- a/mapper/cumulocity/c8y_translator_lib/Cargo.toml
+++ b/mapper/cumulocity/c8y_translator_lib/Cargo.toml
@@ -13,6 +13,7 @@ thiserror = "1.0"
 [dev-dependencies]
 pretty_assertions = "0.6"
 proptest = "0.10"
+assert_matches = "1.5"
 
 [features]
 # use: #[cfg(feature="integration-test")]

--- a/mapper_visitor/Cargo.toml
+++ b/mapper_visitor/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mapper_visitor"
+version = "0.1.0"
+authors = ["Michael Neumann <mneumann@ntecs.de>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chrono = "*"
+thiserror = "*"

--- a/mapper_visitor/src/builder.rs
+++ b/mapper_visitor/src/builder.rs
@@ -1,0 +1,56 @@
+use crate::*;
+use chrono::{DateTime, FixedOffset};
+
+pub struct MeasurementBuilder<'a, T: MeasurementVisitor> {
+    visitor: &'a mut T,
+}
+
+impl<'a, T> MeasurementBuilder<'a, T>
+where
+    T: MeasurementVisitor,
+{
+    pub fn new(visitor: &'a mut T) -> Self {
+        Self { visitor }
+    }
+
+    pub fn measurement_type(self, typename: impl AsRef<str>) -> Result<Self, T::Error> {
+        let () = self.visitor.visit_measurement_type(typename.as_ref())?;
+        Ok(self)
+    }
+
+    pub fn timestamp(self, timestamp: DateTime<FixedOffset>) -> Result<Self, T::Error> {
+        let () = self.visitor.visit_timestamp(timestamp)?;
+        Ok(self)
+    }
+
+    pub fn measurement_data(
+        self,
+        key: impl AsRef<str>,
+        value: impl Into<f64>,
+    ) -> Result<Self, T::Error> {
+        let () = self
+            .visitor
+            .visit_measurement_data(key.as_ref(), value.into())?;
+        Ok(self)
+    }
+
+    pub fn start_group(self, key: impl AsRef<str>) -> Result<Self, T::Error> {
+        let () = self.visitor.visit_start_measurement_group(key.as_ref())?;
+        Ok(self)
+    }
+
+    pub fn end_group(self) -> Result<Self, T::Error> {
+        let () = self.visitor.visit_end_measurement_group()?;
+        Ok(self)
+    }
+
+    pub fn start(self) -> Result<Self, T::Error> {
+        let () = self.visitor.visit_start()?;
+        Ok(self)
+    }
+
+    pub fn end(self) -> Result<(), T::Error> {
+        let () = self.visitor.visit_end()?;
+        Ok(())
+    }
+}

--- a/mapper_visitor/src/c8y_json_serializer.rs
+++ b/mapper_visitor/src/c8y_json_serializer.rs
@@ -1,0 +1,123 @@
+use crate::*;
+use chrono::{DateTime, FixedOffset};
+use std::io::Write;
+
+pub struct C8yJsonSerializer {
+    buffer: Vec<u8>,
+    default_typename: String,
+    default_timestamp: DateTime<FixedOffset>,
+    is_complete: bool,
+    is_within_group: bool,
+    needs_separator: bool,
+    has_seen_type: bool,
+    has_seen_timestamp: bool,
+}
+
+impl C8yJsonSerializer {
+    pub fn new(default_typename: String, default_timestamp: DateTime<FixedOffset>) -> Self {
+        Self {
+            buffer: Vec::new(),
+            default_typename,
+            default_timestamp,
+            is_complete: false,
+            is_within_group: false,
+            needs_separator: false,
+            has_seen_type: false,
+            has_seen_timestamp: false,
+        }
+    }
+
+    pub fn data(self) -> Vec<u8> {
+        assert!(self.is_complete);
+        self.buffer
+    }
+}
+
+impl MeasurementVisitor for C8yJsonSerializer {
+    type Error = MeasurementError;
+
+    fn visit_measurement_type(&mut self, typename: &str) -> Result<(), Self::Error> {
+        assert!(!self.is_within_group);
+        assert!(!self.has_seen_type);
+
+        // XXX: write type
+        self.has_seen_type = true;
+
+        Ok(())
+    }
+
+    fn visit_timestamp(&mut self, timestamp: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+        assert!(!self.is_within_group);
+        assert!(!self.has_seen_timestamp);
+
+        // XXX: write timestamp
+        self.has_seen_timestamp = true;
+
+        Ok(())
+    }
+
+    fn visit_measurement_data(&mut self, key: &str, value: f64) -> Result<(), Self::Error> {
+        if self.needs_separator {
+            self.buffer.push(b',');
+        } else {
+            self.needs_separator = true;
+        }
+        if self.is_within_group {
+            self.buffer
+                .write_fmt(format_args!(r#""{}": {{"value": {}}}"#, key, value))
+                .unwrap();
+        } else {
+            self.buffer
+                .write_fmt(format_args!(
+                    r#""{}": {{"{}": {{"value": {}}}}}"#,
+                    key, key, value
+                ))
+                .unwrap();
+        }
+        Ok(())
+    }
+
+    fn visit_start_measurement_group(&mut self, key: &str) -> Result<(), Self::Error> {
+        assert!(!self.is_within_group, "Nested groups not supported"); // XXX: Error
+        self.is_within_group = true;
+
+        if self.needs_separator {
+            self.buffer.push(b',');
+        }
+
+        self.buffer
+            .write_fmt(format_args!(r#""{}": {{"#, key))
+            .unwrap();
+        self.needs_separator = false;
+        Ok(())
+    }
+
+    fn visit_end_measurement_group(&mut self) -> Result<(), Self::Error> {
+        assert!(self.is_within_group);
+
+        self.buffer.push(b'}');
+
+        self.is_within_group = false;
+        Ok(())
+    }
+
+    fn visit_start(&mut self) -> Result<(), Self::Error> {
+        self.buffer.push(b'{');
+        Ok(())
+    }
+
+    fn visit_end(&mut self) -> Result<(), Self::Error> {
+        assert!(!self.is_within_group);
+
+        if !self.has_seen_type {
+            // XXX: write default_typename
+        }
+        if !self.has_seen_timestamp {
+            // XXX: write default_timestamp
+        }
+
+        self.buffer.push(b'}');
+        self.is_complete = true;
+        Ok(())
+    }
+}

--- a/mapper_visitor/src/error.rs
+++ b/mapper_visitor/src/error.rs
@@ -1,0 +1,2 @@
+#[derive(Debug, thiserror::Error)]
+pub enum MeasurementError {}

--- a/mapper_visitor/src/main.rs
+++ b/mapper_visitor/src/main.rs
@@ -1,0 +1,34 @@
+pub mod builder;
+pub mod c8y_json_serializer;
+pub mod error;
+pub mod visitor;
+
+pub use self::{builder::*, c8y_json_serializer::*, error::*, visitor::*};
+
+fn main() -> Result<(), MeasurementError> {
+    use chrono::{FixedOffset, TimeZone};
+
+    let mut c8y_json_serializer = C8yJsonSerializer::new(
+        "my_measurement".into(),
+        FixedOffset::east(5 * 3600)
+            .ymd(2016, 11, 08)
+            .and_hms(0, 0, 0),
+    );
+
+    MeasurementBuilder::new(&mut c8y_json_serializer)
+        .start()?
+        .measurement_type("c8y")?
+        // A single value measurement
+        .measurement_data("abc", 123.3)?
+        .measurement_data("temp", 333.4)?
+        .start_group("location")?
+        .measurement_data("x", 123.0)?
+        .measurement_data("y", 123.0)?
+        .measurement_data("z", 123.0)?
+        .end_group()?
+        .end()?;
+
+    println!("{}", String::from_utf8(c8y_json_serializer.data()).unwrap());
+
+    Ok(())
+}

--- a/mapper_visitor/src/main.rs
+++ b/mapper_visitor/src/main.rs
@@ -15,7 +15,9 @@ fn main() -> Result<(), MeasurementError> {
             .and_hms(0, 0, 0),
     );
 
-    MeasurementBuilder::new(&mut c8y_json_serializer)
+    let mut builder = MeasurementBuilder::new(&mut c8y_json_serializer);
+
+    builder = builder
         .start()?
         .measurement_type("c8y")?
         // A single value measurement
@@ -25,8 +27,15 @@ fn main() -> Result<(), MeasurementError> {
         .measurement_data("x", 123.0)?
         .measurement_data("y", 123.0)?
         .measurement_data("z", 123.0)?
-        .end_group()?
-        .end()?;
+        .end_group()?;
+
+    builder = builder.start_group("loop")?;
+
+    for i in 1..10 {
+        builder = builder.measurement_data(&format!("k_{}", i), (i * 13) as f64)?;
+    }
+
+    let () = builder.end_group()?.end()?;
 
     println!("{}", String::from_utf8(c8y_json_serializer.data()).unwrap());
 

--- a/mapper_visitor/src/visitor.rs
+++ b/mapper_visitor/src/visitor.rs
@@ -1,0 +1,16 @@
+use chrono::{DateTime, FixedOffset};
+
+pub trait MeasurementVisitor {
+    type Error;
+
+    fn visit_measurement_type(&mut self, typename: &str) -> Result<(), Self::Error>;
+    fn visit_timestamp(&mut self, timestamp: DateTime<FixedOffset>) -> Result<(), Self::Error>;
+
+    fn visit_measurement_data(&mut self, key: &str, value: f64) -> Result<(), Self::Error>;
+
+    fn visit_start_measurement_group(&mut self, key: &str) -> Result<(), Self::Error>;
+    fn visit_end_measurement_group(&mut self) -> Result<(), Self::Error>;
+
+    fn visit_start(&mut self) -> Result<(), Self::Error>;
+    fn visit_end(&mut self) -> Result<(), Self::Error>;
+}


### PR DESCRIPTION
- This is just a minimal spike how I'd like the Builder and Visitor to look like.
- It has a C8Y serializer (probably I got the format wrong...). 
- It is actually runnable. You see the JSON output.
- This is 100% streamable.
- This is 100% non-allocating.
- You really can't optimize that much. Trust me :)
 
TODO:

- Write a parser that emits events for the MeasurementVisitor
- Feel free to modify the API here and there. But remember this is not tied particularily to ThinEdgeJson or C8y. It should support other data formats in the future. So remind that when choosing a naming (hint: might not be wise to use ThinEdge naming conventions...).

NOTE:

- This is not exactly tied to ThinEdgeJson or C8yJson. It can support arbitrarily nested measurements. You can add other measurement types in the future (`measurement_string_data`).
- 