### PR TITLE
[CIT-408] Add az.mapper.timestamp unit tests and refactoring in config tests

### DIFF
--- a/tedge_config/src/tedge_config.rs
+++ b/tedge_config/src/tedge_config.rs
@@ -184,7 +184,7 @@ impl ConfigSettingAccessor<AzureMapperTimestamp> for TEdgeConfig {
             .az
             .mapper_timestamp
             .map(Flag)
-            .unwrap_or_else(|| Flag(true)))
+            .unwrap_or_else(|| self.config_defaults.default_mapper_timestamp.clone()))
     }
 
     fn update(&mut self, _setting: AzureMapperTimestamp, value: Flag) -> ConfigSettingResult<()> {

--- a/tedge_config/src/tedge_config_defaults.rs
+++ b/tedge_config/src/tedge_config_defaults.rs
@@ -1,6 +1,6 @@
 use crate::models::FilePath;
-use crate::Port;
 use crate::TEdgeConfigLocation;
+use crate::{Flag, Port};
 use std::path::Path;
 
 const DEFAULT_ETC_PATH: &str = "/etc";
@@ -32,6 +32,9 @@ pub struct TEdgeConfigDefaults {
     /// Default path for c8y root certificates
     pub default_c8y_root_cert_path: FilePath,
 
+    /// Default mapper timestamp bool
+    pub default_mapper_timestamp: Flag,
+
     /// Default port for mqtt
     pub default_mqtt_port: Port,
 }
@@ -52,6 +55,7 @@ impl From<&TEdgeConfigLocation> for TEdgeConfigDefaults {
                 .into(),
             default_azure_root_cert_path: system_cert_path.clone().into(),
             default_c8y_root_cert_path: system_cert_path.into(),
+            default_mapper_timestamp: Flag(true),
             default_mqtt_port: Port(DEFAULT_PORT),
         }
     }
@@ -73,6 +77,7 @@ fn test_from_tedge_config_location() {
             ),
             default_azure_root_cert_path: FilePath::from("/etc/ssl/certs"),
             default_c8y_root_cert_path: FilePath::from("/etc/ssl/certs"),
+            default_mapper_timestamp: Flag(true),
             default_mqtt_port: Port(DEFAULT_PORT),
         }
     );


### PR DESCRIPTION
## Proposed changes

1) I completely forgot to add unit test cases for `az.mapper.timestamp`. Added those tests.
2) Did small refactoring for the key `az.mapper.timestamp`. Basically, the implementation should be the same with `mqtt.port`, however, there was inconsistency whether adding the key to `TEdgeConfigDefaults` struct. I decided to add `az.mappaer.timestamp` to there.
3) Did refactoring the existing unit tests in config. Some tests should be renamed, some tests should be merged to other tests, something was missing. I consulted with @albinsuresh.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
