### PR TITLE
[CIT-669] Avoid continue on error for Azure smoke test

### DIFF
--- a/.github/workflows/integration-test-workflow.yml
+++ b/.github/workflows/integration-test-workflow.yml
@@ -210,8 +210,6 @@ jobs:
 
       - name: Run Smoke Test for Azure
         run: ./ci/ci_smoke_test_az.sh
-        # Temporarily continue on error
-        continue-on-error: true
         env:
           C8YDEVICE: ${{ secrets.SECRET_C8YDEVICE }}
           SASKEYQUEUE: ${{ secrets.SASKEYQUEUE }}


### PR DESCRIPTION
## Proposed changes

After switching the IoT Hub to the new official one, it works and we can remove that continue-on-error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/669

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
