### PR TITLE
Fix the exit status of `tedge mqtt pub` on error

### DIFF
--- a/tedge/src/cli/mqtt/error.rs
+++ b/tedge/src/cli/mqtt/error.rs
@@ -12,6 +12,6 @@ pub enum MqttError {
     #[error("The input QoS should be 0, 1, or 2")]
     InvalidQoSError,
 
-    #[error("{0}\n\nHint: Is MQTT server running?")]
+    #[error("MQTT connection error: {0}\n\nHint: Is MQTT server running?")]
     ServerError(String),
 }

--- a/tedge/src/cli/mqtt/error.rs
+++ b/tedge/src/cli/mqtt/error.rs
@@ -11,4 +11,7 @@ pub enum MqttError {
 
     #[error("The input QoS should be 0, 1, or 2")]
     InvalidQoSError,
+
+    #[error("{0}\n\nHint: Is MQTT server running?")]
+    ServerError(String),
 }

--- a/tedge/src/cli/mqtt/publish.rs
+++ b/tedge/src/cli/mqtt/publish.rs
@@ -81,7 +81,7 @@ fn publish(cmd: &MqttPublishCommand) -> Result<(), MqttError> {
         eprintln!("ERROR: the message has not been acknowledged");
     }
 
-   client.disconnect()?;
+    client.disconnect()?;
     if let Some(err) = any_error {
         Err(err)
     } else {

--- a/tedge/src/cli/mqtt/publish.rs
+++ b/tedge/src/cli/mqtt/publish.rs
@@ -38,6 +38,7 @@ fn publish(cmd: &MqttPublishCommand) -> Result<(), MqttError> {
     let (mut client, mut connection) = rumqttc::Client::new(options, DEFAULT_QUEUE_CAPACITY);
     let mut published = false;
     let mut acknowledged = false;
+    let mut any_error = None;
 
     client.publish(&cmd.topic, cmd.qos, retain_flag, payload)?;
 
@@ -63,10 +64,11 @@ fn publish(cmd: &MqttPublishCommand) -> Result<(), MqttError> {
                 }
             }
             Ok(Event::Incoming(Incoming::Disconnect)) => {
+                any_error = Some(MqttError::ServerError("Disconnected".to_string()));
                 break;
             }
             Err(err) => {
-                eprintln!("ERROR: {:?}", err);
+                any_error = Some(MqttError::ServerError(err.to_string()));
                 break;
             }
             _ => {}
@@ -79,6 +81,10 @@ fn publish(cmd: &MqttPublishCommand) -> Result<(), MqttError> {
         eprintln!("ERROR: the message has not been acknowledged");
     }
 
-    client.disconnect()?;
-    Ok(())
+   client.disconnect()?;
+    if let Some(err) = any_error {
+        Err(err)
+    } else {
+        Ok(())
+    }
 }

--- a/tedge/src/cli/mqtt/subscribe.rs
+++ b/tedge/src/cli/mqtt/subscribe.rs
@@ -64,8 +64,7 @@ fn subscribe(cmd: &MqttSubscribeCommand) -> Result<(), MqttError> {
             }
             Err(err) => {
                 let err_msg = err.to_string();
-                if err_msg.contains("I/O: Connection refused (os error 111)")
-                {
+                if err_msg.contains("I/O: Connection refused (os error 111)") {
                     return Err(MqttError::ServerError(err_msg));
                 }
 

--- a/tedge/src/cli/mqtt/subscribe.rs
+++ b/tedge/src/cli/mqtt/subscribe.rs
@@ -64,7 +64,10 @@ fn subscribe(cmd: &MqttSubscribeCommand) -> Result<(), MqttError> {
             }
             Err(err) => {
                 eprintln!("ERROR: {:?}", err);
-                if err.to_string().contains("I/O: Connection refused (os error 111)") {
+                if err
+                    .to_string()
+                    .contains("I/O: Connection refused (os error 111)")
+                {
                     return Err(MqttError::ServerError(err.to_string()));
                 }
                 std::thread::sleep(std::time::Duration::from_secs(1));

--- a/tedge/src/cli/mqtt/subscribe.rs
+++ b/tedge/src/cli/mqtt/subscribe.rs
@@ -64,6 +64,9 @@ fn subscribe(cmd: &MqttSubscribeCommand) -> Result<(), MqttError> {
             }
             Err(err) => {
                 eprintln!("ERROR: {:?}", err);
+                if err.to_string().contains("I/O: Connection refused (os error 111)") {
+                    return Err(MqttError::ServerError(err.to_string()));
+                }
                 std::thread::sleep(std::time::Duration::from_secs(1));
             }
             _ => {}

--- a/tedge/src/cli/mqtt/subscribe.rs
+++ b/tedge/src/cli/mqtt/subscribe.rs
@@ -63,13 +63,13 @@ fn subscribe(cmd: &MqttSubscribeCommand) -> Result<(), MqttError> {
                 client.subscribe(cmd.topic.as_str(), cmd.qos).unwrap();
             }
             Err(err) => {
-                eprintln!("ERROR: {:?}", err);
-                if err
-                    .to_string()
-                    .contains("I/O: Connection refused (os error 111)")
+                let err_msg = err.to_string();
+                if err_msg.contains("I/O: Connection refused (os error 111)")
                 {
-                    return Err(MqttError::ServerError(err.to_string()));
+                    return Err(MqttError::ServerError(err_msg));
                 }
+
+                eprintln!("ERROR: {}", err_msg);
                 std::thread::sleep(std::time::Duration::from_secs(1));
             }
             _ => {}

--- a/tests/PySys/local_mqtt_pub_fail/local_mqtt_pub_fail_qos0/run.py
+++ b/tests/PySys/local_mqtt_pub_fail/local_mqtt_pub_fail_qos0/run.py
@@ -29,7 +29,7 @@ class PySysTest(BaseTest):
 
         pub = self.startProcess(
             command=self.sudo,
-            arguments=[self.tedge, "--qos", "0", "mqtt", "pub", "atopic", "amessage"],
+            arguments=[self.tedge, "mqtt", "pub", "--qos", "0", "atopic", "amessage"],
             stdouterr="tedge_pub_fail",
             expectedExitStatus="==1",
         )

--- a/tests/PySys/local_mqtt_pub_fail/local_mqtt_pub_fail_qos1/run.py
+++ b/tests/PySys/local_mqtt_pub_fail/local_mqtt_pub_fail_qos1/run.py
@@ -29,7 +29,7 @@ class PySysTest(BaseTest):
 
         pub = self.startProcess(
             command=self.sudo,
-            arguments=[self.tedge, "--qos", "1", "mqtt", "pub", "atopic", "amessage"],
+            arguments=[self.tedge, "mqtt", "pub", "--qos", "1", "atopic", "amessage"],
             stdouterr="tedge_pub_fail",
             expectedExitStatus="==1",
         )

--- a/tests/PySys/local_mqtt_pub_fail/local_mqtt_pub_fail_qos2/run.py
+++ b/tests/PySys/local_mqtt_pub_fail/local_mqtt_pub_fail_qos2/run.py
@@ -29,7 +29,7 @@ class PySysTest(BaseTest):
 
         pub = self.startProcess(
             command=self.sudo,
-            arguments=[self.tedge, "--qos", "2", "mqtt", "pub", "atopic", "amessage"],
+            arguments=[self.tedge, "mqtt", "pub", "--qos", "2", "atopic", "amessage"],
             stdouterr="tedge_pub_fail",
             expectedExitStatus="==1",
         )


### PR DESCRIPTION
## Proposed changes

* On error, `tedge mqtt pub` must return an exit code of 1.
* This is a fix of an error introduced by https://github.com/thin-edge/thin-edge.io/pull/418.
* Some tests have also been fixed : the were triggering a systemic error independent of the MQTT errors under test.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
