### PR TITLE
Remove unecessary manual clone

### DIFF
--- a/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
+++ b/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
@@ -78,24 +78,15 @@ impl SmartRestUpdateSoftware {
         Ok(request)
     }
 
-    pub fn modules(&self) -> Vec<SmartRestUpdateSoftwareModule> {
-        let mut modules = vec![];
-        for module in &self.update_list {
-            modules.push(SmartRestUpdateSoftwareModule {
-                software: module.software.clone(),
-                version: module.version.clone(),
-                url: module.url.clone(),
-                action: module.action.clone(),
-            });
-        }
-        modules
+    pub fn modules(&self) -> &Vec<SmartRestUpdateSoftwareModule> {
+        &self.update_list
     }
 
     fn map_to_software_update_request(
         &self,
         mut request: SoftwareUpdateRequest,
     ) -> Result<SoftwareUpdateRequest, SmartRestDeserializerError> {
-        for module in &self.modules() {
+        for module in self.modules() {
             match module.action.clone().try_into()? {
                 CumulocitySoftwareUpdateActions::Install => {
                     request.add_update(SoftwareModuleUpdate::Install {
@@ -566,10 +557,7 @@ mod tests {
         let smartrest =
             String::from("528,external_id,software1,version1,url1,install,software2,,,delete");
         let update_software = SmartRestUpdateSoftware::default();
-        let vec = update_software
-            .from_smartrest(&smartrest)
-            .unwrap()
-            .modules();
+        let update_software = update_software.from_smartrest(&smartrest).unwrap();
 
         let expected_vec = vec![
             SmartRestUpdateSoftwareModule {
@@ -586,7 +574,7 @@ mod tests {
             },
         ];
 
-        assert_eq!(vec, expected_vec);
+        assert_eq!(update_software.modules(), &expected_vec);
     }
 
     #[test_case("2021-09-21T11:40:27+0200", "2021-09-22T11:40:27+0200"; "c8y expected")]


### PR DESCRIPTION
## Proposed changes

Removes the manual cloning of the modules vector.

## Types of changes

- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
