### PR TITLE
Remove unstable test

### DIFF
--- a/tests/PySys/apt-plugin/apt-list-format/run.py
+++ b/tests/PySys/apt-plugin/apt-list-format/run.py
@@ -31,9 +31,6 @@ class AptPluginListTest(BaseTest):
         grep_version = open(self.output + '/dpkg_query.out', 'r').read().strip()
         self.assertGrep ("apt_plugin.out", '{"name":"grep","version":"'+ grep_version + '"}', contains=True)
 
-        # systemd is installed but should not be listed
-        self.assertGrep ("apt_plugin.out", '"name":"systemd"', contains=False)
-
     def validate_json(self):
         f = open(self.output + '/apt_plugin.out', 'r')
         lines = f.readlines()


### PR DESCRIPTION
Relaying on the fact that `systemd` is not listed by `apt list --manual-installed` is fragile.
This test has been simply removed, the list feature being tested by the install and remove tests.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
