### PR TITLE
Auto upload certificate

### DIFF
--- a/ci/ci_smoke_test.sh
+++ b/ci/ci_smoke_test.sh
@@ -80,11 +80,21 @@ set -e
 
 echo "Configuring Bridge"
 
+sudo tedge cert remove
+
+sudo tedge cert create --device-id=$C8YDEVICE
+
 sudo tedge cert show
+
+sudo tedge config set c8y.url thin-edge-io.eu-latest.cumulocity.com
+
+sudo tedge config set c8y.root.cert.path /etc/ssl/certs
 
 sudo tedge config list
 
-sudo tedge config set c8y.url thin-edge-io.eu-latest.cumulocity.com
+# Note: This will always upload a new certificate. From time to time
+# we should delete the old ones in c8y
+sudo -E tedge cert upload c8y --user $C8YUSERNAME
 
 cat /etc/mosquitto/mosquitto.conf
 


### PR DESCRIPTION
Signed-off-by: Michael Abel <info@abel-ikt.de>

## Proposed changes

Use the certificate uploading feature with a password given as environment variable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Paste Link to the issue
Not an issue but a failing workflow:
https://github.com/thin-edge/thin-edge.io/actions/runs/726331194

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
