### PR TITLE
Change return type of LogFile::path to &Path

### DIFF
--- a/crates/core/plugin_sm/src/log_file.rs
+++ b/crates/core/plugin_sm/src/log_file.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::path::PathBuf;
 use tokio::fs::File;
 use tokio::io::BufWriter;
@@ -15,8 +16,8 @@ impl LogFile {
         Ok(LogFile { path, buffer })
     }
 
-    pub fn path(&self) -> &str {
-        &self.path.to_str().unwrap_or("/var/log/tedge/agent")
+    pub fn path(&self) -> &Path {
+        &self.path
     }
 
     pub fn buffer(&mut self) -> &mut BufWriter<File> {

--- a/crates/core/plugin_sm/src/plugin_manager.rs
+++ b/crates/core/plugin_sm/src/plugin_manager.rs
@@ -260,12 +260,16 @@ impl ExternalPlugins {
         response
     }
 
-    fn error_message(log_file: &str, error_count: i32) -> Option<String> {
+    fn error_message(log_file: &Path, error_count: i32) -> Option<String> {
         if error_count > 0 {
             let reason = if error_count == 1 {
-                format!("1 error, see device log file {}", log_file)
+                format!("1 error, see device log file {}", log_file.display())
             } else {
-                format!("{} errors, see device log file {}", error_count, log_file)
+                format!(
+                    "{} errors, see device log file {}",
+                    error_count,
+                    log_file.display()
+                )
             };
             Some(reason)
         } else {


### PR DESCRIPTION
## Proposed changes

There's no need in the codebase to convert this to a `&str`. This patch ensures that we return `&Path` and use it appropriately.

## Types of changes

- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

~~Please merge this only after squash and rebase requirements have been removed (see the discussion).~~