### PR TITLE
Clippy fixes for: c8y_smartrest

### DIFF
--- a/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
+++ b/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
@@ -258,20 +258,22 @@ pub struct SmartRestJwtResponse {
     token: JwtToken,
 }
 
-impl SmartRestJwtResponse {
-    pub fn new() -> Self {
+impl Default for SmartRestJwtResponse {
+    fn default() -> Self {
         Self {
             id: 71,
             token: "".into(),
         }
     }
+}
 
+impl SmartRestJwtResponse {
     pub fn try_new(to_parse: &str) -> Result<Self, SmartRestDeserializerError> {
         let mut csv = csv::ReaderBuilder::new()
             .has_headers(false)
             .from_reader(to_parse.as_bytes());
 
-        let mut jwt = Self::new();
+        let mut jwt = Self::default();
         for result in csv.deserialize() {
             jwt = result.unwrap();
         }
@@ -309,7 +311,7 @@ mod tests {
 
     #[test]
     fn jwt_token_create_new() {
-        let jwt = SmartRestJwtResponse::new();
+        let jwt = SmartRestJwtResponse::default();
 
         assert!(jwt.token.is_empty());
     }

--- a/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
+++ b/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
@@ -44,15 +44,17 @@ pub struct SmartRestUpdateSoftwareModule {
     pub action: String,
 }
 
-impl SmartRestUpdateSoftware {
-    pub fn new() -> Self {
+impl Default for SmartRestUpdateSoftware {
+    fn default() -> Self {
         Self {
             message_id: "528".into(),
             external_id: "".into(),
             update_list: vec![],
         }
     }
+}
 
+impl SmartRestUpdateSoftware {
     pub fn from_smartrest(&self, smartrest: &str) -> Result<Self, SmartRestDeserializerError> {
         let mut message_id = smartrest.to_string();
         let () = message_id.truncate(3);
@@ -61,7 +63,7 @@ impl SmartRestUpdateSoftware {
             .has_headers(false)
             .flexible(true)
             .from_reader(smartrest.as_bytes());
-        let mut record: Self = Self::new();
+        let mut record: Self = Self::default();
 
         for result in rdr.deserialize() {
             record = result?;
@@ -382,7 +384,7 @@ mod tests {
     fn deserialize_smartrest_update_software() {
         let smartrest =
             String::from("528,external_id,software1,version1,url1,install,software2,,,delete");
-        let update_software = SmartRestUpdateSoftware::new()
+        let update_software = SmartRestUpdateSoftware::default()
             .from_smartrest(&smartrest)
             .unwrap();
 
@@ -411,7 +413,7 @@ mod tests {
     #[test]
     fn deserialize_incorrect_smartrest_message_id() {
         let smartrest = String::from("516,external_id");
-        assert!(SmartRestUpdateSoftware::new()
+        assert!(SmartRestUpdateSoftware::default()
             .from_smartrest(&smartrest)
             .is_err());
     }
@@ -420,7 +422,7 @@ mod tests {
     fn deserialize_incorrect_smartrest_action() {
         let smartrest =
             String::from("528,external_id,software1,version1,url1,action,software2,,,remove");
-        assert!(SmartRestUpdateSoftware::new()
+        assert!(SmartRestUpdateSoftware::default()
             .from_smartrest(&smartrest)
             .unwrap()
             .to_thin_edge_json()
@@ -475,7 +477,7 @@ mod tests {
             String::from("528,external_id,nodered,1.0.0::debian,,install,\
             collectd,5.7::debian,https://collectd.org/download/collectd-tarballs/collectd-5.12.0.tar.bz2,install,\
             nginx,1.21.0::docker,,install,mongodb,4.4.6::docker,,delete");
-        let update_software = SmartRestUpdateSoftware::new();
+        let update_software = SmartRestUpdateSoftware::default();
         let software_update_request = update_software
             .from_smartrest(&smartrest)
             .unwrap()
@@ -528,7 +530,7 @@ mod tests {
     fn access_smartrest_update_modules() {
         let smartrest =
             String::from("528,external_id,software1,version1,url1,install,software2,,,delete");
-        let update_software = SmartRestUpdateSoftware::new();
+        let update_software = SmartRestUpdateSoftware::default();
         let vec = update_software
             .from_smartrest(&smartrest)
             .unwrap()

--- a/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
+++ b/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
@@ -223,11 +223,11 @@ impl SmartRestLogRequest {
             .flexible(true)
             .from_reader(smartrest.as_bytes());
 
-        match rdr.deserialize().next() {
-            Some(Ok(record)) => Ok(record),
-            Some(Err(err)) => Err(err)?,
-            None => panic!("empty request"),
-        }
+        rdr.deserialize()
+            .next()
+            .ok_or_else(|| panic!("empty request"))
+            .unwrap() // does already panic before this, so this unwrap is only required for type lineup
+            .map_err(SmartRestDeserializerError::from)
     }
 }
 
@@ -244,11 +244,10 @@ impl SmartRestRestartRequest {
             .flexible(true)
             .from_reader(smartrest.as_bytes());
 
-        match rdr.deserialize().next() {
-            Some(Ok(record)) => Ok(record),
-            Some(Err(err)) => Err(err)?,
-            None => Err(SmartRestDeserializerError::EmptyRequest),
-        }
+        rdr.deserialize()
+            .next()
+            .ok_or(SmartRestDeserializerError::EmptyRequest)?
+            .map_err(SmartRestDeserializerError::from)
     }
 }
 

--- a/crates/core/tedge_mapper/src/sm_c8y_mapper/mapper.rs
+++ b/crates/core/tedge_mapper/src/sm_c8y_mapper/mapper.rs
@@ -400,7 +400,7 @@ where
         smartrest: &str,
     ) -> Result<(), SMCumulocityMapperError> {
         let topic = Topic::new(RequestTopic::SoftwareUpdateRequest.as_str())?;
-        let update_software = SmartRestUpdateSoftware::new();
+        let update_software = SmartRestUpdateSoftware::default();
         let mut software_update_request = update_software
             .from_smartrest(smartrest)?
             .to_thin_edge_json()?;


### PR DESCRIPTION
## Proposed changes

This is part of #825 - my patches to fix the clippy warnings in the `c8y_smartrest` crate.

## Types of changes

- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)