### PR TITLE
Remove pathbuf_to_string()

### DIFF
--- a/crates/common/tedge_utils/src/paths.rs
+++ b/crates/common/tedge_utils/src/paths.rs
@@ -37,13 +37,6 @@ pub enum PathsError {
     RelativePathNotPermitted { path: OsString },
 }
 
-pub fn pathbuf_to_string(pathbuf: PathBuf) -> Result<String, PathsError> {
-    pathbuf
-        .into_os_string()
-        .into_string()
-        .map_err(|os_string| PathsError::PathToStringFailed { path: os_string })
-}
-
 pub fn create_directories(dir_path: impl AsRef<Path>) -> Result<(), PathsError> {
     let dir_path = dir_path.as_ref();
     std::fs::create_dir_all(dir_path)
@@ -166,14 +159,6 @@ pub fn validate_parent_dir_exists(path: impl AsRef<Path>) -> Result<(), PathsErr
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-
-    #[test]
-    fn pathbuf_to_string_ok() {
-        let pathbuf: PathBuf = "test".into();
-        let expected: String = "test".into();
-        let result = pathbuf_to_string(pathbuf).unwrap();
-        assert_eq!(result, expected);
-    }
 
     #[test]
     #[cfg(unix)] // On windows the error is unexpectedly RelativePathNotPermitted

--- a/crates/core/plugin_sm/src/plugin_manager.rs
+++ b/crates/core/plugin_sm/src/plugin_manager.rs
@@ -12,7 +12,6 @@ use std::{
     path::PathBuf,
     process::{Command, Stdio},
 };
-use tedge_utils::paths::pathbuf_to_string;
 use tracing::{error, info, warn};
 
 /// The main responsibility of a `Plugins` implementation is to retrieve the appropriate plugin for a given software module.
@@ -141,17 +140,14 @@ impl ExternalPlugins {
                     .status()
                 {
                     Ok(code) if code.success() => {
-                        info!(
-                            "Plugin activated: {}",
-                            pathbuf_to_string(path.clone()).unwrap()
-                        );
+                        info!("Plugin activated: {}", path.display());
                     }
 
                     // If the file is not executable or returned non 0 status code we assume it is not a valid and skip further processing.
                     Ok(_) => {
                         error!(
                             "File {} in plugin directory does not support list operation and may not be a valid plugin, skipping.",
-                            pathbuf_to_string(path.clone()).unwrap()
+                            path.display()
                         );
                         continue;
                     }
@@ -160,7 +156,7 @@ impl ExternalPlugins {
                         error!(
                             "File {} Permission Denied, is the file an executable?\n
                             The file will not be registered as a plugin.",
-                            pathbuf_to_string(path.clone()).unwrap()
+                            path.display()
                         );
                         continue;
                     }
@@ -169,7 +165,7 @@ impl ExternalPlugins {
                         error!(
                             "An error occurred while trying to run: {}: {}\n
                             The file will not be registered as a plugin.",
-                            pathbuf_to_string(path.clone()).unwrap(),
+                            path.display(),
                             err
                         );
                         continue;

--- a/crates/core/tedge/src/cli/certificate/upload.rs
+++ b/crates/core/tedge/src/cli/certificate/upload.rs
@@ -3,7 +3,6 @@ use crate::command::Command;
 use reqwest::{StatusCode, Url};
 use std::{io::prelude::*, path::Path};
 use tedge_config::*;
-use tedge_utils::paths::pathbuf_to_string;
 
 #[derive(Debug, serde::Deserialize)]
 struct CumulocityResponse {
@@ -134,11 +133,10 @@ fn get_tenant_id_blocking(
 }
 
 fn read_cert_to_string(path: impl AsRef<Path>) -> Result<String, CertError> {
-    let path = path.as_ref();
-    let path = pathbuf_to_string(path.to_owned())?;
-
-    let mut file =
-        std::fs::File::open(&path).map_err(|err| CertError::CertificateReadFailed(err, path))?;
+    let mut file = std::fs::File::open(path.as_ref()).map_err(|err| {
+        let path = path.as_ref().display().to_string();
+        CertError::CertificateReadFailed(err, path)
+    })?;
     let mut content = String::new();
     file.read_to_string(&mut content)?;
 


### PR DESCRIPTION
## Proposed changes

This patchset removes the `pathbuf_to_string()` helper function, which is only used to convert pathes to strings and then using these strings in APIs that want pathes as arguments :laughing: 

## Types of changes

- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
