### PR TITLE
creating runtime directory /run/tedge_agent (#683)

### DIFF
--- a/configuration/init/systemd/tedge-agent.service
+++ b/configuration/init/systemd/tedge-agent.service
@@ -4,6 +4,7 @@ After=syslog.target network.target mosquitto.service
 
 [Service]
 User=tedge-agent
+RuntimeDirectory=tedge_agent
 ExecStart=/usr/bin/tedge_agent
 Restart=on-failure
 RestartPreventExitStatus=255

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -539,9 +539,8 @@ async fn publish_capabilities(mqtt: &Client) -> Result<(), AgentError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    const SLASH_RUN_PATH_TEDGE_AGENT_RESTART: &str = "/run/tedge_agent_restart";
+    const SLASH_RUN_PATH_TEDGE_AGENT_RESTART: &str = "/run/tedge_agent/tedge_agent_restart";
 
-    #[ignore]
     #[tokio::test]
     async fn check_agent_restart_file_is_created() -> Result<(), AgentError> {
         assert_eq!(INIT_COMMAND, "echo");

--- a/crates/core/tedge_agent/src/restart_operation_handler.rs
+++ b/crates/core/tedge_agent/src/restart_operation_handler.rs
@@ -4,7 +4,7 @@ pub mod restart_operation {
     use std::{fs::File, fs::OpenOptions, io::Read, io::Write, path::Path};
     use time::OffsetDateTime;
 
-    const SLASH_RUN_PATH_TEDGE_AGENT_RESTART: &str = "/run/tedge_agent_restart";
+    const SLASH_RUN_PATH_TEDGE_AGENT_RESTART: &str = "/run/tedge_agent/tedge_agent_restart";
     const SLASH_PROC_UPTIME: &str = "/proc/uptime";
 
     /// creates an empty file in /run


### PR DESCRIPTION
Signed-off-by: initard <solo@softwareag.com>

## Proposed changes

Currently, there is a permission error to write files in /run. This is required by the restart component, as it needs to make a file in /run to verify the restart actually occurred. 

This PR adds a runtime directory to the systemd configuration, which tedge-agent can write to - fixing this issue. 

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
