### PR TITLE
Add `c8y` argument for tedge_mapper system tests after merging Azure Mapper

### DIFF
--- a/tests/PySys/mapper_awaits_before_reconnect/run.py
+++ b/tests/PySys/mapper_awaits_before_reconnect/run.py
@@ -23,7 +23,7 @@ class MapperReconnectAwait(BaseTest):
 
         subber = self.startProcess(
             command="mosquito_sub",
-            arguments=["-i", "tedge-mapper", "-t", "test"],
+            arguments=["-i", "tedge-mapper-c8y", "-t", "test"],
             stdouterr="mosquitto_sub",
             background=True
         )
@@ -32,7 +32,7 @@ class MapperReconnectAwait(BaseTest):
 
         mapper = self.startProcess(
             command=tedge_mapper,
-            arguments=[],
+            arguments=["c8y"],
             stdouterr="tedge_mapper",
             background=True
         )

--- a/tests/PySys/runtime_start_two_mappers/run.py
+++ b/tests/PySys/runtime_start_two_mappers/run.py
@@ -21,7 +21,7 @@ class RuntimeMultiMappers(BaseTest):
 
         tedge_mapper1 = self.startProcess(
             command=tedge_mapper,
-            arguments=[],
+            arguments=["c8y"],
             stdouterr="tedge_mapper1",
             expectedExitStatus="==0",
             background=True
@@ -31,7 +31,7 @@ class RuntimeMultiMappers(BaseTest):
 
         tedge_mapper2 = self.startProcess(
             command=tedge_mapper,
-            arguments=[],
+            arguments=["c8y"],
             stdouterr="tedge_mapper2",
             expectedExitStatus="==1",
         )


### PR DESCRIPTION
## Proposed changes

Now `tedge-mapper` runs by `tedge_mapper c8y` or `tedge_mapper az`. This change broke the existing system tests. This commit adds the missing argument for `tedge_mapper`.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

