### PR TITLE
Fix purge failure of tedge package

### DIFF
--- a/configuration/debian/tedge/postrm
+++ b/configuration/debian/tedge/postrm
@@ -18,7 +18,7 @@ remove_sudoers_file() {
         rm /etc/sudoers.d/tedge-users
     fi
 
-    if [ -f "/etc/sudoers.d/010_pi-nopasswd" ]; then
+    if [ -f "/etc/sudoers.d/tedge-users-nopasswd" ]; then
         rm /etc/sudoers.d/tedge-users-nopasswd
     fi
 }


### PR DESCRIPTION
## Proposed changes

This is the fix to prevent a purge error of tedge package.

```
Purging configuration files for tedge (0.3.2) ...
rm: cannot remove '/etc/sudoers.d/tedge-users-nopasswd': No such file or directory
dpkg: error processing package tedge (--purge):
 installed tedge package post-removal script subprocess returned error exit status 1
```

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
