### PR TITLE
Features/cit 525/enable sm services

### DIFF
--- a/configuration/debian/tedge_agent/postinst
+++ b/configuration/debian/tedge_agent/postinst
@@ -12,4 +12,16 @@ if ! getent passwd tedge-agent > /dev/null; then
     adduser --quiet --system --no-create-home --ingroup tedge-agent --shell /usr/sbin/nologin tedge-agent
 fi
 
+### Create file in /etc/sudoers.d directory
+echo "%tedge-agent   ALL = (ALL) /usr/bin/tedge_agent" > /etc/sudoers.d/tedge-agent
+
+if [ -f "/etc/sudoers.d/010_pi-nopasswd" ]; then
+    echo "%tedge-agent   ALL = (ALL) NOPASSWD: /usr/bin/tedge_agent" > /etc/sudoers.d/tedge-agent-nopasswd
+fi
+
+## Enable the sm services if the device is connected to c8y cloud
+if [ -f "/etc/tedge/mosquitto-conf/c8y-bridge.conf" ]; then 
+    systemctl start tedge-agent.service
+    systemctl start tedge-mapper-sm-c8y.service    
+fi
 #DEBHELPER#

--- a/tedge/src/cli/connect/command.rs
+++ b/tedge/src/cli/connect/command.rs
@@ -338,6 +338,21 @@ fn new_bridge(
         }
     }
 
+    match cloud {
+        Cloud::C8y => {
+            println!("Checking if tedge-agent and sm-c8y mapper are installed.\n");
+            if which("tedge_agent").is_err() && which("tedge_mapper").is_err() {
+                println!("Warning: tedge_mapper is not installed. We recommend to install it.\n");
+            } else {
+                service_manager
+                    .start_and_enable_service(SystemService::TEdgeSMMapperC8Y, std::io::stdout());
+                service_manager
+                    .start_and_enable_service(SystemService::TEdgeSMAgent, std::io::stdout());
+            }
+        }
+        Cloud::Azure => todo!(),
+    }
+
     Ok(())
 }
 

--- a/tedge/src/cli/disconnect/disconnect_bridge.rs
+++ b/tedge/src/cli/disconnect/disconnect_bridge.rs
@@ -70,6 +70,23 @@ impl DisconnectBridgeCommand {
             self.service_manager()
                 .stop_and_disable_service(self.cloud.dependent_mapper_service(), std::io::stdout());
         }
+        match self.cloud {
+            Cloud::C8y => {
+                if which("tedge_agent").is_err() && which("tedge_mapper").is_err() {
+                    println!(
+                        "Warning: tedge_mapper is not installed. We recommend to install it.\n"
+                    );
+                } else {
+                    self.service_manager().stop_and_disable_service(
+                        SystemService::TEdgeSMMapperC8Y,
+                        std::io::stdout(),
+                    );
+                    self.service_manager()
+                        .stop_and_disable_service(SystemService::TEdgeSMAgent, std::io::stdout());
+                }
+            }
+            _ => todo!(),
+        }
 
         Ok(())
     }

--- a/tedge/src/system_services/managers/bsd.rs
+++ b/tedge/src/system_services/managers/bsd.rs
@@ -181,5 +181,7 @@ fn as_service_name(service: SystemService) -> &'static str {
         SystemService::Mosquitto => "mosquitto",
         SystemService::TEdgeMapperAz => "tedge-mapper-az",
         SystemService::TEdgeMapperC8y => "tedge-mapper-c8y",
+        SystemService::TEdgeSMMapperC8Y => "tedge-mapper-sm-c8y",
+        SystemService::TEdgeSMAgent => "tedge-agent",
     }
 }

--- a/tedge/src/system_services/managers/openrc.rs
+++ b/tedge/src/system_services/managers/openrc.rs
@@ -179,5 +179,7 @@ fn as_service_name(service: SystemService) -> &'static str {
         SystemService::Mosquitto => "mosquitto",
         SystemService::TEdgeMapperAz => "tedge-mapper-az",
         SystemService::TEdgeMapperC8y => "tedge-mapper-c8y",
+        SystemService::TEdgeSMMapperC8Y => "tedge-mapper-sm-c8y",
+        SystemService::TEdgeSMAgent => "tedge-agent",
     }
 }

--- a/tedge/src/system_services/managers/systemd.rs
+++ b/tedge/src/system_services/managers/systemd.rs
@@ -146,6 +146,8 @@ fn as_service_name(service: SystemService) -> &'static str {
         SystemService::Mosquitto => "mosquitto",
         SystemService::TEdgeMapperAz => "tedge-mapper-az",
         SystemService::TEdgeMapperC8y => "tedge-mapper-c8y",
+        SystemService::TEdgeSMMapperC8Y => "tedge-mapper-sm-c8y",
+        SystemService::TEdgeSMAgent => "tedge-agent",
     }
 }
 fn cmd_nullstdio_args_with_code(command: &str, args: &[&str]) -> Result<ExitStatus, Error> {

--- a/tedge/src/system_services/services.rs
+++ b/tedge/src/system_services/services.rs
@@ -7,6 +7,10 @@ pub enum SystemService {
     TEdgeMapperAz,
     /// Cumulocity TEdge mapper
     TEdgeMapperC8y,
+    /// Cumulocity SM TEdge mapper
+    TEdgeSMMapperC8Y,
+    /// TEdge SM agent
+    TEdgeSMAgent,
 }
 
 impl std::fmt::Display for SystemService {
@@ -15,6 +19,8 @@ impl std::fmt::Display for SystemService {
             Self::Mosquitto => "mosquitto",
             Self::TEdgeMapperAz => "tedge-mapper-az",
             Self::TEdgeMapperC8y => "tedge-mapper-c8y",
+            Self::TEdgeSMMapperC8Y => "tedge-mapper-sm-c8y",
+            Self::TEdgeSMAgent => "tedge-agent",
         };
         write!(f, "{}", s)
     }


### PR DESCRIPTION
## Proposed changes

Code changes to enable the Software Management services (sm-agent and sm-mapper) on

"tedge connect c8y" and disable on "tedge disconnect c8y"
 Also, if the device is connected to c8y cloud, then enable the sm services post-installation of sm-agent.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
