### PR TITLE
#912 ignoring apt integration tests

### DIFF
--- a/plugins/tedge_apt_plugin/tests/main.rs
+++ b/plugins/tedge_apt_plugin/tests/main.rs
@@ -72,6 +72,7 @@ fn run_cmd(cmd: &str, args: &str) -> anyhow::Result<(String, String, i32)> {
 // expected exit code
 //
 // description about the test
+#[ignore] // ignored, requires sudo
 #[test_case(
     &format!("install {} --file {}", PACKAGE_NAME, "wrong_path"),
     "ERROR: Parsing Debian package failed",
@@ -120,6 +121,7 @@ fn install_from_local_file_fail(
 // expected exit code
 //
 // description about the test
+#[ignore] // ignored, requires sudo
 #[test_case(
     &format!("install {} --file {}", PACKAGE_NAME, PACKAGE_FILE_PATH),
     PACKAGE_NAME,


### PR DESCRIPTION
Signed-off-by: initard <solo@softwareag.com>

## Proposed changes
Closes #912 
Ignoring apt install tests because they require sudo to run locally. 
These tests are integration tests rather than unit tests and should be turned off until a pipeline is set in place for them. 

_Note that there was no error in the pipeline because sudo is enabled by default there._

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#912

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
