### PR TITLE
Use `futures` channels instead of `tokio` channels

### DIFF
--- a/crates/core/tedge_mapper/src/sm_c8y_mapper/tests.rs
+++ b/crates/core/tedge_mapper/src/sm_c8y_mapper/tests.rs
@@ -8,6 +8,7 @@ use c8y_smartrest::smartrest_deserializer::SmartRestJwtResponse;
 use mqtt_channel::{Connection, TopicFilter};
 use mqtt_tests::test_mqtt_server::MqttProcessHandler;
 use mqtt_tests::with_timeout::{Maybe, WithTimeout};
+use mqtt_tests::StreamExt;
 use serial_test::serial;
 use std::time::Duration;
 use tokio::task::JoinHandle;
@@ -29,7 +30,7 @@ async fn mapper_publishes_a_software_list_request() {
 
     // Expect on `tedge/commands/req/software/list` a software list request.
     let msg = messages
-        .recv()
+        .next()
         .with_timeout(TEST_TIMEOUT_MS)
         .await
         .expect_or("No message received after a second.");
@@ -91,7 +92,7 @@ async fn mapper_publishes_software_update_request() {
 
     // Expect thin-edge json message on `tedge/commands/req/software/update` with expected payload.
     let msg = messages
-        .recv()
+        .next()
         .with_timeout(TEST_TIMEOUT_MS)
         .await
         .expect_or("No message received after a second.");
@@ -134,7 +135,7 @@ async fn mapper_publishes_software_update_status_onto_c8y_topic() {
 
     // Expect `501` smartrest message on `c8y/s/us`.
     let msg = messages
-        .recv()
+        .next()
         .with_timeout(TEST_TIMEOUT_MS)
         .await
         .expect_or("No message received after a second.");
@@ -157,7 +158,7 @@ async fn mapper_publishes_software_update_status_onto_c8y_topic() {
 
     // Expect `503` messages with correct payload have been received on `c8y/s/us`, if no msg received for the timeout the test fails.
     let msg = messages
-        .recv()
+        .next()
         .with_timeout(TEST_TIMEOUT_MS)
         .await
         .expect_or("No message received after a second.");
@@ -209,7 +210,7 @@ async fn mapper_publishes_software_update_failed_status_onto_c8y_topic() {
 
     // `502` messages with correct payload have been received on `c8y/s/us`, if no msg received for the timeout the test fails.
     let msg = messages
-        .recv()
+        .next()
         .with_timeout(TEST_TIMEOUT_MS)
         .await
         .expect_or("No message received after a second.");
@@ -272,7 +273,7 @@ async fn mapper_fails_during_sw_update_recovers_and_process_response() -> Result
 
     // Wait for the request being published by the mapper on `tedge/commands/req/software/update`.
     let msg = requests
-        .recv()
+        .next()
         .with_timeout(TEST_TIMEOUT_MS)
         .await
         .expect_or("No message received after a second.");

--- a/crates/core/tedge_mapper/src/tests.rs
+++ b/crates/core/tedge_mapper/src/tests.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use mqtt_tests::with_timeout::{Maybe, WithTimeout};
+use mqtt_tests::StreamExt;
 use serial_test::serial;
 use tokio::task::JoinHandle;
 
@@ -31,7 +32,7 @@ async fn c8y_mapper_alarm_mapping_to_smartrest() {
         .unwrap();
 
     let mut msg = messages
-        .recv()
+        .next()
         .with_timeout(ALARM_SYNC_TIMEOUT_MS)
         .await
         .expect_or("No message received before timeout");
@@ -41,7 +42,7 @@ async fn c8y_mapper_alarm_mapping_to_smartrest() {
     if msg.contains("114") {
         // Fetch the next message which should be the alarm
         msg = messages
-            .recv()
+            .next()
             .with_timeout(ALARM_SYNC_TIMEOUT_MS)
             .await
             .expect_or("No message received before timeout");
@@ -86,7 +87,7 @@ async fn c8y_mapper_syncs_pending_alarms_on_startup() {
         .unwrap();
 
     let mut msg = messages
-        .recv()
+        .next()
         .with_timeout(ALARM_SYNC_TIMEOUT_MS)
         .await
         .expect_or("No message received before timeout");
@@ -96,7 +97,7 @@ async fn c8y_mapper_syncs_pending_alarms_on_startup() {
     if msg.contains("114") {
         // Fetch the next message which should be the alarm
         msg = messages
-            .recv()
+            .next()
             .with_timeout(ALARM_SYNC_TIMEOUT_MS)
             .await
             .expect_or("No message received before timeout");
@@ -135,7 +136,7 @@ async fn c8y_mapper_syncs_pending_alarms_on_startup() {
     let _ = start_c8y_mapper(broker.port).await.unwrap();
 
     let mut msg = messages
-        .recv()
+        .next()
         .with_timeout(ALARM_SYNC_TIMEOUT_MS)
         .await
         .expect_or("No message received before timeout");
@@ -145,7 +146,7 @@ async fn c8y_mapper_syncs_pending_alarms_on_startup() {
     if msg.contains("114") {
         // Fetch the next message which should be the alarm
         msg = messages
-            .recv()
+            .next()
             .with_timeout(ALARM_SYNC_TIMEOUT_MS)
             .await
             .expect_or("No message received before timeout");
@@ -155,7 +156,7 @@ async fn c8y_mapper_syncs_pending_alarms_on_startup() {
     // Ignored until the rumqttd broker bug that doesn't handle empty retained messages
     // Expect the previously missed clear temperature alarm message
     // let msg = messages
-    //     .recv()
+    //     .next()
     //     .with_timeout(ALARM_SYNC_TIMEOUT_MS)
     //     .await
     //     .expect_or("No message received after a second.");

--- a/crates/tests/mqtt_tests/Cargo.toml
+++ b/crates/tests/mqtt_tests/Cargo.toml
@@ -14,4 +14,4 @@ once_cell = "1.8"
 rumqttc = "0.10"
 rumqttd = "0.9"
 rumqttlog = "0.9"
-tokio = { version = "1.9", default_features = false, features = [ "fs", "io-util", "macros", "rt-multi-thread","signal"] }
+tokio = { version = "1.9", default_features = false, features = [] }

--- a/crates/tests/mqtt_tests/src/lib.rs
+++ b/crates/tests/mqtt_tests/src/lib.rs
@@ -3,6 +3,7 @@ mod test_mqtt_client;
 pub mod test_mqtt_server;
 pub mod with_timeout;
 
+pub use futures::{SinkExt, StreamExt};
 pub use message_streams::*;
 pub use test_mqtt_client::assert_received;
 pub use test_mqtt_client::publish;

--- a/crates/tests/mqtt_tests/src/test_mqtt_server.rs
+++ b/crates/tests/mqtt_tests/src/test_mqtt_server.rs
@@ -4,10 +4,10 @@ use std::{
     time::Duration,
 };
 
+use futures::channel::mpsc::UnboundedReceiver;
 use librumqttd::{Broker, Config, ConnectionSettings, ConsoleSettings, ServerSettings};
 use once_cell::sync::Lazy;
 use rumqttc::QoS;
-use tokio::sync::mpsc::UnboundedReceiver;
 
 const MQTT_TEST_PORT: u16 = 55555;
 


### PR DESCRIPTION
The motivation is to ease testing with the [`StreamExt`](https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html) extension

## Proposed changes

* In the mqtt test helper crate, use [`futures::channel::mpsc`](https://docs.rs/futures/latest/futures/channel/mpsc/index.html) instead of [`tokio::sync::mpsc`](https://docs.rs/tokio/latest/tokio/sync/mpsc/index.html).

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
