### PR TITLE
Add status badges for repository workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.txt)
 [![Twitter Badge](https://img.shields.io/twitter/follow/thin_edge_io?style=social)](https://twitter.com/thin_edge_io)
 [![codecov](https://codecov.io/gh/thin-edge/thin-edge.io/branch/main/graph/badge.svg?token=ZE7576TLOK)](https://codecov.io/gh/thin-edge/thin-edge.io)
+![commit-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/commit-workflow.yml/badge.svg)
+![build-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/build-workflow.yml/badge.svg)
+![integration-test-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/integration-test-workflow.yml/badge.svg)
+![system-test-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/system-test-workflow.yml/badge.svg)
 
 <!-- PROJECT LOGO -->
 <br />

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE.txt)
 [![Twitter Badge](https://img.shields.io/twitter/follow/thin_edge_io?style=social)](https://twitter.com/thin_edge_io)
 [![codecov](https://codecov.io/gh/thin-edge/thin-edge.io/branch/main/graph/badge.svg?token=ZE7576TLOK)](https://codecov.io/gh/thin-edge/thin-edge.io)
-![commit-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/commit-workflow.yml/badge.svg)
-![build-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/build-workflow.yml/badge.svg)
-![integration-test-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/integration-test-workflow.yml/badge.svg)
-![system-test-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/system-test-workflow.yml/badge.svg)
+[![commit-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/commit-workflow.yml/badge.svg)](https://github.com/thin-edge/thin-edge.io/actions/workflows/commit-workflow.yml)
+[![build-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/build-workflow.yml/badge.svg)](https://github.com/thin-edge/thin-edge.io/actions/workflows/build-workflow.yml)
+[![integration-test-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/integration-test-workflow.yml/badge.svg)](https://github.com/thin-edge/thin-edge.io/actions/workflows/integration-test-workflow.yml)
+[![system-test-workflow](https://github.com/thin-edge/thin-edge.io/actions/workflows/system-test-workflow.yml/badge.svg)](https://github.com/thin-edge/thin-edge.io/actions/workflows/system-test-workflow.yml)
 
 <!-- PROJECT LOGO -->
 <br />


### PR DESCRIPTION
Signed-off-by: Michael Abel <info@abel-ikt.de>

## Proposed changes
Add status badges for workflows in the repository

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

