### PR TITLE
Experimental: Run integration tests at GitHub

### DIFF
--- a/.github/workflows/integration-test-workflow.yml
+++ b/.github/workflows/integration-test-workflow.yml
@@ -46,6 +46,26 @@ jobs:
         - name: run tedge help
           run: tedge --help
 
+        - name: Download artifact
+          uses: dawidd6/action-download-artifact@v2
+          # https://github.com/marketplace/actions/download-workflow-artifact
+          with:
+            github_token: ${{secrets.GITHUB_TOKEN}}
+            workflow: build-workflow.yml
+            workflow_conclusion: success
+            branch: continuous_integration
+            name: examples_amd64
+            path: examples
+
+        - name: Run Smoke Test
+          run: ./ci/ci_smoke_test.sh
+          env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            C8YDEVICE: ${{ secrets.SECRET_C8YDEVICE }}_hosted
+            C8YDEVICEID: ${{ secrets.SECRET_C8YDEVICEID_HOSTED }}
+
   cargo-test-features:
 
     name: Run cargo test features


### PR DESCRIPTION
Experimental, may fail if GitHub restricts network
connections again.

Will fail unless GH SECRET_C8YDEVICEID_HOSTED was set.

Signed-off-by: Michael Abel <info@abel-ikt.de>

## Proposed changes

Run Integration tests in a GitHub hosted runner. This avoids security issues with self-hosted runners.
May fail, if GitHub restricts external network connections.
This will enable the additional test-run so that we can observe how often they fail.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
