### PR TITLE
Move cargo outdated to optional

### DIFF
--- a/.github/workflows/commit-workflow-optional.yml
+++ b/.github/workflows/commit-workflow-optional.yml
@@ -70,3 +70,51 @@ jobs:
         # https://github.com/marketplace/actions/rust-cargo
         with:
           command: audit
+
+  cargo-outdated:
+
+    name: Run cargo outdated
+    runs-on: Ubuntu-20.04
+    needs: [cargo-fmt, cargo-clippy]
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Enable cache
+        # https://github.com/marketplace/actions/rust-cache
+        uses: Swatinem/rust-cache@v1
+
+      # In usual case, we don't need this step.
+      # There is an issue with cargo-outdated 0.10.0, therefore, explicitly need to install the latest version.
+      # This step takes a certain time, so it should be removed in the future.
+      - name: Cargo install outdated
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: install
+          args: cargo-outdated --version 0.10.2
+
+      - name: Cargo outdated --version
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: outdated
+          args: --version
+
+      - name: Cargo outdated
+        continue-on-error: true
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: outdated
+
+      - name: Cargo outdated -version
+        continue-on-error: true
+        run: cargo outdated --version
+
+      - name: Cargo outdated
+        continue-on-error: true
+        run: cargo outdated
+

--- a/.github/workflows/commit-workflow-optional.yml
+++ b/.github/workflows/commit-workflow-optional.yml
@@ -75,7 +75,6 @@ jobs:
 
     name: Run cargo outdated
     runs-on: Ubuntu-20.04
-    needs: [cargo-fmt, cargo-clippy]
 
     steps:
 

--- a/.github/workflows/commit-workflow.yml
+++ b/.github/workflows/commit-workflow.yml
@@ -120,44 +120,6 @@ jobs:
           command: build
           args: --release
 
-  cargo-outdated:
-
-    name: Run cargo outdated
-    runs-on: Ubuntu-20.04
-    needs: [cargo-fmt, cargo-clippy]
-
-    steps:
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Enable cache
-        # https://github.com/marketplace/actions/rust-cache
-        uses: Swatinem/rust-cache@v1
-
-      # In usual case, we don't need this step.
-      # There is an issue with cargo-outdated 0.10.0, therefore, explicitly need to install the latest version.
-      # This step takes a certain time, so it should be removed in the future.
-      - name: Cargo install outdated
-        uses: actions-rs/cargo@v1
-        # https://github.com/marketplace/actions/rust-cargo
-        with:
-          command: install
-          args: cargo-outdated --version 0.10.2
-
-      - name: Cargo outdated --version
-        uses: actions-rs/cargo@v1
-        # https://github.com/marketplace/actions/rust-cargo
-        with:
-          command: outdated
-          args: --version
-
-      - name: Cargo outdated
-        uses: actions-rs/cargo@v1
-        # https://github.com/marketplace/actions/rust-cargo
-        with:
-          command: outdated
-
   cargo-msrv:
     name: Run cargo msrv
     runs-on: Ubuntu-20.04


### PR DESCRIPTION
## Proposed changes

Move cargo outdated to optional

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
