### PR TITLE
Make the workflow (temporarily) continue even when tarpaulin fails

### DIFF
--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -99,6 +99,7 @@ jobs:
     name: Run cargo tarpaulin
     runs-on: Ubuntu-20.04
     needs: [cargo-fmt, cargo-clippy]
+    continue-on-error: true # Only temporarily !!!
 
     steps:
 


### PR DESCRIPTION
Signed-off-by: Michael Abel <info@abel-ikt.de>

## Proposed changes

Make the workflow (temporarily) continue even when tarpaulin fails.
Without that we have four failing tests that fail in tarpaulin but not in cargo test.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactorings that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://cumulocity.atlassian.net/browse/CIT-551

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
