### PR TITLE
Fix for cargo test features cache being invalidated

### DIFF
--- a/.github/workflows/integration-test-workflow.yml
+++ b/.github/workflows/integration-test-workflow.yml
@@ -53,7 +53,7 @@ jobs:
         run: sudo apt-get --assume-yes install mosquitto
 
       - name: install libmosquitto1
-        run:  sudo apt-get --assume-yes install libmosquitto1
+        run: sudo apt-get --assume-yes install libmosquitto1
 
       - name: install collectd-core
         run: sudo apt-get --assume-yes install collectd-core
@@ -90,6 +90,12 @@ jobs:
           command: test
           args: --verbose --no-run --features integration-test
 
+      - name: Cargo build dummy plugin
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p tedge_dummy_plugin
+
         # To run the test for features here is kind of experimental
         # they could fail if GitHub blocks external connections.
         # It seems like they rarely do.
@@ -123,7 +129,6 @@ jobs:
         run: sudo systemctl stop tedge-mapper-collectd
         continue-on-error: true
 
-
       - name: disconnect c8y
         run: sudo tedge disconnect c8y
         # We need to continue when there is no tedge already installed
@@ -144,7 +149,7 @@ jobs:
         run: sudo apt-get --assume-yes install mosquitto
 
       - name: install libmosquitto1
-        run:  sudo apt-get --assume-yes install libmosquitto1
+        run: sudo apt-get --assume-yes install libmosquitto1
 
       - name: install mosquitto-clients
         run: sudo apt-get --assume-yes install mosquitto-clients
@@ -212,5 +217,3 @@ jobs:
           AZUREENDPOINT: ${{ secrets.AZUREENDPOINT }}
           AZUREEVENTHUB: ${{ secrets.AZUREEVENTHUB }}
           IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
-
-


### PR DESCRIPTION
Signed-off-by: Lukasz Woznicki <lukasz.woznicki@softwareag.com>

## Proposed changes

Due to new directory struct the caches have been invalidated, we need to build dummy_plugin for tests.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

