### PR TITLE
Deny warnings

### DIFF
--- a/crates/common/batcher/src/lib.rs
+++ b/crates/common/batcher/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 //! Group together events that are close in time.
 
 mod batch;

--- a/crates/common/certificate/src/lib.rs
+++ b/crates/common/certificate/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 use device_id::DeviceIdError;
 use rcgen::Certificate;
 use rcgen::CertificateParams;

--- a/crates/common/clock/src/lib.rs
+++ b/crates/common/clock/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 use mockall::automock;
 use time::OffsetDateTime;
 

--- a/crates/common/download/src/lib.rs
+++ b/crates/common/download/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 mod download;
 mod error;
 

--- a/crates/common/flockfile/src/lib.rs
+++ b/crates/common/flockfile/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 #[cfg(unix)]
 mod unix;
 

--- a/crates/common/json_writer/src/lib.rs
+++ b/crates/common/json_writer/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 use std::num::FpCategory;
 
 #[derive(Debug, Clone)]

--- a/crates/common/mqtt_channel/src/lib.rs
+++ b/crates/common/mqtt_channel/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(test, deny(warnings))]
+
+//!
 //! A library to connect the local MQTT bus, publish messages and subscribe topics.
 //!
 //! ```no_run

--- a/crates/common/tedge_config/src/lib.rs
+++ b/crates/common/tedge_config/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 mod config_setting;
 mod error;
 mod models;

--- a/crates/common/tedge_users/src/lib.rs
+++ b/crates/common/tedge_users/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 #[cfg(unix)]
 mod unix;
 

--- a/crates/common/tedge_utils/src/lib.rs
+++ b/crates/common/tedge_utils/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 pub mod file;
 pub mod fs;
 pub mod paths;

--- a/crates/core/agent_interface/src/lib.rs
+++ b/crates/core/agent_interface/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 pub mod error;
 mod messages;
 mod software;

--- a/crates/core/c8y_api/src/lib.rs
+++ b/crates/core/c8y_api/src/lib.rs
@@ -1,2 +1,4 @@
+#![cfg_attr(test, deny(warnings))]
+
 pub mod http_proxy;
 pub mod json_c8y;

--- a/crates/core/c8y_smartrest/src/lib.rs
+++ b/crates/core/c8y_smartrest/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 pub mod alarm;
 pub mod error;
 pub mod operations;

--- a/crates/core/c8y_translator/src/lib.rs
+++ b/crates/core/c8y_translator/src/lib.rs
@@ -1,2 +1,4 @@
+#![cfg_attr(test, deny(warnings))]
+
 pub mod json;
 pub mod serializer;

--- a/crates/core/plugin_sm/src/lib.rs
+++ b/crates/core/plugin_sm/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 pub mod log_file;
 pub mod operation_logs;
 pub mod plugin;

--- a/crates/core/tedge/src/main.rs
+++ b/crates/core/tedge/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(test, deny(warnings))]
 #![forbid(unsafe_code)]
 #![deny(clippy::mem_forget)]
 

--- a/crates/core/tedge/tests/main.rs
+++ b/crates/core/tedge/tests/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 mod os_related;
 
 mod tests {

--- a/crates/core/tedge_agent/src/main.rs
+++ b/crates/core/tedge_agent/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 use std::path::PathBuf;
 
 use agent::SmAgentConfig;

--- a/crates/core/tedge_agent/tests/main.rs
+++ b/crates/core/tedge_agent/tests/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 #[cfg(test)]
 mod tests {
     use std::process::{Command, Stdio};

--- a/crates/core/tedge_mapper/src/main.rs
+++ b/crates/core/tedge_mapper/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 use std::{fmt, path::PathBuf};
 
 use crate::{

--- a/crates/core/thin_edge_json/src/lib.rs
+++ b/crates/core/thin_edge_json/src/lib.rs
@@ -1,3 +1,6 @@
+#![cfg_attr(test, deny(warnings))]
+
+//!
 //! A library to create [ThinEdgeJson][1] from bytes of json data by validating it.
 //! [1]: https://github.com/thin-edge/thin-edge.io/blob/main/docs/src/architecture/thin-edge-json.md
 

--- a/crates/tests/mqtt_tests/src/lib.rs
+++ b/crates/tests/mqtt_tests/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 mod message_streams;
 mod test_mqtt_client;
 pub mod test_mqtt_server;

--- a/crates/tests/sawtooth_publisher/src/main.rs
+++ b/crates/tests/sawtooth_publisher/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 use futures::future::FutureExt;
 use futures::select;
 use futures_timer::Delay;

--- a/plugins/tedge_apama_plugin/src/main.rs
+++ b/plugins/tedge_apama_plugin/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 mod error;
 
 use crate::error::InternalError;

--- a/plugins/tedge_apt_plugin/src/main.rs
+++ b/plugins/tedge_apt_plugin/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 mod error;
 mod module_check;
 

--- a/plugins/tedge_apt_plugin/tests/main.rs
+++ b/plugins/tedge_apt_plugin/tests/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 #[cfg(feature = "integration-test")]
 mod tests {
     use hamcrest2::prelude::*;

--- a/plugins/tedge_dummy_plugin/src/main.rs
+++ b/plugins/tedge_dummy_plugin/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(test, deny(warnings))]
+
 use clap::Parser;
 
 #[derive(Parser)]


### PR DESCRIPTION
## Proposed changes

Followup to my work in #825 - denying all warnings when building tests (as proposed by @TheNeikos in https://github.com/thin-edge/thin-edge.io/issues/825#issuecomment-1031186016).

This PR does not include all crates yet, because some still report warnings (for example because of the outstanding issue in https://github.com/thin-edge/thin-edge.io/pull/841).

## Types of changes

- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)

## Paste Link to the issue

#825 

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [X] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [X] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [X] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

---

Pinging two random people for this PR :smile: 

