### PR TITLE
Make message field optional in Thin Edge JSON events

### DIFF
--- a/crates/core/thin_edge_json/src/event.rs
+++ b/crates/core/thin_edge_json/src/event.rs
@@ -67,6 +67,7 @@ impl ThinEdgeEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::Result;
     use assert_matches::assert_matches;
     use serde_json::{json, Value};
     use test_case::test_case;
@@ -156,8 +157,11 @@ mod tests {
     }
 
     #[test]
-    fn event_translation_empty_payload() {
-        let result = ThinEdgeEvent::try_from("tedge/events/click_event", "");
-        assert_matches!(result.unwrap().data, None);
+    fn event_translation_empty_payload() -> Result<()> {
+        let result = ThinEdgeEvent::try_from("tedge/events/click_event", "")?;
+        assert_eq!(result.name, "click_event".to_string());
+        assert_matches!(result.data, None);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Proposed changes

Cumulocity-mapper to treat the `message` field as optional in Thin Edge JSON events. When it's not provided, the `event-type` will be substituted as message as well, as Cumulocity mandates a message for events.

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
