### PR TITLE
Improve MQTT error handling

### DIFF
--- a/crates/common/mqtt_channel/src/connection.rs
+++ b/crates/common/mqtt_channel/src/connection.rs
@@ -100,7 +100,10 @@ impl Connection {
 
         loop {
             match event_loop.poll().await {
-                Ok(Event::Incoming(Packet::ConnAck(_))) => {
+                Ok(Event::Incoming(Packet::ConnAck(ack))) => {
+                    if let Some(err) = MqttError::maybe_connection_error(&ack.code) {
+                        return Err(err);
+                    };
                     let subscriptions = config.subscriptions.filters();
                     if subscriptions.is_empty() {
                         break;

--- a/crates/common/mqtt_channel/src/connection.rs
+++ b/crates/common/mqtt_channel/src/connection.rs
@@ -101,7 +101,7 @@ impl Connection {
         loop {
             match event_loop.poll().await {
                 Ok(Event::Incoming(Packet::ConnAck(ack))) => {
-                    if let Some(err) = MqttError::maybe_connection_error(&ack.code) {
+                    if let Some(err) = MqttError::maybe_connection_error(&ack) {
                         return Err(err);
                     };
                     let subscriptions = config.subscriptions.filters();
@@ -111,7 +111,10 @@ impl Connection {
                     mqtt_client.subscribe_many(subscriptions).await?;
                 }
 
-                Ok(Event::Incoming(Packet::SubAck(_))) => {
+                Ok(Event::Incoming(Packet::SubAck(ack))) => {
+                    if let Some(err) = MqttError::maybe_subscription_error(&ack) {
+                        return Err(err);
+                    };
                     break;
                 }
 

--- a/crates/common/mqtt_channel/src/session.rs
+++ b/crates/common/mqtt_channel/src/session.rs
@@ -22,7 +22,7 @@ pub async fn init_session(config: &Config) -> Result<(), MqttError> {
     loop {
         match event_loop.poll().await {
             Ok(Event::Incoming(Packet::ConnAck(ack))) => {
-                if let Some(err) = MqttError::maybe_connection_error(&ack.code) {
+                if let Some(err) = MqttError::maybe_connection_error(&ack) {
                     return Err(err);
                 };
                 let subscriptions = config.subscriptions.filters();
@@ -71,7 +71,7 @@ pub async fn clear_session(config: &Config) -> Result<(), MqttError> {
     loop {
         match event_loop.poll().await {
             Ok(Event::Incoming(Packet::ConnAck(ack))) => {
-                if let Some(err) = MqttError::maybe_connection_error(&ack.code) {
+                if let Some(err) = MqttError::maybe_connection_error(&ack) {
                     return Err(err);
                 };
                 break;

--- a/crates/common/mqtt_channel/src/session.rs
+++ b/crates/common/mqtt_channel/src/session.rs
@@ -67,16 +67,6 @@ pub async fn clear_session(config: &Config) -> Result<(), MqttError> {
     loop {
         match event_loop.poll().await {
             Ok(Event::Incoming(Packet::ConnAck(_))) => {
-                let subscriptions = config.subscriptions.filters();
-                if subscriptions.is_empty() {
-                    break;
-                }
-                for s in subscriptions.iter() {
-                    mqtt_client.unsubscribe(&s.path).await?;
-                }
-            }
-
-            Ok(Event::Incoming(Packet::UnsubAck(_))) => {
                 break;
             }
 

--- a/crates/common/mqtt_channel/src/tests.rs
+++ b/crates/common/mqtt_channel/src/tests.rs
@@ -16,7 +16,7 @@ mod tests {
         let mqtt_config = Config::default().with_port(broker.port);
 
         // A client subscribes to a topic on connect
-        let topic = "test/topic";
+        let topic = "a/test/topic";
         let mqtt_config = mqtt_config
             .with_session_name("test_client")
             .with_subscriptions(topic.try_into()?);
@@ -211,7 +211,7 @@ mod tests {
 
         // A client that connects with a well-known session name, subscribing to some topic.
         let session_name = "remember_me";
-        let topic = "test/topic";
+        let topic = "my/nice/topic";
         let mqtt_config = mqtt_config
             .with_session_name(session_name)
             .with_subscriptions(topic.try_into()?);
@@ -435,5 +435,21 @@ mod tests {
         let result = clear_session(&mqtt_config).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Invalid session"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn subscription_failures() {
+        let broker = mqtt_tests::test_mqtt_broker();
+        let mqtt_config = Config::default().with_port(broker.port);
+
+        let topic = TopicFilter::new_unchecked("test/topic");
+        let mqtt_config = mqtt_config.with_subscriptions(topic);
+
+        if let Err(MqttError::SubscriptionFailure) = Connection::new(&mqtt_config).await {
+            // For some unknown reason, the test MQTT server rejects any subscription on `test/#` topics
+        } else {
+            panic!("The MQTT subscription is expected to fail");
+        }
     }
 }

--- a/crates/common/mqtt_channel/src/tests.rs
+++ b/crates/common/mqtt_channel/src/tests.rs
@@ -446,10 +446,10 @@ mod tests {
         let topic = TopicFilter::new_unchecked("test/topic");
         let mqtt_config = mqtt_config.with_subscriptions(topic);
 
-        if let Err(MqttError::SubscriptionFailure) = Connection::new(&mqtt_config).await {
-            // For some unknown reason, the test MQTT server rejects any subscription on `test/#` topics
-        } else {
-            panic!("The MQTT subscription is expected to fail");
-        }
+        // For some unknown reason, the test MQTT server rejects any subscription on `test/#` topics
+        assert!(matches!(
+            Connection::new(&mqtt_config).await,
+            Err(MqttError::SubscriptionFailure)
+        ));
     }
 }

--- a/crates/common/mqtt_channel/src/tests.rs
+++ b/crates/common/mqtt_channel/src/tests.rs
@@ -403,8 +403,15 @@ mod tests {
             .publish(topic, "A 2nd msg published before clean")
             .await?;
 
-        // If we clean the session
-        clear_session(&mqtt_config).await?;
+        // Then we clean the session
+        {
+            // One just needs a config with the same session name.
+            // Subscriptions can be given - but this not required: any previous subscriptions will be cleared.
+            let mqtt_config = Config::default()
+                .with_port(broker.port)
+                .with_session_name(session_name);
+            clear_session(&mqtt_config).await?;
+        }
 
         // And publish more messages
         broker


### PR DESCRIPTION
## Proposed changes

* Remove useless unsubscribe calls on clear_session
* Improve error handling on connect
* Improve error handling on subscription errors
* There is still a point to clarify with subscription errors on topics name `test`.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* [Code review comment on error handling](https://github.com/thin-edge/thin-edge.io/pull/819#discussion_r799419180)
* [Code review comment on cleared subscriptions](https://github.com/thin-edge/thin-edge.io/pull/819#discussion_r799124260)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

