### PR TITLE
Fix cargo outdated issue temporarily

### DIFF
--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Cargo fmt --version
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: fmt
+          args: --version
+
       - name: Cargo fmt
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
@@ -44,6 +51,13 @@ jobs:
         # https://github.com/marketplace/actions/rust-cache
         uses: Swatinem/rust-cache@v1
 
+      - name: Cargo clippy --version
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: clippy
+          args: --version
+
       - name: Cargo clippy
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
@@ -64,6 +78,12 @@ jobs:
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
         uses: Swatinem/rust-cache@v1
+
+      - name: Cargo --version
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          args: --version
 
       - name: Cargo test
         uses: actions-rs/cargo@v1
@@ -87,6 +107,12 @@ jobs:
         # https://github.com/marketplace/actions/rust-cache
         uses: Swatinem/rust-cache@v1
 
+      - name: Cargo --version
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          args: --version
+
       - name: Cargo build
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
@@ -104,6 +130,13 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Cargo outdated --version
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: outdated
+          args: --version
 
       - name: Cargo outdated
         uses: actions-rs/cargo@v1
@@ -124,12 +157,19 @@ jobs:
         # https://github.com/marketplace/actions/rust-cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Cargo install msrv
+#      - name: Cargo install msrv
+#        uses: actions-rs/cargo@v1
+#        # https://github.com/marketplace/actions/rust-cargo
+#        with:
+#          command: install
+#          args: cargo-msrv
+
+      - name: Cargo msrv --version
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
         with:
-          command: install
-          args: cargo-msrv
+          command: msrv
+          args: --version
 
       - name: Cargo msrv
         uses: actions-rs/cargo@v1

--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -79,11 +79,11 @@ jobs:
         # https://github.com/marketplace/actions/rust-cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Cargo --version
+      - name: Cargo version
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
         with:
-          args: --version
+          args: version
 
       - name: Cargo test
         uses: actions-rs/cargo@v1
@@ -107,11 +107,11 @@ jobs:
         # https://github.com/marketplace/actions/rust-cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Cargo --version
+      - name: Cargo version
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
         with:
-          args: --version
+          args: version
 
       - name: Cargo build
         uses: actions-rs/cargo@v1
@@ -156,13 +156,6 @@ jobs:
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
         uses: Swatinem/rust-cache@v1
-
-#      - name: Cargo install msrv
-#        uses: actions-rs/cargo@v1
-#        # https://github.com/marketplace/actions/rust-cargo
-#        with:
-#          command: install
-#          args: cargo-msrv
 
       - name: Cargo msrv --version
         uses: actions-rs/cargo@v1

--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
         with:
-          args: version
+          command: version
 
       - name: Cargo test
         uses: actions-rs/cargo@v1
@@ -111,7 +111,7 @@ jobs:
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
         with:
-          args: version
+          command: version
 
       - name: Cargo build
         uses: actions-rs/cargo@v1

--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -131,8 +131,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Enable cache
+        # https://github.com/marketplace/actions/rust-cache
+        uses: Swatinem/rust-cache@v1
+
       # In usual case, we don't need this step.
-      # There is an issue with cargo-outdated 0.10.0, therefore, explicitly install latest version for now.
+      # There is an issue with cargo-outdated 0.10.0, therefore, explicitly install the latest version.
       # This step can be removed in the future.
       - name: Cargo install outdated
         uses: actions-rs/cargo@v1
@@ -163,9 +167,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Enable cache
-        # https://github.com/marketplace/actions/rust-cache
-        uses: Swatinem/rust-cache@v1
+#      - name: Enable cache
+#        # https://github.com/marketplace/actions/rust-cache
+#        uses: Swatinem/rust-cache@v1
 
       - name: Cargo msrv --version
         uses: actions-rs/cargo@v1

--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -136,8 +136,8 @@ jobs:
         uses: Swatinem/rust-cache@v1
 
       # In usual case, we don't need this step.
-      # There is an issue with cargo-outdated 0.10.0, therefore, explicitly install the latest version.
-      # This step can be removed in the future.
+      # There is an issue with cargo-outdated 0.10.0, therefore, explicitly need to install the latest version.
+      # This step takes a certain time, so it should be removed in the future.
       - name: Cargo install outdated
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo

--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -143,7 +143,7 @@ jobs:
         # https://github.com/marketplace/actions/rust-cargo
         with:
           command: install
-          args: cargo-outdated
+          args: cargo-outdated --version 0.10.2
 
       - name: Cargo outdated --version
         uses: actions-rs/cargo@v1

--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -167,9 +167,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-#      - name: Enable cache
-#        # https://github.com/marketplace/actions/rust-cache
-#        uses: Swatinem/rust-cache@v1
+      - name: Enable cache
+        # https://github.com/marketplace/actions/rust-cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Cargo install msrv
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: install
+          args: cargo-msrv
 
       - name: Cargo msrv --version
         uses: actions-rs/cargo@v1

--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -131,6 +131,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # In usual case, we don't need this step.
+      # There is an issue with cargo-outdated 0.10.0, therefore, explicitly install latest version for now.
+      # This step can be removed in the future.
+      - name: Cargo install outdated
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: install
+          args: cargo-outdated
+
       - name: Cargo outdated --version
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo


### PR DESCRIPTION
## Proposed changes

Fix #590.

Changes:
- Add steps to print the version of `cargo`; `cargo test` and `cargo build`.
- Add steps to print the version of plugins; all others, e.g. `cargo-msrv`.
- Add a step `cargo install cargo-outdated`. This brings the latest version to the workflow.

Future:
- The step `cargo install cargo-outdated` should be removed. Unfortunately, as of today, without install, the version `0.10.0` of `cargo-outdated` is used. That version panics.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
