### PR TITLE
Fix: Remove unused "use"

### DIFF
--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use crate::command::{BuildCommand, BuildContext, Command};
-use clap;
 use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 
 mod certificate;


### PR DESCRIPTION
Just a small fix I found while browsing the codebase