### PR TITLE
[CIT-623] Enable recording for all PySys calls

### DIFF
--- a/ci/ci_run_all_plugin_tests.sh
+++ b/ci/ci_run_all_plugin_tests.sh
@@ -30,11 +30,19 @@ cd tests/PySys/
 
 sudo tedge config set software.plugin.default apt
 
-pysys.py run -v DEBUG 'apt_*' -XmyPlatform='container'
+set +e
+pysys.py run --record -v DEBUG 'apt_*' -XmyPlatform='container'
+set -e
+
+mv __pysys_junit_xml pysys_junit_xml_apt
 
 sudo cp ../../plugins/tedge_docker_plugin/tedge_docker_plugin.sh /etc/tedge/sm-plugins/docker
 
-pysys.py run -v DEBUG 'docker_*' -XmyPlatform='container' -Xdockerplugin='dockerplugin'
+set +e
+pysys.py run --record -v DEBUG 'docker_*' -XmyPlatform='container' -Xdockerplugin='dockerplugin'
+set -e
+
+mv __pysys_junit_xml pysys_junit_xml_docker
 
 sudo rm -f /etc/tedge/sm-plugins/docker
 

--- a/ci/ci_run_all_sm_tests.sh
+++ b/ci/ci_run_all_sm_tests.sh
@@ -40,10 +40,14 @@ cd tests/PySys/
 
 # Run all software management tests, including the ones for the
 # fake- and the  docker plugin
-pysys.py run -v DEBUG 'SoftwareManagement.*' -XmyPlatform='smcontainer' -Xdockerplugin='dockerplugin' -Xfakeplugin='fakeplugin'
+set +e
+pysys.py run --record -v DEBUG 'SoftwareManagement.*' -XmyPlatform='smcontainer' -Xdockerplugin='dockerplugin' -Xfakeplugin='fakeplugin'
+set -e
 
 deactivate
 
 sudo tedge config unset software.plugin.default
 sudo rm -f /etc/tedge/sm-plugins/docker
 sudo rm -f /etc/tedge/sm-plugins/fruits
+
+mv __pysys_junit_xml pysys_junit_xml_sm

--- a/ci/ci_run_all_tests.sh
+++ b/ci/ci_run_all_tests.sh
@@ -40,5 +40,11 @@ python3 -m venv ~/env-pysys
 source ~/env-pysys/bin/activate
 pip3 install -r tests/requirements.txt
 cd tests/PySys/
-pysys.py run -v DEBUG
+
+set +e
+pysys.py run --record -v DEBUG
+set -e
+
 deactivate
+
+mv __pysys_junit_xml pysys_junit_xml_all

--- a/tests/PySys/pysysproject.xml
+++ b/tests/PySys/pysysproject.xml
@@ -31,6 +31,14 @@
 			<property name="outputDir" value="__pysys_junit_xml"/>
 		</writer>
 
+        <writer classname="pysys.writer.outcomes.XMLResultsWriter">
+                <property name="file" value="__pysys_testsummary_${outDirName}_%Y-%m-%d_%H.%M.%S.xml"/>
+        </writer>
+
+        <writer classname="pysys.writer.outcomes.CSVResultsWriter">
+                <property name="file" value="__pysys_testsummary_%Y-%m-%d_%H.%M.%S.csv"/>
+        </writer>
+
 		<writer classname="pysys.writer.ci.GitHubActionsCIWriter"></writer>
 		<writer classname="pysys.writer.ci.TravisCIWriter"></writer>
 


### PR DESCRIPTION
Signed-off-by: Michael Abel <info@abel-ikt.de>

## Proposed changes

Enable recording for all invocations of PySys.
Avoid to stop when the execution fails (wrap around set +e & -e).
Move report folder, so that it won't be overridden.

This is part one of CIT-623 that only enables reporting but not postprocessing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/623

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
