### PR TITLE
Refactor measurement visitors

### DIFF
--- a/mapper/tedge_mapper/src/collectd_mapper/monitor.rs
+++ b/mapper/tedge_mapper/src/collectd_mapper/monitor.rs
@@ -1,7 +1,6 @@
 use clock::WallClock;
 use mqtt_client::{Client, MqttClient};
 use std::sync::Arc;
-use thin_edge_json::group::MeasurementGrouper;
 use tracing::{instrument, log::error};
 
 use crate::collectd_mapper::{
@@ -70,7 +69,8 @@ impl DeviceMonitor {
         let mqtt_client: Arc<dyn MqttClient> =
             Arc::new(Client::connect(self.device_monitor_config.mqtt_client_id, &config).await?);
 
-        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel::<MeasurementGrouper>();
+        let (sender, receiver) =
+            tokio::sync::mpsc::unbounded_channel::<thin_edge_json::group::MeasurementGroup>();
 
         let message_batch_producer = MessageBatcher::new(
             sender,

--- a/mapper/thin_edge_json/examples/tej_example.rs
+++ b/mapper/thin_edge_json/examples/tej_example.rs
@@ -7,18 +7,21 @@ fn tej_build_serialize() -> anyhow::Result<()> {
     //Produce the TEJ from raw data
     let mut grp_msg = MeasurementGrouper::new();
 
-    grp_msg.timestamp(&WallClock.now())?;
-    grp_msg.measurement(None, "temperature", 25.0)?;
-    grp_msg.measurement(Some("location"), "alti", 2100.4)?;
-    grp_msg.measurement(Some("location"), "longi", 2100.4)?;
-    grp_msg.measurement(Some("location"), "lati", 2100.4)?;
-    grp_msg.measurement(Some("location"), "alti", 2100.5)?;
+    grp_msg.visit_timestamp(WallClock.now())?;
+    grp_msg.visit_measurement("temperature", 25.0)?;
+    grp_msg.visit_start_group("location")?;
+    grp_msg.visit_measurement("alti", 2100.4)?;
+    grp_msg.visit_measurement("longi", 2100.4)?;
+    grp_msg.visit_measurement("lati", 2100.4)?;
+    grp_msg.visit_measurement("alti", 2100.5)?;
+    grp_msg.visit_end_group()?;
 
     println!("Deserialized Tej=> {:#?}", grp_msg);
 
     //Serialize the TEJ to u8 bytes
     let mut visitor = ThinEdgeJsonSerializer::new();
-    grp_msg.accept(&mut visitor)?;
+    let group = grp_msg.end()?;
+    group.accept(&mut visitor)?;
 
     println!("Serialized Tej=> {:?}", visitor.into_string()?);
     Ok(())

--- a/mapper/thin_edge_json/src/measurement.rs
+++ b/mapper/thin_edge_json/src/measurement.rs
@@ -1,116 +1,14 @@
 use chrono::offset::FixedOffset;
 use chrono::DateTime;
 
-/// The `FlatMeasurementVisitor` trait represents the capability to collect/visit a series of measurements.
+/// The `MeasurementVisitor` trait represents the capability to visit a series of measurements, possibly grouped.
 ///
-/// An implementation of this trait is a consumer to which a producer forwards the measurements one after the other.
-///
-/// ```
-/// use thin_edge_json::measurement::*;
-/// use thin_edge_json::group::MeasurementGrouper;
-/// use clock::{Clock, WallClock};
-///
-/// # fn main() -> Result<(), anyhow::Error> {
-///
-/// // A producer first needs a consumer to forward the source measurements.
-/// let mut consumer = MeasurementGrouper::new();
-///
-/// // Then the producer can forward the different measurements,
-/// // possibly attaching each measurement to a group
-/// consumer.measurement(Some("group-name"), "measurement-name", 42.0)?;
-/// consumer.measurement(None, "measurement-unrelated-to-any-group", 42.0)?;
-///
-/// // The measurements can be sourced in an order that is independent of the groups.
-/// consumer.measurement(Some("g1"), "x", 1.0)?;
-/// consumer.measurement(Some("g2"), "a", 2.0)?;
-/// consumer.measurement(Some("g1"), "y", 3.0)?;
-/// consumer.measurement(None, "k", 1.0)?;
-/// consumer.measurement(Some("g2"), "b", 4.0)?;
-///
-/// // A timestamp can be assigned to the whole measurement series
-/// consumer.timestamp(&WallClock.now())?;
-///
-/// // Note that the timestamp or a measurement can be pushed several times.
-/// // __However__, the behavior depends on the actual consumer.
-/// // Here, the consumer is a `MeasurementGrouper` that simply always peeks the latest value.
-/// consumer.timestamp(&WallClock.now())?;             // update the timestamp
-/// consumer.measurement(Some("g1"), "x", 2.0)?;       // update g1.x
-/// consumer.measurement(None, "k", 2.0)?;             // update k
-///
-/// # Ok(()) }
-/// ```
-///
-/// Here is an implementation that simply prints the series of measurements as they are produced.
+/// Here is an implementation of the `MeasurementVisitor` trait that prints the measurements:
 ///
 /// ```
 /// # use thin_edge_json::measurement::*;
 /// # use chrono::*;
-///
-/// #[derive(thiserror::Error, Debug)]
-/// pub enum MeasurementError {
-///     #[error("Unexpected time stamp within a group")]
-///     UnexpectedTimestamp,
-///
-///     #[error("Unexpected end of group")]
-///     UnexpectedEndOfGroup,
-///
-///     #[error("Unexpected start of group")]
-///     UnexpectedStartOfGroup,
-/// }
-///
-/// struct MeasurementPrinter {}
-///
-/// impl FlatMeasurementVisitor for MeasurementPrinter {
-///    type Error = MeasurementError;
-///
-///     fn timestamp(&mut self, value: &DateTime<FixedOffset>) -> Result<(), Self::Error> {
-///         Ok(println!("time = {}", value.to_rfc2822()))
-///     }
-///
-///     fn measurement(
-///         &mut self,
-///         group: Option<&str>,
-///         name: &str, value: f64
-///     ) -> Result<(), Self::Error> {
-///         if let Some(group_name) = group {
-///             Ok(println!("{}.{} = {}", group_name, name, value))
-///         } else {
-///             Ok(println!("{} = {}", name, value))
-///
-///         }
-///     }
-/// }
-/// ```
-pub trait FlatMeasurementVisitor {
-    /// Error type specific to this way of collecting measurements
-    type Error: std::error::Error + std::fmt::Debug;
-
-    /// Set the timestamp shared by all the measurements of this series
-    fn timestamp(&mut self, value: &DateTime<FixedOffset>) -> Result<(), Self::Error>;
-
-    /// Add a new measurement, possibly attached to a group
-    fn measurement(
-        &mut self,
-        group: Option<&str>,
-        name: &str,
-        value: f64,
-    ) -> Result<(), Self::Error>;
-}
-
-/// The `GroupedMeasurementVisitor` trait represents the capability
-/// to collect/visit a series of measurements that have *already* been arranged in groups.
-///
-/// This trait represents the interface between a source and a consumer of measurements
-/// with the assumptions that measurements of two different groups
-/// will never be produced in an interleaved order.
-/// Such a garanty, allows the implementation of streaming consumers.
-///
-/// Here is an implementation of the `GroupedMeasurementVisitor` trait that prints the measurememts.
-///
-/// ```
-/// # use thin_edge_json::measurement::*;
-/// # use chrono::*;
-/// struct GroupedMeasurementPrinter {
+/// struct MeasurementPrinter {
 ///     group: Option<String>,
 /// }
 ///
@@ -126,18 +24,18 @@ pub trait FlatMeasurementVisitor {
 ///     UnexpectedStartOfGroup,
 /// }
 ///
-/// impl GroupedMeasurementVisitor for GroupedMeasurementPrinter {
+/// impl MeasurementVisitor for MeasurementPrinter {
 ///     type Error = MeasurementError;
 ///
-///     fn timestamp(&mut self, value: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+///     fn visit_timestamp(&mut self, timestamp: DateTime<FixedOffset>) -> Result<(), Self::Error> {
 ///         if self.group.is_none() {
-///             Ok(println!("time = {}", value.to_rfc2822()))
+///             Ok(println!("time = {}", timestamp.to_rfc2822()))
 ///         } else {
 ///             Err(MeasurementError::UnexpectedTimestamp)
 ///         }
 ///     }
 ///
-///     fn measurement(&mut self, name: &str, value: f64) -> Result<(), Self::Error> {
+///     fn visit_measurement(&mut self, name: &str, value: f64) -> Result<(), Self::Error> {
 ///         if let Some(group_name) = self.group.as_ref() {
 ///             Ok(println!("{}.{} = {}", group_name, name, value))
 ///         } else {
@@ -145,7 +43,7 @@ pub trait FlatMeasurementVisitor {
 ///         }
 ///     }
 ///
-///     fn start_group(&mut self, group: &str) -> Result<(), Self::Error> {
+///     fn visit_start_group(&mut self, group: &str) -> Result<(), Self::Error> {
 ///         if self.group.is_none() {
 ///             self.group = Some(group.to_owned());
 ///             Ok(())
@@ -154,7 +52,7 @@ pub trait FlatMeasurementVisitor {
 ///         }
 ///     }
 ///
-///     fn end_group(&mut self) -> Result<(), Self::Error> {
+///     fn visit_end_group(&mut self) -> Result<(), Self::Error> {
 ///         if self.group.is_none() {
 ///             Err(MeasurementError::UnexpectedEndOfGroup)
 ///         } else {
@@ -164,19 +62,19 @@ pub trait FlatMeasurementVisitor {
 ///     }
 /// }
 /// ```
-pub trait GroupedMeasurementVisitor {
-    /// Error type specific to this way of collecting measurements
+pub trait MeasurementVisitor {
+    /// Error type specific to this visitor.
     type Error: std::error::Error + std::fmt::Debug;
 
-    /// Set the timestamp shared by all the measurements of this serie
-    fn timestamp(&mut self, value: DateTime<FixedOffset>) -> Result<(), Self::Error>;
+    /// Set the timestamp shared by all the measurements of this series.
+    fn visit_timestamp(&mut self, value: DateTime<FixedOffset>) -> Result<(), Self::Error>;
 
-    /// Start to gather measurements for a group
-    fn measurement(&mut self, name: &str, value: f64) -> Result<(), Self::Error>;
+    /// Add a new measurement, attached to the current group if any.
+    fn visit_measurement(&mut self, name: &str, value: f64) -> Result<(), Self::Error>;
 
-    /// Definitely end to gather measurements for the current group
-    fn start_group(&mut self, group: &str) -> Result<(), Self::Error>;
+    /// Start to gather measurements for a group.
+    fn visit_start_group(&mut self, group: &str) -> Result<(), Self::Error>;
 
-    /// Add a new measurement, attached to the current group if any
-    fn end_group(&mut self) -> Result<(), Self::Error>;
+    /// End to gather measurements for the current group.
+    fn visit_end_group(&mut self) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
## Proposed changes

* Remove FlatMeasurementVisitor in favour of GroupedMeasurementVisitor.
  Either one can be implemented by the other. Rename to just MeasurementVisitor.

  Grouping semantics (whether or not a group can be reopened for instance) depends on the concrete implementation not on the Visitor trait.

* Split MeasurementGrouper according to separation of concerns principle.

* Prefix visitor methods with "visit_". `serde` visitors use that pattern and generally, methods should name an "action".

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
