### PR TITLE
[CIT-391] Accept the old configuration using azure

### DIFF
--- a/tedge_config/src/tedge_config_dto.rs
+++ b/tedge_config/src/tedge_config_dto.rs
@@ -14,7 +14,7 @@ pub(crate) struct TEdgeConfigDto {
     #[serde(default)]
     pub(crate) c8y: CumulocityConfigDto,
 
-    #[serde(default)]
+    #[serde(default, alias = "azure")] // for version 0.1.0 compatibility
     pub(crate) az: AzureConfigDto,
 
     #[serde(default)]


### PR DESCRIPTION
## Proposed changes

By this patch, tedge will accept `[azure]` in tedge.toml file.

How it works?
case 1) Read old configs -> [azure] stays in tedge.toml file unless user sets a new az keys.
case 2) Set az.xxx configs -> tedge will overwrite [azure] to [az] in tedge.toml file.
case 3) No old configs -> tedge will write [az] in tedge.toml file.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#265 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
