### PR TITLE
Clippy fixes for: json_writer

### DIFF
--- a/crates/common/json_writer/src/lib.rs
+++ b/crates/common/json_writer/src/lib.rs
@@ -21,6 +21,7 @@ pub enum JsonWriterError {
     InvalidF64Value { value: f64 },
 }
 
+#[cfg(test)]
 impl Default for JsonWriter {
     fn default() -> Self {
         Self {

--- a/crates/common/json_writer/src/lib.rs
+++ b/crates/common/json_writer/src/lib.rs
@@ -21,14 +21,16 @@ pub enum JsonWriterError {
     InvalidF64Value { value: f64 },
 }
 
-impl JsonWriter {
-    pub fn new() -> Self {
+impl Default for JsonWriter {
+    fn default() -> Self {
         Self {
             buffer: Vec::new(),
             needs_separator: false,
         }
     }
+}
 
+impl JsonWriter {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             buffer: Vec::with_capacity(capacity),
@@ -93,7 +95,7 @@ mod tests {
 
     #[test]
     fn write_empty_message() -> anyhow::Result<()> {
-        let mut jw = JsonWriter::new();
+        let mut jw = JsonWriter::default();
         jw.write_open_obj();
         jw.write_close_obj();
         assert_eq!(jw.into_string()?, "{}");
@@ -102,7 +104,7 @@ mod tests {
 
     #[test]
     fn write_invalid_f64_message() -> anyhow::Result<()> {
-        let mut jw = JsonWriter::new();
+        let mut jw = JsonWriter::default();
         let value = 1.0 / 0.0;
         let error = jw.write_f64(value).unwrap_err();
         assert_eq!(error.to_string(), "Invalid f64 value inf");


### PR DESCRIPTION
## Proposed changes

This is part of #825 - my patches to fix the clippy warnings in the `json_writer` crate.

## Types of changes

- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)