### PR TITLE
Force manually service restart on upgrade

### DIFF
--- a/configuration/debian/tedge_agent/postinst
+++ b/configuration/debian/tedge_agent/postinst
@@ -28,20 +28,6 @@ install -g tedge-agent -o tedge-agent -m 754 -d /etc/tedge/.agent
 # Create /var/log/tedge/agent directory
 install -g tedge-agent -o tedge-agent -m 755 -d /var/log/tedge/agent
 
-# Reenable the services only if systemctl is available
-if command -v systemctl >/dev/null; then
-    ### Enable the sm services if the device is connected to c8y cloud
-    if [ -f "/etc/tedge/mosquitto-conf/c8y-bridge.conf" ]; then
-        # start and enable tedge-agent
-        systemctl start tedge-agent.service
-        systemctl enable tedge-agent.service
-
-        # start and enable tedge-mapper-sm-c8y
-        systemctl start tedge-mapper-sm-c8y.service
-        systemctl enable tedge-mapper-sm-c8y.service
-    fi
-fi
-
 # Initialize the agent
 tedge_agent --init
 #DEBHELPER#

--- a/docs/src/howto-guides/002_installation.md
+++ b/docs/src/howto-guides/002_installation.md
@@ -39,11 +39,12 @@ When all dependencies are in place you can proceed with installation of `thin-ed
 
 If you already have `thin-edge.io` on your device to upgrade `thin-edge.io` follow the steps below, there is no need to remove old version.
 
-> Note: To successfully upgrade `thin-edge.io` all thin-edge.io components should be stopped, eg: `tedge-mapper` and `tedge-agent`:
+> Note: To successfully upgrade `thin-edge.io` all thin-edge.io components must stopped before upgrade, and started again afterwards. Easiest was is to use commands `tedge disconnect <cloud>` and `tedge connect <cloud>`. Example:
 >
 > ```shell
-> systemctl stop tedge-mapper-c8y
-> systemctl stop tedge-agent
+> sudo tedge disconnect c8y
+> ... process upgrade ...
+> sudo tedge connect c8y
 > ```
 
 ### Package download

--- a/docs/src/howto-guides/002_installation.md
+++ b/docs/src/howto-guides/002_installation.md
@@ -39,7 +39,7 @@ When all dependencies are in place you can proceed with installation of `thin-ed
 
 If you already have `thin-edge.io` on your device to upgrade `thin-edge.io` follow the steps below, there is no need to remove old version.
 
-> Note: To successfully upgrade `thin-edge.io` all thin-edge.io components must stopped before upgrade, and started again afterwards. Easiest was is to use commands `tedge disconnect <cloud>` and `tedge connect <cloud>`. Example:
+> Note: To successfully upgrade `thin-edge.io` all thin-edge.io components must be stopped before upgrade, and started again afterwards. The simpler is to use the commands `tedge disconnect <cloud>` and `tedge connect <cloud>`. Example:
 >
 > ```shell
 > sudo tedge disconnect c8y


### PR DESCRIPTION
## Proposed changes

If a user wants to update an existing thin-edge instance on it's device, he must actually stop services manually before any upgrade. It's better to use `tedge disconnect` instead of stopping services directly with `systemctl`, as the knowledge which services to handle is implemented in these commands. Finally it is consequent to let the user afterwards also start services also manually again (using `tedge connect`) instead of trying to start in the DEB maintainer scripts.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/> None

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
