### PR TITLE
Temporarily allow more time for apt_prepare

### DIFF
--- a/tests/PySys/apt_plugin/apt_prepare/run.py
+++ b/tests/PySys/apt_plugin/apt_prepare/run.py
@@ -31,8 +31,9 @@ class AptPluginPrepare(AptPlugin):
         # make sure that the timestamp has changed
         self.assertThat("old != new", old=self.mtime_old, new=self.mtime_new)
         # make sure the cache was updated in the last N seconds
-        # N=100 : Took 91s to update at mythic beasts
-        self.assertThat("(new +100) >= now", new=self.mtime_new, now=self.now)
+        # N=300 : Took 250s to update at Mythic Beasts in October
+        # TODO Investigate: https://cumulocity.atlassian.net/browse/CIT-664
+        self.assertThat("(new +300) >= now", new=self.mtime_new, now=self.now)
 
     def cleanup_prepare(self):
         pass


### PR DESCRIPTION
## Proposed changes

Temporarily allow more time for apt_prepare. It can take far longer on our cloud hosted Pis.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

Documented here : https://cumulocity.atlassian.net/browse/CIT-664

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

