### PR TITLE
Remove ExecutionContext - Inject UserManager where required

### DIFF
--- a/mapper/tedge_mapper/src/main.rs
+++ b/mapper/tedge_mapper/src/main.rs
@@ -57,7 +57,7 @@ fn initialise_logging() {
         .init();
 }
 
-fn tedge_config() -> Result<TEdgeConfig, anyhow::Error> {
+fn tedge_config() -> anyhow::Result<TEdgeConfig> {
     let config_repository = config_repository()?;
     Ok(config_repository.load()?)
 }

--- a/tedge/src/cli/certificate/cli.rs
+++ b/tedge/src/cli/certificate/cli.rs
@@ -35,6 +35,7 @@ impl BuildCommand for TEdgeCertCli {
                     id,
                     cert_path: config.query(DeviceCertPathSetting)?,
                     key_path: config.query(DeviceKeyPathSetting)?,
+                    user_manager: context.user_manager.clone(),
                 };
                 cmd.into_boxed()
             }
@@ -50,6 +51,7 @@ impl BuildCommand for TEdgeCertCli {
                 let cmd = RemoveCertCmd {
                     cert_path: config.query(DeviceCertPathSetting)?,
                     key_path: config.query(DeviceKeyPathSetting)?,
+                    user_manager: context.user_manager.clone(),
                 };
                 cmd.into_boxed()
             }

--- a/tedge/src/cli/certificate/remove.rs
+++ b/tedge/src/cli/certificate/remove.rs
@@ -1,4 +1,4 @@
-use crate::command::{Command, ExecutionContext};
+use crate::command::Command;
 use crate::utils::paths::*;
 
 use tedge_config::*;
@@ -13,6 +13,9 @@ pub struct RemoveCertCmd {
 
     /// The path of the private key to be removed
     pub key_path: FilePath,
+
+    /// The UserManager required to change effective user id.
+    pub user_manager: UserManager,
 }
 
 impl Command for RemoveCertCmd {
@@ -20,15 +23,15 @@ impl Command for RemoveCertCmd {
         "remove the device certificate".into()
     }
 
-    fn execute(&self, context: &ExecutionContext) -> Result<(), anyhow::Error> {
-        let () = self.remove_certificate(&context.user_manager)?;
+    fn execute(&self) -> anyhow::Result<()> {
+        let () = self.remove_certificate()?;
         Ok(())
     }
 }
 
 impl RemoveCertCmd {
-    fn remove_certificate(&self, user_manager: &UserManager) -> Result<(), CertError> {
-        let _user_guard = user_manager.become_user(tedge_users::BROKER_USER)?;
+    fn remove_certificate(&self) -> Result<(), CertError> {
+        let _user_guard = self.user_manager.become_user(tedge_users::BROKER_USER)?;
         std::fs::remove_file(&self.cert_path).or_else(ok_if_not_found)?;
         std::fs::remove_file(&self.key_path).or_else(ok_if_not_found)?;
 

--- a/tedge/src/cli/certificate/show.rs
+++ b/tedge/src/cli/certificate/show.rs
@@ -1,5 +1,5 @@
 use super::error::CertError;
-use crate::command::{Command, ExecutionContext};
+use crate::command::Command;
 
 use certificate::PemCertificate;
 use tedge_config::*;
@@ -15,7 +15,7 @@ impl Command for ShowCertCmd {
         "show the device certificate".into()
     }
 
-    fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+    fn execute(&self) -> anyhow::Result<()> {
         let () = self.show_certificate()?;
         Ok(())
     }

--- a/tedge/src/cli/certificate/upload.rs
+++ b/tedge/src/cli/certificate/upload.rs
@@ -1,8 +1,5 @@
 use super::error::{get_webpki_error_from_reqwest, CertError};
-use crate::{
-    command::{Command, ExecutionContext},
-    utils,
-};
+use crate::{command::Command, utils};
 
 use reqwest::{StatusCode, Url};
 use std::{io::prelude::*, path::Path};
@@ -35,7 +32,7 @@ impl Command for UploadCertCmd {
         "upload root certificate".into()
     }
 
-    fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+    fn execute(&self) -> anyhow::Result<()> {
         Ok(self.upload_certificate()?)
     }
 }

--- a/tedge/src/cli/config/commands/get.rs
+++ b/tedge/src/cli/config/commands/get.rs
@@ -1,5 +1,5 @@
 use crate::cli::config::ConfigKey;
-use crate::command::{Command, ExecutionContext};
+use crate::command::Command;
 
 pub struct GetConfigCommand {
     pub config_key: ConfigKey,
@@ -14,7 +14,7 @@ impl Command for GetConfigCommand {
         )
     }
 
-    fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+    fn execute(&self) -> anyhow::Result<()> {
         match (self.config_key.get)(&self.config) {
             Ok(value) => {
                 println!("{}", value);

--- a/tedge/src/cli/config/commands/list.rs
+++ b/tedge/src/cli/config/commands/list.rs
@@ -1,5 +1,5 @@
 use crate::cli::config::config_key::*;
-use crate::command::{Command, ExecutionContext};
+use crate::command::Command;
 use crate::ConfigError;
 use tedge_config::*;
 
@@ -15,7 +15,7 @@ impl Command for ListConfigCommand {
         "list the configuration keys and values".into()
     }
 
-    fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+    fn execute(&self) -> anyhow::Result<()> {
         if self.is_doc {
             print_config_doc(&self.config_keys);
         } else {

--- a/tedge/src/cli/config/commands/set.rs
+++ b/tedge/src/cli/config/commands/set.rs
@@ -1,5 +1,5 @@
 use crate::cli::config::ConfigKey;
-use crate::command::{Command, ExecutionContext};
+use crate::command::Command;
 use tedge_config::*;
 
 pub struct SetConfigCommand {
@@ -16,7 +16,7 @@ impl Command for SetConfigCommand {
         )
     }
 
-    fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+    fn execute(&self) -> anyhow::Result<()> {
         let mut config = self.config_repository.load()?;
         let () = (self.config_key.set)(&mut config, self.value.to_string())?;
         self.config_repository.store(&config)?;

--- a/tedge/src/cli/config/commands/unset.rs
+++ b/tedge/src/cli/config/commands/unset.rs
@@ -1,5 +1,5 @@
 use crate::cli::config::ConfigKey;
-use crate::command::{Command, ExecutionContext};
+use crate::command::Command;
 use tedge_config::*;
 
 pub struct UnsetConfigCommand {
@@ -15,7 +15,7 @@ impl Command for UnsetConfigCommand {
         )
     }
 
-    fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+    fn execute(&self) -> anyhow::Result<()> {
         let mut config = self.config_repository.load()?;
         let () = (self.config_key.unset)(&mut config)?;
         self.config_repository.store(&config)?;

--- a/tedge/src/cli/connect/command.rs
+++ b/tedge/src/cli/connect/command.rs
@@ -1,10 +1,4 @@
-use crate::{
-    cli::connect::*,
-    command::{Command, ExecutionContext},
-    system_services::*,
-    utils::paths,
-    ConfigError,
-};
+use crate::{cli::connect::*, command::Command, system_services::*, utils::paths, ConfigError};
 use mqtt_client::{Client, Message, MqttClient, Topic, TopicFilter};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -63,7 +57,7 @@ impl Command for ConnectCommand {
         }
     }
 
-    fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+    fn execute(&self) -> anyhow::Result<()> {
         let mut config = self.config_repository.load()?;
 
         if self.is_test_connection {

--- a/tedge/src/cli/disconnect/disconnect_bridge.rs
+++ b/tedge/src/cli/disconnect/disconnect_bridge.rs
@@ -45,7 +45,7 @@ impl Command for DisconnectBridgeCommand {
         format!("remove the bridge to disconnect {:?} cloud", self.cloud)
     }
 
-    fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+    fn execute(&self) -> anyhow::Result<()> {
         match self.stop_bridge() {
             Ok(()) | Err(DisconnectBridgeError::BridgeFileDoesNotExist) => Ok(()),
             Err(err) => Err(err.into()),

--- a/tedge/src/cli/mqtt/publish.rs
+++ b/tedge/src/cli/mqtt/publish.rs
@@ -1,5 +1,5 @@
 use crate::cli::mqtt::MqttError;
-use crate::command::{Command, ExecutionContext};
+use crate::command::Command;
 use futures::future::FutureExt;
 use mqtt_client::{Client, Message, MqttClient, MqttClientError, QoS, Topic};
 use std::time::Duration;
@@ -22,7 +22,7 @@ impl Command for MqttPublishCommand {
         )
     }
 
-    fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+    fn execute(&self) -> anyhow::Result<()> {
         Ok(publish(self)?)
     }
 }

--- a/tedge/src/cli/mqtt/subscribe.rs
+++ b/tedge/src/cli/mqtt/subscribe.rs
@@ -1,5 +1,5 @@
 use crate::cli::mqtt::MqttError;
-use crate::command::{Command, ExecutionContext};
+use crate::command::Command;
 use crate::utils::signals;
 use futures::future::FutureExt;
 use mqtt_client::{Client, Message, MqttClient, QoS, TopicFilter};
@@ -21,7 +21,7 @@ impl Command for MqttSubscribeCommand {
         )
     }
 
-    fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+    fn execute(&self) -> anyhow::Result<()> {
         Ok(subscribe(self)?)
     }
 }

--- a/tedge/src/command.rs
+++ b/tedge/src/command.rs
@@ -17,7 +17,7 @@ use tedge_users::UserManager;
 ///        format!("say hello to '{}'", name),
 ///     }
 ///
-///     fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+///     fn execute(&self) -> anyhow::Result<()> {
 ///        println!("Hello {}!", name};
 ///        Ok(())
 ///     }
@@ -38,7 +38,7 @@ use tedge_users::UserManager;
 ///        format!("get the value of the configuration key '{}'", self.key),
 ///     }
 ///
-///     fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+///     fn execute(&self) -> anyhow::Result<()> {
 ///        match self.config.get_config_value(self.key)? {
 ///             Some(value) => println!("{}", value),
 ///             None => eprintln!("The configuration key `{}` is not set", self.key),
@@ -62,7 +62,7 @@ use tedge_users::UserManager;
 ///        format!("set the value of the configuration key '{}' to '{}'", self.key, self.value),
 ///     }
 ///
-///     fn execute(&self, _context: &ExecutionContext) -> Result<(), anyhow::Error> {
+///     fn execute(&self) -> anyhow::Result<()> {
 ///        let mut config = TEdgeConfig::from_default_config()?;
 ///        config.set_config_value(self.key, self.value)?;
 ///        let _ = config.write_to_default_config()?;
@@ -76,19 +76,7 @@ pub trait Command {
     /// This description is displayed to the end user in case of an error, to give the context of that error.
     fn description(&self) -> String;
 
-    /// Execute this command in a given execution context.
-    ///
-    /// The execution context provides a user manager that can be used to switch to a specific user.
-    ///
-    /// ```
-    ///     fn execute(&self, context: &ExecutionContext) -> Result<(), anyhow::Error> {
-    ///        let _user_guard = context.user_manager.become_user("mosquitto")?;
-    ///
-    ///        // this code is executed on behalf of the `mosquitto` user
-    ///
-    ///        Ok(())
-    ///     }
-    /// ```
+    /// Execute this command.
     ///
     /// The errors returned by this method must be concrete `anyhow::Error` values.
     /// The simplest way to implement a specific `anyhow::Error` type is to derive the `thiserror::Error`.
@@ -102,7 +90,7 @@ pub trait Command {
     ///     UnknownKey{key: String},
     /// }
     /// ```
-    fn execute(&self, context: &ExecutionContext) -> Result<(), anyhow::Error>;
+    fn execute(&self) -> anyhow::Result<()>;
 
     /// Helper method to be used in the `BuildCommand` trait.
     ///
@@ -165,33 +153,5 @@ pub struct BuildContext {
     pub config_repository: tedge_config::TEdgeConfigRepository,
     pub config_location: tedge_config::TEdgeConfigLocation,
     pub service_manager: Arc<dyn SystemServiceManager>,
-}
-
-/// The execution context of a command.
-///
-/// It provides a user manager that can be used to switch to a specific user.
-///
-/// ```
-///     fn execute(&self, context: &ExecutionContext) -> Result<(), anyhow::Error> {
-///        let _user_guard = context.user_manager.become_user("mosquitto")?;
-///
-///        // this code is executed on behalf of the `mosquitto` user
-///
-///        Ok(())
-///     }
-/// ```
-pub struct ExecutionContext {
     pub user_manager: UserManager,
-}
-
-impl ExecutionContext {
-    /// Build a new execution context.
-    ///
-    /// Such a context MUST be created only once,
-    /// in practice in the `main()` function.
-    pub fn new() -> ExecutionContext {
-        ExecutionContext {
-            user_manager: UserManager::new(),
-        }
-    }
 }

--- a/tedge/src/main.rs
+++ b/tedge/src/main.rs
@@ -15,12 +15,12 @@ mod utils;
 
 type ConfigError = crate::error::TEdgeError;
 
-use command::{BuildCommand, BuildContext, ExecutionContext};
+use command::{BuildCommand, BuildContext};
 
 fn main() -> anyhow::Result<()> {
-    let context = ExecutionContext::new();
+    let user_manager = UserManager::new();
 
-    let _user_guard = context.user_manager.become_user(tedge_users::TEDGE_USER)?;
+    let _user_guard = user_manager.become_user(tedge_users::TEDGE_USER)?;
 
     let opt = cli::Opt::from_args();
 
@@ -37,7 +37,8 @@ fn main() -> anyhow::Result<()> {
     let build_context = BuildContext {
         config_repository,
         config_location: tedge_config_location,
-        service_manager: service_manager(context.user_manager.clone()),
+        service_manager: service_manager(user_manager.clone()),
+        user_manager,
     };
 
     let cmd = opt
@@ -45,7 +46,7 @@ fn main() -> anyhow::Result<()> {
         .build_command(build_context)
         .with_context(|| "missing configuration parameter")?;
 
-    cmd.execute(&context)
+    cmd.execute()
         .with_context(|| format!("failed to {}", cmd.description()))
 }
 


### PR DESCRIPTION
* The proper way is to inject dependencies through `BuildContext` in
  `build_command`. There is no need for an `ExecutionContext`.  All
  dependencies are now explicitly passed through the command structure.

* While there, convert `Result<T, anyhow::Error>` to just
  `anyhow::Result<T>`.

