### PR TITLE
Add system command runner facility

### DIFF
--- a/tedge/src/cli/connect/cli.rs
+++ b/tedge/src/cli/connect/cli.rs
@@ -27,6 +27,7 @@ impl BuildCommand for TEdgeConnectOpt {
     fn build_command(self, context: BuildContext) -> Result<Box<dyn Command>, crate::ConfigError> {
         Ok(match self {
             TEdgeConnectOpt::C8y { is_test_connection } => ConnectCommand {
+                system_command_runner: context.system_command_runner.clone(),
                 config_location: context.config_location,
                 config_repository: context.config_repository,
                 cloud: Cloud::C8y,
@@ -34,6 +35,7 @@ impl BuildCommand for TEdgeConnectOpt {
                 is_test_connection,
             },
             TEdgeConnectOpt::Az { is_test_connection } => ConnectCommand {
+                system_command_runner: context.system_command_runner.clone(),
                 config_location: context.config_location,
                 config_repository: context.config_repository,
                 cloud: Cloud::Azure,

--- a/tedge/src/cli/connect/command.rs
+++ b/tedge/src/cli/connect/command.rs
@@ -27,7 +27,7 @@ const MQTT_TLS_PORT: u16 = 8883;
 const TEDGE_BRIDGE_CONF_DIR_PATH: &str = "mosquitto-conf";
 
 pub struct ConnectCommand {
-    pub system_command_runner: Arc<SystemCommandRunner>,
+    pub system_command_runner: Arc<dyn AbstractSystemCommandRunner>,
     pub config_location: TEdgeConfigLocation,
     pub config_repository: TEdgeConfigRepository,
     pub cloud: Cloud,
@@ -277,7 +277,7 @@ fn new_bridge(
     bridge_config: &BridgeConfig,
     cloud: &Cloud,
     common_mosquitto_config: &CommonMosquittoConfig,
-    system_command_runner: &SystemCommandRunner,
+    system_command_runner: &dyn AbstractSystemCommandRunner,
     config_location: &TEdgeConfigLocation,
 ) -> Result<(), ConnectError> {
     println!("Checking if systemd is available.\n");
@@ -390,7 +390,7 @@ fn write_bridge_config_to_file(
     Ok(())
 }
 
-fn start_and_enable_tedge_mapper_c8y(system_command_runner: &SystemCommandRunner) {
+fn start_and_enable_tedge_mapper_c8y(system_command_runner: &dyn AbstractSystemCommandRunner) {
     let mut failed = false;
 
     println!("Starting tedge-mapper service.\n");
@@ -410,7 +410,7 @@ fn start_and_enable_tedge_mapper_c8y(system_command_runner: &SystemCommandRunner
     }
 }
 
-fn start_and_enable_tedge_mapper_az(system_command_runner: &SystemCommandRunner) {
+fn start_and_enable_tedge_mapper_az(system_command_runner: &dyn AbstractSystemCommandRunner) {
     let mut failed = false;
 
     println!("Starting tedge-mapper service.\n");

--- a/tedge/src/cli/disconnect/cli.rs
+++ b/tedge/src/cli/disconnect/cli.rs
@@ -17,12 +17,14 @@ impl BuildCommand for TEdgeDisconnectBridgeCli {
     fn build_command(self, context: BuildContext) -> Result<Box<dyn Command>, crate::ConfigError> {
         let cmd = match self {
             TEdgeDisconnectBridgeCli::C8y => DisconnectBridgeCommand {
+                system_command_runner: context.system_command_runner.clone(),
                 config_location: context.config_location,
                 config_file: C8Y_CONFIG_FILENAME.into(),
                 cloud: Cloud::C8y,
                 use_mapper: true,
             },
             TEdgeDisconnectBridgeCli::Az => DisconnectBridgeCommand {
+                system_command_runner: context.system_command_runner.clone(),
                 config_location: context.config_location,
                 config_file: AZURE_CONFIG_FILENAME.into(),
                 cloud: Cloud::Azure,

--- a/tedge/src/cli/disconnect/disconnect_bridge.rs
+++ b/tedge/src/cli/disconnect/disconnect_bridge.rs
@@ -28,7 +28,7 @@ impl From<Cloud> for String {
 
 #[derive(Debug)]
 pub struct DisconnectBridgeCommand {
-    pub system_command_runner: Arc<SystemCommandRunner>,
+    pub system_command_runner: Arc<dyn AbstractSystemCommandRunner>,
     pub config_location: TEdgeConfigLocation,
     pub config_file: String,
     pub cloud: Cloud,

--- a/tedge/src/command.rs
+++ b/tedge/src/command.rs
@@ -164,7 +164,7 @@ pub trait BuildCommand {
 pub struct BuildContext {
     pub config_repository: tedge_config::TEdgeConfigRepository,
     pub config_location: tedge_config::TEdgeConfigLocation,
-    pub system_command_runner: Arc<SystemCommandRunner>,
+    pub system_command_runner: Arc<dyn AbstractSystemCommandRunner>,
 }
 
 /// The execution context of a command.

--- a/tedge/src/command.rs
+++ b/tedge/src/command.rs
@@ -1,3 +1,5 @@
+use crate::system_commands::*;
+use std::sync::Arc;
 use tedge_users::UserManager;
 
 /// A trait to be implemented by all tedge sub-commands.
@@ -162,6 +164,7 @@ pub trait BuildCommand {
 pub struct BuildContext {
     pub config_repository: tedge_config::TEdgeConfigRepository,
     pub config_location: tedge_config::TEdgeConfigLocation,
+    pub system_command_runner: Arc<SystemCommandRunner>,
 }
 
 /// The execution context of a command.

--- a/tedge/src/main.rs
+++ b/tedge/src/main.rs
@@ -1,13 +1,16 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::mem_forget)]
 
+use crate::system_commands::*;
 use anyhow::Context;
+use std::sync::Arc;
 use structopt::StructOpt;
 
 mod cli;
 mod command;
 mod error;
 mod services;
+mod system_commands;
 mod utils;
 
 type ConfigError = crate::error::TEdgeError;
@@ -31,7 +34,12 @@ fn main() -> anyhow::Result<()> {
     };
     let config_repository = tedge_config::TEdgeConfigRepository::new(tedge_config_location.clone());
 
+    let system_command_runner = Arc::new(SystemCommandRunner {
+        user_manager: context.user_manager.clone(),
+    });
+
     let build_context = BuildContext {
+        system_command_runner,
         config_repository,
         config_location: tedge_config_location,
     };

--- a/tedge/src/services/mod.rs
+++ b/tedge/src/services/mod.rs
@@ -19,7 +19,10 @@ const SYSTEMCTL_ERROR_SERVICE_NOT_LOADED: ExitCode = 5;
 pub trait SystemdService {
     const SERVICE_NAME: &'static str;
 
-    fn stop(&self, system_command_runner: &SystemCommandRunner) -> Result<(), ServicesError> {
+    fn stop(
+        &self,
+        system_command_runner: &dyn AbstractSystemCommandRunner,
+    ) -> Result<(), ServicesError> {
         let command = SystemdStopService {
             service_name: Self::SERVICE_NAME.into(),
         };
@@ -49,7 +52,10 @@ pub trait SystemdService {
     // as long as the unit has a job pending, and is only cleared when the unit is fully stopped and no jobs are pending anymore.
     // If it is intended that the file descriptor store is flushed out, too, during a restart operation an explicit
     // systemctl stop command followed by systemctl start should be issued.
-    fn restart(&self, system_command_runner: &SystemCommandRunner) -> Result<(), ServicesError> {
+    fn restart(
+        &self,
+        system_command_runner: &dyn AbstractSystemCommandRunner,
+    ) -> Result<(), ServicesError> {
         let command = SystemdRestartService {
             service_name: Self::SERVICE_NAME.into(),
         };
@@ -74,7 +80,10 @@ pub trait SystemdService {
         }
     }
 
-    fn enable(&self, system_command_runner: &SystemCommandRunner) -> Result<(), ServicesError> {
+    fn enable(
+        &self,
+        system_command_runner: &dyn AbstractSystemCommandRunner,
+    ) -> Result<(), ServicesError> {
         let command = SystemdEnableService {
             service_name: Self::SERVICE_NAME.into(),
         };
@@ -94,7 +103,10 @@ pub trait SystemdService {
         }
     }
 
-    fn disable(&self, system_command_runner: &SystemCommandRunner) -> Result<(), ServicesError> {
+    fn disable(
+        &self,
+        system_command_runner: &dyn AbstractSystemCommandRunner,
+    ) -> Result<(), ServicesError> {
         let command = SystemdDisableService {
             service_name: Self::SERVICE_NAME.into(),
         };
@@ -116,7 +128,7 @@ pub trait SystemdService {
 
     fn is_active(
         &self,
-        system_command_runner: &SystemCommandRunner,
+        system_command_runner: &dyn AbstractSystemCommandRunner,
     ) -> Result<bool, ServicesError> {
         let command = SystemdIsServiceActive {
             service_name: Self::SERVICE_NAME.into(),
@@ -177,7 +189,7 @@ pub enum ServicesError {
 }
 
 pub(crate) fn systemd_available(
-    system_command_runner: &SystemCommandRunner,
+    system_command_runner: &dyn AbstractSystemCommandRunner,
 ) -> Result<(), ServicesError> {
     match system_command_runner.run(SystemdVersion) {
         Ok(status) if status.success() => Ok(()),

--- a/tedge/src/system_commands/core.rs
+++ b/tedge/src/system_commands/core.rs
@@ -1,0 +1,34 @@
+use std::process::ExitStatus;
+
+pub trait SystemCommand {}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct SystemCommandExitStatus(ExitStatus);
+
+impl From<ExitStatus> for SystemCommandExitStatus {
+    fn from(exit_status: ExitStatus) -> Self {
+        Self(exit_status)
+    }
+}
+
+impl SystemCommandExitStatus {
+    pub fn success(&self) -> bool {
+        self.0.success()
+    }
+    pub fn code(&self) -> Option<i32> {
+        self.0.code()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SystemCommandError {
+    #[error("Insufficient permissions for running command.")]
+    InsufficientPermissions,
+
+    #[error("Failed to execute command")]
+    CommandExecutionFailed(std::io::Error),
+}
+
+pub trait RunSystemCommand<T: SystemCommand> {
+    fn run(&self, command: T) -> Result<SystemCommandExitStatus, SystemCommandError>;
+}

--- a/tedge/src/system_commands/mod.rs
+++ b/tedge/src/system_commands/mod.rs
@@ -1,0 +1,7 @@
+//! SystemCommand runner facility.
+
+mod core;
+mod system_command_runner;
+mod system_commands;
+
+pub use self::{core::*, system_command_runner::*, system_commands::*};

--- a/tedge/src/system_commands/mod.rs
+++ b/tedge/src/system_commands/mod.rs
@@ -4,4 +4,15 @@ mod core;
 mod system_command_runner;
 mod system_commands;
 
-pub use self::{core::*, system_command_runner::*, system_commands::*};
+pub trait AbstractSystemCommandRunner:
+    RunSystemCommand<SystemdStopService>
+    + RunSystemCommand<SystemdRestartService>
+    + RunSystemCommand<SystemdEnableService>
+    + RunSystemCommand<SystemdDisableService>
+    + RunSystemCommand<SystemdIsServiceActive>
+    + RunSystemCommand<SystemdVersion>
+    + std::fmt::Debug
+{
+}
+
+pub use self::{core::*, system_command_runner::SystemCommandRunner, system_commands::*};

--- a/tedge/src/system_commands/system_command_runner.rs
+++ b/tedge/src/system_commands/system_command_runner.rs
@@ -6,6 +6,8 @@ pub struct SystemCommandRunner {
     pub user_manager: UserManager,
 }
 
+impl AbstractSystemCommandRunner for SystemCommandRunner {}
+
 // We need this as `UserManager` is not `Debug`
 impl std::fmt::Debug for SystemCommandRunner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/tedge/src/system_commands/system_command_runner.rs
+++ b/tedge/src/system_commands/system_command_runner.rs
@@ -1,0 +1,89 @@
+use super::*;
+use std::process::*;
+use tedge_users::*;
+
+pub struct SystemCommandRunner {
+    pub user_manager: UserManager,
+}
+
+// We need this as `UserManager` is not `Debug`
+impl std::fmt::Debug for SystemCommandRunner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SystemCommandRunner")
+    }
+}
+
+impl RunSystemCommand<SystemdStopService> for SystemCommandRunner {
+    fn run(
+        &self,
+        command: SystemdStopService,
+    ) -> Result<SystemCommandExitStatus, SystemCommandError> {
+        let _root_guard = self.user_manager.become_user(ROOT_USER);
+        run_systemctl("stop", &command.service_name)
+    }
+}
+
+impl RunSystemCommand<SystemdRestartService> for SystemCommandRunner {
+    fn run(
+        &self,
+        command: SystemdRestartService,
+    ) -> Result<SystemCommandExitStatus, SystemCommandError> {
+        let _root_guard = self.user_manager.become_user(ROOT_USER);
+        run_systemctl("restart", &command.service_name)
+    }
+}
+
+impl RunSystemCommand<SystemdEnableService> for SystemCommandRunner {
+    fn run(
+        &self,
+        command: SystemdEnableService,
+    ) -> Result<SystemCommandExitStatus, SystemCommandError> {
+        let _root_guard = self.user_manager.become_user(ROOT_USER);
+        run_systemctl("enable", &command.service_name)
+    }
+}
+
+impl RunSystemCommand<SystemdDisableService> for SystemCommandRunner {
+    fn run(
+        &self,
+        command: SystemdDisableService,
+    ) -> Result<SystemCommandExitStatus, SystemCommandError> {
+        let _root_guard = self.user_manager.become_user(ROOT_USER);
+        run_systemctl("disable", &command.service_name)
+    }
+}
+
+impl RunSystemCommand<SystemdIsServiceActive> for SystemCommandRunner {
+    fn run(
+        &self,
+        command: SystemdIsServiceActive,
+    ) -> Result<SystemCommandExitStatus, SystemCommandError> {
+        run_systemctl("is-active", &command.service_name)
+    }
+}
+
+impl RunSystemCommand<SystemdVersion> for SystemCommandRunner {
+    fn run(&self, _command: SystemdVersion) -> Result<SystemCommandExitStatus, SystemCommandError> {
+        Command::new("systemctl")
+            .arg("version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(Into::into)
+            .map_err(SystemCommandError::CommandExecutionFailed)
+    }
+}
+
+fn run_systemctl(
+    cmd: &str,
+    service_name: &str,
+) -> Result<SystemCommandExitStatus, SystemCommandError> {
+    Command::new("systemctl")
+        .arg(cmd)
+        .arg(service_name)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(Into::into)
+        .map_err(SystemCommandError::CommandExecutionFailed)
+}

--- a/tedge/src/system_commands/system_commands.rs
+++ b/tedge/src/system_commands/system_commands.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+pub struct SystemdStopService {
+    pub service_name: String,
+}
+
+pub struct SystemdRestartService {
+    pub service_name: String,
+}
+
+pub struct SystemdEnableService {
+    pub service_name: String,
+}
+
+pub struct SystemdDisableService {
+    pub service_name: String,
+}
+
+pub struct SystemdIsServiceActive {
+    pub service_name: String,
+}
+
+pub struct SystemdVersion;
+
+impl SystemCommand for SystemdStopService {}
+impl SystemCommand for SystemdRestartService {}
+impl SystemCommand for SystemdEnableService {}
+impl SystemCommand for SystemdDisableService {}
+impl SystemCommand for SystemdIsServiceActive {}
+impl SystemCommand for SystemdVersion {}


### PR DESCRIPTION
Add `SystemCommandRunner` facility to partially hide `UserManager` implementation details.

- NOTE: This branch is based upon branch `remove-use-of-build_path_for_sudo_or_user`, so when reviewing, you are reviewing some changes twice.

- Add traits `RunSystemCommand` and `SystemCommand` (tag trait)

- Add `SystemCommandRunner` facility.

- Note that the `RunSystemCommand` implementation knows about which role
   is required for command execution, which means, the caller does not
   have to care about the role.

- This hides `UserManager` behind `SystemCommandRunner`. The concrete
   `SystemCommandRunner` implemenation can be hidden by using `dyn AbstractSystemCommandRunner` (TODO: better name).

- Remove superfluous calls to `become_user`.

- This is preparational work for other pending PRs:

    https://github.com/mneumann/thin-edge.io/tree/feature/system-command-runner
    https://github.com/mneumann/thin-edge.io/tree/feature/system-service-manager

- The SystemCommandRunner abstraction enables us to plug in a different
   SystemCommandRunner implementation, e.g. one that uses priviledge separation, without having to change any of the 
   remaining code.