### PR TITLE
Add functions to init/clear mqtt session

### DIFF
--- a/crates/common/mqtt_channel/src/config.rs
+++ b/crates/common/mqtt_channel/src/config.rs
@@ -118,4 +118,20 @@ impl Config {
             ..self
         }
     }
+
+    /// Wrap this config into an internal set of options for `rumqttc`.
+    pub(crate) fn mqtt_options(&self) -> rumqttc::MqttOptions {
+        let id = match &self.session_name {
+            None => std::iter::repeat_with(fastrand::lowercase)
+                .take(10)
+                .collect(),
+            Some(name) => name.clone(),
+        };
+
+        let mut mqtt_options = rumqttc::MqttOptions::new(id, &self.host, self.port);
+        mqtt_options.set_clean_session(self.clean_session);
+        mqtt_options.set_max_packet_size(self.max_packet_size, self.max_packet_size);
+
+        mqtt_options
+    }
 }

--- a/crates/common/mqtt_channel/src/connection.rs
+++ b/crates/common/mqtt_channel/src/connection.rs
@@ -119,12 +119,12 @@ impl Connection {
                 }
 
                 Err(err) => {
-                    let delay = Connection::pause_on_error(&err);
+                    let should_delay = Connection::pause_on_error(&err);
 
                     // Errors on send are ignored: it just means the client has closed the receiving channel.
                     let _ = error_sender.send(err.into()).await;
 
-                    if delay {
+                    if should_delay {
                         Connection::do_pause().await;
                     }
                 }

--- a/crates/common/mqtt_channel/src/connection.rs
+++ b/crates/common/mqtt_channel/src/connection.rs
@@ -90,27 +90,12 @@ impl Connection {
         })
     }
 
-    fn mqtt_options(config: &Config) -> rumqttc::MqttOptions {
-        let id = match &config.session_name {
-            None => std::iter::repeat_with(fastrand::lowercase)
-                .take(10)
-                .collect(),
-            Some(name) => name.clone(),
-        };
-
-        let mut mqtt_options = rumqttc::MqttOptions::new(id, &config.host, config.port);
-        mqtt_options.set_clean_session(config.clean_session);
-        mqtt_options.set_max_packet_size(config.max_packet_size, config.max_packet_size);
-
-        mqtt_options
-    }
-
     async fn open(
         config: &Config,
         mut message_sender: mpsc::UnboundedSender<Message>,
         mut error_sender: mpsc::UnboundedSender<MqttError>,
     ) -> Result<(AsyncClient, EventLoop), MqttError> {
-        let mqtt_options = Connection::mqtt_options(config);
+        let mqtt_options = config.mqtt_options();
         let (mqtt_client, mut event_loop) = AsyncClient::new(mqtt_options, config.queue_capacity);
 
         let topic = &config.subscriptions;

--- a/crates/common/mqtt_channel/src/connection.rs
+++ b/crates/common/mqtt_channel/src/connection.rs
@@ -202,7 +202,7 @@ impl Connection {
         let _ = mqtt_client.disconnect().await;
     }
 
-    fn pause_on_error(err: &ConnectionError) -> bool {
+    pub(crate) fn pause_on_error(err: &ConnectionError) -> bool {
         match &err {
             rumqttc::ConnectionError::Io(_) => true,
             rumqttc::ConnectionError::MqttState(state_error)
@@ -216,7 +216,7 @@ impl Connection {
         }
     }
 
-    async fn do_pause() {
+    pub(crate) async fn do_pause() {
         sleep(Duration::from_secs(1)).await;
     }
 }

--- a/crates/common/mqtt_channel/src/connection.rs
+++ b/crates/common/mqtt_channel/src/connection.rs
@@ -98,19 +98,14 @@ impl Connection {
         let mqtt_options = config.mqtt_options();
         let (mqtt_client, mut event_loop) = AsyncClient::new(mqtt_options, config.queue_capacity);
 
-        let topic = &config.subscriptions;
-        let qos = topic.qos;
-
         loop {
             match event_loop.poll().await {
                 Ok(Event::Incoming(Packet::ConnAck(_))) => {
-                    if topic.patterns.is_empty() {
+                    let subscriptions = config.subscriptions.filters();
+                    if subscriptions.is_empty() {
                         break;
                     }
-
-                    for pattern in topic.patterns.iter() {
-                        let () = mqtt_client.subscribe(pattern, qos).await?;
-                    }
+                    mqtt_client.subscribe_many(subscriptions).await?;
                 }
 
                 Ok(Event::Incoming(Packet::SubAck(_))) => {

--- a/crates/common/mqtt_channel/src/errors.rs
+++ b/crates/common/mqtt_channel/src/errors.rs
@@ -7,7 +7,7 @@ pub enum MqttError {
     #[error("Invalid topic filter: {pattern:?}")]
     InvalidFilter { pattern: String },
 
-    #[error("Invalid session: a session name must be provided and the clean session unset")]
+    #[error("Invalid session: a session name must be provided")]
     InvalidSessionConfig,
 
     #[error("MQTT client error: {0}")]

--- a/crates/common/mqtt_channel/src/errors.rs
+++ b/crates/common/mqtt_channel/src/errors.rs
@@ -7,6 +7,9 @@ pub enum MqttError {
     #[error("Invalid topic filter: {pattern:?}")]
     InvalidFilter { pattern: String },
 
+    #[error("Invalid session: a session name must be provided and the clean session unset")]
+    InvalidSessionConfig,
+
     #[error("MQTT client error: {0}")]
     ClientError(#[from] rumqttc::ClientError),
 

--- a/crates/common/mqtt_channel/src/lib.rs
+++ b/crates/common/mqtt_channel/src/lib.rs
@@ -34,6 +34,7 @@ mod config;
 mod connection;
 mod errors;
 mod messages;
+mod session;
 mod topics;
 
 mod tests;
@@ -43,6 +44,7 @@ pub use config::*;
 pub use connection::*;
 pub use errors::*;
 pub use messages::*;
+pub use session::*;
 pub use topics::*;
 
 pub use futures::{

--- a/crates/common/mqtt_channel/src/session.rs
+++ b/crates/common/mqtt_channel/src/session.rs
@@ -31,9 +31,7 @@ pub async fn init_session(config: &Config) -> Result<(), MqttError> {
             }
 
             Err(err) => {
-                let delay = Connection::pause_on_error(&err);
-
-                if delay {
+                if Connection::pause_on_error(&err) {
                     Connection::do_pause().await;
                 }
             }
@@ -73,9 +71,7 @@ pub async fn clear_session(config: &Config) -> Result<(), MqttError> {
             }
 
             Err(err) => {
-                let delay = Connection::pause_on_error(&err);
-
-                if delay {
+                if Connection::pause_on_error(&err) {
                     Connection::do_pause().await;
                 }
             }

--- a/crates/common/mqtt_channel/src/session.rs
+++ b/crates/common/mqtt_channel/src/session.rs
@@ -1,7 +1,7 @@
 use crate::{Config, Connection, MqttError};
 use rumqttc::{AsyncClient, Event, Packet};
 
-/// Create a session using the `config.name`
+/// Create a session using the `config.session_name`
 ///
 /// The config can be used to connect later using `Connection::new(config)`.
 /// All the messages that have been published meantime with `QoS > 1`
@@ -27,6 +27,48 @@ pub async fn init_session(config: &Config) -> Result<(), MqttError> {
             }
 
             Ok(Event::Incoming(Packet::SubAck(_))) => {
+                break;
+            }
+
+            Err(err) => {
+                let delay = Connection::pause_on_error(&err);
+
+                if delay {
+                    Connection::do_pause().await;
+                }
+            }
+            _ => (),
+        }
+    }
+
+    Ok(())
+}
+
+/// Clear any session named as `config.session_name`
+///
+/// The config can be used to connect later using `Connection::new(config)`.
+/// No messages that have been published meantime will be received by the new connection.
+pub async fn clear_session(config: &Config) -> Result<(), MqttError> {
+    if config.session_name.is_none() {
+        return Err(MqttError::InvalidSessionConfig);
+    }
+    let mut mqtt_options = config.mqtt_options();
+    mqtt_options.set_clean_session(true);
+    let (mqtt_client, mut event_loop) = AsyncClient::new(mqtt_options, config.queue_capacity);
+
+    loop {
+        match event_loop.poll().await {
+            Ok(Event::Incoming(Packet::ConnAck(_))) => {
+                let subscriptions = config.subscriptions.filters();
+                if subscriptions.is_empty() {
+                    break;
+                }
+                for s in subscriptions.iter() {
+                    mqtt_client.unsubscribe(&s.path).await?;
+                }
+            }
+
+            Ok(Event::Incoming(Packet::UnsubAck(_))) => {
                 break;
             }
 

--- a/crates/common/mqtt_channel/src/session.rs
+++ b/crates/common/mqtt_channel/src/session.rs
@@ -42,6 +42,7 @@ pub async fn init_session(config: &Config) -> Result<(), MqttError> {
         }
     }
 
+    let _ = mqtt_client.disconnect().await;
     Ok(())
 }
 
@@ -88,5 +89,6 @@ pub async fn clear_session(config: &Config) -> Result<(), MqttError> {
         }
     }
 
+    let _ = mqtt_client.disconnect().await;
     Ok(())
 }

--- a/crates/common/mqtt_channel/src/session.rs
+++ b/crates/common/mqtt_channel/src/session.rs
@@ -1,0 +1,50 @@
+use crate::{Config, Connection, MqttError};
+use rumqttc::{AsyncClient, Event, Packet};
+
+/// Create a session using the `config.name`
+///
+/// The config can be used to connect later using `Connection::new(config)`.
+/// All the messages that have been published meantime with `QoS > 1`
+/// on the `config.subscriptions` topics will be received by the new connection.
+///
+/// `mqtt_channel::init_session(&config) consumes no messages.
+pub async fn init_session(config: &Config) -> Result<(), MqttError> {
+    if config.clean_session || config.session_name.is_none() {
+        return Err(MqttError::InvalidSessionConfig);
+    }
+
+    let mqtt_options = config.mqtt_options();
+    let (mqtt_client, mut event_loop) = AsyncClient::new(mqtt_options, config.queue_capacity);
+
+    let topic = &config.subscriptions;
+    let qos = topic.qos;
+
+    loop {
+        match event_loop.poll().await {
+            Ok(Event::Incoming(Packet::ConnAck(_))) => {
+                if topic.patterns.is_empty() {
+                    break;
+                }
+
+                for pattern in topic.patterns.iter() {
+                    let () = mqtt_client.subscribe(pattern, qos).await?;
+                }
+            }
+
+            Ok(Event::Incoming(Packet::SubAck(_))) => {
+                break;
+            }
+
+            Err(err) => {
+                let delay = Connection::pause_on_error(&err);
+
+                if delay {
+                    Connection::do_pause().await;
+                }
+            }
+            _ => (),
+        }
+    }
+
+    Ok(())
+}

--- a/crates/common/mqtt_channel/src/session.rs
+++ b/crates/common/mqtt_channel/src/session.rs
@@ -1,13 +1,16 @@
 use crate::{Config, Connection, MqttError};
 use rumqttc::{AsyncClient, Event, Packet};
 
-/// Create a session using the `config.session_name`
+/// Create a persistent session on the MQTT server `config.host`.
 ///
-/// The config can be used to connect later using `Connection::new(config)`.
-/// All the messages that have been published meantime with `QoS > 1`
-/// on the `config.subscriptions` topics will be received by the new connection.
+/// The session is named after the `config.session_name`
+/// subscribing to all the topics given by the `config.subscriptions`.
 ///
-/// `mqtt_channel::init_session(&config) consumes no messages.
+/// A new `Connection` created with a config with the same session name,
+/// will receive all the messages published meantime on the subscribed topics.
+///
+/// This function can be called multiple times with the same session name,
+/// since it consumes no messages.
 pub async fn init_session(config: &Config) -> Result<(), MqttError> {
     if config.clean_session || config.session_name.is_none() {
         return Err(MqttError::InvalidSessionConfig);
@@ -42,10 +45,16 @@ pub async fn init_session(config: &Config) -> Result<(), MqttError> {
     Ok(())
 }
 
-/// Clear any session named as `config.session_name`
+/// Clear a persistent session on the MQTT server `config.host`.
 ///
-/// The config can be used to connect later using `Connection::new(config)`.
-/// No messages that have been published meantime will be received by the new connection.
+/// The session named after the `config.session_name` is cleared
+/// unsubscribing to all the topics given by the `config.subscriptions`.
+///
+/// All the messages persisted for that session all cleared.
+/// and no more messages will be stored till the session is re-created.
+///
+/// A new `Connection` created with a config with the same session name,
+/// will receive no messages that have been published meantime.
 pub async fn clear_session(config: &Config) -> Result<(), MqttError> {
     if config.session_name.is_none() {
         return Err(MqttError::InvalidSessionConfig);

--- a/crates/common/mqtt_channel/src/tests.rs
+++ b/crates/common/mqtt_channel/src/tests.rs
@@ -377,4 +377,56 @@ mod tests {
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Invalid session"));
     }
+
+    #[tokio::test]
+    #[serial]
+    async fn cleaning_a_session() -> Result<(), anyhow::Error> {
+        // Given an MQTT broker
+        let broker = mqtt_tests::test_mqtt_broker();
+        let mqtt_config = Config::default().with_port(broker.port);
+
+        // Given an MQTT config with a well-known session name
+        let session_name = "a-session-name";
+        let topic = "a/topic";
+        let mqtt_config = mqtt_config
+            .with_session_name(session_name)
+            .with_subscriptions(topic.try_into()?);
+
+        // The session being initialized
+        init_session(&mqtt_config).await?;
+
+        // And some messages published
+        broker
+            .publish(topic, "A fst msg published before clean")
+            .await?;
+        broker
+            .publish(topic, "A 2nd msg published before clean")
+            .await?;
+
+        // If we clean the session
+        clear_session(&mqtt_config).await?;
+
+        // And publish more messages
+        broker
+            .publish(topic, "A 3nd msg published after clean")
+            .await?;
+
+        // Then no messages will be received by the client with the same session name
+        let mut con = Connection::new(&mqtt_config).await?;
+
+        assert_eq!(MaybeMessage::Timeout, next_message(&mut con.received).await);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn to_be_cleared_a_session_must_have_a_name() {
+        let broker = mqtt_tests::test_mqtt_broker();
+        let mqtt_config = Config::default().with_port(broker.port);
+
+        let result = clear_session(&mqtt_config).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid session"));
+    }
 }

--- a/crates/common/mqtt_channel/src/tests.rs
+++ b/crates/common/mqtt_channel/src/tests.rs
@@ -305,4 +305,76 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    #[serial]
+    async fn creating_a_session() -> Result<(), anyhow::Error> {
+        // Given an MQTT broker
+        let broker = mqtt_tests::test_mqtt_broker();
+        let mqtt_config = Config::default().with_port(broker.port);
+
+        // Given an MQTT config with a well-known session name
+        let session_name = "my-session-name";
+        let topic = "my/topic";
+        let mqtt_config = mqtt_config
+            .with_session_name(session_name)
+            .with_subscriptions(topic.try_into()?);
+
+        // This config can be created to initialize an MQTT session
+        init_session(&mqtt_config).await?;
+
+        // Any messages published on that topic
+        broker
+            .publish(topic, "1st msg sent before a first connection")
+            .await?;
+        broker
+            .publish(topic, "2nd msg sent before a first connection")
+            .await?;
+        broker
+            .publish(topic, "3rd msg sent before a first connection")
+            .await?;
+
+        // Will be received by the client with the same session name even for its first connection
+        let mut con = Connection::new(&mqtt_config).await?;
+
+        assert_eq!(
+            MaybeMessage::Next(message(topic, "1st msg sent before a first connection")),
+            next_message(&mut con.received).await
+        );
+        assert_eq!(
+            MaybeMessage::Next(message(topic, "2nd msg sent before a first connection")),
+            next_message(&mut con.received).await
+        );
+        assert_eq!(
+            MaybeMessage::Next(message(topic, "3rd msg sent before a first connection")),
+            next_message(&mut con.received).await
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn a_session_must_have_a_name() {
+        let broker = mqtt_tests::test_mqtt_broker();
+        let mqtt_config = Config::default().with_port(broker.port);
+
+        let result = init_session(&mqtt_config).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid session"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn a_named_session_must_not_set_clean_session() {
+        let broker = mqtt_tests::test_mqtt_broker();
+        let mqtt_config = Config::default()
+            .with_port(broker.port)
+            .with_session_name("useless name")
+            .with_clean_session(true);
+
+        let result = init_session(&mqtt_config).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid session"));
+    }
 }

--- a/crates/common/mqtt_channel/src/topics.rs
+++ b/crates/common/mqtt_channel/src/topics.rs
@@ -116,7 +116,7 @@ impl TopicFilter {
             .iter()
             .map(|path| SubscribeFilter {
                 path: path.clone(),
-                qos: qos.clone(),
+                qos,
             })
             .collect()
     }

--- a/crates/common/mqtt_channel/src/topics.rs
+++ b/crates/common/mqtt_channel/src/topics.rs
@@ -1,6 +1,6 @@
 use crate::errors::MqttError;
 use crate::Message;
-use rumqttc::QoS;
+use rumqttc::{QoS, SubscribeFilter};
 use std::convert::TryInto;
 
 /// An MQTT topic
@@ -107,6 +107,18 @@ impl TopicFilter {
     /// A clone topic filter with the given QoS
     pub fn with_qos(self, qos: QoS) -> Self {
         Self { qos, ..self }
+    }
+
+    /// The list of `SubscribeFilter` expected by `mqttc`
+    pub(crate) fn filters(&self) -> Vec<SubscribeFilter> {
+        let qos = self.qos;
+        self.patterns
+            .iter()
+            .map(|path| SubscribeFilter {
+                path: path.clone(),
+                qos: qos.clone(),
+            })
+            .collect()
     }
 }
 


### PR DESCRIPTION
## Proposed changes

Improve the `mqtt_chanel` crate with two functions:

* `mqtt_channel::init_session(&mqtt_config)` create an MQTT session with the provided session name.
* `mqtt_channel::clear_session(&mqtt_config)` clear an MQTT session previously created.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

* Issue: [The sm-c8y and the agent should not expect the other to start first](https://github.com/thin-edge/thin-edge.io/issues/699)
* Related PR: [init/clear agent and mapper sessions](https://github.com/thin-edge/thin-edge.io/pull/797)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

