### PR TITLE
[CIT-648] Use time instead of chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,7 +2780,14 @@ dependencies = [
  "itoa",
  "libc",
  "serde",
+ "time-macros",
 ]
+
+[[package]]
+name = "time-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25eb0ca3468fc0acc11828786797f6ef9aa1555e4a211a60d64cc8e4d1be47d6"
 
 [[package]]
 name = "tinytemplate"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 name = "batcher"
 version = "0.4.2"
 dependencies = [
- "chrono",
+ "time 0.3.5",
  "tokio",
 ]
 
@@ -310,12 +310,12 @@ version = "0.4.2"
 dependencies = [
  "assert-json-diff",
  "assert_matches",
- "chrono",
  "csv",
  "json_sm",
  "serde",
  "serde_json",
  "thiserror",
+ "time 0.3.5",
 ]
 
 [[package]]
@@ -325,7 +325,6 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "assert_matches",
- "chrono",
  "clock",
  "criterion",
  "json-writer",
@@ -335,6 +334,7 @@ dependencies = [
  "test-case",
  "thin_edge_json",
  "thiserror",
+ "time 0.3.5",
 ]
 
 [[package]]
@@ -395,7 +395,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "serde",
  "time 0.1.43",
  "winapi",
 ]
@@ -2616,7 +2615,6 @@ dependencies = [
  "batcher",
  "c8y_smartrest",
  "c8y_translator_lib",
- "chrono",
  "clock",
  "csv",
  "flockfile",
@@ -2637,6 +2635,7 @@ dependencies = [
  "test-case",
  "thin_edge_json",
  "thiserror",
+ "time 0.3.5",
  "tokio",
  "tokio-test",
  "tracing",
@@ -2720,7 +2719,6 @@ name = "thin_edge_json"
 version = "0.4.2"
 dependencies = [
  "anyhow",
- "chrono",
  "clock",
  "criterion",
  "json-writer",
@@ -2730,6 +2728,7 @@ dependencies = [
  "serde_json",
  "stats_alloc",
  "thiserror",
+ "time 0.3.5",
  "walkdir",
 ]
 
@@ -2780,6 +2779,7 @@ checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
  "itoa",
  "libc",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,8 +419,8 @@ dependencies = [
 name = "clock"
 version = "0.4.2"
 dependencies = [
- "chrono",
  "mockall",
+ "time 0.3.5",
 ]
 
 [[package]]
@@ -2531,6 +2531,7 @@ dependencies = [
  "tedge_utils",
  "tempfile",
  "thiserror",
+ "time 0.3.5",
  "toml",
  "url",
  "webpki",
@@ -2544,7 +2545,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
- "chrono",
  "flockfile",
  "futures",
  "json_sm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "gimli",
 ]
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "argh"
@@ -68,9 +68,9 @@ checksum = "48ad219abc0c06ca788aface2e3a1970587e3413ab70acd20e54b6ec524c1f8f"
 dependencies = [
  "argh_shared",
  "heck",
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -158,9 +158,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -169,9 +169,9 @@ version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -198,18 +198,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
 dependencies = [
  "futures-core",
- "getrandom 0.2.3",
+ "getrandom",
  "instant",
  "pin-project",
- "rand 0.8.4",
+ "rand",
  "tokio",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.61"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
  "addr2line",
  "cc",
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.7.1"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9df67f7bf9ef8498769f994239c45613ef0c5899415fb58e9add412d2c1a538"
+checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
 name = "byteorder"
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "certificate"
@@ -366,7 +366,7 @@ dependencies = [
  "assert_matches",
  "base64",
  "chrono",
- "pem 1.0.0",
+ "pem",
  "rcgen",
  "sha-1",
  "thiserror",
@@ -396,7 +396,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
+ "time 0.1.43",
  "winapi",
 ]
 
@@ -572,7 +572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -587,9 +587,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c73af209b6a5dc8ca7cbaba720732304792cddc933cfea3d74509c2b1ef2f436"
 dependencies = [
- "num-bigint 0.4.2",
+ "num-bigint 0.4.3",
  "num-traits",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -600,7 +600,7 @@ checksum = "9807efb310ce4ea172924f3a69d82f9fd6c9c3a19336344591153e665b31c43e"
 dependencies = [
  "der-oid-macro",
  "nom",
- "num-bigint 0.4.2",
+ "num-bigint 0.4.3",
  "num-traits",
  "rusticata-macros",
 ]
@@ -694,9 +694,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -855,9 +855,9 @@ checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -911,37 +911,26 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "h2"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c06815895acec637cd6ed6e9662c935b866d20a106f8361892893a7d9234964"
+checksum = "7fd819562fcebdac5afc5c113c3ec36f902840b70fd4fc458799c8ce4607ae55"
 dependencies = [
  "bytes",
  "fnv",
@@ -958,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.7.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hamcrest2"
@@ -980,18 +969,18 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "headers"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
+checksum = "a4c4eb0471fcb85846d8b0690695ef354f9afb11cb03cac2e1d7c9253351afb0"
 dependencies = [
  "base64",
  "bitflags",
  "bytes",
  "headers-core",
  "http",
+ "httpdate",
  "mime",
  "sha-1",
- "time",
 ]
 
 [[package]]
@@ -1034,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
 dependencies = [
  "bytes",
  "http",
@@ -1051,9 +1040,9 @@ checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
@@ -1072,9 +1061,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.13"
+version = "0.14.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
+checksum = "436ec0091e4f20e655156a30a0df3770fe2900aa301e548e08446ec794b6953c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1131,19 +1120,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "input_buffer"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
-dependencies = [
- "bytes",
-]
-
-[[package]]
 name = "instant"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "716d3d89f35ac6a34fd0eed635395f4c3b76fa889338a4632e5231a8684216bd"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1245,9 +1225,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "lock_api"
@@ -1326,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "minimal-lexical"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c64630dcdd71f1a64c435f54885086a0de5d6a12d104d69b165fb7d5286d677"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1342,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
@@ -1384,9 +1364,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1401,7 +1381,7 @@ dependencies = [
  "httparse",
  "lazy_static",
  "log",
- "rand 0.8.4",
+ "rand",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -1421,7 +1401,7 @@ dependencies = [
  "log",
  "mockall",
  "mqtt_tests",
- "rand 0.8.4",
+ "rand",
  "rumqttc",
  "serde",
  "thiserror",
@@ -1453,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "multipart"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050aeedc89243f5347c3e237e3e13dc76fbe4ae3742a57b94dc14f69acf76d4"
+checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
 dependencies = [
  "buf_redux",
  "httparse",
@@ -1463,7 +1443,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "quick-error 1.2.3",
- "rand 0.7.3",
+ "rand",
  "safemem",
  "tempfile",
  "twoway",
@@ -1475,7 +1455,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
- "rand 0.8.4",
+ "rand",
 ]
 
 [[package]]
@@ -1493,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1544,9 +1524,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1617,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.2"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr",
 ]
@@ -1687,20 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "0.8.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
-dependencies = [
- "base64",
- "once_cell",
- "regex",
-]
-
-[[package]]
-name = "pem"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2373df5233932a893d3bc2c78a0bf3f6d12590a1edd546b4fbefcac32c5c0f"
+checksum = "06673860db84d02a63942fa69cd9543f2624a5df3aea7f33173048fa7ad5cf1a"
 dependencies = [
  "base64",
  "once_cell",
@@ -1728,9 +1697,9 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -1802,9 +1771,9 @@ checksum = "bb20dcc30536a1508e75d47dd0e399bb2fe7354dcf35cda9127f2bf1ed92e30e"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
 name = "predicates"
@@ -1878,9 +1847,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
  "version_check",
 ]
 
@@ -1890,7 +1859,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
  "version_check",
 ]
@@ -1918,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -1937,8 +1906,8 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error 2.0.1",
- "rand 0.8.4",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1972,20 +1941,7 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
- "proc-macro2 1.0.29",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "proc-macro2 1.0.32",
 ]
 
 [[package]]
@@ -1995,19 +1951,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.3",
- "rand_hc 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
 ]
 
 [[package]]
@@ -2017,16 +1963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -2035,16 +1972,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -2053,7 +1981,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -2062,7 +1990,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -2092,12 +2020,12 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2351cbef4bf91837f5ff7face6091cb277ba960d1638d2c5ae2327859912fbba"
+checksum = "5911d1403f4143c9d56a702069d593e8d0f3fab880a85e103604d0893ea31ba7"
 dependencies = [
  "chrono",
- "pem 0.8.3",
+ "pem",
  "ring",
  "yasna",
  "zeroize",
@@ -2118,7 +2046,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom",
  "redox_syscall",
 ]
 
@@ -2159,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51c732d463dd300362ffb44b7b125f299c23d2990411a4253824630ebc7467fb"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
  "base64",
  "bytes",
@@ -2411,16 +2339,16 @@ version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
 dependencies = [
  "itoa",
  "ryu",
@@ -2456,9 +2384,9 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2476,9 +2404,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
@@ -2494,9 +2422,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "smallvec"
@@ -2534,9 +2462,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2545,15 +2473,15 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2569,11 +2497,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "f2afee18b8beb5a596ecb4a2dce128c719b4ba399d34126b9e4396e3f9860966"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
  "unicode-xid 0.2.2",
 ]
@@ -2590,7 +2518,7 @@ dependencies = [
  "futures",
  "hyper",
  "mockito",
- "pem 1.0.0",
+ "pem",
  "predicates 2.0.3",
  "reqwest",
  "rpassword",
@@ -2633,6 +2561,7 @@ dependencies = [
  "tedge_utils",
  "tempfile",
  "thiserror",
+ "time 0.3.5",
  "tokio",
  "toml",
  "tracing",
@@ -2743,7 +2672,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.4",
+ "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -2760,20 +2689,20 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78fbf2dd23e79c28ccfa2472d3e6b3b189866ffef1aeb91f17c2d968b6586378"
+checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
 name = "test-case"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b114ece25254e97bf48dd4bfc2a12bad0647adacfe4cae1247a9ca6ad302cec"
+checksum = "c7cad0a06f9a61e94355aa3b3dc92d85ab9c83406722b1ca5e918d4297c12c23"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
  "version_check",
 ]
 
@@ -2819,9 +2748,9 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2844,6 +2773,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
+dependencies = [
+ "itoa",
+ "libc",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2870,9 +2809,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2890,13 +2829,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154794c8f499c2619acd19e839294703e9e32e7630ef5f46ea80d4ef0fbee5eb"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -2912,9 +2851,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2936,9 +2875,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a5f475f1b9d077ea1017ecbc60890fda8e54942d680ca0b1d2b47cfa2d861b"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
 dependencies = [
  "futures-util",
  "log",
@@ -2949,9 +2888,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2995,9 +2934,9 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
 ]
 
 [[package]]
@@ -3060,19 +2999,19 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
 dependencies = [
  "base64",
  "byteorder",
  "bytes",
  "http",
  "httparse",
- "input_buffer",
  "log",
- "rand 0.8.4",
+ "rand",
  "sha-1",
+ "thiserror",
  "url",
  "utf-8",
 ]
@@ -3176,9 +3115,9 @@ checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "value-bag"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd320e1520f94261153e96f7534476ad869c14022aee1e59af7c778075d840ae"
+checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
 dependencies = [
  "ctor",
  "version_check",
@@ -3228,12 +3167,13 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
+checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
 dependencies = [
  "bytes",
- "futures",
+ "futures-channel",
+ "futures-util",
  "headers",
  "http",
  "hyper",
@@ -3254,12 +3194,6 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -3286,9 +3220,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
  "wasm-bindgen-shared",
 ]
 
@@ -3320,9 +3254,9 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
- "proc-macro2 1.0.29",
+ "proc-macro2 1.0.32",
  "quote 1.0.10",
- "syn 1.0.80",
+ "syn 1.0.81",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3441,6 +3375,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"

--- a/common/batcher/Cargo.toml
+++ b/common/batcher/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
+time = "0.3"
 tokio = { version = "1.12", features = ["sync", "time"] }
 
 [dev-dependencies]

--- a/common/batcher/src/batch.rs
+++ b/common/batcher/src/batch.rs
@@ -1,7 +1,7 @@
 use crate::batchable::Batchable;
-use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::iter::once;
+use time::OffsetDateTime;
 
 #[must_use]
 #[derive(Debug)]
@@ -13,13 +13,13 @@ pub enum BatchAdd<B: Batchable> {
 
 #[derive(Debug)]
 pub struct Batch<B: Batchable> {
-    batch_start: DateTime<Utc>,
-    batch_end: DateTime<Utc>,
+    batch_start: OffsetDateTime,
+    batch_end: OffsetDateTime,
     events: HashMap<B::Key, B>,
 }
 
 impl<B: Batchable> Batch<B> {
-    pub fn new(batch_start: DateTime<Utc>, batch_end: DateTime<Utc>, event: B) -> Batch<B> {
+    pub fn new(batch_start: OffsetDateTime, batch_end: OffsetDateTime, event: B) -> Batch<B> {
         let mut events = HashMap::new();
         events.insert(event.key(), event);
 
@@ -30,11 +30,11 @@ impl<B: Batchable> Batch<B> {
         }
     }
 
-    pub fn batch_start(&self) -> DateTime<Utc> {
+    pub fn batch_start(&self) -> OffsetDateTime {
         self.batch_start
     }
 
-    pub fn batch_end(&self) -> DateTime<Utc> {
+    pub fn batch_end(&self) -> OffsetDateTime {
         self.batch_end
     }
 
@@ -55,7 +55,7 @@ impl<B: Batchable> Batch<B> {
         BatchAdd::Added
     }
 
-    fn split(&mut self, existing_event_time: DateTime<Utc>, event: B) -> Batch<B> {
+    fn split(&mut self, existing_event_time: OffsetDateTime, event: B) -> Batch<B> {
         let split_point = midpoint(existing_event_time, event.event_time());
 
         let mut new_batch_events = HashMap::new();
@@ -92,8 +92,9 @@ impl<B: Batchable> Batch<B> {
     }
 }
 
-fn midpoint(event_time1: DateTime<Utc>, event_time2: DateTime<Utc>) -> DateTime<Utc> {
-    let gap = event_time1.signed_duration_since(event_time2);
+fn midpoint(event_time1: OffsetDateTime, event_time2: OffsetDateTime) -> OffsetDateTime {
+    let gap = event_time1 - event_time2;
+    // let gap = event_time1.signed_duration_since(event_time2);
     event_time2 + gap / 2
 }
 

--- a/common/batcher/src/batch.rs
+++ b/common/batcher/src/batch.rs
@@ -101,12 +101,11 @@ fn midpoint(event_time1: OffsetDateTime, event_time2: OffsetDateTime) -> OffsetD
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
 
     #[test]
     fn add() {
-        let batch_start = Utc.timestamp_millis(0);
-        let batch_end = Utc.timestamp_millis(100);
+        let batch_start = OffsetDateTime::from_unix_timestamp(0).unwrap();
+        let batch_end = OffsetDateTime::from_unix_timestamp(100).unwrap();
         let event1 = TestBatchEvent::new(1, 40);
         let event2 = TestBatchEvent::new(2, 60);
 
@@ -121,8 +120,8 @@ mod tests {
 
     #[test]
     fn split() {
-        let batch_start = Utc.timestamp_millis(0);
-        let batch_end = Utc.timestamp_millis(100);
+        let batch_start = OffsetDateTime::from_unix_timestamp(0).unwrap();
+        let batch_end = OffsetDateTime::from_unix_timestamp(100).unwrap();
         let event1 = TestBatchEvent::new(1, 40);
         let event2 = TestBatchEvent::new(1, 60);
 
@@ -143,8 +142,8 @@ mod tests {
 
     #[test]
     fn duplicate() {
-        let batch_start = Utc.timestamp_millis(0);
-        let batch_end = Utc.timestamp_millis(100);
+        let batch_start = OffsetDateTime::from_unix_timestamp(0).unwrap();
+        let batch_end = OffsetDateTime::from_unix_timestamp(100).unwrap();
         let event1 = TestBatchEvent::new(1, 40);
         let event2 = TestBatchEvent::new(1, 40);
 
@@ -159,12 +158,12 @@ mod tests {
     #[derive(Debug, Clone, Eq, PartialEq)]
     struct TestBatchEvent {
         key: u64,
-        event_time: DateTime<Utc>,
+        event_time: OffsetDateTime,
     }
 
     impl TestBatchEvent {
         fn new(key: u64, event_time: i64) -> TestBatchEvent {
-            let event_time = Utc.timestamp_millis(event_time);
+            let event_time = OffsetDateTime::from_unix_timestamp(event_time).unwrap();
             TestBatchEvent { key, event_time }
         }
     }
@@ -176,7 +175,7 @@ mod tests {
             self.key
         }
 
-        fn event_time(&self) -> DateTime<Utc> {
+        fn event_time(&self) -> OffsetDateTime {
             self.event_time
         }
     }

--- a/common/batcher/src/batchable.rs
+++ b/common/batcher/src/batchable.rs
@@ -1,6 +1,6 @@
-use chrono::{DateTime, Utc};
 use std::fmt::Debug;
 use std::hash::Hash;
+use time::OffsetDateTime;
 
 /// Implement this interface for the items that you want batched.
 /// No items with the same key will go in the same batch.
@@ -13,5 +13,5 @@ pub trait Batchable {
     fn key(&self) -> Self::Key;
 
     /// The time at which this item was created. This time is used to group items into a batch.
-    fn event_time(&self) -> DateTime<Utc>;
+    fn event_time(&self) -> OffsetDateTime;
 }

--- a/common/batcher/src/batcher.rs
+++ b/common/batcher/src/batcher.rs
@@ -148,6 +148,8 @@ impl<B: Batchable> Batcher<B> {
 
 #[cfg(test)]
 mod tests {
+    use time::Duration;
+
     use super::*;
     use crate::batchable::Batchable;
     use crate::config::BatchConfigBuilder;
@@ -422,7 +424,7 @@ mod tests {
 
     #[derive(Debug, Clone, Eq, PartialEq)]
     struct TestBatchEvent {
-        event_time: DateTime<Utc>,
+        event_time: OffsetDateTime,
         key: String,
         value: u64,
     }
@@ -434,7 +436,7 @@ mod tests {
             self.key.clone()
         }
 
-        fn event_time(&self) -> DateTime<Utc> {
+        fn event_time(&self) -> OffsetDateTime {
             self.event_time
         }
     }
@@ -446,11 +448,11 @@ mod tests {
     }
 
     struct BatcherTest {
-        start_time: DateTime<Utc>,
+        start_time: OffsetDateTime,
         batcher: Batcher<TestBatchEvent>,
-        inputs: BTreeMap<DateTime<Utc>, EventOrTimer>,
-        flush_time: Option<DateTime<Utc>>,
-        expected_batches: BTreeMap<DateTime<Utc>, Vec<Vec<TestBatchEvent>>>,
+        inputs: BTreeMap<OffsetDateTime, EventOrTimer>,
+        flush_time: Option<OffsetDateTime>,
+        expected_batches: BTreeMap<OffsetDateTime, Vec<Vec<TestBatchEvent>>>,
     }
 
     impl BatcherTest {
@@ -461,7 +463,7 @@ mod tests {
                 .message_leap_limit(message_leap_limit)
                 .build();
 
-            let start_time = Utc.timestamp_millis(0);
+            let start_time = OffsetDateTime::from_unix_timestamp(0).unwrap();
             let batcher = Batcher::new(batcher_config);
 
             BatcherTest {
@@ -536,10 +538,10 @@ mod tests {
 
         fn handle_outputs(
             &mut self,
-            t: DateTime<Utc>,
+            t: OffsetDateTime,
             outputs: Vec<BatcherOutput<TestBatchEvent>>,
-            all_batches: &mut BTreeMap<DateTime<Utc>, Vec<Vec<TestBatchEvent>>>,
-            flush_time: Option<DateTime<Utc>>,
+            all_batches: &mut BTreeMap<OffsetDateTime, Vec<Vec<TestBatchEvent>>>,
+            flush_time: Option<OffsetDateTime>,
         ) {
             let mut batches = vec![];
 
@@ -575,14 +577,14 @@ mod tests {
             }
         }
 
-        fn create_instant(&self, time: i64) -> DateTime<Utc> {
+        fn create_instant(&self, time: i64) -> OffsetDateTime {
             self.start_time + Duration::milliseconds(time)
         }
     }
 
     fn verify(
-        expected_batches: BTreeMap<DateTime<Utc>, Vec<Vec<TestBatchEvent>>>,
-        mut actual_batches: BTreeMap<DateTime<Utc>, Vec<Vec<TestBatchEvent>>>,
+        expected_batches: BTreeMap<OffsetDateTime, Vec<Vec<TestBatchEvent>>>,
+        mut actual_batches: BTreeMap<OffsetDateTime, Vec<Vec<TestBatchEvent>>>,
     ) {
         assert_eq!(
             actual_batches.keys().collect::<Vec<_>>(),

--- a/common/batcher/src/config.rs
+++ b/common/batcher/src/config.rs
@@ -1,4 +1,4 @@
-use chrono::Duration;
+use time::Duration;
 
 /// The parameters for the batching process.
 #[derive(Debug, Clone)]

--- a/common/batcher/src/driver.rs
+++ b/common/batcher/src/driver.rs
@@ -164,7 +164,7 @@ mod tests {
     async fn flush_one_batch() -> Result<(), SendError<BatchDriverInput<TestBatchEvent>>> {
         let (input_send, mut output_recv) = spawn_driver();
 
-        let event1 = TestBatchEvent::new(1, Utc::now());
+        let event1 = TestBatchEvent::new(1, OffsetDateTime::now_utc());
         input_send.send(BatchDriverInput::Event(event1)).await?;
         input_send.send(BatchDriverInput::Flush).await?;
 
@@ -178,12 +178,12 @@ mod tests {
     async fn two_batches_with_timer() -> Result<(), SendError<BatchDriverInput<TestBatchEvent>>> {
         let (input_send, mut output_recv) = spawn_driver();
 
-        let event1 = TestBatchEvent::new(1, Utc::now());
+        let event1 = TestBatchEvent::new(1, OffsetDateTime::now_utc());
         input_send.send(BatchDriverInput::Event(event1)).await?;
 
         assert_recv_batch(&mut output_recv, vec![event1]).await;
 
-        let event2 = TestBatchEvent::new(2, Utc::now());
+        let event2 = TestBatchEvent::new(2, OffsetDateTime::now_utc());
         input_send.send(BatchDriverInput::Event(event2)).await?;
 
         assert_recv_batch(&mut output_recv, vec![event2]).await;
@@ -240,11 +240,11 @@ mod tests {
     #[derive(Debug, Copy, Clone, Eq, PartialEq)]
     struct TestBatchEvent {
         key: u64,
-        event_time: DateTime<Utc>,
+        event_time: OffsetDateTime,
     }
 
     impl TestBatchEvent {
-        fn new(key: u64, event_time: DateTime<Utc>) -> TestBatchEvent {
+        fn new(key: u64, event_time: OffsetDateTime) -> TestBatchEvent {
             TestBatchEvent { key, event_time }
         }
     }
@@ -256,7 +256,7 @@ mod tests {
             self.key
         }
 
-        fn event_time(&self) -> DateTime<Utc> {
+        fn event_time(&self) -> OffsetDateTime {
             self.event_time
         }
     }

--- a/common/batcher/src/driver.rs
+++ b/common/batcher/src/driver.rs
@@ -100,7 +100,10 @@ impl<B: Batchable> BatchDriver<B> {
                 if signed_duration.is_negative() {
                     return TimeTo::Past(*timer);
                 }
-                TimeTo::Future(std::time::Duration::new(signed_duration.abs()))
+                TimeTo::Future(std::time::Duration::new(
+                    signed_duration.abs().whole_seconds() as u64,
+                    0,
+                ))
             }
         }
     }

--- a/common/clock/Cargo.toml
+++ b/common/clock/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["thin-edge.io team <info@thin-edge.io>"]
 edition = "2018"
 
 [dependencies]
-chrono = "0.4"
 mockall = "0.10"
+time = "0.3"

--- a/common/clock/src/lib.rs
+++ b/common/clock/src/lib.rs
@@ -1,7 +1,7 @@
-use chrono::{DateTime, FixedOffset, Local};
 use mockall::automock;
+use time::OffsetDateTime;
 
-pub type Timestamp = DateTime<FixedOffset>;
+pub type Timestamp = OffsetDateTime;
 
 #[automock]
 pub trait Clock: Sync + Send + 'static {
@@ -13,7 +13,6 @@ pub struct WallClock;
 
 impl Clock for WallClock {
     fn now(&self) -> Timestamp {
-        let local_time_now = Local::now();
-        local_time_now.with_timezone(local_time_now.offset())
+        OffsetDateTime::now_utc()
     }
 }

--- a/mapper/cumulocity/c8y_smartrest/Cargo.toml
+++ b/mapper/cumulocity/c8y_smartrest/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["thin-edge.io team <info@thin-edge.io>"]
 edition = "2018"
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
 csv = "1.1"
 json_sm = { path = "../../../sm/json_sm" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
+time = { version = "0.3", features = ["formatting", "serde"] }
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/mapper/cumulocity/c8y_smartrest/Cargo.toml
+++ b/mapper/cumulocity/c8y_smartrest/Cargo.toml
@@ -9,7 +9,7 @@ csv = "1.1"
 json_sm = { path = "../../../sm/json_sm" }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-time = { version = "0.3", features = ["formatting", "serde"] }
+time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/mapper/cumulocity/c8y_translator_lib/Cargo.toml
+++ b/mapper/cumulocity/c8y_translator_lib/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["thin-edge.io team <info@thin-edge.io>"]
 edition = "2018"
 
 [dependencies]
-chrono = "0.4"
 clock = { path = "../../../common/clock" }
 json-writer = { path = "../../../common/json_writer" }
 thin_edge_json = { path = "../../thin_edge_json" }
 thiserror = "1.0"
+time = "0.3"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/mapper/cumulocity/c8y_translator_lib/Cargo.toml
+++ b/mapper/cumulocity/c8y_translator_lib/Cargo.toml
@@ -20,6 +20,7 @@ pretty_assertions = "1.0"
 proptest = "1.0"
 serde_json = "1.0"
 test-case = "1.2"
+time = { version = "0.3", features = ["macros"] }
 
 [features]
 # use: #[cfg(feature="integration-test")]

--- a/mapper/cumulocity/c8y_translator_lib/src/json.rs
+++ b/mapper/cumulocity/c8y_translator_lib/src/json.rs
@@ -14,9 +14,9 @@
 //! ```
 
 use crate::serializer;
-use chrono::prelude::*;
 use clock::{Clock, WallClock};
 use thin_edge_json::parser::*;
+use time::{self, OffsetDateTime};
 
 #[derive(thiserror::Error, Debug)]
 pub enum CumulocityJsonError {
@@ -46,7 +46,7 @@ pub fn from_thin_edge_json_with_child(
 
 fn from_thin_edge_json_with_timestamp(
     input: &str,
-    timestamp: DateTime<FixedOffset>,
+    timestamp: OffsetDateTime,
     maybe_child_id: Option<&str>,
 ) -> Result<String, CumulocityJsonError> {
     let mut serializer = serializer::C8yJsonSerializer::new(timestamp, maybe_child_id);

--- a/mapper/cumulocity/c8y_translator_lib/src/json.rs
+++ b/mapper/cumulocity/c8y_translator_lib/src/json.rs
@@ -68,14 +68,17 @@ mod tests {
                   "pressure": 220.0
                }"#;
 
-        let timestamp = FixedOffset::east(5 * 3600).ymd(2021, 4, 8).and_hms(0, 0, 0);
+        let timestamp = datetime!(2021-04-08 0:00:0 +05:00);
 
         let output =
             from_thin_edge_json_with_timestamp(single_value_thin_edge_json, timestamp, None);
 
         let expected_output = json!({
             "type": "ThinEdgeMeasurement",
-            "time": timestamp.to_rfc3339(),
+            "time":             timestamp
+                .format(&format_description::well_known::Rfc3339)
+                .unwrap()
+                .as_str(),
             "temperature": {
                 "temperature": {
                     "value": 23.0
@@ -137,14 +140,17 @@ mod tests {
             "pressure": 98.0
         }"#;
 
-        let timestamp = FixedOffset::east(5 * 3600).ymd(2021, 4, 8).and_hms(0, 0, 0);
+        let timestamp = datetime!(2021-04-08 0:00:0 +05:00);
 
         let output =
             from_thin_edge_json_with_timestamp(multi_value_thin_edge_json, timestamp, None);
 
         let expected_output = json!({
             "type": "ThinEdgeMeasurement",
-            "time": timestamp.to_rfc3339(),
+            "time":             timestamp
+            .format(&format_description::well_known::Rfc3339)
+            .unwrap()
+            .as_str(),
             "temperature": {
                 "temperature": {
                     "value": 25.0
@@ -201,6 +207,7 @@ mod tests {
         );
     }
     use proptest::prelude::*;
+    use time::{format_description, macros::datetime};
 
     proptest! {
 
@@ -270,7 +277,7 @@ mod tests {
         thin_edge_json: &str,
         expected_output: Value,
     ) {
-        let timestamp = FixedOffset::east(5 * 3600).ymd(2021, 4, 8).and_hms(0, 0, 0);
+        let timestamp = datetime!(2021-04-08 0:00:0 +05:00);
         let output = from_thin_edge_json_with_timestamp(thin_edge_json, timestamp, Some(child_id));
         assert_json_eq!(
             serde_json::from_str::<serde_json::Value>(output.unwrap().as_str()).unwrap(),

--- a/mapper/cumulocity/c8y_translator_lib/src/serializer.rs
+++ b/mapper/cumulocity/c8y_translator_lib/src/serializer.rs
@@ -151,6 +151,7 @@ impl MeasurementVisitor for C8yJsonSerializer {
 
 #[cfg(test)]
 mod tests {
+    use ::time::macros::datetime;
     use assert_json_diff::*;
     use assert_matches::*;
     use serde_json::json;
@@ -159,9 +160,7 @@ mod tests {
 
     #[test]
     fn serialize_single_value_message() -> anyhow::Result<()> {
-        let timestamp = FixedOffset::east(5 * 3600)
-            .ymd(2021, 6, 22)
-            .and_hms_nano(17, 3, 14, 123456789);
+        let timestamp = datetime!(2021-06-22 17:03:14.123456789 +05:00);
 
         let mut serializer = C8yJsonSerializer::new(timestamp, None);
         serializer.visit_timestamp(timestamp)?;
@@ -187,9 +186,7 @@ mod tests {
     }
     #[test]
     fn serialize_multi_value_message() -> anyhow::Result<()> {
-        let timestamp = FixedOffset::east(5 * 3600)
-            .ymd(2021, 6, 22)
-            .and_hms_nano(17, 3, 14, 123456789);
+        let timestamp = datetime!(2021-06-22 17:03:14.123456789 +05:00);
 
         let mut serializer = C8yJsonSerializer::new(timestamp, None);
         serializer.visit_timestamp(timestamp)?;
@@ -240,9 +237,7 @@ mod tests {
 
     #[test]
     fn serialize_empty_message() -> anyhow::Result<()> {
-        let timestamp = FixedOffset::east(5 * 3600)
-            .ymd(2021, 6, 22)
-            .and_hms_nano(17, 3, 14, 123456789);
+        let timestamp = datetime!(2021-06-22 17:03:14.123456789 +05:00);
 
         let mut serializer = C8yJsonSerializer::new(timestamp, None);
 
@@ -261,9 +256,7 @@ mod tests {
 
     #[test]
     fn serialize_timestamp_message() -> anyhow::Result<()> {
-        let timestamp = FixedOffset::east(5 * 3600)
-            .ymd(2021, 6, 22)
-            .and_hms_nano(17, 3, 14, 123456789);
+        let timestamp = datetime!(2021-06-22 17:03:14.123456789 +05:00);
 
         let mut serializer = C8yJsonSerializer::new(timestamp, None);
         serializer.visit_timestamp(timestamp)?;
@@ -285,9 +278,7 @@ mod tests {
 
     #[test]
     fn serialize_timestamp_within_group() -> anyhow::Result<()> {
-        let timestamp = FixedOffset::east(5 * 3600)
-            .ymd(2021, 6, 22)
-            .and_hms_nano(17, 3, 14, 123456789);
+        let timestamp = datetime!(2021-06-22 17:03:14.123456789 +05:00);
 
         let mut serializer = C8yJsonSerializer::new(timestamp, None);
         serializer.visit_start_group("location")?;
@@ -305,9 +296,7 @@ mod tests {
 
     #[test]
     fn serialize_unexpected_end_of_group() -> anyhow::Result<()> {
-        let timestamp = FixedOffset::east(5 * 3600)
-            .ymd(2021, 6, 22)
-            .and_hms_nano(17, 3, 14, 123456789);
+        let timestamp = datetime!(2021-06-22 17:03:14.123456789 +05:00);
 
         let mut serializer = C8yJsonSerializer::new(timestamp, None);
         serializer.visit_measurement("alti", 2100.4)?;
@@ -327,9 +316,7 @@ mod tests {
 
     #[test]
     fn serialize_unexpected_start_of_group() -> anyhow::Result<()> {
-        let timestamp = FixedOffset::east(5 * 3600)
-            .ymd(2021, 6, 22)
-            .and_hms_nano(17, 3, 14, 123456789);
+        let timestamp = datetime!(2021-06-22 17:03:14.123456789 +05:00);
 
         let mut serializer = C8yJsonSerializer::new(timestamp, None);
         serializer.visit_start_group("location")?;
@@ -350,9 +337,7 @@ mod tests {
 
     #[test]
     fn serialize_unexpected_end_of_message() -> anyhow::Result<()> {
-        let timestamp = FixedOffset::east(5 * 3600)
-            .ymd(2021, 6, 22)
-            .and_hms_nano(17, 3, 14, 123456789);
+        let timestamp = datetime!(2021-06-22 17:03:14.123456789 +05:00);
 
         let mut serializer = C8yJsonSerializer::new(timestamp, None);
         serializer.visit_start_group("location")?;
@@ -373,9 +358,7 @@ mod tests {
 
     #[test]
     fn serialize_timestamp_child_message() -> anyhow::Result<()> {
-        let timestamp = FixedOffset::east(5 * 3600)
-            .ymd(2021, 6, 22)
-            .and_hms_nano(17, 3, 14, 123456789);
+        let timestamp = datetime!(2021-06-22 17:03:14.123456789 +05:00);
 
         let mut serializer = C8yJsonSerializer::new(timestamp, Some("child1"));
         serializer.visit_timestamp(timestamp)?;

--- a/mapper/tedge_mapper/Cargo.toml
+++ b/mapper/tedge_mapper/Cargo.toml
@@ -30,7 +30,6 @@ async-trait = "0.1"
 batcher = { path = "../../common/batcher" }
 c8y_smartrest = { path = "../cumulocity/c8y_smartrest" }
 c8y_translator_lib = { path = "../cumulocity/c8y_translator_lib" }
-chrono = "0.4"
 clock = { path = "../../common/clock" }
 csv = "1.1"
 flockfile = { path = "../../common/flockfile" }
@@ -47,6 +46,7 @@ tedge_users = { path = "../../common/tedge_users" }
 tedge_utils = { path = "../../common/tedge_utils", features = ["logging"] }
 thin_edge_json = {path = "../thin_edge_json" }
 thiserror = "1.0"
+time = "0.3"
 tokio = { version = "1.8", features = ["rt", "sync", "time"] }
 tracing = { version = "0.1", features = ["attributes", "log"] }
 

--- a/mapper/tedge_mapper/Cargo.toml
+++ b/mapper/tedge_mapper/Cargo.toml
@@ -59,6 +59,7 @@ serde_json = "1.0"
 serial_test = "0.5"
 tempfile = "3.2"
 test-case = "1.2"
+time = { version = "0.3", features = ["macros"] }
 tokio-test = "0.4"
 
 [features]

--- a/mapper/tedge_mapper/src/az_converter.rs
+++ b/mapper/tedge_mapper/src/az_converter.rs
@@ -55,12 +55,14 @@ mod tests {
     use assert_matches::*;
     use mqtt_client::Topic;
     use serde_json::json;
+    use time::macros::datetime;
 
     struct TestClock;
 
     impl Clock for TestClock {
         fn now(&self) -> clock::Timestamp {
-            FixedOffset::east(5 * 3600).ymd(2021, 4, 8).and_hms(0, 0, 0)
+            datetime!(2021-04-08 00:00:00 +05:00)
+            // FixedOffset::east(5 * 3600).ymd(2021, 4, 8).and_hms(0, 0, 0)
         }
     }
 

--- a/mapper/tedge_mapper/src/az_converter.rs
+++ b/mapper/tedge_mapper/src/az_converter.rs
@@ -53,7 +53,6 @@ mod tests {
     use crate::size_threshold::SizeThresholdExceeded;
     use assert_json_diff::*;
     use assert_matches::*;
-    use chrono::{FixedOffset, TimeZone};
     use mqtt_client::Topic;
     use serde_json::json;
 

--- a/mapper/tedge_mapper/src/collectd_mapper/batcher.rs
+++ b/mapper/tedge_mapper/src/collectd_mapper/batcher.rs
@@ -21,7 +21,7 @@ impl MessageBatch {
         let mut messages = messages.into_iter();
 
         if let Some(first_message) = messages.next() {
-            let timestamp = first_message.timestamp.with_timezone(Local::now().offset());
+            let timestamp = first_message.timestamp;
             let mut batch = MessageBatch::start_batch(first_message, timestamp)?;
             for message in messages {
                 batch.add_to_batch(message)?;

--- a/mapper/tedge_mapper/src/collectd_mapper/batcher.rs
+++ b/mapper/tedge_mapper/src/collectd_mapper/batcher.rs
@@ -7,7 +7,6 @@ use thin_edge_json::{
 };
 
 use crate::collectd_mapper::{collectd::CollectdMessage, error::DeviceMonitorError};
-use chrono::Local;
 use thin_edge_json::group::MeasurementGrouperError;
 
 #[derive(Debug)]
@@ -72,7 +71,6 @@ impl MessageBatch {
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use chrono::{TimeZone, Utc};
     use clock::{Clock, WallClock};
 
     #[test]

--- a/mapper/tedge_mapper/src/collectd_mapper/batcher.rs
+++ b/mapper/tedge_mapper/src/collectd_mapper/batcher.rs
@@ -72,10 +72,11 @@ mod tests {
     use super::*;
     use assert_matches::assert_matches;
     use clock::{Clock, WallClock};
+    use time::macros::datetime;
 
     #[test]
     fn test_message_batch_processor() -> anyhow::Result<()> {
-        let timestamp = Utc.ymd(2015, 5, 15).and_hms_milli(0, 0, 1, 444);
+        let timestamp = datetime!(2015-05-15 0:00:01.444 UTC);
         let collectd_message = CollectdMessage::new("temperature", "value", 32.5, timestamp);
         let mut message_batch = MessageBatch::start_batch(collectd_message, WallClock.now())?;
 

--- a/mapper/tedge_mapper/src/collectd_mapper/collectd.rs
+++ b/mapper/tedge_mapper/src/collectd_mapper/collectd.rs
@@ -179,6 +179,7 @@ impl Batchable for CollectdMessage {
 mod tests {
     use assert_matches::assert_matches;
     use mqtt_client::Topic;
+    use time::macros::datetime;
 
     use super::*;
 
@@ -198,10 +199,7 @@ mod tests {
 
         assert_eq!(metric_group_key, "temperature");
         assert_eq!(metric_key, "value");
-        assert_eq!(
-            timestamp,
-            Utc.ymd(1973, 11, 29).and_hms_milli(21, 33, 09, 0)
-        );
+        assert_eq!(timestamp, datetime!(1973-11-29 21:33:09 UTC));
         assert_eq!(metric_value, 32.5);
     }
 
@@ -221,10 +219,7 @@ mod tests {
 
         assert_eq!(metric_group_key, "temperature");
         assert_eq!(metric_key, "value");
-        assert_eq!(
-            timestamp,
-            Utc.ymd(1973, 11, 29).and_hms_milli(21, 33, 09, 125)
-        );
+        assert_eq!(timestamp, datetime!(1973-11-29 21:33:09.125 UTC));
         assert_eq!(metric_value, 32.5);
     }
 

--- a/mapper/tedge_mapper/src/sm_c8y_mapper/error.rs
+++ b/mapper/tedge_mapper/src/sm_c8y_mapper/error.rs
@@ -35,6 +35,15 @@ pub(crate) enum SMCumulocityMapperError {
     #[error(transparent)]
     FromTedgeConfig(#[from] tedge_config::ConfigSettingError),
 
+    #[error(transparent)]
+    FromTimeFormat(#[from] time::error::Format),
+
+    #[error(transparent)]
+    FromTimeInvalidFormatDescription(#[from] time::error::InvalidFormatDescription),
+
+    #[error(transparent)]
+    FromTimeParse(#[from] time::error::Parse),
+
     #[error("Invalid date in file name: {0}")]
     InvalidDateInFileName(String),
 

--- a/mapper/tedge_mapper/src/sm_c8y_mapper/error.rs
+++ b/mapper/tedge_mapper/src/sm_c8y_mapper/error.rs
@@ -42,9 +42,6 @@ pub(crate) enum SMCumulocityMapperError {
     InvalidUtf8Path,
 
     #[error(transparent)]
-    FromChronoParse(#[from] chrono::ParseError),
-
-    #[error(transparent)]
     FromIo(#[from] std::io::Error),
 
     #[error("Request timed out")]

--- a/mapper/tedge_mapper/src/sm_c8y_mapper/mapper.rs
+++ b/mapper/tedge_mapper/src/sm_c8y_mapper/mapper.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::{convert::TryInto, time::Duration};
 use tedge_config::{C8yUrlSetting, ConfigSettingAccessorStringExt, DeviceIdSetting, TEdgeConfig};
-use time::OffsetDateTime;
+use time::{format_description, OffsetDateTime};
 use tokio::time::Instant;
 use tracing::{debug, error, info, instrument};
 
@@ -450,10 +450,13 @@ async fn create_log_event(
 
     let local = time::OffsetDateTime::now_utc();
 
+    let format =
+        format_description::parse("[year]-[month]-[day]T[hour repr:24]:[minute]:[seconds]Z")?;
+
     let c8y_log_event = C8yCreateEvent::new(
         c8y_managed_object.to_owned(),
         "c8y_Logfile",
-        &local.format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+        &local.format(&format)?,
         "software-management",
     );
 
@@ -490,7 +493,7 @@ fn get_datetime_from_file_path(
         stem_string_vec.reverse();
         // join on '-' to get the date string
         let date_string = stem_string_vec.join("-");
-        let dt = DateTime::parse_from_rfc3339(&date_string)?;
+        let dt = OffsetDateTime::parse(&date_string, &format_description::well_known::Rfc3339)?;
 
         return Ok(dt);
     }

--- a/mapper/tedge_mapper/src/sm_c8y_mapper/mapper.rs
+++ b/mapper/tedge_mapper/src/sm_c8y_mapper/mapper.rs
@@ -14,7 +14,6 @@ use c8y_smartrest::{
         SmartRestSetSupportedLogType, SmartRestSetSupportedOperations,
     },
 };
-use chrono::{DateTime, FixedOffset, Local};
 use json_sm::{
     Auth, DownloadInfo, Jsonify, SoftwareListRequest, SoftwareListResponse,
     SoftwareOperationStatus, SoftwareUpdateResponse,
@@ -25,6 +24,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::{convert::TryInto, time::Duration};
 use tedge_config::{C8yUrlSetting, ConfigSettingAccessorStringExt, DeviceIdSetting, TEdgeConfig};
+use time::OffsetDateTime;
 use tokio::time::Instant;
 use tracing::{debug, error, info, instrument};
 
@@ -448,7 +448,7 @@ async fn create_log_event(
 
     let create_event_url = get_url_for_create_event(&url_host);
 
-    let local: DateTime<Local> = Local::now();
+    let local = time::OffsetDateTime::now_utc();
 
     let c8y_log_event = C8yCreateEvent::new(
         c8y_managed_object.to_owned(),
@@ -481,7 +481,7 @@ async fn create_log_event(
 /// ```
 fn get_datetime_from_file_path(
     log_path: &PathBuf,
-) -> Result<DateTime<FixedOffset>, SMCumulocityMapperError> {
+) -> Result<OffsetDateTime, SMCumulocityMapperError> {
     if let Some(stem_string) = log_path.file_stem().and_then(|s| s.to_str()) {
         // a typical file stem looks like this: software-list-2021-10-27T10:29:58Z.
         // to extract the date, rsplit string on "-" and take (last) 3

--- a/mapper/tedge_mapper/src/sm_c8y_mapper/mapper.rs
+++ b/mapper/tedge_mapper/src/sm_c8y_mapper/mapper.rs
@@ -497,6 +497,7 @@ fn get_datetime_from_file_path(
 
         return Ok(dt);
     }
+
     match log_path.to_str() {
         Some(path) => Err(SMCumulocityMapperError::InvalidDateInFileName(
             path.to_string(),

--- a/mapper/tedge_mapper/src/sm_c8y_mapper/mapper.rs
+++ b/mapper/tedge_mapper/src/sm_c8y_mapper/mapper.rs
@@ -451,7 +451,7 @@ async fn create_log_event(
     let local = time::OffsetDateTime::now_utc();
 
     let format =
-        format_description::parse("[year]-[month]-[day]T[hour repr:24]:[minute]:[seconds]Z")?;
+        format_description::parse("[year]-[month]-[day]T[hour repr:24]:[minute]:[seconds]z")?;
 
     let c8y_log_event = C8yCreateEvent::new(
         c8y_managed_object.to_owned(),

--- a/mapper/tedge_mapper/src/sm_c8y_mapper/tests.rs
+++ b/mapper/tedge_mapper/src/sm_c8y_mapper/tests.rs
@@ -28,7 +28,6 @@ async fn mapper_publishes_a_software_list_request() {
         .with_timeout(TEST_TIMEOUT_MS)
         .await
         .expect_or("No message received after a second.");
-    dbg!(&msg);
     assert!(&msg.contains(r#"{"id":"#));
 
     sm_mapper.unwrap().abort();

--- a/mapper/thin_edge_json/Cargo.toml
+++ b/mapper/thin_edge_json/Cargo.toml
@@ -20,6 +20,7 @@ criterion = "0.3"
 mockall = "0.10"
 proptest = "1.0"
 stats_alloc = "0.1"
+time = { version = "0.3", features = ["macros"] }
 walkdir = "2"
 
 [[bench]]

--- a/mapper/thin_edge_json/Cargo.toml
+++ b/mapper/thin_edge_json/Cargo.toml
@@ -11,7 +11,7 @@ json-writer = { path = "../../common/json_writer" }
 serde = "1"
 serde_json = "1"
 thiserror = "1.0"
-time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "parsing", "serde"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/mapper/thin_edge_json/Cargo.toml
+++ b/mapper/thin_edge_json/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
 json-writer = { path = "../../common/json_writer" }
 serde = "1"
 serde_json = "1"
 thiserror = "1.0"
+time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/mapper/thin_edge_json/benches/parsing.rs
+++ b/mapper/thin_edge_json/benches/parsing.rs
@@ -1,6 +1,6 @@
-use chrono::prelude::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use thin_edge_json::measurement::MeasurementVisitor;
+use time::OffsetDateTime;
 
 const INPUT: &str = r#"{
     "time" : "2021-04-30T17:03:14.123+02:00",
@@ -26,7 +26,7 @@ struct DummyVisitor;
 impl MeasurementVisitor for DummyVisitor {
     type Error = DummyError;
 
-    fn visit_timestamp(&mut self, _value: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+    fn visit_timestamp(&mut self, _value: OffsetDateTime) -> Result<(), Self::Error> {
         Ok(())
     }
     fn visit_measurement(&mut self, _name: &str, _value: f64) -> Result<(), Self::Error> {
@@ -41,7 +41,7 @@ impl MeasurementVisitor for DummyVisitor {
 }
 
 fn parse_stream(input: &str) {
-    thin_edge_json::stream::parse_str(input, &mut DummyVisitor).unwrap();
+    thin_edge_json::parser::parse_str(input, &mut DummyVisitor).unwrap();
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/mapper/thin_edge_json/examples/validate.rs
+++ b/mapper/thin_edge_json/examples/validate.rs
@@ -1,6 +1,6 @@
-use chrono::prelude::*;
 use std::env;
 use thin_edge_json::measurement::MeasurementVisitor;
+use time::OffsetDateTime;
 
 #[global_allocator]
 static GLOBAL: &stats_alloc::StatsAlloc<std::alloc::System> = &stats_alloc::INSTRUMENTED_SYSTEM;
@@ -36,7 +36,7 @@ struct DummyVisitor;
 impl MeasurementVisitor for DummyVisitor {
     type Error = DummyError;
 
-    fn visit_timestamp(&mut self, _value: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+    fn visit_timestamp(&mut self, _value: OffsetDateTime) -> Result<(), Self::Error> {
         Ok(())
     }
     fn visit_measurement(&mut self, _name: &str, _value: f64) -> Result<(), Self::Error> {

--- a/mapper/thin_edge_json/src/builder.rs
+++ b/mapper/thin_edge_json/src/builder.rs
@@ -1,9 +1,10 @@
+use time::OffsetDateTime;
+
 use crate::{data::*, measurement::*};
-use chrono::prelude::*;
 
 /// A `MeasurementVisitor` that builds up `ThinEdgeJson`.
 pub struct ThinEdgeJsonBuilder {
-    timestamp: Option<DateTime<FixedOffset>>,
+    timestamp: Option<OffsetDateTime>,
     inside_group: Option<MultiValueMeasurement>,
     measurements: Vec<ThinEdgeValue>,
 }
@@ -36,7 +37,7 @@ impl ThinEdgeJsonBuilder {
 impl MeasurementVisitor for ThinEdgeJsonBuilder {
     type Error = ThinEdgeJsonBuilderError;
 
-    fn visit_timestamp(&mut self, value: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+    fn visit_timestamp(&mut self, value: OffsetDateTime) -> Result<(), Self::Error> {
         match self.timestamp {
             None => {
                 self.timestamp = Some(value);

--- a/mapper/thin_edge_json/src/data.rs
+++ b/mapper/thin_edge_json/src/data.rs
@@ -1,11 +1,11 @@
 //! The in-memory data model representing ThinEdge JSON.
 
-use chrono::prelude::*;
+use time::OffsetDateTime;
 
 /// In-memory representation of parsed ThinEdge JSON.
 #[derive(Debug)]
 pub struct ThinEdgeJson {
-    pub timestamp: Option<DateTime<FixedOffset>>,
+    pub timestamp: Option<OffsetDateTime>,
     pub values: Vec<ThinEdgeValue>,
 }
 
@@ -14,7 +14,7 @@ impl ThinEdgeJson {
         self.timestamp.is_some()
     }
 
-    pub fn set_timestamp(&mut self, timestamp: DateTime<FixedOffset>) {
+    pub fn set_timestamp(&mut self, timestamp: OffsetDateTime) {
         self.timestamp = Some(timestamp)
     }
 }

--- a/mapper/thin_edge_json/src/group.rs
+++ b/mapper/thin_edge_json/src/group.rs
@@ -192,7 +192,7 @@ mod tests {
     use super::*;
     use mockall::predicate::*;
     use mockall::*;
-    use time::macros::datetime;
+    use time::{macros::datetime, Duration};
 
     #[derive(thiserror::Error, Debug, Clone)]
     pub enum TestError {
@@ -294,6 +294,8 @@ mod tests {
         let _ = grouper.visit_timestamp(test_timestamp(6));
         let _ = grouper.visit_timestamp(test_timestamp(5));
 
+        dbg!(&grouper);
+
         let mut mock = MockGroupedVisitor::new();
         mock.expect_visit_timestamp()
             .times(1)
@@ -347,7 +349,10 @@ mod tests {
     }
 
     fn test_timestamp(minute: u32) -> OffsetDateTime {
-        datetime!(2021-04-08 13:00:00 +05:00)
+        // let dt = format!("2021-04-08T13:{}:00+05:00", minute);
+        let mut dt = datetime!(2021-04-08 13:00:00 +05:00);
+        dt += Duration::minutes(minute as i64);
+        dt
         // FixedOffset::east(5 * 3600)
         //     .ymd(2021, 4, 8)
         //     .and_hms(13, minute, 00)

--- a/mapper/thin_edge_json/src/group.rs
+++ b/mapper/thin_edge_json/src/group.rs
@@ -1,12 +1,10 @@
-use chrono::offset::FixedOffset;
-use chrono::DateTime;
-use std::collections::HashMap;
-
 use crate::measurement::MeasurementVisitor;
+use std::collections::HashMap;
+use time::OffsetDateTime;
 
 #[derive(Debug)]
 pub struct MeasurementGroup {
-    timestamp: Option<DateTime<FixedOffset>>,
+    timestamp: Option<OffsetDateTime>,
     values: HashMap<String, Measurement>,
 }
 
@@ -18,7 +16,7 @@ impl MeasurementGroup {
         }
     }
 
-    pub fn timestamp(&self) -> Option<DateTime<FixedOffset>> {
+    pub fn timestamp(&self) -> Option<OffsetDateTime> {
         self.timestamp
     }
 
@@ -138,7 +136,7 @@ impl Default for MeasurementGrouper {
 impl MeasurementVisitor for MeasurementGrouper {
     type Error = MeasurementGrouperError;
 
-    fn visit_timestamp(&mut self, time: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+    fn visit_timestamp(&mut self, time: OffsetDateTime) -> Result<(), Self::Error> {
         self.measurement_group.timestamp = Some(time);
         Ok(())
     }
@@ -192,7 +190,6 @@ impl MeasurementVisitor for MeasurementGrouper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::prelude::*;
     use mockall::predicate::*;
     use mockall::*;
 
@@ -209,7 +206,7 @@ mod tests {
         impl MeasurementVisitor for GroupedVisitor {
             type Error = TestError;
 
-            fn visit_timestamp(&mut self, value: DateTime<FixedOffset>) -> Result<(), TestError>;
+            fn visit_timestamp(&mut self, value: OffsetDateTime) -> Result<(), TestError>;
             fn visit_measurement(&mut self, name: &str, value: f64) -> Result<(), TestError>;
             fn visit_start_group(&mut self, group: &str) -> Result<(), TestError>;
             fn visit_end_group(&mut self) -> Result<(), TestError>;
@@ -348,7 +345,7 @@ mod tests {
         Ok(())
     }
 
-    fn test_timestamp(minute: u32) -> DateTime<FixedOffset> {
+    fn test_timestamp(minute: u32) -> OffsetDateTime {
         FixedOffset::east(5 * 3600)
             .ymd(2021, 4, 8)
             .and_hms(13, minute, 00)

--- a/mapper/thin_edge_json/src/group.rs
+++ b/mapper/thin_edge_json/src/group.rs
@@ -192,6 +192,7 @@ mod tests {
     use super::*;
     use mockall::predicate::*;
     use mockall::*;
+    use time::macros::datetime;
 
     #[derive(thiserror::Error, Debug, Clone)]
     pub enum TestError {
@@ -346,8 +347,9 @@ mod tests {
     }
 
     fn test_timestamp(minute: u32) -> OffsetDateTime {
-        FixedOffset::east(5 * 3600)
-            .ymd(2021, 4, 8)
-            .and_hms(13, minute, 00)
+        datetime!(2021-04-08 13:00:00 +05:00)
+        // FixedOffset::east(5 * 3600)
+        //     .ymd(2021, 4, 8)
+        //     .and_hms(13, minute, 00)
     }
 }

--- a/mapper/thin_edge_json/src/measurement.rs
+++ b/mapper/thin_edge_json/src/measurement.rs
@@ -1,5 +1,4 @@
-use chrono::offset::FixedOffset;
-use chrono::DateTime;
+use time::OffsetDateTime;
 
 /// The `MeasurementVisitor` trait represents the capability to visit a series of measurements, possibly grouped.
 ///
@@ -7,7 +6,8 @@ use chrono::DateTime;
 ///
 /// ```
 /// # use thin_edge_json::measurement::*;
-/// # use chrono::*;
+/// # use time::OffsetDateTime;
+///
 /// struct MeasurementPrinter {
 ///     group: Option<String>,
 /// }
@@ -27,7 +27,7 @@ use chrono::DateTime;
 /// impl MeasurementVisitor for MeasurementPrinter {
 ///     type Error = MeasurementError;
 ///
-///     fn visit_timestamp(&mut self, timestamp: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+///     fn visit_timestamp(&mut self, timestamp: OffsetDateTime) -> Result<(), Self::Error> {
 ///         if self.group.is_none() {
 ///             Ok(println!("time = {}", timestamp.to_rfc2822()))
 ///         } else {
@@ -67,7 +67,7 @@ pub trait MeasurementVisitor {
     type Error: std::error::Error + std::fmt::Debug;
 
     /// Set the timestamp shared by all the measurements of this series.
-    fn visit_timestamp(&mut self, value: DateTime<FixedOffset>) -> Result<(), Self::Error>;
+    fn visit_timestamp(&mut self, value: OffsetDateTime) -> Result<(), Self::Error>;
 
     /// Add a new measurement, attached to the current group if any.
     fn visit_measurement(&mut self, name: &str, value: f64) -> Result<(), Self::Error>;

--- a/mapper/thin_edge_json/src/measurement.rs
+++ b/mapper/thin_edge_json/src/measurement.rs
@@ -6,7 +6,7 @@ use time::OffsetDateTime;
 ///
 /// ```
 /// # use thin_edge_json::measurement::*;
-/// # use time::OffsetDateTime;
+/// # use time::{OffsetDateTime, format_description};
 ///
 /// struct MeasurementPrinter {
 ///     group: Option<String>,
@@ -28,8 +28,10 @@ use time::OffsetDateTime;
 ///     type Error = MeasurementError;
 ///
 ///     fn visit_timestamp(&mut self, timestamp: OffsetDateTime) -> Result<(), Self::Error> {
+///     let format =
+///         format_description::parse("[day] [month repr:short] [year] [hour repr:24]:[minute]:[seconds] [offset_hour sign:mandatory]:[offset_minute]").unwrap();
 ///         if self.group.is_none() {
-///             Ok(println!("time = {}", timestamp.to_rfc2822()))
+///             Ok(println!("time = {}", timestamp.format(&format).unwrap()))
 ///         } else {
 ///             Err(MeasurementError::UnexpectedTimestamp)
 ///         }

--- a/mapper/thin_edge_json/src/parser.rs
+++ b/mapper/thin_edge_json/src/parser.rs
@@ -10,7 +10,7 @@ use serde::{
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;
-use time::{format_description, OffsetDateTime};
+use time::{format_description, macros::datetime, OffsetDateTime};
 
 /// Parses `input` as ThinEdge JSON yielding the parsed measurements to the `visitor`.
 pub fn parse_str<T: MeasurementVisitor>(
@@ -320,11 +320,7 @@ fn it_deserializes_thin_edge_json() -> anyhow::Result<()> {
 
     assert_eq!(
         output.timestamp,
-        Some(
-            FixedOffset::east(2 * 3600)
-                .ymd(2021, 4, 30)
-                .and_hms_milli(17, 3, 14, 123)
-        )
+        Some(datetime!(2021-04-30 17:03:14.123 +02:00))
     );
 
     assert_eq!(

--- a/mapper/thin_edge_json/src/parser.rs
+++ b/mapper/thin_edge_json/src/parser.rs
@@ -3,7 +3,6 @@
 //! [^1]: It only allocates in presence of escaped strings as keys.
 //!
 use crate::measurement::MeasurementVisitor;
-use chrono::prelude::*;
 use serde::{
     de::{self, DeserializeSeed, MapAccess},
     Deserializer,
@@ -11,6 +10,7 @@ use serde::{
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;
+use time::{format_description, OffsetDateTime};
 
 /// Parses `input` as ThinEdge JSON yielding the parsed measurements to the `visitor`.
 pub fn parse_str<T: MeasurementVisitor>(
@@ -99,8 +99,11 @@ where
                 }
                 "time" => {
                     let timestamp_str: &str = map.next_value()?;
-                    let timestamp = DateTime::parse_from_rfc3339(timestamp_str)
-                        .map_err(|err| de::Error::custom(invalid_timestamp(timestamp_str, err)))?;
+                    let timestamp = OffsetDateTime::parse(
+                        timestamp_str,
+                        &format_description::well_known::Rfc3339,
+                    )
+                    .map_err(|err| de::Error::custom(invalid_timestamp(timestamp_str, err)))?;
 
                     let () = self
                         .visitor

--- a/mapper/thin_edge_json/src/serialize.rs
+++ b/mapper/thin_edge_json/src/serialize.rs
@@ -141,7 +141,7 @@ mod tests {
     use time::OffsetDateTime;
 
     fn test_timestamp() -> OffsetDateTime {
-        OffsetDateTime::now_local().unwrap()
+        OffsetDateTime::now_utc()
     }
 
     #[test]
@@ -198,6 +198,8 @@ mod tests {
                 .as_str(),
             body
         );
+        dbg!(&expected_output);
+
         let output = serializer.into_string()?;
         assert_eq!(expected_output, output);
         Ok(())

--- a/mapper/thin_edge_json/src/serialize.rs
+++ b/mapper/thin_edge_json/src/serialize.rs
@@ -141,8 +141,7 @@ mod tests {
     use time::OffsetDateTime;
 
     fn test_timestamp() -> OffsetDateTime {
-        let local_time_now: DateTime<Local> = Local::now();
-        local_time_now.with_timezone(local_time_now.offset())
+        OffsetDateTime::now_local().unwrap()
     }
 
     #[test]
@@ -154,7 +153,15 @@ mod tests {
         serializer.visit_measurement("temperature", 25.5)?;
 
         let body = r#""temperature":25.5"#;
-        let expected_output = format!(r#"{{"time":"{}",{}}}"#, timestamp.to_rfc3339(), body);
+
+        let expected_output = format!(
+            r#"{{"time":"{}",{}}}"#,
+            timestamp
+                .format(&format_description::well_known::Rfc3339)
+                .unwrap()
+                .as_str(),
+            body
+        );
         let output = serializer.into_string()?;
         assert_eq!(output, expected_output);
         Ok(())
@@ -183,7 +190,14 @@ mod tests {
         serializer.visit_end_group()?;
         serializer.visit_measurement("pressure", 255.0)?;
         let body = r#""temperature":25.5,"location":{"alti":2100.4,"longi":2200.4,"lati":2300.4},"pressure":255.0}"#;
-        let expected_output = format!(r#"{{"time":"{}",{}"#, timestamp.to_rfc3339(), body);
+        let expected_output = format!(
+            r#"{{"time":"{}",{}"#,
+            timestamp
+                .format(&format_description::well_known::Rfc3339)
+                .unwrap()
+                .as_str(),
+            body
+        );
         let output = serializer.into_string()?;
         assert_eq!(expected_output, output);
         Ok(())
@@ -203,7 +217,14 @@ mod tests {
         let mut serializer = ThinEdgeJsonSerializer::new();
         let timestamp = test_timestamp();
         serializer.visit_timestamp(timestamp)?;
-        let expected_output = format!(r#"{{"time":"{}"{}"#, timestamp.to_rfc3339(), "}");
+        let expected_output = format!(
+            r#"{{"time":"{}"{}"#,
+            timestamp
+                .format(&format_description::well_known::Rfc3339)
+                .unwrap()
+                .as_str(),
+            "}"
+        );
         let output = serializer.into_string()?;
         assert_eq!(expected_output, output);
         Ok(())

--- a/mapper/thin_edge_json/tests/fixtures/invalid/reject_invalid_timestamp.expected_error
+++ b/mapper/thin_edge_json/tests/fixtures/invalid/reject_invalid_timestamp.expected_error
@@ -1,4 +1,4 @@
-Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-22 3am": input contains invalid characters at line 2 column 27: `",
+Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-22 3am": a character literal was not valid at line 2 column 27: `",
   "pressure": 220
 }
 `

--- a/mapper/thin_edge_json/tests/fixtures/invalid/reject_partial_timestamp.expected_error
+++ b/mapper/thin_edge_json/tests/fixtures/invalid/reject_partial_timestamp.expected_error
@@ -1,4 +1,4 @@
-Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-22": premature end of input at line 2 column 23: `",
+Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-22": a character literal was not valid at line 2 column 23: `",
   "pressure": 220
 }
 `

--- a/mapper/thin_edge_json/tests/fixtures/invalid/reject_timestamp_missing_time_separator.expected_error
+++ b/mapper/thin_edge_json/tests/fixtures/invalid/reject_timestamp_missing_time_separator.expected_error
@@ -1,2 +1,2 @@
-Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-2217:03:14.000658767+02:00": input contains invalid characters at line 3 column 1: `}
+Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-2217:03:14.000658767+02:00": a character literal was not valid at line 3 column 1: `}
 `

--- a/sm/tedge_agent/Cargo.toml
+++ b/sm/tedge_agent/Cargo.toml
@@ -23,7 +23,6 @@ stop-on-upgrade = false
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-chrono = "0.4"
 flockfile = { path = "../../common/flockfile" }
 futures = "0.3"
 json_sm = { path = "../json_sm" }
@@ -36,6 +35,7 @@ structopt = "0.3"
 tedge_config = { path = "../../tedge_config" }
 tedge_utils = { path = "../../common/tedge_utils", features = ["logging"] }
 thiserror = "1.0"
+time = { version = "0.3", features = ["formatting"] }
 tokio = { version = "1.8", features = ["fs","process", "rt"] }
 toml = "0.5"
 tracing = { version = "0.1", features = ["attributes", "log"] }

--- a/sm/tedge_agent/src/error.rs
+++ b/sm/tedge_agent/src/error.rs
@@ -36,7 +36,7 @@ pub enum AgentError {
     FromFlockfileError(#[from] FlockfileError),
 
     #[error(transparent)]
-    FromTime(#[from] crate::operation_logs::OperationLogsError),
+    FromOperationsLogs(#[from] crate::operation_logs::OperationLogsError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/sm/tedge_agent/src/error.rs
+++ b/sm/tedge_agent/src/error.rs
@@ -34,6 +34,9 @@ pub enum AgentError {
 
     #[error(transparent)]
     FromFlockfileError(#[from] FlockfileError),
+
+    #[error(transparent)]
+    FromTime(#[from] crate::operation_logs::OperationLogsError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/sm/tedge_agent/src/operation_logs.rs
+++ b/sm/tedge_agent/src/operation_logs.rs
@@ -58,9 +58,8 @@ impl OperationLogs {
         }
 
         let now = OffsetDateTime::now_utc();
-        let format = format_description::parse(
-            "[year]-[month]-[day]T[hour repr:24]:[minute]:[seconds]+[offset_hour]:[offset_minute]",
-        )?;
+        let format =
+            format_description::parse("[year]-[month]-[day]T[hour repr:24]:[minute]:[second]z")?;
 
         let file_prefix = match kind {
             LogKind::SoftwareUpdate => UPDATE_PREFIX,

--- a/tedge/Cargo.toml
+++ b/tedge/Cargo.toml
@@ -27,6 +27,7 @@ tedge_config = { path = "../tedge_config" }
 tedge_users = { path = "../common/tedge_users" }
 tedge_utils = { path = "../common/tedge_utils" }
 thiserror = "1.0"
+time = { version = "0.3", features = ["formatting"] }
 toml = "0.5"
 url = "2.2"
 webpki = "0.21"


### PR DESCRIPTION
## Proposed changes

Due to RUSTSEC and `chrono` marked as unmaintained we swap all use of `chrono` in favour of `time` crate.

Outstanding is crate `rcgen`.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
