### PR TITLE
Clippy fixes for: c8y_smartrest

### DIFF
--- a/crates/core/c8y_smartrest/src/operations.rs
+++ b/crates/core/c8y_smartrest/src/operations.rs
@@ -49,14 +49,16 @@ pub struct Operations {
     operations_by_trigger: HashMap<String, usize>,
 }
 
-impl Operations {
-    pub fn new() -> Self {
+impl Default for Operations {
+    fn default() -> Self {
         Self {
             operations: vec![],
             operations_by_trigger: HashMap::new(),
         }
     }
+}
 
+impl Operations {
     pub fn add(&mut self, operation: Operation) {
         if let Some(detail) = operation.exec() {
             if let Some(on_message) = &detail.on_message {
@@ -93,7 +95,7 @@ impl Operations {
 }
 
 fn get_operations(dir: impl AsRef<Path>, cloud_name: &str) -> Result<Operations, OperationsError> {
-    let mut operations = Operations::new();
+    let mut operations = Operations::default();
 
     let path = dir.as_ref().join(&cloud_name);
     let dir_entries = fs::read_dir(&path)?

--- a/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
+++ b/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
@@ -321,8 +321,8 @@ pub fn get_datetime_from_file_path(
     match log_path.to_str() {
         Some(path) => Err(SMCumulocityMapperError::InvalidDateInFileName(
             path.to_string(),
-        ))?,
-        None => Err(SMCumulocityMapperError::InvalidUtf8Path)?,
+        )),
+        None => Err(SMCumulocityMapperError::InvalidUtf8Path),
     }
 }
 

--- a/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
+++ b/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
@@ -5,7 +5,7 @@ use download::DownloadInfo;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::convert::{TryFrom, TryInto};
-use std::path::PathBuf;
+use std::path::Path;
 use time::{format_description, OffsetDateTime};
 
 #[derive(Debug)]
@@ -304,7 +304,7 @@ impl SmartRestJwtResponse {
 /// let path_bufdate_time = get_datetime_from_file_path(&path).unwrap();
 /// ```
 pub fn get_datetime_from_file_path(
-    log_path: &PathBuf,
+    log_path: &Path,
 ) -> Result<OffsetDateTime, SMCumulocityMapperError> {
     if let Some(stem_string) = log_path.file_stem().and_then(|s| s.to_str()) {
         // a typical file stem looks like this: software-list-2021-10-27T10:29:58Z.
@@ -332,6 +332,7 @@ mod tests {
     use agent_interface::*;
     use assert_json_diff::*;
     use serde_json::json;
+    use std::path::PathBuf;
     use std::str::FromStr;
     use test_case::test_case;
 

--- a/crates/core/tedge_mapper/src/c8y/tests.rs
+++ b/crates/core/tedge_mapper/src/c8y/tests.rs
@@ -489,7 +489,7 @@ async fn test_sync_alarms() {
     let size_threshold = SizeThreshold(16 * 1024);
     let device_name = String::from("test");
     let device_type = String::from("test_type");
-    let operations = Operations::new();
+    let operations = Operations::default();
     let http_proxy = FakeC8YHttpProxy {};
 
     let mut converter = CumulocityConverter::new(
@@ -554,7 +554,7 @@ async fn test_sync_alarms() {
 async fn convert_thin_edge_json_with_child_id() {
     let device_name = String::from("test");
     let device_type = String::from("test");
-    let operations = Operations::new();
+    let operations = Operations::default();
     let http_proxy = FakeC8YHttpProxy {};
 
     let mut converter = Box::new(CumulocityConverter::new(
@@ -598,7 +598,7 @@ async fn convert_thin_edge_json_with_child_id() {
 async fn convert_first_thin_edge_json_invalid_then_valid_with_child_id() {
     let device_name = String::from("test");
     let device_type = String::from("test");
-    let operations = Operations::new();
+    let operations = Operations::default();
     let http_proxy = FakeC8YHttpProxy {};
 
     let mut converter = Box::new(CumulocityConverter::new(
@@ -644,7 +644,7 @@ async fn convert_first_thin_edge_json_invalid_then_valid_with_child_id() {
 async fn convert_two_thin_edge_json_messages_given_different_child_id() {
     let device_name = String::from("test");
     let device_type = String::from("test");
-    let operations = Operations::new();
+    let operations = Operations::default();
     let http_proxy = FakeC8YHttpProxy {};
 
     let mut converter = Box::new(CumulocityConverter::new(
@@ -722,7 +722,7 @@ fn check_c8y_threshold_packet_size() -> Result<(), anyhow::Error> {
     let size_threshold = SizeThreshold(16 * 1024);
     let device_name = String::from("test");
     let device_type = String::from("test");
-    let operations = Operations::new();
+    let operations = Operations::default();
     let http_proxy = FakeC8YHttpProxy {};
 
     let converter = CumulocityConverter::new(
@@ -786,7 +786,7 @@ async fn start_c8y_mapper(mqtt_port: u16) -> Result<JoinHandle<()>, anyhow::Erro
     let device_name = "test-device".into();
     let device_type = "test-device-type".into();
     let size_threshold = SizeThreshold(16 * 1024);
-    let operations = Operations::new();
+    let operations = Operations::default();
     let http_proxy = FakeC8YHttpProxy {};
 
     let converter = Box::new(CumulocityConverter::new(


### PR DESCRIPTION
## Proposed changes

This is part of #825 - my patches to fix the clippy warnings in the `c8y_smartrest` crate.

## Types of changes

- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
