### PR TITLE
Use 'time' instead of 'chrono' due to CVE for thin_edge_json and all dependent crates [1/3]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 name = "batcher"
 version = "0.5.2"
 dependencies = [
- "chrono",
+ "time 0.3.5",
  "tokio",
 ]
 
@@ -354,7 +354,6 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "assert_matches",
- "chrono",
  "clock",
  "criterion",
  "json-writer",
@@ -364,6 +363,7 @@ dependencies = [
  "test-case",
  "thin_edge_json",
  "thiserror",
+ "time 0.3.5",
 ]
 
 [[package]]
@@ -424,7 +424,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time 0.1.43",
  "winapi",
 ]
 
@@ -447,7 +446,6 @@ dependencies = [
 name = "clock"
 version = "0.5.2"
 dependencies = [
- "chrono",
  "mockall",
  "serde",
  "time 0.3.5",
@@ -2704,7 +2702,6 @@ dependencies = [
  "batcher",
  "c8y_smartrest",
  "c8y_translator",
- "chrono",
  "clock",
  "csv",
  "download",
@@ -2811,7 +2808,6 @@ version = "0.5.2"
 dependencies = [
  "anyhow",
  "assert_matches",
- "chrono",
  "clock",
  "criterion",
  "json-writer",

--- a/crates/common/batcher/Cargo.toml
+++ b/crates/common/batcher/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.58.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
+time = "0.3"
 tokio = { version = "1.12", features = ["sync", "time"] }
 
 [dev-dependencies]

--- a/crates/common/batcher/src/batchable.rs
+++ b/crates/common/batcher/src/batchable.rs
@@ -1,6 +1,6 @@
-use chrono::{DateTime, Utc};
 use std::fmt::Debug;
 use std::hash::Hash;
+use time::OffsetDateTime;
 
 /// Implement this interface for the items that you want batched.
 /// No items with the same key will go in the same batch.
@@ -13,5 +13,5 @@ pub trait Batchable {
     fn key(&self) -> Self::Key;
 
     /// The time at which this item was created. This time is used to group items into a batch.
-    fn event_time(&self) -> DateTime<Utc>;
+    fn event_time(&self) -> OffsetDateTime;
 }

--- a/crates/common/batcher/src/batcher.rs
+++ b/crates/common/batcher/src/batcher.rs
@@ -1,12 +1,12 @@
 use crate::batch::{Batch, BatchAdd};
 use crate::batchable::Batchable;
 use crate::config::BatchConfig;
-use chrono::{DateTime, Utc};
+use time::OffsetDateTime;
 
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum BatcherOutput<B> {
     Batch(Vec<B>),
-    Timer(DateTime<Utc>),
+    Timer(OffsetDateTime),
 }
 
 /// Provides the core implementation of the batching algorithm.
@@ -27,7 +27,7 @@ impl<B: Batchable> Batcher<B> {
 
     pub(crate) fn event(
         &mut self,
-        processing_time: DateTime<Utc>,
+        processing_time: OffsetDateTime,
         event: B,
     ) -> Vec<BatcherOutput<B>> {
         let event_time = event.event_time();
@@ -63,8 +63,8 @@ impl<B: Batchable> Batcher<B> {
 
     fn output_for_batch_end(
         &mut self,
-        processing_time: DateTime<Utc>,
-        batch_end: DateTime<Utc>,
+        processing_time: OffsetDateTime,
+        batch_end: OffsetDateTime,
     ) -> Vec<BatcherOutput<B>> {
         let batch_timeout = batch_end + self.config.delivery_jitter();
         if processing_time < batch_timeout {
@@ -77,7 +77,7 @@ impl<B: Batchable> Batcher<B> {
         }
     }
 
-    pub(crate) fn time(&mut self, time: DateTime<Utc>) -> Vec<Vec<B>> {
+    pub(crate) fn time(&mut self, time: OffsetDateTime) -> Vec<Vec<B>> {
         let batches = std::mem::take(&mut self.batches);
 
         let (open_batches, closed_batches) = batches
@@ -92,7 +92,7 @@ impl<B: Batchable> Batcher<B> {
             .collect()
     }
 
-    fn is_open(&self, batch: &Batch<B>, time: DateTime<Utc>) -> bool {
+    fn is_open(&self, batch: &Batch<B>, time: OffsetDateTime) -> bool {
         batch.batch_end() + self.config.delivery_jitter() > time
     }
 
@@ -106,7 +106,7 @@ impl<B: Batchable> Batcher<B> {
         batches
     }
 
-    fn find_target_batch(&mut self, event_time: DateTime<Utc>) -> Option<&mut Batch<B>> {
+    fn find_target_batch(&mut self, event_time: OffsetDateTime) -> Option<&mut Batch<B>> {
         for batch in &mut self.batches {
             if batch.batch_start() <= event_time && event_time <= batch.batch_end() {
                 return Some(batch);
@@ -131,14 +131,14 @@ impl<B: Batchable> Batcher<B> {
         Batch::new(batch_start, batch_end, event)
     }
 
-    fn previous_batch(&self, event_time: DateTime<Utc>) -> Option<&Batch<B>> {
+    fn previous_batch(&self, event_time: OffsetDateTime) -> Option<&Batch<B>> {
         self.batches
             .iter()
             .filter(|batch| batch.batch_end() < event_time)
             .max_by(|batch1, batch2| batch1.batch_end().cmp(&batch2.batch_end()))
     }
 
-    fn next_batch(&self, event_time: DateTime<Utc>) -> Option<&Batch<B>> {
+    fn next_batch(&self, event_time: OffsetDateTime) -> Option<&Batch<B>> {
         self.batches
             .iter()
             .filter(|batch| batch.batch_start() > event_time)
@@ -151,9 +151,8 @@ mod tests {
     use super::*;
     use crate::batchable::Batchable;
     use crate::config::BatchConfigBuilder;
-    use chrono::offset::TimeZone;
-    use chrono::{DateTime, Duration, Utc};
     use std::collections::BTreeMap;
+    use time::Duration;
 
     #[test]
     fn single_event_batch() {
@@ -424,7 +423,7 @@ mod tests {
 
     #[derive(Debug, Clone, Eq, PartialEq)]
     struct TestBatchEvent {
-        event_time: DateTime<Utc>,
+        event_time: OffsetDateTime,
         key: String,
         value: u64,
     }
@@ -436,7 +435,7 @@ mod tests {
             self.key.clone()
         }
 
-        fn event_time(&self) -> DateTime<Utc> {
+        fn event_time(&self) -> OffsetDateTime {
             self.event_time
         }
     }
@@ -448,11 +447,11 @@ mod tests {
     }
 
     struct BatcherTest {
-        start_time: DateTime<Utc>,
+        start_time: OffsetDateTime,
         batcher: Batcher<TestBatchEvent>,
-        inputs: BTreeMap<DateTime<Utc>, EventOrTimer>,
-        flush_time: Option<DateTime<Utc>>,
-        expected_batches: BTreeMap<DateTime<Utc>, Vec<Vec<TestBatchEvent>>>,
+        inputs: BTreeMap<OffsetDateTime, EventOrTimer>,
+        flush_time: Option<OffsetDateTime>,
+        expected_batches: BTreeMap<OffsetDateTime, Vec<Vec<TestBatchEvent>>>,
     }
 
     impl BatcherTest {
@@ -463,7 +462,7 @@ mod tests {
                 .message_leap_limit(message_leap_limit)
                 .build();
 
-            let start_time = Utc.timestamp_millis(0);
+            let start_time = OffsetDateTime::from_unix_timestamp(0).unwrap();
             let batcher = Batcher::new(batcher_config);
 
             BatcherTest {
@@ -538,10 +537,10 @@ mod tests {
 
         fn handle_outputs(
             &mut self,
-            t: DateTime<Utc>,
+            t: OffsetDateTime,
             outputs: Vec<BatcherOutput<TestBatchEvent>>,
-            all_batches: &mut BTreeMap<DateTime<Utc>, Vec<Vec<TestBatchEvent>>>,
-            flush_time: Option<DateTime<Utc>>,
+            all_batches: &mut BTreeMap<OffsetDateTime, Vec<Vec<TestBatchEvent>>>,
+            flush_time: Option<OffsetDateTime>,
         ) {
             let mut batches = vec![];
 
@@ -577,14 +576,14 @@ mod tests {
             }
         }
 
-        fn create_instant(&self, time: i64) -> DateTime<Utc> {
+        fn create_instant(&self, time: i64) -> OffsetDateTime {
             self.start_time + Duration::milliseconds(time)
         }
     }
 
     fn verify(
-        expected_batches: BTreeMap<DateTime<Utc>, Vec<Vec<TestBatchEvent>>>,
-        mut actual_batches: BTreeMap<DateTime<Utc>, Vec<Vec<TestBatchEvent>>>,
+        expected_batches: BTreeMap<OffsetDateTime, Vec<Vec<TestBatchEvent>>>,
+        mut actual_batches: BTreeMap<OffsetDateTime, Vec<Vec<TestBatchEvent>>>,
     ) {
         assert_eq!(
             actual_batches.keys().collect::<Vec<_>>(),

--- a/crates/common/batcher/src/config.rs
+++ b/crates/common/batcher/src/config.rs
@@ -1,4 +1,4 @@
-use chrono::Duration;
+use time::Duration;
 
 /// The parameters for the batching process.
 #[derive(Debug, Clone)]

--- a/crates/common/clock/Cargo.toml
+++ b/crates/common/clock/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 rust-version = "1.58.1"
 
 [dependencies]
-time = { version = "0.3", features = ["serde-human-readable"] }
-chrono = "0.4"
-serde = { version = "1.0", features = ["derive"] }
 mockall = "0.10"
+serde = { version = "1.0", features = ["derive"] }
+time = { version = "0.3", features = ["serde-human-readable"] }

--- a/crates/common/clock/src/lib.rs
+++ b/crates/common/clock/src/lib.rs
@@ -1,9 +1,8 @@
-use chrono::{DateTime, FixedOffset, Local};
 use mockall::automock;
 use serde::{Deserialize, Deserializer};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
-pub type Timestamp = DateTime<FixedOffset>;
+pub type Timestamp = OffsetDateTime;
 
 #[automock]
 pub trait Clock: Sync + Send + 'static {
@@ -15,8 +14,7 @@ pub struct WallClock;
 
 impl Clock for WallClock {
     fn now(&self) -> Timestamp {
-        let local_time_now = Local::now();
-        local_time_now.with_timezone(local_time_now.offset())
+        OffsetDateTime::now_utc()
     }
 }
 
@@ -29,5 +27,5 @@ where
     let timestamp = String::deserialize(deserializer)?;
     OffsetDateTime::parse(timestamp.as_str(), &Rfc3339)
         .map_err(serde::de::Error::custom)
-        .map(|val| Some(val))
+        .map(Some)
 }

--- a/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
+++ b/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
@@ -170,8 +170,7 @@ fn to_datetime<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
 where
     D: Deserializer<'de>,
 {
-    // NOTE `OffsetDateTime` is used here because c8y uses for log requests a date time string which
-    // does not exactly equal `chrono::DateTime::parse_from_rfc3339`
+    // NOTE `OffsetDateTime` is used here because c8y uses for log requests a date time string which is not compliant with rfc3339
     // c8y result:
     // 2021-10-23T19:03:26+0100
     // rfc3339 expected:

--- a/crates/core/c8y_translator/Cargo.toml
+++ b/crates/core/c8y_translator/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 rust-version = "1.58.1"
 
 [dependencies]
-chrono = "0.4"
 clock = { path = "../../common/clock" }
 json-writer = { path = "../../common/json_writer" }
 thin_edge_json = { path = "../thin_edge_json" }
 thiserror = "1.0"
+time = "0.3"
 
 [dev-dependencies]
 anyhow = "1.0"
@@ -21,6 +21,7 @@ pretty_assertions = "1.0"
 proptest = "1.0"
 serde_json = "1.0"
 test-case = "1.2"
+time = { version = "0.3", features = ["macros"] }
 
 [features]
 # use: #[cfg(feature="integration-test")]

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -32,7 +32,6 @@ async-trait = "0.1"
 batcher = { path = "../../common/batcher" }
 c8y_smartrest = { path = "../c8y_smartrest" }
 c8y_translator = { path = "../c8y_translator" }
-chrono = "0.4"
 clock = { path = "../../common/clock" }
 csv = "1.1"
 download = { path = "../../common/download" }

--- a/crates/core/tedge_mapper/src/az_converter.rs
+++ b/crates/core/tedge_mapper/src/az_converter.rs
@@ -53,15 +53,15 @@ mod tests {
     use crate::size_threshold::SizeThresholdExceeded;
     use assert_json_diff::*;
     use assert_matches::*;
-    use chrono::{FixedOffset, TimeZone};
     use mqtt_channel::Topic;
     use serde_json::json;
+    use time::macros::datetime;
 
     struct TestClock;
 
     impl Clock for TestClock {
         fn now(&self) -> clock::Timestamp {
-            FixedOffset::east(5 * 3600).ymd(2021, 4, 8).and_hms(0, 0, 0)
+            datetime!(2021-04-08 00:00:00 +05:00)
         }
     }
 

--- a/crates/core/tedge_mapper/src/collectd_mapper/batcher.rs
+++ b/crates/core/tedge_mapper/src/collectd_mapper/batcher.rs
@@ -7,7 +7,6 @@ use thin_edge_json::{
 };
 
 use crate::collectd_mapper::{collectd::CollectdMessage, error::DeviceMonitorError};
-use chrono::Local;
 use thin_edge_json::group::MeasurementGrouperError;
 
 #[derive(Debug)]
@@ -22,7 +21,7 @@ impl MessageBatch {
         let mut messages = messages.into_iter();
 
         if let Some(first_message) = messages.next() {
-            let timestamp = first_message.timestamp.with_timezone(Local::now().offset());
+            let timestamp = first_message.timestamp;
             let mut batch = MessageBatch::start_batch(first_message, timestamp)?;
             for message in messages {
                 batch.add_to_batch(message)?;
@@ -72,12 +71,12 @@ impl MessageBatch {
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use chrono::{TimeZone, Utc};
     use clock::{Clock, WallClock};
+    use time::macros::datetime;
 
     #[test]
     fn test_message_batch_processor() -> anyhow::Result<()> {
-        let timestamp = Utc.ymd(2015, 5, 15).and_hms_milli(0, 0, 1, 444);
+        let timestamp = datetime!(2015-05-15 0:00:01.444 UTC);
         let collectd_message = CollectdMessage::new("temperature", "value", 32.5, timestamp);
         let mut message_batch = MessageBatch::start_batch(collectd_message, WallClock.now())?;
 

--- a/crates/core/tedge_mapper/src/sm_c8y_mapper/mapper.rs
+++ b/crates/core/tedge_mapper/src/sm_c8y_mapper/mapper.rs
@@ -618,7 +618,7 @@ mod tests {
     #[test_case("/path/to/another-variant-2021-10-25T07:45:41Z.log")]
     #[test_case("/yet-another-variant-2021-10-25T07:45:41Z.log")]
     fn test_datetime_parsing_from_path(file_path: &str) {
-        // checking that `get_date_from_file_path` unwraps a `chrono::NaiveDateTime` object.
+        // checking that `get_date_from_file_path` unwraps a `OffsetDateTime` object.
         // this should return an Ok Result.
         let path_buf = PathBuf::from_str(file_path).unwrap();
         let path_buf_datetime = get_datetime_from_file_path(&path_buf);
@@ -630,7 +630,7 @@ mod tests {
     #[test_case("/path/to/another-variant-07:45:41Z-2021-10-25T.log")]
     #[test_case("/yet-another-variant-2021-10-25T07:45Z.log")]
     fn test_datetime_parsing_from_path_fail(file_path: &str) {
-        // checking that `get_date_from_file_path` unwraps a `chrono::NaiveDateTime` object.
+        // checking that `get_date_from_file_path` unwraps a `OffsetDateTime` object.
         // this should return an err.
         let path_buf = PathBuf::from_str(file_path).unwrap();
         let path_buf_datetime = get_datetime_from_file_path(&path_buf);

--- a/crates/core/thin_edge_json/Cargo.toml
+++ b/crates/core/thin_edge_json/Cargo.toml
@@ -8,13 +8,12 @@ rust-version = "1.58.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-time = { version = "0.3", features = ["macros"] }
 clock = { path = "../../common/clock" }
-chrono = "0.4"
 json-writer = { path = "../../common/json_writer" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 thiserror = "1.0"
+time = { version = "0.3", features = ["formatting", "local-offset", "parsing", "serde"] }
 
 [dev-dependencies]
 anyhow = "1.0"
@@ -26,6 +25,7 @@ stats_alloc = "0.1"
 walkdir = "2"
 assert_matches = "1.5"
 test-case = "1.2"
+time = { version = "0.3", features = ["macros"] }
 
 [[bench]]
 name = "parsing"

--- a/crates/core/thin_edge_json/benches/parsing.rs
+++ b/crates/core/thin_edge_json/benches/parsing.rs
@@ -1,6 +1,6 @@
-use chrono::prelude::*;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use thin_edge_json::measurement::MeasurementVisitor;
+use time::OffsetDateTime;
 
 const INPUT: &str = r#"{
     "time" : "2021-04-30T17:03:14.123+02:00",
@@ -26,7 +26,7 @@ struct DummyVisitor;
 impl MeasurementVisitor for DummyVisitor {
     type Error = DummyError;
 
-    fn visit_timestamp(&mut self, _value: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+    fn visit_timestamp(&mut self, _value: OffsetDateTime) -> Result<(), Self::Error> {
         Ok(())
     }
     fn visit_measurement(&mut self, _name: &str, _value: f64) -> Result<(), Self::Error> {

--- a/crates/core/thin_edge_json/examples/validate.rs
+++ b/crates/core/thin_edge_json/examples/validate.rs
@@ -1,6 +1,6 @@
-use chrono::prelude::*;
 use std::env;
 use thin_edge_json::measurement::MeasurementVisitor;
+use time::OffsetDateTime;
 
 #[global_allocator]
 static GLOBAL: &stats_alloc::StatsAlloc<std::alloc::System> = &stats_alloc::INSTRUMENTED_SYSTEM;
@@ -36,7 +36,7 @@ struct DummyVisitor;
 impl MeasurementVisitor for DummyVisitor {
     type Error = DummyError;
 
-    fn visit_timestamp(&mut self, _value: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+    fn visit_timestamp(&mut self, _value: OffsetDateTime) -> Result<(), Self::Error> {
         Ok(())
     }
     fn visit_measurement(&mut self, _name: &str, _value: f64) -> Result<(), Self::Error> {

--- a/crates/core/thin_edge_json/src/builder.rs
+++ b/crates/core/thin_edge_json/src/builder.rs
@@ -1,9 +1,10 @@
+use time::OffsetDateTime;
+
 use crate::{data::*, measurement::*};
-use chrono::prelude::*;
 
 /// A `MeasurementVisitor` that builds up `ThinEdgeJson`.
 pub struct ThinEdgeJsonBuilder {
-    timestamp: Option<DateTime<FixedOffset>>,
+    timestamp: Option<OffsetDateTime>,
     inside_group: Option<MultiValueMeasurement>,
     measurements: Vec<ThinEdgeValue>,
 }
@@ -36,7 +37,7 @@ impl ThinEdgeJsonBuilder {
 impl MeasurementVisitor for ThinEdgeJsonBuilder {
     type Error = ThinEdgeJsonBuilderError;
 
-    fn visit_timestamp(&mut self, value: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+    fn visit_timestamp(&mut self, value: OffsetDateTime) -> Result<(), Self::Error> {
         match self.timestamp {
             None => {
                 self.timestamp = Some(value);

--- a/crates/core/thin_edge_json/src/data.rs
+++ b/crates/core/thin_edge_json/src/data.rs
@@ -1,11 +1,11 @@
 //! The in-memory data model representing ThinEdge JSON.
 
-use chrono::prelude::*;
+use time::OffsetDateTime;
 
 /// In-memory representation of parsed ThinEdge JSON.
 #[derive(Debug)]
 pub struct ThinEdgeJson {
-    pub timestamp: Option<DateTime<FixedOffset>>,
+    pub timestamp: Option<OffsetDateTime>,
     pub values: Vec<ThinEdgeValue>,
 }
 
@@ -14,7 +14,7 @@ impl ThinEdgeJson {
         self.timestamp.is_some()
     }
 
-    pub fn set_timestamp(&mut self, timestamp: DateTime<FixedOffset>) {
+    pub fn set_timestamp(&mut self, timestamp: OffsetDateTime) {
         self.timestamp = Some(timestamp)
     }
 }

--- a/crates/core/thin_edge_json/src/group.rs
+++ b/crates/core/thin_edge_json/src/group.rs
@@ -1,12 +1,11 @@
-use chrono::offset::FixedOffset;
-use chrono::DateTime;
 use std::collections::HashMap;
+use time::OffsetDateTime;
 
 use crate::measurement::MeasurementVisitor;
 
 #[derive(Debug)]
 pub struct MeasurementGroup {
-    timestamp: Option<DateTime<FixedOffset>>,
+    timestamp: Option<OffsetDateTime>,
     values: HashMap<String, Measurement>,
 }
 
@@ -18,7 +17,7 @@ impl MeasurementGroup {
         }
     }
 
-    pub fn timestamp(&self) -> Option<DateTime<FixedOffset>> {
+    pub fn timestamp(&self) -> Option<OffsetDateTime> {
         self.timestamp
     }
 
@@ -138,7 +137,7 @@ impl Default for MeasurementGrouper {
 impl MeasurementVisitor for MeasurementGrouper {
     type Error = MeasurementGrouperError;
 
-    fn visit_timestamp(&mut self, time: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+    fn visit_timestamp(&mut self, time: OffsetDateTime) -> Result<(), Self::Error> {
         self.measurement_group.timestamp = Some(time);
         Ok(())
     }
@@ -192,9 +191,9 @@ impl MeasurementVisitor for MeasurementGrouper {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::prelude::*;
     use mockall::predicate::*;
     use mockall::*;
+    use time::{macros::datetime, Duration};
 
     #[derive(thiserror::Error, Debug, Clone)]
     pub enum TestError {
@@ -209,7 +208,7 @@ mod tests {
         impl MeasurementVisitor for GroupedVisitor {
             type Error = TestError;
 
-            fn visit_timestamp(&mut self, value: DateTime<FixedOffset>) -> Result<(), TestError>;
+            fn visit_timestamp(&mut self, value: OffsetDateTime) -> Result<(), TestError>;
             fn visit_measurement(&mut self, name: &str, value: f64) -> Result<(), TestError>;
             fn visit_start_group(&mut self, group: &str) -> Result<(), TestError>;
             fn visit_end_group(&mut self) -> Result<(), TestError>;
@@ -348,9 +347,9 @@ mod tests {
         Ok(())
     }
 
-    fn test_timestamp(minute: u32) -> DateTime<FixedOffset> {
-        FixedOffset::east(5 * 3600)
-            .ymd(2021, 4, 8)
-            .and_hms(13, minute, 00)
+    fn test_timestamp(minute: u32) -> OffsetDateTime {
+        let mut dt = datetime!(2021-04-08 13:00:00 +05:00);
+        dt += Duration::minutes(minute as i64);
+        dt
     }
 }

--- a/crates/core/thin_edge_json/src/measurement.rs
+++ b/crates/core/thin_edge_json/src/measurement.rs
@@ -1,5 +1,4 @@
-use chrono::offset::FixedOffset;
-use chrono::DateTime;
+use time::OffsetDateTime;
 
 /// The `MeasurementVisitor` trait represents the capability to visit a series of measurements, possibly grouped.
 ///
@@ -7,7 +6,8 @@ use chrono::DateTime;
 ///
 /// ```
 /// # use thin_edge_json::measurement::*;
-/// # use chrono::*;
+/// # use time::{OffsetDateTime, format_description};
+///
 /// struct MeasurementPrinter {
 ///     group: Option<String>,
 /// }
@@ -27,9 +27,11 @@ use chrono::DateTime;
 /// impl MeasurementVisitor for MeasurementPrinter {
 ///     type Error = MeasurementError;
 ///
-///     fn visit_timestamp(&mut self, timestamp: DateTime<FixedOffset>) -> Result<(), Self::Error> {
+///     fn visit_timestamp(&mut self, timestamp: OffsetDateTime) -> Result<(), Self::Error> {
+///         let format =
+///             format_description::parse("[day] [month repr:short] [year] [hour repr:24]:[minute]:[seconds] [offset_hour sign:mandatory]:[offset_minute]").unwrap();
 ///         if self.group.is_none() {
-///             Ok(println!("time = {}", timestamp.to_rfc2822()))
+///             Ok(println!("time = {}", timestamp.format(&format).unwrap()))
 ///         } else {
 ///             Err(MeasurementError::UnexpectedTimestamp)
 ///         }
@@ -67,7 +69,7 @@ pub trait MeasurementVisitor {
     type Error: std::error::Error + std::fmt::Debug;
 
     /// Set the timestamp shared by all the measurements of this series.
-    fn visit_timestamp(&mut self, value: DateTime<FixedOffset>) -> Result<(), Self::Error>;
+    fn visit_timestamp(&mut self, value: OffsetDateTime) -> Result<(), Self::Error>;
 
     /// Add a new measurement, attached to the current group if any.
     fn visit_measurement(&mut self, name: &str, value: f64) -> Result<(), Self::Error>;

--- a/crates/core/thin_edge_json/src/parser.rs
+++ b/crates/core/thin_edge_json/src/parser.rs
@@ -3,7 +3,6 @@
 //! [^1]: It only allocates in presence of escaped strings as keys.
 //!
 use crate::measurement::MeasurementVisitor;
-use chrono::prelude::*;
 use serde::{
     de::{self, DeserializeSeed, MapAccess},
     Deserializer,
@@ -11,6 +10,7 @@ use serde::{
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;
+use time::{format_description, OffsetDateTime};
 
 /// Parses `input` as ThinEdge JSON yielding the parsed measurements to the `visitor`.
 pub fn parse_str<T: MeasurementVisitor>(
@@ -99,8 +99,11 @@ where
                 }
                 "time" => {
                     let timestamp_str: &str = map.next_value()?;
-                    let timestamp = DateTime::parse_from_rfc3339(timestamp_str)
-                        .map_err(|err| de::Error::custom(invalid_timestamp(timestamp_str, err)))?;
+                    let timestamp = OffsetDateTime::parse(
+                        timestamp_str,
+                        &format_description::well_known::Rfc3339,
+                    )
+                    .map_err(|err| de::Error::custom(invalid_timestamp(timestamp_str, err)))?;
 
                     let () = self
                         .visitor
@@ -293,69 +296,71 @@ fn map_error(error: serde_json::Error, input: &str) -> ThinEdgeJsonParserError {
         input_excerpt,
     }
 }
+#[cfg(test)]
+mod tests {
+    use time::macros::datetime;
 
-#[test]
-fn it_deserializes_thin_edge_json() -> anyhow::Result<()> {
-    use crate::builder::ThinEdgeJsonBuilder;
-    let input = r#"{
-            "time" : "2021-04-30T17:03:14.123+02:00",
-            "pressure": 123.4,
-            "temperature": 24,
-            "coordinate": {
-                "x": 1,
-                "y": 2.0,
-                "z": -42.0
-            },
-            "escaped\\": 123.0
-        }"#;
+    use crate::parser::parse_str;
 
-    let mut builder = ThinEdgeJsonBuilder::new();
+    #[test]
+    fn it_deserializes_thin_edge_json() -> anyhow::Result<()> {
+        use crate::builder::ThinEdgeJsonBuilder;
+        let input = r#"{
+        "time" : "2021-04-30T17:03:14.123+02:00",
+        "pressure": 123.4,
+        "temperature": 24,
+        "coordinate": {
+            "x": 1,
+            "y": 2.0,
+            "z": -42.0
+        },
+        "escaped\\": 123.0
+    }"#;
 
-    let () = parse_str(input, &mut builder)?;
+        let mut builder = ThinEdgeJsonBuilder::new();
 
-    let output = builder.done()?;
+        let () = parse_str(input, &mut builder)?;
 
-    assert_eq!(
-        output.timestamp,
-        Some(
-            FixedOffset::east(2 * 3600)
-                .ymd(2021, 4, 30)
-                .and_hms_milli(17, 3, 14, 123)
-        )
-    );
+        let output = builder.done()?;
 
-    assert_eq!(
-        output.values,
-        vec![
-            ("pressure", 123.4).into(),
-            ("temperature", 24.0).into(),
-            (
-                "coordinate",
-                vec![("x", 1.0).into(), ("y", 2.0).into(), ("z", -42.0).into(),]
-            )
-                .into(),
-            (r#"escaped\"#, 123.0).into(),
-        ]
-    );
-    Ok(())
-}
+        assert_eq!(
+            output.timestamp,
+            Some(datetime!(2021-04-30 17:03:14.123 +02:00))
+        );
 
-#[test]
-fn it_shows_input_excerpt_on_error() -> anyhow::Result<()> {
-    use crate::builder::ThinEdgeJsonBuilder;
+        assert_eq!(
+            output.values,
+            vec![
+                ("pressure", 123.4).into(),
+                ("temperature", 24.0).into(),
+                (
+                    "coordinate",
+                    vec![("x", 1.0).into(), ("y", 2.0).into(), ("z", -42.0).into(),]
+                )
+                    .into(),
+                (r#"escaped\"#, 123.0).into(),
+            ]
+        );
+        Ok(())
+    }
 
-    let input = "{\n\"time\" : null\n}";
+    #[test]
+    fn it_shows_input_excerpt_on_error() -> anyhow::Result<()> {
+        use crate::builder::ThinEdgeJsonBuilder;
 
-    let mut builder = ThinEdgeJsonBuilder::new();
+        let input = "{\n\"time\" : null\n}";
 
-    let res = parse_str(input, &mut builder);
+        let mut builder = ThinEdgeJsonBuilder::new();
 
-    assert!(res.is_err());
+        let res = parse_str(input, &mut builder);
 
-    assert_eq!(
+        assert!(res.is_err());
+
+        assert_eq!(
         res.unwrap_err().to_string(),
         "Invalid JSON: invalid type: null, expected a borrowed string at line 2 column 13: `l\n}`",
     );
 
-    Ok(())
+        Ok(())
+    }
 }

--- a/crates/core/thin_edge_json/tests/fixtures/invalid/reject_invalid_timestamp.expected_error
+++ b/crates/core/thin_edge_json/tests/fixtures/invalid/reject_invalid_timestamp.expected_error
@@ -1,4 +1,4 @@
-Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-22 3am": input contains invalid characters at line 2 column 27: `",
+Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-22 3am": a character literal was not valid at line 2 column 27: `",
   "pressure": 220
 }
 `

--- a/crates/core/thin_edge_json/tests/fixtures/invalid/reject_partial_timestamp.expected_error
+++ b/crates/core/thin_edge_json/tests/fixtures/invalid/reject_partial_timestamp.expected_error
@@ -1,4 +1,4 @@
-Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-22": premature end of input at line 2 column 23: `",
+Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-22": a character literal was not valid at line 2 column 23: `",
   "pressure": 220
 }
 `

--- a/crates/core/thin_edge_json/tests/fixtures/invalid/reject_timestamp_missing_time_separator.expected_error
+++ b/crates/core/thin_edge_json/tests/fixtures/invalid/reject_timestamp_missing_time_separator.expected_error
@@ -1,2 +1,2 @@
-Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-2217:03:14.000658767+02:00": input contains invalid characters at line 3 column 1: `}
+Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "2013-06-2217:03:14.000658767+02:00": a character literal was not valid at line 3 column 1: `}
 `


### PR DESCRIPTION
## Proposed changes

This is first in a series (part 2 #851 part 3 #852) of changes to remove `chrono` from dependencies.

To replace #629.
Partial fix for #625.

This removes `chrono` in favour of `time ^0.3` in `thin-edge-json` and all dependents crates.
Caused by RUSTSEC-2020-0159 - no movement on the issue in the `chrono` crate since ~10.2020

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
