### PR TITLE
Fix: We only need one approval right now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Git commit messages should explain the how and why of your change and be separat
 
 ## Reviewing, addressing feedback, and merging
 
-Generally, pull requests need two approvals from maintainers to be merged.
+Generally, pull requests need at least an approval from one maintainer to be merged.
 
 When addressing review feedback, it is helpful to the reviewer if additional changes are made in new commits. This allows the reviewer to easily see the delta between what they previously reviewed and the changes you added to address their feedback.
 


### PR DESCRIPTION
Changes the wording in the CONTRIBUTING file, that we only need one approval right now.

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)

## Further comments

I just found this while browsing over the repository.