### PR TITLE
Fix workflow toolchain version

### DIFF
--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -92,7 +92,7 @@ jobs:
         # https://github.com/marketplace/actions/rust-cargo
         with:
           command: build
-          args:  --release
+          args: --release
 
   cargo-tarpaulin:
 
@@ -108,6 +108,12 @@ jobs:
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
         uses: Swatinem/rust-cache@v1
+
+      - name: Install rust v1.51.0
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.51.0"
+          override: true
 
       - name: install libssl
         run: sudo apt install libssl-dev


### PR DESCRIPTION
## Proposed changes

This adds a workaround for failing `tarpaulin` build due to change in the latest toolchain (1.52), alternative is to use experimental version of tarpaulin 0.18alpha3.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [z] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


