### PR TITLE
Clippy fixes for: tedge_config

### DIFF
--- a/crates/common/tedge_config/src/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config.rs
@@ -5,8 +5,7 @@ use std::convert::{TryFrom, TryInto};
 /// loads tedge config from system default
 pub fn get_tedge_config() -> Result<TEdgeConfig, TEdgeConfigError> {
     let tedge_config_location = TEdgeConfigLocation::default();
-    let config_repository = TEdgeConfigRepository::new(tedge_config_location);
-    Ok(config_repository.load()?)
+    TEdgeConfigRepository::new(tedge_config_location).load()
 }
 
 /// Represents the complete configuration of a thin edge device.


### PR DESCRIPTION
## Proposed changes

This is part of #825 - my patches to fix the clippy warnings in the `tedge_config` crate.
This seems to have slipped in the first iteration.

## Types of changes

- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)