### PR TITLE
Hotfix after switch to timezone aware timestamps

### DIFF
--- a/ci/roundtrip_local_to_c8y.py
+++ b/ci/roundtrip_local_to_c8y.py
@@ -118,18 +118,17 @@ def check_timestamps(timestamps, laststamp):
     assert is_timezone_aware(laststamp)
 
     for tstamp in timestamps:
-        # All timestamps seem to be in UTC time -> will end with 'Z'
-        # fromisoformat does not seem to cope with the Z, so we remove it
-        #
-        # This does not support parsing arbitrary ISO 8601 strings - it is
-        # only intended as the inverse operation of datetime.isoformat().
-        #
-        # See here: dateutil.parser.isoparse is available in the third-party package dateutil.
-        # https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse
 
         if tstamp.endswith("Z"):
-            print("Error: Timestamp verification: Z is not expected")
-            sys.exit(1)
+            # fromisoformat does not seem to cope with the Z, so we remove it
+            # Workaround: remove the Z and make the timestamp UTC aware
+            #
+            # Alternativelyuse:
+            # dateutil.parser.isoparse is available in the third-party package dateutil.
+            # https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse
+
+            tstamp=tstamp[:-1]
+            tstamp += '+00:00'
 
         tstampiso = datetime.fromisoformat(tstamp)
 

--- a/ci/roundtrip_local_to_c8y.py
+++ b/ci/roundtrip_local_to_c8y.py
@@ -117,18 +117,25 @@ def check_timestamps(timestamps, laststamp):
 
     warning = 0
 
+    assert is_timezone_aware(laststamp)
+
     for tstamp in timestamps:
         # All timestamps seem to be in UTC time -> will end with 'Z'
         # fromisoformat does not seem to cope with the Z, so we remove it
+        #
+        # This does not support parsing arbitrary ISO 8601 strings - it is
+        # only intended as the inverse operation of datetime.isoformat().
+        #
+        # See here: dateutil.parser.isoparse is available in the third-party package dateutil.
+        # https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse
 
         if tstamp.endswith("Z"):
-            tstamp = tstamp[:-1]
-        else:
-            print("Timestamp verification: Z is missing")
-            failed = True
+            print("Error: Timestamp verification: Z is not expected")
+            sys.exit(1)
 
         tstampiso = datetime.fromisoformat(tstamp)
 
+        assert is_timezone_aware(tstampiso)
 
         if tstampiso > laststamp:
             laststamp = tstampiso

--- a/ci/roundtrip_local_to_c8y.py
+++ b/ci/roundtrip_local_to_c8y.py
@@ -32,13 +32,11 @@ CMD_PUBLISH_JSON = "sawtooth_publisher %s %s 1 flux"
 
 
 def is_timezone_aware(stamp):  #:datetime):
-    # determine if object is timezone aware or naive
-    # https://docs.python.org/3/library/datetime.html?highlight=tzinfo#determining-if-an-object-is-aware-or-naive
+    """determine if object is timezone aware or naive
+    See also: https://docs.python.org/3/library/datetime.html?highlight=tzinfo#determining-if-an-object-is-aware-or-naive
+    """
 
-    if stamp.tzinfo != None and stamp.tzinfo.utcoffset(stamp) != None:
-        return True
-    else:
-        return False
+    return stamp.tzinfo is not None and stamp.tzinfo.utcoffset(stamp) is not None
 
 
 def act(path_publisher, mode, publish_amount, delay):

--- a/ci/roundtrip_local_to_c8y.py
+++ b/ci/roundtrip_local_to_c8y.py
@@ -151,7 +151,7 @@ def check_timestamps(timestamps, laststamp):
         print("Timestamp verification PASSED")
     else:
         print("Timestamp verification FAILED")
-        sys.exit(1)
+        return False
 
     return True
 
@@ -225,7 +225,9 @@ def assert_values(
         print("Data verification FAILED")
         sys.exit(1)
 
-    check_timestamps(timestamps, time_from)
+    ret = check_timestamps(timestamps, time_from)
+    if not ret:
+        sys.exit(1)
 
 
 def main():

--- a/ci/roundtrip_local_to_c8y.py
+++ b/ci/roundtrip_local_to_c8y.py
@@ -30,14 +30,16 @@ CMD_PUBLISH_REST = "sudo tedge mqtt pub c8y/s/us 211,%i"
 
 CMD_PUBLISH_JSON = "sawtooth_publisher %s %s 1 flux"
 
-def is_timezone_aware(stamp):#:datetime):
+
+def is_timezone_aware(stamp):  #:datetime):
     # determine if object is timezone aware or naive
     # https://docs.python.org/3/library/datetime.html?highlight=tzinfo#determining-if-an-object-is-aware-or-naive
 
-    if stamp.tzinfo !=  None and stamp.tzinfo.utcoffset(stamp) != None:
+    if stamp.tzinfo != None and stamp.tzinfo.utcoffset(stamp) != None:
         return True
     else:
         return False
+
 
 def act(path_publisher, mode, publish_amount, delay):
     """Act: Publishing values with temperature_publisher"""
@@ -66,8 +68,10 @@ def act(path_publisher, mode, publish_amount, delay):
 
     time.sleep(3)
 
-def retrieve_data(user, device_id, password, tenant, verbose, timeslot) \
-    -> Tuple[requests.models.Response, datetime]:
+
+def retrieve_data(
+    user, device_id, password, tenant, verbose, timeslot
+) -> Tuple[requests.models.Response, datetime]:
     """Download via REST"""
 
     time_to = datetime.now(timezone.utc).replace(microsecond=0)
@@ -84,7 +88,12 @@ def retrieve_data(user, device_id, password, tenant, verbose, timeslot) \
     cloud = "eu-latest.cumulocity.com"
 
     url = f"https://{user}.{cloud}/measurement/measurements"
-    payload = {'source': device_id, 'pageSize':PAGE_SIZE, 'dateFrom':date_from, 'dateTo':date_to}
+    payload = {
+        "source": device_id,
+        "pageSize": PAGE_SIZE,
+        "dateFrom": date_from,
+        "dateTo": date_to,
+    }
     auth = bytes(f"{tenant}/{user}:{password}", "utf-8")
     header = {b"Authorization": b"Basic " + base64.b64encode(auth)}
 
@@ -97,7 +106,7 @@ def retrieve_data(user, device_id, password, tenant, verbose, timeslot) \
     req = requests.get(url, params=payload, headers=header)
 
     if verbose:
-        print('Requested URL:', req.url)
+        print("Requested URL:", req.url)
 
     if req.status_code != 200:
         print("Http request failed !!!")
@@ -127,8 +136,8 @@ def check_timestamps(timestamps, laststamp):
             # dateutil.parser.isoparse is available in the third-party package dateutil.
             # https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse
 
-            tstamp=tstamp[:-1]
-            tstamp += '+00:00'
+            tstamp = tstamp[:-1]
+            tstamp += "+00:00"
 
         tstampiso = datetime.fromisoformat(tstamp)
 
@@ -154,6 +163,7 @@ def check_timestamps(timestamps, laststamp):
         return False
 
     return True
+
 
 def assert_values(
     mode, user, device_id, password, tenant, verbose, publish_amount, timeslot

--- a/ci/roundtrip_local_to_c8y.py
+++ b/ci/roundtrip_local_to_c8y.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 import os
 import sys
 import time
-
+from typing import Tuple
 import requests
 
 # Warning: the list begins with the earliest one
@@ -68,8 +68,8 @@ def act(path_publisher, mode, publish_amount, delay):
 
     time.sleep(3)
 
-
-def retrieve_data(user, device_id, password, tenant, verbose, timeslot):
+def retrieve_data(user, device_id, password, tenant, verbose, timeslot) \
+    -> Tuple[requests.models.Response, datetime]:
     """Download via REST"""
 
     time_to = datetime.utcnow().replace(microsecond=0)

--- a/ci/roundtrip_local_to_c8y.py
+++ b/ci/roundtrip_local_to_c8y.py
@@ -30,6 +30,16 @@ CMD_PUBLISH_REST = "sudo tedge mqtt pub c8y/s/us 211,%i"
 
 CMD_PUBLISH_JSON = "sawtooth_publisher %s %s 1 flux"
 
+def is_timezone_aware(stamp):#:datetime):
+    # determine if object is timezone aware or naive
+    # https://docs.python.org/3/library/datetime.html?highlight=tzinfo#determining-if-an-object-is-aware-or-naive
+
+    if stamp.tzinfo !=  None and stamp.tzinfo.utcoffset(stamp) != None:
+        print("Timezone aware", stamp)
+        return True
+    else:
+        print("Not timezone aware: Naive", stamp)
+        return False
 
 def act(path_publisher, mode, publish_amount, delay):
     """Act: Publishing values with temperature_publisher"""

--- a/ci/roundtrip_local_to_c8y.py
+++ b/ci/roundtrip_local_to_c8y.py
@@ -35,10 +35,8 @@ def is_timezone_aware(stamp):#:datetime):
     # https://docs.python.org/3/library/datetime.html?highlight=tzinfo#determining-if-an-object-is-aware-or-naive
 
     if stamp.tzinfo !=  None and stamp.tzinfo.utcoffset(stamp) != None:
-        print("Timezone aware", stamp)
         return True
     else:
-        print("Not timezone aware: Naive", stamp)
         return False
 
 def act(path_publisher, mode, publish_amount, delay):

--- a/ci/roundtrip_local_to_c8y.py
+++ b/ci/roundtrip_local_to_c8y.py
@@ -115,6 +115,8 @@ def check_timestamps(timestamps, laststamp):
 
     failed = False
 
+    warning = 0
+
     for tstamp in timestamps:
         # All timestamps seem to be in UTC time -> will end with 'Z'
         # fromisoformat does not seem to cope with the Z, so we remove it
@@ -127,13 +129,13 @@ def check_timestamps(timestamps, laststamp):
 
         tstampiso = datetime.fromisoformat(tstamp)
 
-        warning = 0
 
         if tstampiso > laststamp:
             laststamp = tstampiso
-        if tstampiso == laststamp:
-            laststamp = tstampiso
+        elif tstampiso == laststamp:
             warning += 1
+            print("Warning", tstampiso, "is equal to", laststamp)
+            laststamp = tstampiso
         else:
             print("Oops", tstampiso, "is smaller than", laststamp)
             failed = True
@@ -147,6 +149,7 @@ def check_timestamps(timestamps, laststamp):
         print("Timestamp verification FAILED")
         sys.exit(1)
 
+    return True
 
 def assert_values(
     mode, user, device_id, password, tenant, verbose, publish_amount, timeslot

--- a/tests/pytest/test_roundtrip_local_to_c8y.py
+++ b/tests/pytest/test_roundtrip_local_to_c8y.py
@@ -18,7 +18,7 @@ def test_check_timestamps_increasing_ms_timezone_aware():
     ]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
-    assert ret == True
+    assert ret is True
 
 
 def test_check_timestamps_increasing_timezone_naive():
@@ -31,54 +31,54 @@ def test_check_timestamps_increasing_timezone_naive():
     ]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
-    assert ret == True
+    assert ret is True
 
 
 def test_check_timestamps_wrong_order():
     timestamps = ["2021-01-01T01:00:00.002Z", "2021-01-01T01:00:00.001Z"]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
-    assert ret == False
+    assert ret is False
 
 
 def test_check_timestamps_equal():
     timestamps = ["2021-01-01T01:00:00.002Z", "2021-01-01T01:00:00.002Z"]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
-    assert ret == True
+    assert ret is True
 
 
 def test_check_timestamps_equal_tz_aware():
     timestamps = ["2021-01-01T01:00:00.002+00:00", "2021-01-01T01:00:00.002+00:00"]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
-    assert ret == True
+    assert ret is True
 
 
 def test_check_timestamps_tz_aware_different_timezone():
     timestamps = ["2021-01-01T03:00:00.002+02:00", "2021-01-01T03:00:00.003+02:00"]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
-    assert ret == True
+    assert ret is True
 
 
 def test_check_timestamps_too_early():
     timestamps = ["2021-01-01T01:00:00.002Z", "2021-01-01T01:00:00.002Z"]
     laststamp = datetime(2021, 1, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
-    assert ret == False
+    assert ret is False
 
 
 def test_is_timezone_aware():
     stamp = datetime.fromisoformat("2021-01-01T01:00:00.001+00:00")
-    assert is_timezone_aware(stamp) == True
+    assert is_timezone_aware(stamp) is True
 
     stamp = datetime.fromisoformat("2021-01-01T01:00:00.000+00:00")
-    assert is_timezone_aware(stamp) == True
+    assert is_timezone_aware(stamp) is True
 
     # TODO: needs: https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse
     # stamp = datetime.fromisoformat('2021-01-01T01:00:00.000Z')
-    # assert is_timezone_aware(stamp) == True
+    # assert is_timezone_aware(stamp) is True
 
     stamp = datetime.fromisoformat("2021-01-01T01:00:00.000")
-    assert is_timezone_aware(stamp) == False
+    assert is_timezone_aware(stamp) is False

--- a/tests/pytest/test_roundtrip_local_to_c8y.py
+++ b/tests/pytest/test_roundtrip_local_to_c8y.py
@@ -1,4 +1,3 @@
-
 import sys
 from datetime import datetime, timezone
 
@@ -10,70 +9,76 @@ from roundtrip_local_to_c8y import check_timestamps, is_timezone_aware
 
 
 def test_check_timestamps_increasing_ms_timezone_aware():
-    timestamps = ['2021-01-01T01:00:00.001+00:00',
-                  '2021-01-01T01:00:00.002+00:00',
-                  '2021-01-01T01:00:00.003+00:00',
-                  '2021-01-01T01:00:00.004+00:00',
-                  '2021-01-01T01:00:00.005+00:00']
+    timestamps = [
+        "2021-01-01T01:00:00.001+00:00",
+        "2021-01-01T01:00:00.002+00:00",
+        "2021-01-01T01:00:00.003+00:00",
+        "2021-01-01T01:00:00.004+00:00",
+        "2021-01-01T01:00:00.005+00:00",
+    ]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
     assert ret == True
+
 
 def test_check_timestamps_increasing_timezone_naive():
-    timestamps = ['2021-01-01T01:00:00.001Z',
-                  '2021-01-01T01:00:00.002Z',
-                  '2021-01-01T01:00:00.003Z',
-                  '2021-01-01T01:00:00.004Z',
-                  '2021-01-01T01:00:00.005Z']
+    timestamps = [
+        "2021-01-01T01:00:00.001Z",
+        "2021-01-01T01:00:00.002Z",
+        "2021-01-01T01:00:00.003Z",
+        "2021-01-01T01:00:00.004Z",
+        "2021-01-01T01:00:00.005Z",
+    ]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
     assert ret == True
 
+
 def test_check_timestamps_wrong_order():
-    timestamps = ['2021-01-01T01:00:00.002Z',
-                  '2021-01-01T01:00:00.001Z']
+    timestamps = ["2021-01-01T01:00:00.002Z", "2021-01-01T01:00:00.001Z"]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
     assert ret == False
 
+
 def test_check_timestamps_equal():
-    timestamps = ['2021-01-01T01:00:00.002Z',
-                  '2021-01-01T01:00:00.002Z']
+    timestamps = ["2021-01-01T01:00:00.002Z", "2021-01-01T01:00:00.002Z"]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
     assert ret == True
+
 
 def test_check_timestamps_equal_tz_aware():
-    timestamps = ['2021-01-01T01:00:00.002+00:00',
-                  '2021-01-01T01:00:00.002+00:00']
+    timestamps = ["2021-01-01T01:00:00.002+00:00", "2021-01-01T01:00:00.002+00:00"]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
     assert ret == True
+
 
 def test_check_timestamps_tz_aware_different_timezone():
-    timestamps = ['2021-01-01T03:00:00.002+02:00',
-                  '2021-01-01T03:00:00.003+02:00']
+    timestamps = ["2021-01-01T03:00:00.002+02:00", "2021-01-01T03:00:00.003+02:00"]
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
     assert ret == True
 
+
 def test_check_timestamps_too_early():
-    timestamps = ['2021-01-01T01:00:00.002Z',
-                  '2021-01-01T01:00:00.002Z']
+    timestamps = ["2021-01-01T01:00:00.002Z", "2021-01-01T01:00:00.002Z"]
     laststamp = datetime(2021, 1, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
     assert ret == False
 
+
 def test_is_timezone_aware():
-    stamp = datetime.fromisoformat('2021-01-01T01:00:00.001+00:00')
+    stamp = datetime.fromisoformat("2021-01-01T01:00:00.001+00:00")
     assert is_timezone_aware(stamp) == True
 
-    stamp = datetime.fromisoformat('2021-01-01T01:00:00.000+00:00')
+    stamp = datetime.fromisoformat("2021-01-01T01:00:00.000+00:00")
     assert is_timezone_aware(stamp) == True
 
-    #TODO: needs: https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse
-    #stamp = datetime.fromisoformat('2021-01-01T01:00:00.000Z')
-    #assert is_timezone_aware(stamp) == True
+    # TODO: needs: https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse
+    # stamp = datetime.fromisoformat('2021-01-01T01:00:00.000Z')
+    # assert is_timezone_aware(stamp) == True
 
-    stamp = datetime.fromisoformat('2021-01-01T01:00:00.000')
+    stamp = datetime.fromisoformat("2021-01-01T01:00:00.000")
     assert is_timezone_aware(stamp) == False

--- a/tests/pytest/test_roundtrip_local_to_c8y.py
+++ b/tests/pytest/test_roundtrip_local_to_c8y.py
@@ -9,7 +9,7 @@ sys.path.append("ci")
 from roundtrip_local_to_c8y import check_timestamps, is_timezone_aware
 
 
-def test_check_timestamps_increasing_ms():
+def test_check_timestamps_increasing_ms_timezone_aware():
     timestamps = ['2021-01-01T01:00:00.001+00:00',
                   '2021-01-01T01:00:00.002+00:00',
                   '2021-01-01T01:00:00.003+00:00',
@@ -18,6 +18,51 @@ def test_check_timestamps_increasing_ms():
     laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ret = check_timestamps(timestamps, laststamp)
     assert ret == True
+
+def test_check_timestamps_increasing_timezone_naive():
+    timestamps = ['2021-01-01T01:00:00.001Z',
+                  '2021-01-01T01:00:00.002Z',
+                  '2021-01-01T01:00:00.003Z',
+                  '2021-01-01T01:00:00.004Z',
+                  '2021-01-01T01:00:00.005Z']
+    laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ret = check_timestamps(timestamps, laststamp)
+    assert ret == True
+
+def test_check_timestamps_wrong_order():
+    timestamps = ['2021-01-01T01:00:00.002Z',
+                  '2021-01-01T01:00:00.001Z']
+    laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ret = check_timestamps(timestamps, laststamp)
+    assert ret == False
+
+def test_check_timestamps_equal():
+    timestamps = ['2021-01-01T01:00:00.002Z',
+                  '2021-01-01T01:00:00.002Z']
+    laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ret = check_timestamps(timestamps, laststamp)
+    assert ret == True
+
+def test_check_timestamps_equal_tz_aware():
+    timestamps = ['2021-01-01T01:00:00.002+00:00',
+                  '2021-01-01T01:00:00.002+00:00']
+    laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ret = check_timestamps(timestamps, laststamp)
+    assert ret == True
+
+def test_check_timestamps_tz_aware_different_timezone():
+    timestamps = ['2021-01-01T03:00:00.002+02:00',
+                  '2021-01-01T03:00:00.003+02:00']
+    laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ret = check_timestamps(timestamps, laststamp)
+    assert ret == True
+
+def test_check_timestamps_too_early():
+    timestamps = ['2021-01-01T01:00:00.002Z',
+                  '2021-01-01T01:00:00.002Z']
+    laststamp = datetime(2021, 1, 1, 2, 0, 0, 0, tzinfo=timezone.utc)
+    ret = check_timestamps(timestamps, laststamp)
+    assert ret == False
 
 def test_is_timezone_aware():
     stamp = datetime.fromisoformat('2021-01-01T01:00:00.001+00:00')

--- a/tests/pytest/test_roundtrip_local_to_c8y.py
+++ b/tests/pytest/test_roundtrip_local_to_c8y.py
@@ -9,6 +9,16 @@ sys.path.append("ci")
 from roundtrip_local_to_c8y import check_timestamps, is_timezone_aware
 
 
+def test_check_timestamps_increasing_ms():
+    timestamps = ['2021-01-01T01:00:00.001+00:00',
+                  '2021-01-01T01:00:00.002+00:00',
+                  '2021-01-01T01:00:00.003+00:00',
+                  '2021-01-01T01:00:00.004+00:00',
+                  '2021-01-01T01:00:00.005+00:00']
+    laststamp = datetime(2021, 1, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ret = check_timestamps(timestamps, laststamp)
+    assert ret == True
+
 def test_is_timezone_aware():
     stamp = datetime.fromisoformat('2021-01-01T01:00:00.001+00:00')
     assert is_timezone_aware(stamp) == True

--- a/tests/pytest/test_roundtrip_local_to_c8y.py
+++ b/tests/pytest/test_roundtrip_local_to_c8y.py
@@ -1,0 +1,24 @@
+
+import sys
+from datetime import datetime, timezone
+
+# Run :
+# pytest-3 --capture no tests/pytest/test_roundtrip_local_to_c8y.py
+
+sys.path.append("ci")
+from roundtrip_local_to_c8y import check_timestamps, is_timezone_aware
+
+
+def test_is_timezone_aware():
+    stamp = datetime.fromisoformat('2021-01-01T01:00:00.001+00:00')
+    assert is_timezone_aware(stamp) == True
+
+    stamp = datetime.fromisoformat('2021-01-01T01:00:00.000+00:00')
+    assert is_timezone_aware(stamp) == True
+
+    #TODO: needs: https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.isoparse
+    #stamp = datetime.fromisoformat('2021-01-01T01:00:00.000Z')
+    #assert is_timezone_aware(stamp) == True
+
+    stamp = datetime.fromisoformat('2021-01-01T01:00:00.000')
+    assert is_timezone_aware(stamp) == False


### PR DESCRIPTION
## Proposed changes
With this we switch to timezone-aware timestamps when using thin-edge JSON. When C8y generates the timestamps itself (when we publish via SmartREST), there is still a Z appended - we just replace that with +00:00 to use the utc timestamps.
Since there is again a plus sign in the code that needs to be encoded, we rely on the requests package to do that.
In addition, some unit-tests with pytest were added to ensure that timestamp validation works right.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

Signed-off-by: Michael Abel <info@abel-ikt.de>