### PR TITLE
Use 'time' instead of 'chrono' due to CVE for certificate and all dependent crates [3/3]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,11 +394,11 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "base64",
- "chrono",
  "pem",
  "rcgen",
  "sha-1",
  "thiserror",
+ "time 0.3.5",
  "x509-parser",
  "zeroize",
 ]
@@ -2038,13 +2038,13 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.8.14"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5911d1403f4143c9d56a702069d593e8d0f3fab880a85e103604d0893ea31ba7"
+checksum = "e2296a75ce93ea619bd9686d9f4b060f28845236e67d8666bcd02954e872b400"
 dependencies = [
- "chrono",
  "pem",
  "ring",
+ "time 0.3.5",
  "yasna",
  "zeroize",
 ]
@@ -2588,7 +2588,6 @@ dependencies = [
  "assert_matches",
  "base64",
  "certificate",
- "chrono",
  "futures",
  "hyper",
  "mockito",
@@ -3496,11 +3495,11 @@ checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
 
 [[package]]
 name = "yasna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
+checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
 dependencies = [
- "chrono",
+ "time 0.3.5",
 ]
 
 [[package]]

--- a/crates/common/certificate/Cargo.toml
+++ b/crates/common/certificate/Cargo.toml
@@ -8,10 +8,10 @@ rust-version = "1.58.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
-rcgen = { version = "0.8", features = ["pem", "zeroize"] }
+rcgen = { version = "0.9", features = ["pem", "zeroize"] }
 sha-1 = "0.9"
 thiserror = "1.0"
+time = "0.3"
 x509-parser = "0.12"
 zeroize = "1.4"
 
@@ -20,3 +20,4 @@ anyhow = "1.0"
 assert_matches = "1.5"
 base64 = "0.13"
 pem = "1.0"
+time = {version = "0.3", features = ["macros"]}

--- a/crates/common/certificate/src/lib.rs
+++ b/crates/common/certificate/src/lib.rs
@@ -1,12 +1,10 @@
-use chrono::offset::Utc;
-use chrono::DateTime;
-use chrono::Duration;
 use device_id::DeviceIdError;
 use rcgen::Certificate;
 use rcgen::CertificateParams;
 use rcgen::RcgenError;
 use sha1::{Digest, Sha1};
 use std::path::Path;
+use time::{Duration, OffsetDateTime};
 use zeroize::Zeroizing;
 
 pub mod device_id;
@@ -94,7 +92,7 @@ impl KeyCertPair {
         config: &NewCertificateConfig,
         id: &str,
     ) -> Result<KeyCertPair, CertificateError> {
-        let today = Utc::now();
+        let today = OffsetDateTime::now_utc();
         let not_before = today - Duration::days(1); // Ensure the certificate is valid today
         KeyCertPair::new_selfsigned_certificate_at(config, id, not_before)
     }
@@ -102,7 +100,7 @@ impl KeyCertPair {
     pub fn new_selfsigned_certificate_at(
         config: &NewCertificateConfig,
         id: &str,
-        not_before: DateTime<Utc>,
+        not_before: OffsetDateTime,
     ) -> Result<KeyCertPair, CertificateError> {
         let () = KeyCertPair::check_identifier(id, config.max_cn_size)?;
         let mut distinguished_name = rcgen::DistinguishedName::new();
@@ -178,6 +176,8 @@ impl Default for NewCertificateConfig {
 
 #[cfg(test)]
 mod tests {
+    use time::macros::datetime;
+
     use super::*;
 
     fn pem_of_keypair(keypair: &KeyCertPair) -> PemCertificate {
@@ -251,9 +251,7 @@ mod tests {
         // Create a certificate with a given birthdate.
         let config = NewCertificateConfig::default();
         let id = "some-id";
-        let birthdate = DateTime::parse_from_rfc3339("2021-03-31T16:39:57+01:00")
-            .unwrap()
-            .with_timezone(&Utc);
+        let birthdate = datetime!(2021-03-31 16:39:57 +01:00);
 
         let keypair = KeyCertPair::new_selfsigned_certificate_at(&config, id, birthdate)
             .expect("Fail to create a certificate");
@@ -274,9 +272,7 @@ mod tests {
             ..Default::default()
         };
         let id = "some-id";
-        let birthdate = DateTime::parse_from_rfc3339("2021-03-31T16:39:57+01:00")
-            .unwrap()
-            .with_timezone(&Utc);
+        let birthdate = datetime!(2021-03-31 16:39:57 +01:00);
 
         let keypair = KeyCertPair::new_selfsigned_certificate_at(&config, id, birthdate)
             .expect("Fail to create a certificate");

--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -16,7 +16,6 @@ maintainer-scripts = "../../../configuration/debian/tedge"
 anyhow = "1.0"
 base64 = "0.13"
 certificate = { path = "../../common/certificate" }
-chrono = "0.4"
 futures = "0.3"
 hyper = { version = "0.14", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls", "stream"] }


### PR DESCRIPTION
## Proposed changes

This is third in a series (part 1 #850 and part 2 #851) of changes to remove `chrono` from dependencies.

To replace #629.
Partial fix for #625.

This removes `chrono` in favour of `time ^0.3` in `certificate` and all dependents crates.
Caused by RUSTSEC-2020-0159 - no movement on the issue in the `chrono` crate since ~10.2020

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
