### PR TITLE
[CIT-697] Allowing colon in datetime deserialisation

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -116,7 +116,7 @@ jobs:
             aarch64-unknown-linux-musl,
             arm-unknown-linux-gnueabihf,
             armv7-unknown-linux-gnueabihf,
-            armv7-unknown-linux-musleabihf,
+            #armv7-unknown-linux-musleabihf, # Temporarily disabled due to build issues
           ]
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "json_sm",
  "serde",
  "serde_json",
+ "test-case",
  "thiserror",
 ]
 
@@ -2766,9 +2767,9 @@ checksum = "78fbf2dd23e79c28ccfa2472d3e6b3b189866ffef1aeb91f17c2d968b6586378"
 
 [[package]]
 name = "test-case"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b114ece25254e97bf48dd4bfc2a12bad0647adacfe4cae1247a9ca6ad302cec"
+checksum = "c7cad0a06f9a61e94355aa3b3dc92d85ab9c83406722b1ca5e918d4297c12c23"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2 1.0.29",

--- a/mapper/cumulocity/c8y_smartrest/Cargo.toml
+++ b/mapper/cumulocity/c8y_smartrest/Cargo.toml
@@ -15,5 +15,4 @@ thiserror = "1.0"
 assert_matches = "1.5"
 assert-json-diff = "2.0"
 serde_json = "1.0"
-
-
+test-case = "1.2.1"

--- a/mapper/cumulocity/c8y_smartrest/src/smartrest_deserializer.rs
+++ b/mapper/cumulocity/c8y_smartrest/src/smartrest_deserializer.rs
@@ -179,11 +179,16 @@ where
     let mut date_string: String = Deserialize::deserialize(deserializer)?;
     let str_size = date_string.len();
     // check if `date_string` does not have a colon.
-    if !date_string.contains(':') {
-        date_string = date_string[0..str_size - 2].to_string()
-            + ":"
-            + &date_string[str_size - 2..str_size].to_string();
-    }
+    let date_string_end = &date_string.split('+').last();
+    date_string = match date_string_end {
+        Some(string) if !string.contains(':') => {
+            date_string[0..str_size - 2].to_string()
+                + ":"
+                + &date_string[str_size - 2..str_size].to_string()
+        }
+        _ => date_string,
+    };
+
     match DateTime::parse_from_rfc3339(&date_string) {
         Ok(result) => Ok(result),
         Err(e) => Err(D::Error::custom(&format!("Error: {}", e))),

--- a/mapper/cumulocity/c8y_smartrest/src/smartrest_deserializer.rs
+++ b/mapper/cumulocity/c8y_smartrest/src/smartrest_deserializer.rs
@@ -178,9 +178,12 @@ where
     // so we add a ':'
     let mut date_string: String = Deserialize::deserialize(deserializer)?;
     let str_size = date_string.len();
-    date_string = date_string[0..str_size - 2].to_string()
-        + ":"
-        + &date_string[str_size - 2..str_size].to_string();
+    // check if `date_string` does not have a colon.
+    if !date_string.contains(':') {
+        date_string = date_string[0..str_size - 2].to_string()
+            + ":"
+            + &date_string[str_size - 2..str_size].to_string();
+    }
     match DateTime::parse_from_rfc3339(&date_string) {
         Ok(result) => Ok(result),
         Err(e) => Err(D::Error::custom(&format!("Error: {}", e))),

--- a/mapper/cumulocity/c8y_smartrest/src/smartrest_deserializer.rs
+++ b/mapper/cumulocity/c8y_smartrest/src/smartrest_deserializer.rs
@@ -271,6 +271,7 @@ mod tests {
     use assert_json_diff::*;
     use json_sm::*;
     use serde_json::json;
+    use test_case::test_case;
 
     // To avoid using an ID randomly generated, which is not convenient for testing.
     impl SmartRestUpdateSoftware {
@@ -524,5 +525,18 @@ mod tests {
         ];
 
         assert_eq!(vec, expected_vec);
+    }
+
+    #[test_case("2021-09-21T11:40:27+0200", "2021-09-22T11:40:27+0200"; "c8y expected")]
+    #[test_case("2021-09-21T11:40:27+02:00", "2021-09-22T11:40:27+02:00"; "with colon both")]
+    #[test_case("2021-09-21T11:40:27+02:00", "2021-09-22T11:40:27+0200"; "with colon date from")]
+    #[test_case("2021-09-21T11:40:27+0200", "2021-09-22T11:40:27+02:00"; "with colon date to")]
+    fn deserialize_smartrest_log_file_request_operation(date_from: &str, date_to: &str) {
+        let smartrest = String::from(&format!(
+            "522,DeviceSerial,syslog,{},{},ERROR,1000",
+            date_from, date_to
+        ));
+        let log = SmartRestLogRequest::from_smartrest(&smartrest);
+        assert!(log.is_ok());
     }
 }


### PR DESCRIPTION
Signed-off-by: initard <solo@softwareag.com>

## Proposed changes

C8y smartrest payload returns datetime as follows:

```shell
c8y result: 2021-10-23T19:03:26+0100
```
However, chrono expects the following datetime:
```shell
rfc3339 expected: 2021-10-23T19:03:26+01:00
```
The only difference being the colon (:) at the end. This fix allows both types of date formats to be parsed.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://cumulocity.atlassian.net/browse/CIT-612

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

