### PR TITLE
[CIT-506] Use nanoid to generate request ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -1192,6 +1192,8 @@ dependencies = [
 name = "json_sm"
 version = "0.2.3"
 dependencies = [
+ "nanoid",
+ "regex",
  "serde",
  "serde_json",
  "thiserror",
@@ -1258,9 +1260,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memmap"
@@ -1423,6 +1425,15 @@ dependencies = [
  "safemem",
  "tempfile",
  "twoway",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand 0.8.3",
 ]
 
 [[package]]
@@ -1986,9 +1997,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2007,9 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"

--- a/sm/json_sm/Cargo.toml
+++ b/sm/json_sm/Cargo.toml
@@ -9,6 +9,10 @@ description = "json_sm defines the thin-edge json extension for software managem
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+nanoid = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
+
+[dev-dependencies]
+regex = "1.5"

--- a/sm/json_sm/src/lib.rs
+++ b/sm/json_sm/src/lib.rs
@@ -37,24 +37,24 @@ mod tests {
 
     #[test]
     fn creating_a_software_list_request() {
-        let request = SoftwareListRequest::new(1);
+        let request = SoftwareListRequest::new("1");
 
-        let expected_json = r#"{"id":1}"#;
+        let expected_json = r#"{"id":"1"}"#;
         let actual_json = request.to_json().expect("Failed to serialize");
         assert_eq!(actual_json, expected_json);
     }
 
     #[test]
     fn using_a_software_list_request() {
-        let json_request = r#"{"id":123}"#;
+        let json_request = r#"{"id":"123"}"#;
         let request = SoftwareListRequest::from_json(json_request).expect("Failed to deserialize");
 
-        assert_eq!(request.id, 123);
+        assert_eq!(request.id, "123");
     }
 
     #[test]
     fn creating_a_software_list_response() {
-        let request = SoftwareListRequest::new(1);
+        let request = SoftwareListRequest::new("1");
         let mut response = SoftwareListResponse::new(&request);
 
         response.add_modules(
@@ -98,7 +98,7 @@ mod tests {
         );
 
         let expected_json = r#"{
-            "id":1,
+            "id":"1",
             "status":"successful",
             "currentSoftwareList":[
                 {"type":"debian", "modules":[
@@ -118,7 +118,7 @@ mod tests {
     #[test]
     fn using_a_software_list_response() {
         let json_response = r#"{
-            "id": 123,
+            "id": "123",
             "status": "successful",
             "currentSoftwareList":[
                 {"type":"debian", "modules":[
@@ -135,7 +135,7 @@ mod tests {
         let response =
             SoftwareListResponse::from_json(json_response).expect("Failed to deserialize");
 
-        assert_eq!(response.id(), 123);
+        assert_eq!(response.id(), "123");
         assert_eq!(response.status(), SoftwareOperationStatus::Successful);
         assert_eq!(response.error(), None);
 
@@ -179,13 +179,13 @@ mod tests {
 
     #[test]
     fn creating_a_software_list_error() {
-        let request = SoftwareListRequest::new(123);
+        let request = SoftwareListRequest::new("123");
         let mut response = SoftwareListResponse::new(&request);
 
         response.set_error("Request_timed-out");
 
         let expected_json = r#"{
-            "id": 123,
+            "id": "123",
             "status": "failed",
             "reason": "Request_timed-out"
         }"#;
@@ -197,14 +197,14 @@ mod tests {
     #[test]
     fn using_a_software_list_error() {
         let json_response = r#"{
-            "id": 123,
+            "id": "123",
             "status": "failed",
             "reason": "Request timed-out"
         }"#;
         let response =
             SoftwareListResponse::from_json(json_response).expect("Failed to deserialize");
 
-        assert_eq!(response.id(), 123);
+        assert_eq!(response.id(), "123");
         assert_eq!(response.status(), SoftwareOperationStatus::Failed);
         assert_eq!(response.error(), Some("Request timed-out".into()));
         assert_eq!(response.modules(), vec![]);
@@ -212,7 +212,7 @@ mod tests {
 
     #[test]
     fn creating_a_software_update_request() {
-        let mut request = SoftwareUpdateRequest::new(123);
+        let mut request = SoftwareUpdateRequest::new("123");
 
         request.add_updates(
             "debian",
@@ -254,7 +254,7 @@ mod tests {
         );
 
         let expected_json = r#"{
-            "id": 123,
+            "id": "123",
             "updateList": [
                 {
                     "type": "debian",
@@ -436,7 +436,7 @@ mod tests {
     #[test]
     fn using_a_software_update_request() {
         let json_request = r#"{
-            "id": 123,
+            "id": "123",
             "updateList": [
                 {
                     "type": "debian",
@@ -474,7 +474,7 @@ mod tests {
         let request =
             SoftwareUpdateRequest::from_json(json_request).expect("Failed to deserialize");
 
-        assert_eq!(request.id, 123);
+        assert_eq!(request.id, "123");
 
         assert_eq!(
             request.modules_types(),
@@ -523,11 +523,11 @@ mod tests {
 
     #[test]
     fn creating_a_software_update_response() {
-        let request = SoftwareUpdateRequest::new(123);
+        let request = SoftwareUpdateRequest::new("123");
         let response = SoftwareUpdateResponse::new(&request);
 
         let expected_json = r#"{
-            "id": 123,
+            "id": "123",
             "status": "executing"
         }"#;
 
@@ -538,13 +538,13 @@ mod tests {
     #[test]
     fn using_a_software_update_executing_response() {
         let json_response = r#"{
-            "id": 123,
+            "id": "123",
             "status": "executing"
         }"#;
         let response =
             SoftwareUpdateResponse::from_json(json_response).expect("Failed to deserialize");
 
-        assert_eq!(response.id(), 123);
+        assert_eq!(response.id(), "123".to_string());
         assert_eq!(response.status(), SoftwareOperationStatus::Executing);
         assert_eq!(response.error(), None);
         assert_eq!(response.modules(), vec![]);
@@ -552,7 +552,7 @@ mod tests {
 
     #[test]
     fn finalizing_a_software_update_response() {
-        let request = SoftwareUpdateRequest::new(123);
+        let request = SoftwareUpdateRequest::new("123");
         let mut response = SoftwareUpdateResponse::new(&request);
 
         response.add_modules(
@@ -592,7 +592,7 @@ mod tests {
         );
 
         let expected_json = r#"{
-            "id": 123,
+            "id": "123",
             "status": "successful",
             "currentSoftwareList": [
                 {
@@ -630,7 +630,7 @@ mod tests {
 
     #[test]
     fn finalizing_a_software_update_error() {
-        let request = SoftwareUpdateRequest::new(123);
+        let request = SoftwareUpdateRequest::new("123");
         let mut response = SoftwareUpdateResponse::new(&request);
 
         response.add_errors(
@@ -688,7 +688,7 @@ mod tests {
         );
 
         let expected_json = r#"{
-            "id": 123,
+            "id": "123",
             "status":"failed",
             "reason":"2 errors: fail to install [ collectd ] fail to remove [ mongodb ]",
             "currentSoftwareList": [
@@ -751,7 +751,7 @@ mod tests {
     #[test]
     fn using_a_software_update_response() {
         let json_response = r#"{
-            "id": 123,
+            "id": "123",
             "status":"failed",
             "reason":"2 errors: fail to install [ collectd ] fail to remove [ mongodb ]",
             "currentSoftwareList": [
@@ -806,7 +806,7 @@ mod tests {
         let response =
             SoftwareUpdateResponse::from_json(json_response).expect("Failed to deserialize");
 
-        assert_eq!(response.id(), 123);
+        assert_eq!(response.id(), "123");
         assert_eq!(response.status(), SoftwareOperationStatus::Failed);
         assert_eq!(
             response.error(),

--- a/sm/json_sm/src/lib.rs
+++ b/sm/json_sm/src/lib.rs
@@ -12,6 +12,7 @@ pub use software::*;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use regex::Regex;
 
     #[test]
     fn topic_names() {
@@ -37,11 +38,21 @@ mod tests {
 
     #[test]
     fn creating_a_software_list_request() {
-        let request = SoftwareListRequest::new("1");
+        let request = SoftwareListRequest::new_with_id("1");
 
         let expected_json = r#"{"id":"1"}"#;
         let actual_json = request.to_json().expect("Failed to serialize");
         assert_eq!(actual_json, expected_json);
+    }
+
+    #[test]
+    fn creating_a_software_list_request_with_generated_id() {
+        let request = SoftwareListRequest::new();
+        let generated_id = request.id;
+
+        // The generated id is a nanoid of 21 characters from A-Za-z0-9_~
+        let re = Regex::new(r"[A-Za-z0-9_~-]{21,21}").unwrap();
+        assert!(re.is_match(&generated_id));
     }
 
     #[test]
@@ -54,7 +65,7 @@ mod tests {
 
     #[test]
     fn creating_a_software_list_response() {
-        let request = SoftwareListRequest::new("1");
+        let request = SoftwareListRequest::new_with_id("1");
         let mut response = SoftwareListResponse::new(&request);
 
         response.add_modules(
@@ -179,7 +190,7 @@ mod tests {
 
     #[test]
     fn creating_a_software_list_error() {
-        let request = SoftwareListRequest::new("123");
+        let request = SoftwareListRequest::new_with_id("123");
         let mut response = SoftwareListResponse::new(&request);
 
         response.set_error("Request_timed-out");
@@ -212,7 +223,7 @@ mod tests {
 
     #[test]
     fn creating_a_software_update_request() {
-        let mut request = SoftwareUpdateRequest::new("123");
+        let mut request = SoftwareUpdateRequest::new_with_id("123");
 
         request.add_updates(
             "debian",
@@ -295,7 +306,7 @@ mod tests {
 
     #[test]
     fn creating_a_software_update_request_grouping_updates_per_plugin() {
-        let mut request = SoftwareUpdateRequest::new(123);
+        let mut request = SoftwareUpdateRequest::new_with_id("123");
 
         request.add_update(SoftwareModuleUpdate::install(SoftwareModule {
             module_type: Some("debian".to_string()),
@@ -326,7 +337,7 @@ mod tests {
         }));
 
         let expected_json = r#"{
-            "id": 123,
+            "id": "123",
             "updateList": [
                 {
                     "type": "debian",
@@ -367,7 +378,7 @@ mod tests {
 
     #[test]
     fn creating_a_software_update_request_grouping_updates_per_plugin_using_default() {
-        let mut request = SoftwareUpdateRequest::new(123);
+        let mut request = SoftwareUpdateRequest::new_with_id("123");
 
         request.add_update(SoftwareModuleUpdate::install(SoftwareModule {
             module_type: None, // I.e. default
@@ -395,7 +406,7 @@ mod tests {
         }));
 
         let expected_json = r#"{
-            "id": 123,
+            "id": "123",
             "updateList": [
                 {
                     "type": "default",
@@ -431,6 +442,16 @@ mod tests {
         }"#;
         let actual_json = request.to_json().expect("Failed to serialize");
         assert_eq!(actual_json, remove_whitespace(expected_json));
+    }
+
+    #[test]
+    fn creating_a_software_update_request_with_generated_id() {
+        let request = SoftwareUpdateRequest::new();
+        let generated_id = request.id;
+
+        // The generated id is a nanoid of 21 characters from A-Za-z0-9_~
+        let re = Regex::new(r"[A-Za-z0-9_~-]{21,21}").unwrap();
+        assert!(re.is_match(&generated_id));
     }
 
     #[test]
@@ -523,7 +544,7 @@ mod tests {
 
     #[test]
     fn creating_a_software_update_response() {
-        let request = SoftwareUpdateRequest::new("123");
+        let request = SoftwareUpdateRequest::new_with_id("123");
         let response = SoftwareUpdateResponse::new(&request);
 
         let expected_json = r#"{
@@ -552,7 +573,7 @@ mod tests {
 
     #[test]
     fn finalizing_a_software_update_response() {
-        let request = SoftwareUpdateRequest::new("123");
+        let request = SoftwareUpdateRequest::new_with_id("123");
         let mut response = SoftwareUpdateResponse::new(&request);
 
         response.add_modules(
@@ -630,7 +651,7 @@ mod tests {
 
     #[test]
     fn finalizing_a_software_update_error() {
-        let request = SoftwareUpdateRequest::new("123");
+        let request = SoftwareUpdateRequest::new_with_id("123");
         let mut response = SoftwareUpdateResponse::new(&request);
 
         response.add_errors(

--- a/sm/json_sm/src/messages.rs
+++ b/sm/json_sm/src/messages.rs
@@ -1,4 +1,5 @@
 use crate::{error::SoftwareError, software::*};
+use nanoid::nanoid;
 use serde::{Deserialize, Serialize};
 
 /// All the messages are serialized using json.
@@ -34,7 +35,12 @@ pub struct SoftwareListRequest {
 impl<'a> Jsonify<'a> for SoftwareListRequest {}
 
 impl SoftwareListRequest {
-    pub fn new(id: &str) -> SoftwareListRequest {
+    pub fn new() -> SoftwareListRequest {
+        let id = nanoid!();
+        SoftwareListRequest { id }
+    }
+
+    pub fn new_with_id(id: &str) -> SoftwareListRequest {
         SoftwareListRequest { id: id.to_string() }
     }
 
@@ -55,7 +61,15 @@ pub struct SoftwareUpdateRequest {
 impl<'a> Jsonify<'a> for SoftwareUpdateRequest {}
 
 impl SoftwareUpdateRequest {
-    pub fn new(id: &str) -> SoftwareUpdateRequest {
+    pub fn new() -> SoftwareUpdateRequest {
+        let id = nanoid!();
+        SoftwareUpdateRequest {
+            id,
+            update_list: vec![],
+        }
+    }
+
+    pub fn new_with_id(id: &str) -> SoftwareUpdateRequest {
         SoftwareUpdateRequest {
             id: id.to_string(),
             update_list: vec![],
@@ -305,7 +319,6 @@ pub struct SoftwareModuleItem {
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SoftwareRequestResponse {
-    // TODO: Is this the right approach, maybe nanoid?
     pub id: String,
     pub status: SoftwareOperationStatus,
 

--- a/sm/json_sm/src/messages.rs
+++ b/sm/json_sm/src/messages.rs
@@ -28,14 +28,14 @@ where
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct SoftwareListRequest {
-    pub id: usize,
+    pub id: String,
 }
 
 impl<'a> Jsonify<'a> for SoftwareListRequest {}
 
 impl SoftwareListRequest {
-    pub fn new(id: usize) -> SoftwareListRequest {
-        SoftwareListRequest { id }
+    pub fn new(id: &str) -> SoftwareListRequest {
+        SoftwareListRequest { id: id.to_string() }
     }
 
     pub fn topic_name() -> &'static str {
@@ -48,16 +48,16 @@ impl SoftwareListRequest {
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct SoftwareUpdateRequest {
-    pub id: usize,
+    pub id: String,
     pub update_list: Vec<SoftwareRequestResponseSoftwareList>,
 }
 
 impl<'a> Jsonify<'a> for SoftwareUpdateRequest {}
 
 impl SoftwareUpdateRequest {
-    pub fn new(id: usize) -> SoftwareUpdateRequest {
+    pub fn new(id: &str) -> SoftwareUpdateRequest {
         SoftwareUpdateRequest {
-            id,
+            id: id.to_string(),
             update_list: vec![],
         }
     }
@@ -170,7 +170,7 @@ impl<'a> Jsonify<'a> for SoftwareListResponse {}
 impl SoftwareListResponse {
     pub fn new(req: &SoftwareListRequest) -> SoftwareListResponse {
         SoftwareListResponse {
-            response: SoftwareRequestResponse::new(req.id, SoftwareOperationStatus::Executing),
+            response: SoftwareRequestResponse::new(&req.id, SoftwareOperationStatus::Executing),
         }
     }
 
@@ -193,8 +193,8 @@ impl SoftwareListResponse {
         self.response.reason = Some(reason.into());
     }
 
-    pub fn id(&self) -> usize {
-        self.response.id
+    pub fn id(&self) -> &str {
+        &self.response.id
     }
 
     pub fn status(&self) -> SoftwareOperationStatus {
@@ -225,7 +225,7 @@ impl<'a> Jsonify<'a> for SoftwareUpdateResponse {}
 impl SoftwareUpdateResponse {
     pub fn new(req: &SoftwareUpdateRequest) -> SoftwareUpdateResponse {
         SoftwareUpdateResponse {
-            response: SoftwareRequestResponse::new(req.id, SoftwareOperationStatus::Executing),
+            response: SoftwareRequestResponse::new(&req.id, SoftwareOperationStatus::Executing),
             errors: vec![],
         }
     }
@@ -256,8 +256,8 @@ impl SoftwareUpdateResponse {
         );
     }
 
-    pub fn id(&self) -> usize {
-        self.response.id
+    pub fn id(&self) -> &str {
+        &self.response.id
     }
 
     pub fn status(&self) -> SoftwareOperationStatus {
@@ -306,7 +306,7 @@ pub struct SoftwareModuleItem {
 #[serde(rename_all = "camelCase")]
 pub struct SoftwareRequestResponse {
     // TODO: Is this the right approach, maybe nanoid?
-    pub id: usize,
+    pub id: String,
     pub status: SoftwareOperationStatus,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -322,9 +322,9 @@ pub struct SoftwareRequestResponse {
 impl<'a> Jsonify<'a> for SoftwareRequestResponse {}
 
 impl SoftwareRequestResponse {
-    pub fn new(id: usize, status: SoftwareOperationStatus) -> Self {
+    pub fn new(id: &str, status: SoftwareOperationStatus) -> Self {
         SoftwareRequestResponse {
-            id,
+            id: id.to_string(),
             status,
             current_software_list: None,
             reason: None,
@@ -491,8 +491,10 @@ mod tests {
 
     #[test]
     fn serde_software_request_list() {
-        let request = SoftwareListRequest { id: 1234 };
-        let expected_json = r#"{"id":1234}"#;
+        let request = SoftwareListRequest {
+            id: "1234".to_string(),
+        };
+        let expected_json = r#"{"id":"1234"}"#;
 
         let actual_json = request.to_json().expect("Failed to serialize");
 
@@ -540,11 +542,11 @@ mod tests {
         };
 
         let request = SoftwareUpdateRequest {
-            id: 1234,
+            id: "1234".to_string(),
             update_list: vec![debian_list, docker_list],
         };
 
-        let expected_json = r#"{"id":1234,"updateList":[{"type":"debian","modules":[{"name":"debian1","version":"0.0.1","action":"install"},{"name":"debian2","version":"0.0.2","action":"install"}]},{"type":"docker","modules":[{"name":"docker1","version":"0.0.1","url":"test.com","action":"remove"}]}]}"#;
+        let expected_json = r#"{"id":"1234","updateList":[{"type":"debian","modules":[{"name":"debian1","version":"0.0.1","action":"install"},{"name":"debian2","version":"0.0.2","action":"install"}]},{"type":"docker","modules":[{"name":"docker1","version":"0.0.1","url":"test.com","action":"remove"}]}]}"#;
 
         let actual_json = request.to_json().expect("Fail to serialize the request");
         assert_eq!(actual_json, expected_json);
@@ -557,14 +559,14 @@ mod tests {
     #[test]
     fn serde_software_list_empty_successful() {
         let request = SoftwareRequestResponse {
-            id: 1234,
+            id: "1234".to_string(),
             status: SoftwareOperationStatus::Successful,
             reason: None,
             current_software_list: Some(vec![]),
             failures: vec![],
         };
 
-        let expected_json = r#"{"id":1234,"status":"successful","currentSoftwareList":[]}"#;
+        let expected_json = r#"{"id":"1234","status":"successful","currentSoftwareList":[]}"#;
 
         let actual_json = request.to_json().expect("Fail to serialize the request");
         assert_eq!(actual_json, expected_json);
@@ -590,14 +592,14 @@ mod tests {
         };
 
         let request = SoftwareRequestResponse {
-            id: 1234,
+            id: "1234".to_string(),
             status: SoftwareOperationStatus::Successful,
             reason: None,
             current_software_list: Some(vec![docker_module1]),
             failures: vec![],
         };
 
-        let expected_json = r#"{"id":1234,"status":"successful","currentSoftwareList":[{"type":"debian","modules":[{"name":"debian1","version":"0.0.1"}]}]}"#;
+        let expected_json = r#"{"id":"1234","status":"successful","currentSoftwareList":[{"type":"debian","modules":[{"name":"debian1","version":"0.0.1"}]}]}"#;
 
         let actual_json = request.to_json().expect("Fail to serialize the request");
         assert_eq!(actual_json, expected_json);


### PR DESCRIPTION
## Proposed changes

* Change the type of request ids from usize to string.
* Introduce two constructors per request type:
    * `::new()` use nanoid to generate the id of the request
    * `::new_with_id()` use the given id.
* The responses are built after a request re-using the request id

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
