### PR TITLE
Stop the collect-mapper everywhere and continue if service is not there

### DIFF
--- a/.github/workflows/integration-test-workflow.yml
+++ b/.github/workflows/integration-test-workflow.yml
@@ -31,6 +31,10 @@ jobs:
           name: debian-packages-amd64
           path: debian-package_unpack
 
+      - name: Workaround Stop collectd mapper
+        run: sudo systemctl stop tedge-mapper-collectd
+        continue-on-error: true
+
       - name: disconnect c8y
         run: sudo tedge disconnect c8y
         # We need to continue when there is no tedge already installed
@@ -117,6 +121,7 @@ jobs:
 
       - name: Workaround Stop collectd mapper
         run: sudo systemctl stop tedge-mapper-collectd
+        continue-on-error: true
 
       - name: disconnect c8y
         run: sudo tedge disconnect c8y

--- a/.github/workflows/system-test-offsite.yml
+++ b/.github/workflows/system-test-offsite.yml
@@ -33,6 +33,10 @@ jobs:
           name: debian-packages-armv7-unknown-linux-gnueabihf
           path: debian-package_unpack
 
+      - name: Workaround Stop collectd mapper
+        run: sudo systemctl stop tedge-mapper-collectd
+        continue-on-error: true
+
       - name: delete old publisher
         run: rm -f /home/pi/examples/sawtooth_publisher
 


### PR DESCRIPTION
Signed-off-by: Michael Abel <info@abel-ikt.de>

## Proposed changes

Stop the collect-mapper everywhere and continue if service is not there

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
