### PR TITLE
Always check if c8y bridge is working

### DIFF
--- a/tests/PySys/environments/environment_c8y.py
+++ b/tests/PySys/environments/environment_c8y.py
@@ -36,6 +36,13 @@ class EnvironmentC8y(BaseTest):
             stdouterr="tedge_connect",
         )
 
+        # Test the bridge connection
+        connect = self.startProcess(
+            command=self.sudo,
+            arguments=[self.tedge, "connect", "c8y", "--test"],
+            stdouterr="tedge_connect",
+        )
+
         # Check if mosquitto is running well
         serv_mosq = self.startProcess(
             command=self.systemctl,


### PR DESCRIPTION
Signed-off-by: Michael Abel <info@abel-ikt.de>

## Proposed changes

Always check if c8y bridge is working in system tests.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

comment