### PR TITLE
Improve the agent with async operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ version = "0.6.1"
 dependencies = [
  "csv",
  "download",
+ "mqtt_channel",
  "nanoid",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2310,6 +2310,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,6 +2394,18 @@ dependencies = [
  "mqttbytes",
  "segments",
  "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "rustbreak"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460d97902465327d69ecfe8cefdb5972c6f94d6127ac9e992acdb51458bebc27"
+dependencies = [
+ "ron",
+ "serde",
+ "tempfile",
  "thiserror",
 ]
 
@@ -2788,6 +2811,7 @@ dependencies = [
  "once_cell",
  "plugin_sm",
  "predicates 2.1.1",
+ "rustbreak",
  "serde",
  "serde_json",
  "serial_test",

--- a/crates/core/agent_interface/Cargo.toml
+++ b/crates/core/agent_interface/Cargo.toml
@@ -12,6 +12,7 @@ description = "agent_interface defines all the mqtt topics and messages to be us
 [dependencies]
 csv = "1.1"
 download = { path = "../../common/download" }
+mqtt_channel = { path = "../../common/mqtt_channel" }
 nanoid = "0.4"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"

--- a/crates/core/agent_interface/src/error.rs
+++ b/crates/core/agent_interface/src/error.rs
@@ -7,6 +7,9 @@ use serde::{Deserialize, Serialize};
 pub enum ApiError {
     #[error("Topic {topic} is unknown.")]
     UnknownTopic { topic: String },
+
+    #[error("JSON parse error: {reason:?}")]
+    ParseError { reason: String },
 }
 
 #[derive(thiserror::Error, Debug, Clone, Deserialize, Serialize, PartialEq)]
@@ -31,9 +34,6 @@ pub enum SoftwareError {
         software_type: SoftwareType,
         reason: String,
     },
-
-    #[error("JSON parse error: {reason:?}")]
-    ParseError { reason: String },
 
     #[error("Plugin error for {software_type:?}, reason: {reason:?}")]
     Plugin {
@@ -94,9 +94,9 @@ pub enum SoftwareError {
     FromCSV { reason: String },
 }
 
-impl From<serde_json::Error> for SoftwareError {
+impl From<serde_json::Error> for ApiError {
     fn from(err: serde_json::Error) -> Self {
-        SoftwareError::ParseError {
+        ApiError::ParseError {
             reason: format!("{}", err),
         }
     }

--- a/crates/core/agent_interface/src/error.rs
+++ b/crates/core/agent_interface/src/error.rs
@@ -4,7 +4,7 @@ use csv;
 use serde::{Deserialize, Serialize};
 
 #[derive(thiserror::Error, Debug)]
-pub enum TopicError {
+pub enum ApiError {
     #[error("Topic {topic} is unknown.")]
     UnknownTopic { topic: String },
 }

--- a/crates/core/agent_interface/src/lib.rs
+++ b/crates/core/agent_interface/src/lib.rs
@@ -7,9 +7,9 @@ pub mod topic;
 pub use download::*;
 pub use error::*;
 pub use messages::{
-    control_filter_topic, health_check_topic_filter, software_filter_topic, Jsonify, OperationStatus,
-    RestartOperationRequest, RestartOperationResponse, SoftwareListRequest, SoftwareListResponse,
-    SoftwareRequestResponse, SoftwareUpdateRequest, SoftwareUpdateResponse,
+    control_filter_topic, health_check_topic_filter, software_filter_topic, Jsonify,
+    OperationStatus, RestartOperationRequest, RestartOperationResponse, SoftwareListRequest,
+    SoftwareListResponse, SoftwareRequestResponse, SoftwareUpdateRequest, SoftwareUpdateResponse,
 };
 pub use software::*;
 

--- a/crates/core/agent_interface/src/lib.rs
+++ b/crates/core/agent_interface/src/lib.rs
@@ -1,12 +1,13 @@
 pub mod error;
 mod messages;
+pub mod request;
 mod software;
 pub mod topic;
 
 pub use download::*;
 pub use error::*;
 pub use messages::{
-    control_filter_topic, health_check_topics, software_filter_topic, Jsonify, OperationStatus,
+    control_filter_topic, health_check_topic_filter, software_filter_topic, Jsonify, OperationStatus,
     RestartOperationRequest, RestartOperationResponse, SoftwareListRequest, SoftwareListResponse,
     SoftwareRequestResponse, SoftwareUpdateRequest, SoftwareUpdateResponse,
 };

--- a/crates/core/agent_interface/src/messages.rs
+++ b/crates/core/agent_interface/src/messages.rs
@@ -1,4 +1,4 @@
-use crate::{error::SoftwareError, software::*};
+use crate::{error::SoftwareError, software::*, ApiError};
 use download::DownloadInfo;
 use nanoid::nanoid;
 use serde::{Deserialize, Serialize};
@@ -8,19 +8,19 @@ pub trait Jsonify<'a>
 where
     Self: Deserialize<'a> + Serialize + Sized,
 {
-    fn from_json(json_str: &'a str) -> Result<Self, SoftwareError> {
+    fn from_json(json_str: &'a str) -> Result<Self, ApiError> {
         Ok(serde_json::from_str(json_str)?)
     }
 
-    fn from_slice(bytes: &'a [u8]) -> Result<Self, SoftwareError> {
+    fn from_slice(bytes: &'a [u8]) -> Result<Self, ApiError> {
         Ok(serde_json::from_slice(bytes)?)
     }
 
-    fn to_json(&self) -> Result<String, SoftwareError> {
+    fn to_json(&self) -> Result<String, ApiError> {
         Ok(serde_json::to_string(self)?)
     }
 
-    fn to_bytes(&self) -> Result<Vec<u8>, SoftwareError> {
+    fn to_bytes(&self) -> Result<Vec<u8>, ApiError> {
         Ok(serde_json::to_vec(self)?)
     }
 }

--- a/crates/core/agent_interface/src/messages.rs
+++ b/crates/core/agent_interface/src/messages.rs
@@ -2,6 +2,7 @@ use crate::{error::SoftwareError, software::*, ApiError};
 use download::DownloadInfo;
 use nanoid::nanoid;
 use serde::{Deserialize, Serialize};
+use mqtt_channel::TopicFilter;
 
 /// All the messages are serialized using json.
 pub trait Jsonify<'a>
@@ -27,6 +28,12 @@ where
 
 pub fn health_check_topics() -> Vec<&'static str> {
     vec!["tedge/health-check", "tedge/health-check/tedge-agent"]
+}
+
+pub fn health_check_topic_filter() -> TopicFilter {
+    health_check_topics()
+        .try_into()
+        .expect("Invalid topic filter")
 }
 
 pub const fn software_filter_topic() -> &'static str {

--- a/crates/core/agent_interface/src/messages.rs
+++ b/crates/core/agent_interface/src/messages.rs
@@ -45,7 +45,7 @@ pub const fn control_filter_topic() -> &'static str {
 }
 
 /// Message payload definition for SoftwareList request.
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct SoftwareListRequest {
@@ -72,7 +72,7 @@ impl SoftwareListRequest {
 }
 
 /// Message payload definition for SoftwareUpdate request.
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct SoftwareUpdateRequest {
@@ -480,7 +480,7 @@ pub enum RestartOperation {
 }
 
 /// Message payload definition for restart operation request.
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub struct RestartOperationRequest {

--- a/crates/core/agent_interface/src/messages.rs
+++ b/crates/core/agent_interface/src/messages.rs
@@ -1,8 +1,8 @@
 use crate::{error::SoftwareError, software::*, ApiError};
 use download::DownloadInfo;
+use mqtt_channel::TopicFilter;
 use nanoid::nanoid;
 use serde::{Deserialize, Serialize};
-use mqtt_channel::TopicFilter;
 
 /// All the messages are serialized using json.
 pub trait Jsonify<'a>

--- a/crates/core/agent_interface/src/request.rs
+++ b/crates/core/agent_interface/src/request.rs
@@ -1,0 +1,37 @@
+use crate::error::ApiError;
+use crate::messages::*;
+use crate::topic::*;
+use mqtt_channel::Message;
+
+pub enum AgentRequest {
+    HealthCheck,
+    SoftwareList(SoftwareListRequest),
+    SoftwareUpdate(SoftwareUpdateRequest),
+    DeviceRestart(RestartOperationRequest),
+}
+
+impl TryFrom<mqtt_channel::Message> for AgentRequest {
+    type Error = ApiError;
+
+    fn try_from(message: Message) -> Result<Self, Self::Error> {
+        let topic = message.topic.name.as_str();
+        let payload = message.payload_bytes();
+
+        if health_check_topic_filter().accept(&message) {
+            return Ok(AgentRequest::HealthCheck);
+        }
+        if topic == RequestTopic::SoftwareListRequest.as_str() {
+            return SoftwareListRequest::from_slice(payload).map(AgentRequest::SoftwareList);
+        }
+        if topic == RequestTopic::SoftwareUpdateRequest.as_str() {
+            return SoftwareUpdateRequest::from_slice(payload).map(AgentRequest::SoftwareUpdate);
+        }
+        if topic == RequestTopic::RestartRequest.as_str() {
+            return RestartOperationRequest::from_slice(payload).map(AgentRequest::DeviceRestart);
+        }
+
+        Err(ApiError::UnknownTopic {
+            topic: message.topic.name,
+        })
+    }
+}

--- a/crates/core/agent_interface/src/request.rs
+++ b/crates/core/agent_interface/src/request.rs
@@ -2,12 +2,26 @@ use crate::error::ApiError;
 use crate::messages::*;
 use crate::topic::*;
 use mqtt_channel::Message;
+use serde::{Deserialize, Serialize};
 
+pub type RequestId = String;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AgentRequest {
     HealthCheck,
     SoftwareList(SoftwareListRequest),
     SoftwareUpdate(SoftwareUpdateRequest),
     DeviceRestart(RestartOperationRequest),
+}
+
+impl AgentRequest {
+    pub fn request_id(&self) -> &RequestId {
+        match self {
+            AgentRequest::SoftwareList(r) => &r.id,
+            AgentRequest::SoftwareUpdate(r) => &r.id,
+            AgentRequest::DeviceRestart(r) => &r.id,
+        }
+    }
 }
 
 impl TryFrom<mqtt_channel::Message> for AgentRequest {

--- a/crates/core/agent_interface/src/request.rs
+++ b/crates/core/agent_interface/src/request.rs
@@ -15,11 +15,12 @@ pub enum AgentRequest {
 }
 
 impl AgentRequest {
-    pub fn request_id(&self) -> &RequestId {
+    pub fn request_id(&self) -> Option<&RequestId> {
         match self {
-            AgentRequest::SoftwareList(r) => &r.id,
-            AgentRequest::SoftwareUpdate(r) => &r.id,
-            AgentRequest::DeviceRestart(r) => &r.id,
+            AgentRequest::HealthCheck => None,
+            AgentRequest::SoftwareList(r) => Some(&r.id),
+            AgentRequest::SoftwareUpdate(r) => Some(&r.id),
+            AgentRequest::DeviceRestart(r) => Some(&r.id),
         }
     }
 }

--- a/crates/core/agent_interface/src/topic.rs
+++ b/crates/core/agent_interface/src/topic.rs
@@ -1,4 +1,4 @@
-use crate::error::TopicError;
+use crate::error::ApiError;
 use std::convert::TryFrom;
 #[derive(Debug, Clone, PartialEq)]
 pub enum ResponseTopic {
@@ -18,14 +18,14 @@ impl ResponseTopic {
 }
 
 impl TryFrom<String> for ResponseTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         match value.as_str() {
             r#"tedge/commands/res/software/list"# => Ok(ResponseTopic::SoftwareListResponse),
             r#"tedge/commands/res/software/update"# => Ok(ResponseTopic::SoftwareUpdateResponse),
             r#"tedge/commands/res/control/restart"# => Ok(ResponseTopic::RestartResponse),
-            err => Err(TopicError::UnknownTopic {
+            err => Err(ApiError::UnknownTopic {
                 topic: err.to_string(),
             }),
         }
@@ -33,7 +33,7 @@ impl TryFrom<String> for ResponseTopic {
 }
 
 impl TryFrom<&str> for ResponseTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Self::try_from(value.to_string())
@@ -81,7 +81,7 @@ mod tests {
         let update: ResponseTopic = "tedge/commands/res/software/update".try_into().unwrap();
         assert_eq!(update, ResponseTopic::SoftwareUpdateResponse);
 
-        let error: Result<ResponseTopic, TopicError> = "test".try_into();
+        let error: Result<ResponseTopic, ApiError> = "test".try_into();
         assert!(error.is_err());
     }
 

--- a/crates/core/c8y_smartrest/src/error.rs
+++ b/crates/core/c8y_smartrest/src/error.rs
@@ -62,7 +62,7 @@ pub enum SMCumulocityMapperError {
     InvalidMqttMessage,
 
     #[error(transparent)]
-    InvalidTopicError(#[from] agent_interface::TopicError),
+    InvalidApiError(#[from] agent_interface::ApiError),
 
     #[error(transparent)]
     InvalidThinEdgeJson(#[from] agent_interface::SoftwareError),

--- a/crates/core/c8y_smartrest/src/topic.rs
+++ b/crates/core/c8y_smartrest/src/topic.rs
@@ -25,7 +25,7 @@ impl C8yTopic {
 }
 
 impl TryFrom<String> for C8yTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         match value.as_str() {
@@ -35,7 +35,7 @@ impl TryFrom<String> for C8yTopic {
                 if topic_name[..3].contains("c8y") {
                     Ok(C8yTopic::OperationTopic(topic_name.to_string()))
                 } else {
-                    Err(TopicError::UnknownTopic {
+                    Err(ApiError::UnknownTopic {
                         topic: topic_name.to_string(),
                     })
                 }
@@ -44,7 +44,7 @@ impl TryFrom<String> for C8yTopic {
     }
 }
 impl TryFrom<&str> for C8yTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Self::try_from(value.to_string())
@@ -52,7 +52,7 @@ impl TryFrom<&str> for C8yTopic {
 }
 
 impl TryFrom<Topic> for C8yTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: Topic) -> Result<Self, Self::Error> {
         value.name.try_into()
@@ -66,7 +66,7 @@ pub enum MapperSubscribeTopic {
 }
 
 impl TryFrom<String> for MapperSubscribeTopic {
-    type Error = TopicError;
+    type Error = ApiError;
     fn try_from(value: String) -> Result<Self, Self::Error> {
         match ResponseTopic::try_from(value.clone()) {
             Ok(response_topic) => Ok(MapperSubscribeTopic::ResponseTopic(response_topic)),
@@ -79,7 +79,7 @@ impl TryFrom<String> for MapperSubscribeTopic {
 }
 
 impl TryFrom<&str> for MapperSubscribeTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Self::try_from(value.to_string())
@@ -87,7 +87,7 @@ impl TryFrom<&str> for MapperSubscribeTopic {
 }
 
 impl TryFrom<Topic> for MapperSubscribeTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: Topic) -> Result<Self, Self::Error> {
         value.name.try_into()
@@ -111,7 +111,7 @@ mod tests {
         assert_eq!(c8y_req, C8yTopic::SmartRestRequest);
         let c8y_resp: C8yTopic = "c8y/s/us".try_into().unwrap();
         assert_eq!(c8y_resp, C8yTopic::SmartRestResponse);
-        let error: Result<C8yTopic, TopicError> = "test".try_into();
+        let error: Result<C8yTopic, ApiError> = "test".try_into();
         assert!(error.is_err());
     }
 
@@ -122,7 +122,7 @@ mod tests {
 
         let c8y_resp: C8yTopic = Topic::new("c8y/s/us").unwrap().try_into().unwrap();
         assert_eq!(c8y_resp, C8yTopic::SmartRestResponse);
-        let error: Result<C8yTopic, TopicError> = Topic::new("test").unwrap().try_into();
+        let error: Result<C8yTopic, ApiError> = Topic::new("test").unwrap().try_into();
         assert!(error.is_err());
     }
 }

--- a/crates/core/c8y_smartrest/src/topic.rs
+++ b/crates/core/c8y_smartrest/src/topic.rs
@@ -1,5 +1,5 @@
 use agent_interface::topic::ResponseTopic;
-use agent_interface::TopicError;
+use agent_interface::ApiError;
 use mqtt_channel::MqttError;
 use mqtt_channel::Topic;
 

--- a/crates/core/tedge_agent/Cargo.toml
+++ b/crates/core/tedge_agent/Cargo.toml
@@ -31,6 +31,7 @@ futures = "0.3"
 mockall = "0.10"
 mqtt_channel = { path = "../../common/mqtt_channel" }
 plugin_sm = { path = "../plugin_sm" }
+rustbreak = { version = "2.0", features = ["ron_enc"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tedge_config = { path = "../../common/tedge_config" }

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -13,7 +13,6 @@ use agent_interface::{
     SoftwareListResponse, SoftwareRequestResponse, SoftwareType, SoftwareUpdateRequest,
     SoftwareUpdateResponse,
 };
-use flockfile::{check_another_instance_is_not_running, Flockfile};
 use mqtt_channel::{Connection, Message, PubChannel, StreamExt, SubChannel, Topic, TopicFilter};
 use plugin_sm::plugin_manager::{ExternalPlugins, Plugins};
 use serde_json::json;
@@ -199,12 +198,10 @@ pub struct SmAgent {
     config: SmAgentConfig,
     operation_logs: OperationLogs,
     persistance_store: AgentStateRepository,
-    _flock: Flockfile,
 }
 
 impl SmAgent {
     pub fn try_new(name: &str, mut config: SmAgentConfig) -> Result<Self, AgentError> {
-        let flock = check_another_instance_is_not_running(name, &config.run_dir)?;
         info!("{} starting", &name);
 
         let persistance_store = AgentStateRepository::new(config.sm_home.clone());
@@ -219,7 +216,6 @@ impl SmAgent {
             config,
             operation_logs,
             persistance_store,
-            _flock: flock,
         })
     }
 

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use agent_interface::{
     control_filter_topic, health_check_topics, software_filter_topic, Jsonify, OperationStatus,
-    RestartOperationRequest, RestartOperationResponse, SoftwareError, SoftwareListRequest,
+    RestartOperationRequest, RestartOperationResponse, SoftwareListRequest,
     SoftwareListResponse, SoftwareRequestResponse, SoftwareType, SoftwareUpdateRequest,
     SoftwareUpdateResponse,
 };
@@ -394,10 +394,7 @@ impl SmAgent {
                     ))
                     .await?;
 
-                return Err(SoftwareError::ParseError {
-                    reason: "Parsing Error".into(),
-                }
-                .into());
+                return Err(error.into());
             }
         };
         let mut executing_response = SoftwareListResponse::new(&request);
@@ -460,10 +457,7 @@ impl SmAgent {
                     ))
                     .await?;
 
-                return Err(SoftwareError::ParseError {
-                    reason: "Parsing failed".into(),
-                }
-                .into());
+                return Err(error.into());
             }
         };
 
@@ -526,10 +520,7 @@ impl SmAgent {
                     ))
                     .await?;
 
-                return Err(SoftwareError::ParseError {
-                    reason: "Parsing failed".into(),
-                }
-                .into());
+                return Err(error.into());
             }
         };
         Ok(request)

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -630,7 +630,6 @@ mod tests {
     use serde_json::Value;
 
     use super::*;
-    use tempfile::tempdir;
 
     const SLASH_RUN_PATH_TEDGE_AGENT_RESTART: &str = "tedge_agent/tedge_agent_restart";
 
@@ -646,7 +645,7 @@ mod tests {
         )
         .unwrap();
 
-        let journal_path = tempdir().expect("tmp dir").path().join("journal").into();
+        let journal_path = dir.path().join("journal").into();
         let journal = Journal::open(journal_path).await.expect("an empty journal");
 
         // calling handle_restart_operation should create a file in /run/tedge_agent_restart

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -4,14 +4,13 @@ use crate::{
     error::AgentError,
     restart_operation_handler::restart_operation,
     state::{
-        RestartOperationStatus, SoftwareOperationVariants, State,
-        StateRepository, StateStatus,
+        RestartOperationStatus, SoftwareOperationVariants, State, StateRepository, StateStatus,
     },
 };
 use agent_interface::request::AgentRequest;
 use agent_interface::{
-    control_filter_topic, health_check_topic_filter, software_filter_topic, Jsonify, OperationStatus,
-    RestartOperationRequest, RestartOperationResponse, SoftwareListRequest,
+    control_filter_topic, health_check_topic_filter, software_filter_topic, Jsonify,
+    OperationStatus, RestartOperationRequest, RestartOperationResponse, SoftwareListRequest,
     SoftwareListResponse, SoftwareRequestResponse, SoftwareType, SoftwareUpdateRequest,
     SoftwareUpdateResponse,
 };
@@ -342,7 +341,7 @@ impl SmAgent {
                         "status": "up",
                         "pid": process::id()
                     })
-                        .to_string();
+                    .to_string();
                     let health_message =
                         Message::new(&self.config.response_topic_health, health_status);
                     let _ = responses.publish(health_message).await;
@@ -625,8 +624,8 @@ mod tests {
     use assert_json_diff::assert_json_include;
     use serde_json::Value;
 
-    use tempfile::tempdir;
     use super::*;
+    use tempfile::tempdir;
 
     const SLASH_RUN_PATH_TEDGE_AGENT_RESTART: &str = "tedge_agent/tedge_agent_restart";
 
@@ -647,8 +646,7 @@ mod tests {
 
         // calling handle_restart_operation should create a file in /run/tedge_agent_restart
         let (_, mut output_stream) = mqtt_tests::output_stream();
-        let response_topic_restart =
-            Topic::new_unchecked(RestartOperationResponse::topic_name());
+        let response_topic_restart = Topic::new_unchecked(RestartOperationResponse::topic_name());
         let () = agent
             .handle_restart_operation(&journal, &mut output_stream, &response_topic_restart)
             .await?;

--- a/crates/core/tedge_agent/src/error.rs
+++ b/crates/core/tedge_agent/src/error.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use agent_interface::SoftwareError;
+use agent_interface::{ApiError, SoftwareError};
 use flockfile::FlockfileError;
 use mqtt_channel::MqttError;
 use tedge_config::{ConfigSettingError, TEdgeConfigError};
@@ -25,6 +25,9 @@ pub enum AgentError {
 
     #[error(transparent)]
     FromSoftware(#[from] SoftwareError),
+
+    #[error(transparent)]
+    FromAPI(#[from] ApiError),
 
     #[error(transparent)]
     FromState(#[from] StateError),

--- a/crates/core/tedge_agent/src/error.rs
+++ b/crates/core/tedge_agent/src/error.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use crate::journal::JournalError;
 use agent_interface::{ApiError, SoftwareError};
 use flockfile::FlockfileError;
 use mqtt_channel::MqttError;
@@ -31,6 +32,9 @@ pub enum AgentError {
 
     #[error(transparent)]
     FromState(#[from] StateError),
+
+    #[error(transparent)]
+    FromJournal(#[from] JournalError),
 
     #[error(transparent)]
     FromTedgeConfig(#[from] TEdgeConfigError),

--- a/crates/core/tedge_agent/src/journal.rs
+++ b/crates/core/tedge_agent/src/journal.rs
@@ -1,17 +1,57 @@
 use crate::state::{State, StateStatus};
+use agent_interface::request::AgentRequest;
+use futures::channel::mpsc;
+use futures::{SinkExt, StreamExt};
 use rustbreak::deser::Ron;
 use rustbreak::PathDatabase;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::collections::VecDeque;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
-#[derive(Debug)]
+/// The journal of pending operations
+///
+/// This journal contains all the pending operations
+/// and is written on disk each time an operation is:
+/// - scheduled   (the new operation is added)
+/// - launched    (the operation status is updated)
+/// - completed   (the operation is removed)
+/// - cancelled   (the operation is removed)
+#[derive(Clone)]
 pub struct Journal {
+    db: Arc<Mutex<JournalDB>>,
+}
+
+impl Journal {
+    pub async fn open(path: PathBuf) -> Result<Journal, JournalError> {
+        let db = JournalDB::open(path).await?;
+        Ok(Journal {
+            db: Arc::new(Mutex::new(db)),
+        })
+    }
+
+    pub async fn schedule(&self, request: AgentRequest) -> Result<(), JournalError> {
+        let mut db = self.db.lock().await;
+        db.schedule(request).await
+    }
+
+    pub async fn next_request(&self) -> Option<AgentRequest> {
+        let mut db = self.db.lock().await;
+        db.next_request().await
+    }
+}
+
+pub struct JournalDB {
     db: PathDatabase<JournalData, Ron>,
+    request_sender: mpsc::UnboundedSender<AgentRequest>,
+    request_receiver: mpsc::UnboundedReceiver<AgentRequest>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
-pub struct JournalData {
-    pub state: State,
+struct JournalData {
+    state: State,
+    pending: VecDeque<AgentRequest>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -20,17 +60,69 @@ pub enum JournalError {
     RustbreakError(#[from] rustbreak::error::RustbreakError),
 }
 
-impl Journal {
-    pub fn open(path: PathBuf) -> Result<Journal, JournalError> {
+impl JournalDB {
+    pub async fn open(path: PathBuf) -> Result<JournalDB, JournalError> {
         let empty = JournalData::default();
         let db = PathDatabase::<JournalData, Ron>::load_from_path_or(path, empty)?;
+        let (mut request_sender, request_receiver) = mpsc::unbounded();
 
-        Ok(Journal { db })
+        {
+            let data = db.borrow_data()?;
+            for request in data.pending.iter() {
+                let _ = request_sender.send(request.clone()).await;
+            }
+        }
+
+        Ok(JournalDB {
+            db,
+            request_sender,
+            request_receiver,
+        })
+    }
+
+    pub async fn schedule(&mut self, request: AgentRequest) -> Result<(), JournalError> {
+        {
+            let mut data = self.db.borrow_data_mut()?;
+            data.pending.push_back(request.clone());
+        }
+        self.db.save()?;
+
+        let _ = self.request_sender.send(request).await;
+        Ok(())
+    }
+
+    pub async fn next_request(&mut self) -> Option<AgentRequest> {
+        self.request_receiver.next().await
     }
 }
 
 #[async_trait::async_trait]
 impl crate::state::StateRepository for Journal {
+    type Error = JournalError;
+
+    async fn load(&self) -> Result<State, Self::Error> {
+        let db = self.db.lock().await;
+        db.load().await
+    }
+
+    async fn store(&self, state: &State) -> Result<(), Self::Error> {
+        let db = self.db.lock().await;
+        db.store(state).await
+    }
+
+    async fn clear(&self) -> Result<State, Self::Error> {
+        let db = self.db.lock().await;
+        db.clear().await
+    }
+
+    async fn update(&self, status: &StateStatus) -> Result<(), Self::Error> {
+        let db = self.db.lock().await;
+        db.update(status).await
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::state::StateRepository for JournalDB {
     type Error = JournalError;
 
     async fn load(&self) -> Result<State, Self::Error> {

--- a/crates/core/tedge_agent/src/journal.rs
+++ b/crates/core/tedge_agent/src/journal.rs
@@ -1,0 +1,62 @@
+use crate::state::{State, StateStatus};
+use rustbreak::deser::Ron;
+use rustbreak::PathDatabase;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug)]
+pub struct Journal {
+    db: PathDatabase<JournalData, Ron>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+pub struct JournalData {
+    pub state: State,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum JournalError {
+    #[error("Agent database error: {0}")]
+    RustbreakError(#[from] rustbreak::error::RustbreakError),
+}
+
+impl Journal {
+    pub fn open(path: PathBuf) -> Result<Journal, JournalError> {
+        let empty = JournalData::default();
+        let db = PathDatabase::<JournalData, Ron>::load_from_path_or(path, empty)?;
+
+        Ok(Journal { db })
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::state::StateRepository for Journal {
+    type Error = JournalError;
+
+    async fn load(&self) -> Result<State, Self::Error> {
+        let data = self.db.borrow_data()?;
+        Ok(data.state.clone())
+    }
+
+    async fn store(&self, state: &State) -> Result<(), Self::Error> {
+        {
+            let mut data = self.db.borrow_data_mut()?;
+            data.state = state.clone();
+        }
+        Ok(self.db.save()?)
+    }
+
+    async fn clear(&self) -> Result<State, Self::Error> {
+        let state = State::default();
+        self.store(&state).await?;
+        Ok(state)
+    }
+
+    async fn update(&self, status: &StateStatus) -> Result<(), Self::Error> {
+        {
+            let mut data = self.db.borrow_data_mut()?;
+            data.state.operation = Some(status.to_owned());
+        }
+        Ok(self.db.save()?)
+    }
+}

--- a/crates/core/tedge_agent/src/main.rs
+++ b/crates/core/tedge_agent/src/main.rs
@@ -6,6 +6,7 @@ use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 
 mod agent;
 mod error;
+mod journal;
 mod operation_logs;
 mod restart_operation_handler;
 mod state;

--- a/crates/core/tedge_agent/src/state.rs
+++ b/crates/core/tedge_agent/src/state.rs
@@ -1,16 +1,5 @@
-use crate::error::StateError;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::{path::PathBuf, str::FromStr};
-use tedge_utils::fs::atomically_write_file_async;
-use tokio::fs;
-use tracing::error;
-
-#[derive(Debug)]
-pub struct AgentStateRepository {
-    state_repo_path: PathBuf,
-    state_repo_root: PathBuf,
-}
 
 #[async_trait]
 pub trait StateRepository {
@@ -21,75 +10,7 @@ pub trait StateRepository {
     async fn update(&self, status: &StateStatus) -> Result<(), Self::Error>;
 }
 
-#[async_trait]
-impl StateRepository for AgentStateRepository {
-    type Error = StateError;
-
-    async fn load(&self) -> Result<State, StateError> {
-        match fs::read(&self.state_repo_path).await {
-            Ok(bytes) => Ok(toml::from_slice::<State>(bytes.as_slice())?),
-
-            Err(err) => {
-                error!("Error reading: {:?}", &self.state_repo_path);
-                Err(StateError::FromIo(err))
-            }
-        }
-    }
-
-    async fn store(&self, state: &State) -> Result<(), StateError> {
-        let toml = toml::to_string_pretty(&state)?;
-
-        // Create `$HOME/.tedge` or `/etc/tedge` directory in case it does not exist yet
-        if !self.state_repo_root.exists() {
-            let () = fs::create_dir(&self.state_repo_root).await?;
-        }
-
-        let mut temppath = self.state_repo_path.clone();
-        temppath.set_extension("tmp");
-
-        let () =
-            atomically_write_file_async(temppath, &self.state_repo_path, toml.as_bytes()).await?;
-
-        Ok(())
-    }
-
-    async fn clear(&self) -> Result<State, Self::Error> {
-        let state = State {
-            operation_id: None,
-            operation: None,
-        };
-        let () = self.store(&state).await?;
-
-        Ok(state)
-    }
-
-    async fn update(&self, status: &StateStatus) -> Result<(), Self::Error> {
-        let mut state = self.load().await?;
-        state.operation = Some(status.to_owned());
-
-        self.store(&state).await?;
-
-        Ok(())
-    }
-}
-
-impl AgentStateRepository {
-    pub fn new(tedge_root: PathBuf) -> Self {
-        let mut state_repo_root = tedge_root;
-        state_repo_root.push(PathBuf::from_str(".agent").expect("infallible"));
-
-        let mut state_repo_path = state_repo_root.clone();
-        state_repo_path.push(PathBuf::from_str("current-operation").expect("infallible"));
-
-        Self {
-            state_repo_path,
-            state_repo_root,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(untagged)]
 pub enum StateStatus {
     Software(SoftwareOperationVariants),
     Restart(RestartOperationStatus),
@@ -97,7 +18,6 @@ pub enum StateStatus {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(rename_all = "lowercase")]
 pub enum SoftwareOperationVariants {
     List,
     Update,
@@ -118,9 +38,9 @@ pub struct State {
 
 #[cfg(test)]
 mod tests {
+    use crate::journal::Journal;
     use crate::state::{
-        AgentStateRepository, RestartOperationStatus, SoftwareOperationVariants, State,
-        StateRepository, StateStatus,
+        RestartOperationStatus, SoftwareOperationVariants, State, StateRepository, StateStatus,
     };
 
     use tempfile::tempdir;
@@ -128,9 +48,7 @@ mod tests {
     #[tokio::test]
     async fn agent_state_repository_not_exists_fail() {
         let temp_dir = tempdir().unwrap();
-        let repo = AgentStateRepository::new(temp_dir.into_path());
-
-        repo.load().await.unwrap_err();
+        assert!(Journal::open(temp_dir.into_path()).await.is_err());
     }
 
     #[tokio::test]
@@ -140,11 +58,19 @@ mod tests {
         let _ = tokio::fs::create_dir(temp_dir.path().join(".agent/")).await;
         let destination_path = temp_dir.path().join(".agent/current-operation");
 
-        let content = "operation_id = \'1234\'\noperation = \"list\"";
+        let content = r#"(
+            state: (
+                operation_id: Some("1234"),
+                operation: Some(Software(List)),
+            ),
+            pending: [],
+        )"#;
 
-        let _ = tokio::fs::write(destination_path, content.as_bytes()).await;
+        let _ = tokio::fs::write(destination_path.clone(), content.as_bytes()).await;
 
-        let repo = AgentStateRepository::new(temp_dir.into_path());
+        let repo = Journal::open(destination_path)
+            .await
+            .expect("the previous journal");
 
         let data = repo.load().await.unwrap();
         assert_eq!(
@@ -162,12 +88,18 @@ mod tests {
 
         let _ = tokio::fs::create_dir(temp_dir.path().join(".agent/")).await;
         let destination_path = temp_dir.path().join(".agent/current-operation");
+        let content = r#"(
+            state: (
+                operation_id: Some("1234"),
+                operation: Some(Restart(Restarting)),
+            ),
+            pending: [],
+        )"#;
+        let _ = tokio::fs::write(destination_path.clone(), content.as_bytes()).await;
 
-        let content = "operation_id = \'1234\'\noperation = \"Restarting\"";
-
-        let _ = tokio::fs::write(destination_path, content.as_bytes()).await;
-
-        let repo = AgentStateRepository::new(temp_dir.into_path());
+        let repo = Journal::open(destination_path)
+            .await
+            .expect("the previous journal");
 
         let data = repo.load().await.unwrap();
         assert_eq!(
@@ -186,11 +118,9 @@ mod tests {
         let _ = tokio::fs::create_dir(temp_dir.path().join(".agent/")).await;
         let destination_path = temp_dir.path().join(".agent/current-operation");
 
-        let content = "";
-
-        let _ = tokio::fs::write(destination_path, content.as_bytes()).await;
-
-        let repo = AgentStateRepository::new(temp_dir.into_path());
+        let repo = Journal::open(destination_path)
+            .await
+            .expect("the previous journal");
 
         let data = repo.load().await.unwrap();
         assert_eq!(
@@ -209,7 +139,9 @@ mod tests {
         let _ = tokio::fs::create_dir(temp_dir.path().join(".agent/")).await;
         let destination_path = temp_dir.path().join(".agent/current-operation");
 
-        let repo = AgentStateRepository::new(temp_dir.into_path());
+        let repo = Journal::open(destination_path.clone())
+            .await
+            .expect("the previous journal");
 
         repo.store(&State {
             operation_id: Some("1234".into()),
@@ -220,6 +152,17 @@ mod tests {
 
         let data = tokio::fs::read_to_string(destination_path).await.unwrap();
 
-        assert_eq!(data, "operation_id = \'1234\'\noperation = \'list\'\n");
+        assert_eq!(
+            data.split_ascii_whitespace().collect::<String>(),
+            r#"(
+            state: (
+                operation_id: Some("1234"),
+                operation: Some(Software(List)),
+            ),
+            pending: [],
+        )"#
+            .split_ascii_whitespace()
+            .collect::<String>()
+        );
     }
 }

--- a/crates/core/tedge_agent/src/state.rs
+++ b/crates/core/tedge_agent/src/state.rs
@@ -109,7 +109,7 @@ pub enum RestartOperationStatus {
     Restarting,
 }
 
-#[derive(Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct State {
     pub operation_id: Option<String>,

--- a/crates/core/tedge_mapper/src/c8y/error.rs
+++ b/crates/core/tedge_mapper/src/c8y/error.rs
@@ -6,7 +6,7 @@ use c8y_smartrest::error::{
 #[allow(clippy::enum_variant_names)]
 pub enum CumulocityMapperError {
     #[error(transparent)]
-    InvalidTopicError(#[from] agent_interface::TopicError),
+    InvalidTopicError(#[from] agent_interface::ApiError),
 
     #[error(transparent)]
     InvalidThinEdgeJson(#[from] agent_interface::SoftwareError),

--- a/crates/core/tedge_mapper/src/c8y/error.rs
+++ b/crates/core/tedge_mapper/src/c8y/error.rs
@@ -6,7 +6,7 @@ use c8y_smartrest::error::{
 #[allow(clippy::enum_variant_names)]
 pub enum CumulocityMapperError {
     #[error(transparent)]
-    InvalidTopicError(#[from] agent_interface::ApiError),
+    InvalidApiError(#[from] agent_interface::ApiError),
 
     #[error(transparent)]
     InvalidThinEdgeJson(#[from] agent_interface::SoftwareError),

--- a/crates/core/tedge_mapper/src/c8y/topic.rs
+++ b/crates/core/tedge_mapper/src/c8y/topic.rs
@@ -1,5 +1,5 @@
 use agent_interface::topic::ResponseTopic;
-use agent_interface::TopicError;
+use agent_interface::ApiError;
 use mqtt_channel::MqttError;
 use mqtt_channel::Topic;
 
@@ -25,7 +25,7 @@ impl C8yTopic {
 }
 
 impl TryFrom<String> for C8yTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         match value.as_str() {
@@ -35,7 +35,7 @@ impl TryFrom<String> for C8yTopic {
                 if topic_name[..3].contains("c8y") {
                     Ok(C8yTopic::OperationTopic(topic_name.to_string()))
                 } else {
-                    Err(TopicError::UnknownTopic {
+                    Err(ApiError::UnknownTopic {
                         topic: topic_name.to_string(),
                     })
                 }
@@ -44,7 +44,7 @@ impl TryFrom<String> for C8yTopic {
     }
 }
 impl TryFrom<&str> for C8yTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Self::try_from(value.to_string())
@@ -52,7 +52,7 @@ impl TryFrom<&str> for C8yTopic {
 }
 
 impl TryFrom<Topic> for C8yTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: Topic) -> Result<Self, Self::Error> {
         value.name.try_into()
@@ -66,7 +66,7 @@ pub enum MapperSubscribeTopic {
 }
 
 impl TryFrom<String> for MapperSubscribeTopic {
-    type Error = TopicError;
+    type Error = ApiError;
     fn try_from(value: String) -> Result<Self, Self::Error> {
         match ResponseTopic::try_from(value.clone()) {
             Ok(response_topic) => Ok(MapperSubscribeTopic::ResponseTopic(response_topic)),
@@ -79,7 +79,7 @@ impl TryFrom<String> for MapperSubscribeTopic {
 }
 
 impl TryFrom<&str> for MapperSubscribeTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         Self::try_from(value.to_string())
@@ -87,7 +87,7 @@ impl TryFrom<&str> for MapperSubscribeTopic {
 }
 
 impl TryFrom<Topic> for MapperSubscribeTopic {
-    type Error = TopicError;
+    type Error = ApiError;
 
     fn try_from(value: Topic) -> Result<Self, Self::Error> {
         value.name.try_into()
@@ -111,7 +111,7 @@ mod tests {
         assert_eq!(c8y_req, C8yTopic::SmartRestRequest);
         let c8y_resp: C8yTopic = "c8y/s/us".try_into().unwrap();
         assert_eq!(c8y_resp, C8yTopic::SmartRestResponse);
-        let error: Result<C8yTopic, TopicError> = "test".try_into();
+        let error: Result<C8yTopic, ApiError> = "test".try_into();
         assert!(error.is_err());
     }
 
@@ -122,7 +122,7 @@ mod tests {
 
         let c8y_resp: C8yTopic = Topic::new("c8y/s/us").unwrap().try_into().unwrap();
         assert_eq!(c8y_resp, C8yTopic::SmartRestResponse);
-        let error: Result<C8yTopic, TopicError> = Topic::new("test").unwrap().try_into();
+        let error: Result<C8yTopic, ApiError> = Topic::new("test").unwrap().try_into();
         assert!(error.is_err());
     }
 }

--- a/crates/tests/mqtt_tests/src/message_streams.rs
+++ b/crates/tests/mqtt_tests/src/message_streams.rs
@@ -38,6 +38,12 @@ impl<T> MessageOutputStream<T> {
     }
 }
 
+impl<T> MessageOutputStream<T> {
+    pub async fn next_msg(&mut self) -> Option<T> {
+        self.receiver.next().await
+    }
+}
+
 /// A `Stream` of `T` that is populated using a vector of `T` samples.
 ///
 /// ```


### PR DESCRIPTION
## Proposed changes

Add a background loop to process the requests independently of the loop consuming the MQTT messages.

* This PRs introduces no new features and the agent is expected to behave exactly as before.
* The next step will be to persist in a journal the requests that have been accepted and have still to be executed.
* In preparation to this following step, this PR introduces a serializable type to represent any request to the agent.
* On purpose the changes on the `handle_xxx_request` methods have been minimized. There are still room for improvement and more code sharing, but this will be done while adding the operation journal.
 
## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This is a first step toward a more robust agent. Next steps will be:
* to persist the scheduled requests into a journal,
* to handle on restart the operations still pending,
* to unify the journal with the state currently used by the agent to persist the current operation,
* to have more systematic treatment for operation progress monitoring,
* to add a support to run operation defined by plugins and triggered by the mappers.
