### PR TITLE
[CIT-279] Fix smartrest system-test to 20ms 

### DIFF
--- a/tests/PySys/smoketest_smartrest_400_samples_20ms/run.py
+++ b/tests/PySys/smoketest_smartrest_400_samples_20ms/run.py
@@ -17,6 +17,6 @@ class SmoketestSmartRest400Samples20ms(Environment_roundtrip_c8y):
     def setup(self):
         super().setup()
         self.samples = "400"
-        self.delay = "10"
-        self.timeslot = "20"
+        self.delay = "20"
+        self.timeslot = "35"
         self.style = "REST"


### PR DESCRIPTION
Signed-off-by: Michael Abel <info@abel-ikt.de>

## Proposed changes
Actually use 20ms delay in the test named with 20ms delay.
Extend time slot to download values from c8y from 20s to 30s (35s is heuristic).

## Types of changes
  
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
