### PR TITLE
System-Test: Increase monitoring intervall in system-test

### DIFF
--- a/tests/PySys/monitoring/monitoring_smaller_interval/run.py
+++ b/tests/PySys/monitoring/monitoring_smaller_interval/run.py
@@ -54,7 +54,7 @@ class MonitoringSmallInterval(BaseTest):
         # to initialize. This is a heuristic measure.
         # Without an additional wait we observe failures in 1% of the test
         # runs.
-        time.sleep(0.1)
+        time.sleep(0.2)
 
         for _ in range(10):
 
@@ -73,7 +73,7 @@ class MonitoringSmallInterval(BaseTest):
             )
 
             # publish every 100ms
-            time.sleep(0.1)
+            time.sleep(0.2)
 
         # wait for tedge-mapper-collectd to batch messages
         time.sleep(1)

--- a/tests/PySys/monitoring/monitoring_smaller_interval/run.py
+++ b/tests/PySys/monitoring/monitoring_smaller_interval/run.py
@@ -11,10 +11,10 @@ Given a configured system
 When we start the tedge-mapper-collectd with sudo in the background
 When we start tedge sub with sudo in the background
 When we start two publishers to publish the simulated collectd messages
-Publish the messages in 100ms interval
+Publish the messages in 200ms interval
 Wait for couple of seconds to publish couple of batch of messages
 Then we kill tedge sub with sudo as it is running with a different user account
-Then we validate the  messages in the output of tedge sub,
+Then we validate the messages in the output of tedge sub,
 
 """
 


### PR DESCRIPTION
## Proposed changes

Increase the monitoring interval from 0.1s to 0.2 s as the test is failing sometimes with 0.1s intervals.
This just makes the test pass again. The requirement is unclear.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
