### PR TITLE
[#809] Cumulocity mapper to send large events > 16K size with HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
  "csv",
  "download",
  "futures",
- "mockall",
+ "mockall 0.10.2",
  "mqtt_channel",
  "reqwest",
  "serde",
@@ -504,7 +504,7 @@ dependencies = [
 name = "clock"
 version = "0.5.3"
 dependencies = [
- "mockall",
+ "mockall 0.10.2",
  "time 0.3.7",
 ]
 
@@ -758,6 +758,12 @@ name = "downcast"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "download"
@@ -1434,11 +1440,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab571328afa78ae322493cacca3efac6a0f2e0a67305b4df31fd439ef129ac0"
 dependencies = [
  "cfg-if 1.0.0",
- "downcast",
+ "downcast 0.10.0",
  "fragile",
  "lazy_static",
- "mockall_derive",
+ "mockall_derive 0.10.2",
  "predicates 1.0.8",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4d70639a72f972725db16350db56da68266ca368b2a1fe26724a903ad3d6b8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "downcast 0.11.0",
+ "fragile",
+ "lazy_static",
+ "mockall_derive 0.11.0",
+ "predicates 2.1.0",
  "predicates-tree",
 ]
 
@@ -1447,6 +1468,18 @@ name = "mockall_derive"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.82",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ef208208a0dea3f72221e26e904cdc6db2e481d9ade89081ddd494f1dbaa6b"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2 1.0.32",
@@ -2670,7 +2703,7 @@ dependencies = [
  "clap 3.0.13",
  "flockfile",
  "futures",
- "mockall",
+ "mockall 0.10.2",
  "mqtt_channel",
  "mqtt_tests",
  "once_cell",
@@ -2750,7 +2783,7 @@ dependencies = [
  "c8y_smartrest",
  "csv",
  "futures",
- "mockall",
+ "mockall 0.10.2",
  "mqtt_channel",
  "reqwest",
  "serde",
@@ -2782,7 +2815,7 @@ dependencies = [
  "download",
  "flockfile",
  "futures",
- "mockall",
+ "mockall 0.11.0",
  "mqtt_channel",
  "mqtt_tests",
  "reqwest",
@@ -2891,7 +2924,7 @@ dependencies = [
  "clock",
  "criterion",
  "json-writer",
- "mockall",
+ "mockall 0.10.2",
  "proptest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,13 +334,15 @@ name = "c8y_api"
 version = "0.5.3"
 dependencies = [
  "agent_interface",
+ "anyhow",
  "async-trait",
  "c8y_smartrest",
  "clock",
  "csv",
  "download",
  "futures",
- "mockall 0.10.2",
+ "mockall 0.11.0",
+ "mockito",
  "mqtt_channel",
  "reqwest",
  "serde",

--- a/crates/core/c8y_api/Cargo.toml
+++ b/crates/core/c8y_api/Cargo.toml
@@ -15,7 +15,7 @@ clock = { path = "../../common/clock" }
 csv = "1.1"
 download = { path = "../../common/download" }
 futures = "0.3"
-mockall = "0.10"
+mockall = "0.11"
 mqtt_channel = { path = "../../common/mqtt_channel" }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -30,5 +30,7 @@ toml = "0.5"
 tracing = { version = "0.1", features = ["attributes", "log"] }
 
 [dev-dependencies]
+anyhow = "1.0"
+mockito = "0.30"
 tempfile = "3.3"
 test-case = "1.2"

--- a/crates/core/c8y_api/src/json_c8y.rs
+++ b/crates/core/c8y_api/src/json_c8y.rs
@@ -17,6 +17,13 @@ pub struct C8yCreateEvent {
     text: String,
 }
 
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+/// used to retrieve the id of a log event
+pub struct C8yEventResponse {
+    pub id: String,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct C8yManagedObject {

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -37,7 +37,7 @@ csv = "1.1"
 download = { path = "../../common/download" }
 flockfile = { path = "../../common/flockfile" }
 futures = "0.3"
-mockall = "0.10"
+mockall = "0.11"
 mqtt_channel = { path = "../../common/mqtt_channel" }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/core/tedge_mapper/src/c8y/converter.rs
+++ b/crates/core/tedge_mapper/src/c8y/converter.rs
@@ -29,6 +29,7 @@ use std::{
     process::Stdio,
 };
 use thin_edge_json::{alarm::ThinEdgeAlarm, event::ThinEdgeEvent};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tracing::{debug, info, log::error};
 
 use super::{
@@ -149,26 +150,43 @@ where
         input: &Message,
     ) -> Result<Vec<Message>, ConversionError> {
         let tedge_event = ThinEdgeEvent::try_from(input.topic.name.as_str(), input.payload_str()?)?;
-        match self.size_threshold.validate(input.payload_str()?) {
-            // If the message size is well within the Cumulocity MQTT size limit, use MQTT to send the mapped event as well
-            Ok(()) => {
-                let smartrest_alarm = event::serialize_event(tedge_event)?;
-                let smartrest_topic = Topic::new_unchecked(SMARTREST_PUBLISH_TOPIC);
 
-                Ok(vec![Message::new(&smartrest_topic, smartrest_alarm)])
-            }
+        // If the message size is well within the Cumulocity MQTT size limit, use MQTT to send the mapped event as well
+        if input.payload_bytes().len() < self.size_threshold.0 {
+            let smartrest_alarm = event::serialize_event(tedge_event)?;
+            let smartrest_topic = Topic::new_unchecked(SMARTREST_PUBLISH_TOPIC);
+
+            Ok(vec![Message::new(&smartrest_topic, smartrest_alarm)])
+        } else {
             // If the message size is larger than the MQTT size limit, use HTTP to send the mapped event
-            Err(_) => {
-                let event_text = tedge_event
-                    .data
-                    .and_then(|data| data.message)
-                    .unwrap_or_else(|| "generic event".into());
-                let _ = self
-                    .http_proxy
-                    .send_event(tedge_event.name.as_str(), event_text.as_str(), None)
-                    .await?;
-                Ok(vec![])
-            }
+            let (event_text, event_time) = match tedge_event.data {
+                None => {
+                    let message = tedge_event.name.clone();
+                    let time = OffsetDateTime::now_utc().format(&Rfc3339)?;
+
+                    (message, time)
+                }
+                Some(event_data) => {
+                    let message = event_data
+                        .message
+                        .unwrap_or_else(|| tedge_event.name.clone());
+                    let time = event_data.time.map_or_else(
+                        || OffsetDateTime::now_utc().format(&Rfc3339),
+                        |timestamp| timestamp.format(&Rfc3339),
+                    )?;
+                    (message, time)
+                }
+            };
+
+            let _ = self
+                .http_proxy
+                .send_event(
+                    tedge_event.name.as_str(),
+                    event_text.as_str(),
+                    Some(event_time),
+                )
+                .await?;
+            Ok(vec![])
         }
     }
 }
@@ -186,11 +204,11 @@ where
     async fn try_convert(&mut self, message: &Message) -> Result<Vec<Message>, ConversionError> {
         match &message.topic {
             topic if topic.name.starts_with("tedge/measurements") => {
-                let () = self.size_threshold.validate(message.payload_str()?)?;
+                let () = self.size_threshold.validate(message)?;
                 self.try_convert_measurement(message)
             }
             topic if topic.name.starts_with("tedge/alarms") => {
-                let () = self.size_threshold.validate(message.payload_str()?)?;
+                let () = self.size_threshold.validate(message)?;
                 self.alarm_converter.try_convert_alarm(message)
             }
             topic if topic.name.starts_with(INTERNAL_ALARMS_TOPIC) => {

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -16,6 +16,7 @@ use tracing::{info, info_span, Instrument};
 use super::topic::C8yTopic;
 
 const CUMULOCITY_MAPPER_NAME: &str = "tedge-mapper-c8y";
+const MQTT_MESSAGE_SIZE_THRESHOLD: usize = 16 * 1024;
 
 pub struct CumulocityMapper {}
 
@@ -65,7 +66,7 @@ impl CumulocityMapper {
 #[async_trait]
 impl TEdgeComponent for CumulocityMapper {
     async fn start(&self, tedge_config: TEdgeConfig) -> Result<(), anyhow::Error> {
-        let size_threshold = SizeThreshold(16 * 1024);
+        let size_threshold = SizeThreshold(MQTT_MESSAGE_SIZE_THRESHOLD);
 
         let operations = Operations::try_new("/etc/tedge/operations", "c8y")?;
         let mut http_proxy = JwtAuthHttpProxy::try_new(&tedge_config).await?;

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use agent_interface::topic::ResponseTopic;
 use async_trait::async_trait;
-use c8y_api::http_proxy::JwtAuthHttpProxy;
+use c8y_api::http_proxy::{C8YHttpProxy, JwtAuthHttpProxy};
 use c8y_smartrest::operations::Operations;
 use mqtt_channel::{Config, TopicFilter};
 use tedge_config::{
@@ -68,7 +68,8 @@ impl TEdgeComponent for CumulocityMapper {
         let size_threshold = SizeThreshold(16 * 1024);
 
         let operations = Operations::try_new("/etc/tedge/operations", "c8y")?;
-        let http_proxy = JwtAuthHttpProxy::try_new(&tedge_config).await?;
+        let mut http_proxy = JwtAuthHttpProxy::try_new(&tedge_config).await?;
+        http_proxy.init().await?;
         let device_name = tedge_config.query(DeviceIdSetting)?;
         let device_type = tedge_config.query(DeviceTypeSetting)?;
         let mqtt_port = tedge_config.query(MqttPortSetting)?.into();

--- a/crates/core/tedge_mapper/src/c8y/tests.rs
+++ b/crates/core/tedge_mapper/src/c8y/tests.rs
@@ -1,7 +1,7 @@
 use crate::core::{converter::Converter, mapper::create_mapper, size_threshold::SizeThreshold};
 use anyhow::Result;
 use c8y_api::{
-    http_proxy::{C8YHttpProxy, JwtAuthHttpProxy, MockC8YHttpProxy},
+    http_proxy::{C8YHttpProxy, C8yMqttJwtTokenRetriever, JwtAuthHttpProxy, MockC8YHttpProxy},
     json_c8y::C8yUpdateSoftwareListResponse,
 };
 use c8y_smartrest::{

--- a/crates/core/tedge_mapper/src/core/error.rs
+++ b/crates/core/tedge_mapper/src/core/error.rs
@@ -1,4 +1,4 @@
-use crate::{c8y::error::CumulocityMapperError, core::size_threshold::SizeThresholdExceeded};
+use crate::c8y::error::CumulocityMapperError;
 
 use c8y_smartrest::error::OperationsError;
 use mqtt_channel::MqttError;
@@ -54,8 +54,12 @@ pub enum ConversionError {
     #[error(transparent)]
     FromThinEdgeJsonParser(#[from] thin_edge_json::parser::ThinEdgeJsonParserError),
 
-    #[error(transparent)]
-    FromSizeThresholdExceeded(#[from] SizeThresholdExceeded),
+    #[error("The size of the message received on {topic} is {actual_size} which is greater than the threshold size of {threshold}.")]
+    SizeThresholdExceeded {
+        topic: String,
+        actual_size: usize,
+        threshold: usize,
+    },
 
     #[error("The given Child ID '{id}' is invalid.")]
     InvalidChildId { id: String },
@@ -83,4 +87,7 @@ pub enum ConversionError {
 
     #[error(transparent)]
     FromUtf8Error(#[from] std::string::FromUtf8Error),
+
+    #[error(transparent)]
+    FromTimeFormatError(#[from] time::error::Format),
 }

--- a/crates/core/tedge_mapper/src/core/error.rs
+++ b/crates/core/tedge_mapper/src/core/error.rs
@@ -33,7 +33,10 @@ pub enum ConversionError {
     FromCumulocityJsonError(#[from] c8y_translator::json::CumulocityJsonError),
 
     #[error(transparent)]
-    FromCumulocityCumulocityMapperError(#[from] CumulocityMapperError),
+    FromCumulocityMapperError(#[from] CumulocityMapperError),
+
+    #[error(transparent)]
+    FromCumulocitySmartRestMapperError(#[from] c8y_smartrest::error::SMCumulocityMapperError),
 
     #[error(transparent)]
     FromThinEdgeJsonSerialization(#[from] ThinEdgeJsonSerializationError),

--- a/crates/core/tedge_mapper/src/core/size_threshold.rs
+++ b/crates/core/tedge_mapper/src/core/size_threshold.rs
@@ -1,12 +1,17 @@
+use mqtt_channel::Message;
+
+use super::error::ConversionError;
+
 #[derive(Debug)]
 pub struct SizeThreshold(pub usize);
 
 impl SizeThreshold {
-    pub fn validate(&self, input: &str) -> Result<(), SizeThresholdExceeded> {
-        let actual_size = input.len();
+    pub fn validate(&self, input: &Message) -> Result<(), ConversionError> {
+        let actual_size = input.payload_bytes().len();
         let threshold = self.0;
         if actual_size > threshold {
-            Err(SizeThresholdExceeded {
+            Err(ConversionError::SizeThresholdExceeded {
+                topic: input.topic.name.clone(),
                 actual_size,
                 threshold,
             })
@@ -14,11 +19,4 @@ impl SizeThreshold {
             Ok(())
         }
     }
-}
-
-#[derive(thiserror::Error, Debug)]
-#[error("The input size {actual_size} is too big. The threshold is {threshold}.")]
-pub struct SizeThresholdExceeded {
-    pub actual_size: usize,
-    pub threshold: usize,
 }


### PR DESCRIPTION
## Proposed changes

Cumulocity has a 16K limit for events that can be sent over MQTT. So, if the thin-edge event size is more than that limit, it must be sent via HTTP. This PR implements that switching mechanism based on event payload size.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
