### PR TITLE
CIE-437: Use Display for the path in the certificate exists message rather than Debug

### DIFF
--- a/tedge/src/cli/certificate/error.rs
+++ b/tedge/src/cli/certificate/error.rs
@@ -10,7 +10,7 @@ use std::error::Error;
 pub enum CertError {
     #[error(
         r#"A certificate already exists and would be overwritten.
-        Existing file: {path:?}
+        Existing file: "{path}"
         Run `tedge cert remove` first to generate a new certificate.
     "#
     )]

--- a/tedge_config/src/models/file_path.rs
+++ b/tedge_config/src/models/file_path.rs
@@ -41,9 +41,6 @@ impl AsRef<Path> for FilePath {
 
 impl std::fmt::Display for FilePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.0.to_str() {
-            Some(s) => write!(f, "{}", s),
-            None => Err(std::fmt::Error),
-        }
+        write!(f, "{}", self.0.display())
     }
 }


### PR DESCRIPTION
## Proposed changes

When creating the certificate and it already exists, the error included:
```
Existing file: FilePath("/etc/tedge/device-certs/tedge-certificate.pem")
```
it's changed to:
```
Existing file: "/etc/tedge/device-certs/tedge-certificate.pem"
```

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://cumulocity.atlassian.net/browse/CIT-437
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
