### PR TITLE
GitHub templates comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,16 +8,16 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is.  -->
 
 **To Reproduce**
-Steps to reproduce the behavior. The more detail you add here, the better we can reproduce the bug.
+<!-- Steps to reproduce the behavior. The more detail you add here, the better we can reproduce the bug. -->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Environment (please complete the following information):**
  - OS [incl. version]
@@ -26,4 +26,4 @@ If applicable, add screenshots to help explain your problem.
  - thin-edge.io version [e.g. 0.1.0]
 
 **Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/doc_improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc_improvement.md
@@ -7,10 +7,10 @@ assignees: ''
 ---
 
 **Is your documentation request related to a problem? Please describe.**
-A clear and concise description of what the problem is. E.g. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. E.g. I'm always frustrated when [...] -->
 
 **Describe the improvement you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Additional context**
-Add any other context or screenshots about the documentation request here.
+<!-- Add any other context or screenshots about the documentation request here. -->

--- a/.github/ISSUE_TEMPLATE/feature_improvement.md
+++ b/.github/ISSUE_TEMPLATE/feature_improvement.md
@@ -8,13 +8,13 @@ assignees: ''
 ---
 
 **Is your feature improvement request related to a problem? Please describe.**
-A clear and concise description of what the problem is. E.g. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. E.g. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,13 +7,13 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. E.g. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. E.g. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,17 @@
 ## Proposed changes
 
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+<!--
+Describe the big picture of your changes here to communicate to the
+maintainers why we should accept this pull request. If it fixes a bug or
+resolves a feature request, be sure to link to that issue.
+-->
 
 ## Types of changes
 
+<!--
 What types of changes does your code introduce to `thin-edge.io`?
 _Put an `x` in the boxes that apply_
+-->
 
 - [ ] Bugfix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
@@ -18,7 +24,12 @@ _Put an `x` in the boxes that apply_
 
 ## Checklist
 
-_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+<!--
+_Put an `x` in the boxes that apply. You can also fill these out after
+creating the PR. If you're unsure about any of them, don't hesitate to ask.
+We're here to help! This is simply a reminder of what we are going to look for
+before merging your code._
+-->
 
 - [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
 - [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
@@ -29,4 +40,9 @@ _Put an `x` in the boxes that apply. You can also fill these out after creating 
 
 ## Further comments
 
-If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
+<!--
+If this is a relatively large or complex change, kick off the discussion by
+explaining why you chose the solution you did and what alternatives you
+considered, etc...
+-->
+


### PR DESCRIPTION
## Proposed changes

This changes the github issue template and the pull request template so that the notes about what to fill in are HTML comments. For example this section:

```
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
```

Would still be in the template, but as soon as one creates a issue/PR, it wouldn't be shown anymore, reducing the noise one has to read over when browsing issues/PRs.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)

## Further comments

I'm not yet 100% positive that the desired effect is applied by this change, but as far as I remember, that's the way it used to be with github templates, am I right @TheNeikos ?

---

**Asking for review from all, as this effects all of us!** Of course I am open to discussion here.