### PR TITLE
[CIT-293] Add lock to allow only one mapper running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flockfile"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "log",
+ "nix",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1023,18 @@ version = "0.1.0"
 source = "git+https://github.com/mneumann/rumqtt?branch=support-publish-ack#d15c73fcf21102f781a7f1c965d6d607cef7ce48"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "nix"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1873,9 +1896,11 @@ dependencies = [
 name = "tedge_mapper"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "c8y_translator_lib",
  "chrono",
  "env_logger",
+ "flockfile",
  "log",
  "mqtt_client",
  "thin_edge_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,13 +2,14 @@
 
 members = [
     "common/certificate",
+    "common/flockfile",
     "common/mqtt_client",
     "tedge",
     "tedge_config",
-    "mapper/tedge_mapper",
     "mapper/cumulocity/c8y_translator_lib",
+    "mapper/dm_agent",
+    "mapper/tedge_mapper",
     "mapper/thin_edge_json",
-    "mapper/dm_agent"
 ]
 
 [profile.release]

--- a/common/flockfile/Cargo.toml
+++ b/common/flockfile/Cargo.toml
@@ -9,7 +9,6 @@ log = "0.4"
 nix = "0.20"
 thiserror = "1.0"
 
-
 [dev-dependencies]
 assert_matches = "1.5"
 tempfile = "3.2"

--- a/common/flockfile/Cargo.toml
+++ b/common/flockfile/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "flockfile"
+version = "0.1.0"
+authors = ["Software AG <thin-edge-team@softwareag.com>"]
+edition = "2018"
+
+[dependencies]
+log = "0.4"
+nix = "0.20"
+thiserror = "1.0"
+
+
+[dev-dependencies]
+assert_matches = "1.5"
+tempfile = "3.2"

--- a/common/flockfile/src/lib.rs
+++ b/common/flockfile/src/lib.rs
@@ -1,0 +1,118 @@
+use log::{debug, warn};
+use nix::fcntl::{flock, FlockArg};
+use std::{
+    fs::{self, File, OpenOptions},
+    io,
+    os::unix::io::AsRawFd,
+    path::{Path, PathBuf},
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum FlockfileError {
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+
+    #[error("Couldn't acquire file lock.")]
+    NixError(#[from] nix::Error),
+}
+
+/// flockfile creates a lockfile in the filesystem under `/run/lock` and then creates a filelock using system fcntl with flock.
+/// flockfile will automatically remove lockfile on application exit and the OS should cleanup the filelock afterwards.
+/// If application exits unexpectedly the filelock will be dropped, but the lockfile will not be removed unless handled in signal handler.
+#[derive(Debug)]
+pub struct Flockfile {
+    handle: Option<File>,
+    pub path: PathBuf,
+}
+
+impl Flockfile {
+    /// Create new lockfile in `/run/lock` with specific name:
+    ///
+    /// #Example
+    ///
+    /// let _lockfile = match flockfile::Flockfile::new_lock("app")).unwrap();
+    ///
+    pub fn new_lock(lock_name: impl AsRef<Path>) -> Result<Flockfile, FlockfileError> {
+        let path = Path::new("/run/lock").join(lock_name);
+
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&path)?;
+
+        if let Err(err) = flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock) {
+            return Err(err.into());
+        }
+
+        Ok(Flockfile {
+            handle: Some(file),
+            path,
+        })
+    }
+
+    /// Manually remove filelock and lockfile from the filesystem, this method doesn't have to be called explicitly,
+    /// however if access to the locked file is required this must be called.
+    pub fn unlock(mut self) -> Result<(), io::Error> {
+        self.handle.take().expect("handle dropped");
+        fs::remove_file(&self.path)?;
+        Ok(())
+    }
+}
+
+impl Drop for Flockfile {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            drop(handle);
+
+            match fs::remove_file(&self.path) {
+                Ok(()) => debug!(r#"Lockfile deleted "{:?}""#, self.path),
+                Err(err) => warn!(
+                    r#"Error while handling lockfile at "{:?}": {:?}"#,
+                    self.path, err
+                ),
+            }
+        }
+    }
+}
+
+impl AsRef<Path> for Flockfile {
+    fn as_ref(&self) -> &Path {
+        self.path.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use assert_matches::*;
+    use std::{fs, io};
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn lock_access_remove() {
+        let path = NamedTempFile::new().unwrap().into_temp_path().to_owned();
+        let lockfile = Flockfile::new_lock(&path).unwrap();
+
+        assert_eq!(lockfile.path, path);
+
+        lockfile.unlock().unwrap();
+
+        assert_eq!(
+            fs::metadata(path).unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn lock_twice() {
+        let path = NamedTempFile::new().unwrap().into_temp_path().to_owned();
+        let _lockfile = Flockfile::new_lock(&path).unwrap();
+
+        assert_matches!(
+            Flockfile::new_lock(&path).unwrap_err(),
+            FlockfileError::NixError(_)
+        );
+    }
+}

--- a/common/flockfile/src/lib.rs
+++ b/common/flockfile/src/lib.rs
@@ -104,6 +104,21 @@ mod tests {
     }
 
     #[test]
+    fn lock_out_of_scope() {
+        let path = NamedTempFile::new().unwrap().into_temp_path().to_owned();
+        {
+            let _lockfile = Flockfile::new_lock(&path).unwrap();
+            // assert!(path.exists());
+            assert!(fs::metadata(&path).is_ok());
+        }
+
+        assert_eq!(
+            fs::metadata(path).unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
     fn lock_twice() {
         let path = NamedTempFile::new().unwrap().into_temp_path().to_owned();
         let _lockfile = Flockfile::new_lock(&path).unwrap();

--- a/common/flockfile/src/lib.rs
+++ b/common/flockfile/src/lib.rs
@@ -41,9 +41,7 @@ impl Flockfile {
             .write(true)
             .open(&path)?;
 
-        if let Err(err) = flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock) {
-            return Err(err.into());
-        }
+        let () = flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock)?;
 
         Ok(Flockfile {
             handle: Some(file),

--- a/common/flockfile/src/lib.rs
+++ b/common/flockfile/src/lib.rs
@@ -59,10 +59,14 @@ impl Flockfile {
 }
 
 impl Drop for Flockfile {
+    /// The Drop trait will be called always when the lock goes out of scope, however,
+    /// if the program exits unexpectedly and drop is not called the lock will be removed by the system.
     fn drop(&mut self) {
         if let Some(handle) = self.handle.take() {
             drop(handle);
 
+            // Even if the file is not removed this is not an issue, as OS will take care of the flock.
+            // Additionally if the file is created before an attempt to create the lock that won't be an issue as we rely on filesystem lock.
             match fs::remove_file(&self.path) {
                 Ok(()) => debug!(r#"Lockfile deleted "{:?}""#, self.path),
                 Err(err) => warn!(

--- a/mapper/tedge_mapper/Cargo.toml
+++ b/mapper/tedge_mapper/Cargo.toml
@@ -18,10 +18,12 @@ start = false
 stop-on-upgrade = false
 
 [dependencies]
+anyhow = "1.0"
 c8y_translator_lib = {path = "../cumulocity/c8y_translator_lib" }
 thin_edge_json = {path = "../../mapper/thin_edge_json"}
 chrono = "0.4"
 env_logger = "0.8"
+flockfile = {path = "../../common/flockfile" }
 log = "0.4"
 mqtt_client = {path = "../../common/mqtt_client" }
 tokio = { version = "1.1", features = ["full"] }


### PR DESCRIPTION
## Proposed changes

This introduces crate `flockfile` which allows for only single mapper running on the system.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
