### PR TITLE
Use correct artifact location for new sawtooth_publisher

### DIFF
--- a/.github/workflows/system-test-offsite.yml
+++ b/.github/workflows/system-test-offsite.yml
@@ -48,7 +48,7 @@ jobs:
           workflow: build-workflow.yml
           workflow_conclusion: success
           branch: main
-          name: examples_armv7-unknown-linux-gnueabihf
+          name: sawtooth_publisher_armv7-unknown-linux-gnueabihf
           path: /home/pi/examples
 
       - name: purge packages


### PR DESCRIPTION
## Proposed changes

Use correct artifact location for new sawtooth_publisher

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

Aftermath of: https://github.com/thin-edge/thin-edge.io/pull/778

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
