### PR TITLE
Remove capabilities messages on tedge agent start

### DIFF
--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -195,8 +195,6 @@ impl SmAgent {
 
         let () = self.process_pending_operation(&mqtt).await?;
 
-        // * Maybe it would be nice if mapper/registry responds
-        let () = publish_capabilities(&mqtt).await?;
         while let Err(error) = self
             .process_subscribed_messages(&mqtt, &mut operations, &plugins)
             .await
@@ -524,16 +522,6 @@ fn get_default_plugin(
     let tedge_config = config_repository.load()?;
 
     Ok(tedge_config.query_string_optional(SoftwarePluginDefaultSetting)?)
-}
-
-async fn publish_capabilities(mqtt: &Client) -> Result<(), AgentError> {
-    mqtt.publish(Message::new(&Topic::new("tedge/capabilities/software/list")?, "").retain())
-        .await?;
-
-    mqtt.publish(Message::new(&Topic::new("tedge/capabilities/software/update")?, "").retain())
-        .await?;
-
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Signed-off-by: Didier Wenzek <didier.wenzek@free.fr>

## Proposed changes

There is no point for `tedge_agent` to publish capabilities on start. These messages are used nowhere, corresponding to an idea that has never been fully implemented.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
