### PR TITLE
Ensure UserManager can only be instantiated once

### DIFF
--- a/crates/common/tedge_users/src/unix.rs
+++ b/crates/common/tedge_users/src/unix.rs
@@ -100,7 +100,7 @@ impl UserManager {
     ///
     /// ```
     /// # use tedge_users::UserManager;
-    /// let user_manager = UserManager::new();
+    /// let user_manager = UserManager::new().expect("Only one asking for UserManager");
     /// let _user_guard_1 = user_manager.become_user("user_1").expect("Fail to become user_1");
     /// // Running as user1
     /// {
@@ -229,5 +229,17 @@ pub struct UserGuard {
 impl Drop for UserGuard {
     fn drop(&mut self) {
         self.user_manager.drop_guard();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::UserManager;
+
+    #[test]
+    fn check_user_manager_instantiate_once() {
+        let _um = UserManager::new().unwrap();
+
+        assert!(UserManager::new().is_none());
     }
 }

--- a/crates/core/tedge/src/cli/certificate/create.rs
+++ b/crates/core/tedge/src/cli/certificate/create.rs
@@ -99,7 +99,7 @@ mod tests {
             id: String::from(id),
             cert_path: cert_path.clone(),
             key_path: key_path.clone(),
-            user_manager: UserManager::new(),
+            user_manager: UserManager::new().expect("To get a Usermanager"),
         };
 
         assert_matches!(
@@ -127,7 +127,7 @@ mod tests {
             id: "my-device-id".into(),
             cert_path: cert_path.clone(),
             key_path: key_path.clone(),
-            user_manager: UserManager::new(),
+            user_manager: UserManager::new().expect("To get a Usermanager"),
         };
 
         assert!(cmd
@@ -149,7 +149,7 @@ mod tests {
             id: "my-device-id".into(),
             cert_path,
             key_path,
-            user_manager: UserManager::new(),
+            user_manager: UserManager::new().expect("To get a Usermanager"),
         };
 
         let cert_error = cmd
@@ -168,7 +168,7 @@ mod tests {
             id: "my-device-id".into(),
             cert_path,
             key_path,
-            user_manager: UserManager::new(),
+            user_manager: UserManager::new().expect("To get a Usermanager"),
         };
 
         let cert_error = cmd

--- a/crates/core/tedge/src/cli/connect/c8y_direct_connection.rs
+++ b/crates/core/tedge/src/cli/connect/c8y_direct_connection.rs
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn parse_supported_key() {
-        let user_manager = UserManager::new();
+        let user_manager = UserManager::new().expect("To get a Usermanager");
         let key = concat!(
             "-----BEGIN RSA PRIVATE KEY-----\n",
             "MC4CAQ\n",
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn parse_unsupported_key() {
-        let user_manager = UserManager::new();
+        let user_manager = UserManager::new().expect("To get a Usermanager");
         let key = concat!(
             "-----BEGIN DSA PRIVATE KEY-----\n",
             "MC4CAQ\n",

--- a/crates/core/tedge/src/main.rs
+++ b/crates/core/tedge/src/main.rs
@@ -16,7 +16,11 @@ type ConfigError = crate::error::TEdgeError;
 use command::{BuildCommand, BuildContext};
 
 fn main() -> anyhow::Result<()> {
-    let user_manager = UserManager::new();
+    let user_manager = if let Some(um) = UserManager::new() {
+        um
+    } else {
+        anyhow::bail!("Could not acquire UserManager. This is a bug.");
+    };
 
     let _user_guard = user_manager.become_user(tedge_users::TEDGE_USER)?;
 


### PR DESCRIPTION
## Proposed changes

This change makes the `UserManager` only creatable once per process.

(From https://github.com/thin-edge/thin-edge.io/pull/841#discussion_r802467124)

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This change can cause problems in tests, as they are all run in a single excecutable. A possible fix for this can be that the check requirement is disabled when in `test` environment.
