### PR TITLE
Fix method signature

### DIFF
--- a/tests/PySys/software_management_end_to_end/environment_sm_management.py
+++ b/tests/PySys/software_management_end_to_end/environment_sm_management.py
@@ -407,7 +407,7 @@ class SoftwareManagement(EnvironmentC8y):
                 break
         return ret
 
-    def remove_package_apt(name):
+    def remove_package_apt(self, name):
         """Remove a package with apt
         """
         assert isinstance(name, str)


### PR DESCRIPTION
Signed-off-by: Michael Abel <info@abel-ikt.de>

## Proposed changes

Fix Python method signature.
Will fix test SoftwareManagement.sm_apt_install_remove if rolldice was installed before.
Seems like nobody used the method yet, as the reference to self was missing. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
