### PR TITLE
Clippy fixes for: tedge_apt_plugin

### DIFF
--- a/plugins/tedge_apt_plugin/src/main.rs
+++ b/plugins/tedge_apt_plugin/src/main.rs
@@ -120,10 +120,7 @@ fn run(operation: PluginOp) -> Result<ExitStatus, InternalError> {
             // Maintaining this metadata list to keep the debian package symlinks until the installation is complete,
             // which will get cleaned up once it goes out of scope after this block
             let mut metadata_vec = Vec::new();
-            let mut args: Vec<String> = Vec::new();
-            args.push("install".into());
-            args.push("--quiet".into());
-            args.push("--yes".into());
+            let mut args: Vec<String> = vec!["install".into(), "--quiet".into(), "--yes".into()];
             for update_module in updates {
                 match update_module.action {
                     UpdateAction::Install => {

--- a/plugins/tedge_apt_plugin/src/module_check.rs
+++ b/plugins/tedge_apt_plugin/src/module_check.rs
@@ -44,10 +44,7 @@ impl PackageMetadata {
         if self.metadata_contains_all(contain_args) {
             // In the current implementation using `apt-get` it is required that the file has '.deb' extension (if we use dpkg extension doesn't matter).
             if self.file_path.extension() != Some(OsStr::new("deb")) {
-                let new_path = PathBuf::from(format!(
-                    "{}.deb",
-                    self.file_path().to_string_lossy().to_string()
-                ));
+                let new_path = PathBuf::from(format!("{}.deb", self.file_path().to_string_lossy()));
 
                 let _res = std::os::unix::fs::symlink(self.file_path(), &new_path);
                 self.file_path = new_path;


### PR DESCRIPTION
## Proposed changes

This is part of #825 - my patches to fix the clippy warnings in the `tedge_apt_plugin` crate.

## Types of changes

- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)