### PR TITLE
[CIT-510] Add type option support to apt plugin

### DIFF
--- a/sm/plugins/tedge_apt_plugin/src/main.rs
+++ b/sm/plugins/tedge_apt_plugin/src/main.rs
@@ -55,7 +55,7 @@ impl InternalError {
 fn run(operation: PluginOp) -> Result<std::process::ExitStatus, InternalError> {
     let status = match operation {
         PluginOp::Type {} => {
-            println!("debian");
+            println!(r#"{{"type": "apt"}}"#);
             let status = ExitStatus::from_raw(0);
             status
         }

--- a/sm/plugins/tedge_apt_plugin/src/main.rs
+++ b/sm/plugins/tedge_apt_plugin/src/main.rs
@@ -1,4 +1,7 @@
-use std::process::{Command, Stdio};
+use std::{
+    os::unix::prelude::ExitStatusExt,
+    process::{Command, ExitStatus, Stdio},
+};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
@@ -11,6 +14,9 @@ struct AptCli {
 pub enum PluginOp {
     /// List all the installed modules
     List,
+
+    /// Print the software module type that can be handled by this plugin
+    Type,
 
     /// Install a module
     Install {
@@ -48,6 +54,12 @@ impl InternalError {
 
 fn run(operation: PluginOp) -> Result<std::process::ExitStatus, InternalError> {
     let status = match operation {
+        PluginOp::Type {} => {
+            println!("debian");
+            let status = ExitStatus::from_raw(0);
+            status
+        }
+
         PluginOp::List {} => {
             let apt = Command::new("apt")
                 .args(vec!["--manual-installed", "list"])

--- a/tests/PySys/apt_plugin/apt_type_option/pysystest.xml
+++ b/tests/PySys/apt_plugin/apt_type_option/pysystest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pysystest type="auto">
+
+    <description>
+        <title>Validate apt plugin type option output</title>
+        <purpose><![CDATA[
+]]>
+        </purpose>
+    </description>
+    <classification>
+        <groups inherit="true">
+            <group></group>
+        </groups>
+        <modes inherit="true">
+        </modes>
+    </classification>
+    <data>
+        <class name="AptPluginTypeOption" module="run"/>
+    </data>
+    <traceability>
+        <requirements>
+            <requirement id=""/>
+        </requirements>
+    </traceability>
+</pysystest>

--- a/tests/PySys/apt_plugin/apt_type_option/run.py
+++ b/tests/PySys/apt_plugin/apt_type_option/run.py
@@ -1,0 +1,12 @@
+from environment_apt_plugin import AptPlugin
+import sys
+
+sys.path.append("apt_plugin")
+
+
+class AptPluginTypeOption(AptPlugin):
+    def execute(self):
+        self.plugin_cmd("type", "type_output", 1)
+
+    def validate(self):
+        self.assertGrep("type_output.out", "debian")

--- a/tests/PySys/apt_plugin/apt_type_option/run.py
+++ b/tests/PySys/apt_plugin/apt_type_option/run.py
@@ -1,12 +1,17 @@
-from environment_apt_plugin import AptPlugin
+import json
 import sys
 
 sys.path.append("apt_plugin")
+from environment_apt_plugin import AptPlugin
 
 
 class AptPluginTypeOption(AptPlugin):
     def execute(self):
-        self.plugin_cmd("type", "type_output", 1)
+        self.plugin_cmd("type", "type_output", 0)
 
     def validate(self):
-        self.assertGrep("type_output.out", "debian")
+        output_file = open(self.output + "/type_output.out", "r")
+        json_output = json.load(output_file)
+
+        self.assertTrue(len(json_output) == 1)
+        self.assertTrue(json_output["type"] == "apt")


### PR DESCRIPTION
## Proposed changes

Add the `type` option support to the apt plugin

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
