### PR TITLE
Add note about fixup commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,10 @@ Git commit messages should explain the how and why of your change and be separat
 Generally, pull requests need at least an approval from one maintainer to be merged.
 
 When addressing review feedback, it is helpful to the reviewer if additional changes are made in new commits. This allows the reviewer to easily see the delta between what they previously reviewed and the changes you added to address their feedback.
+If applicable, the `git commit --fixup=<sha>` feature should be used.
+These fixup commits should then be squashed
+(usually `git rebase -i --autosquash main`) by the author of the PR after it
+passed review and before it is merged.
 
 Once a PR has the necessary approvals, it can be merged. Here’s how the merge should be handled:
 


### PR DESCRIPTION
## Proposed changes

This patch adds a note about "fixup-commits".

I noticed that we still see some commits that are addressing review comments that could potentially be squashed into other commits before merging a PR.
Right now, this is not yet that much of an issue because these PRs are still squash-merged. As soon as we move fully away from squash merging, these kind of commits can be squashed away by the author of the PR as soon as a PR passes review (and CI of course).

This patch adds to the `CONTRIBUTING` documentation for this to be documented.

## Types of changes

- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)

## Further comments

This is probably a bit controversial, so I'm opening this as a draft for now, opening up for discussion here. :smiley: :sunny: 