### PR TITLE
#937 fixing sm plugins path error message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
+checksum = "86f8c0e2a6b902acc18214e24a6935cdaf8a8e34231913d4404dcaee659f65a1"
 dependencies = [
  "atty",
  "bitflags",
@@ -2191,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
@@ -2725,7 +2725,7 @@ dependencies = [
  "assert_matches",
  "base64",
  "certificate",
- "clap 3.1.2",
+ "clap 3.1.3",
  "futures",
  "hyper",
  "mockito",
@@ -2757,7 +2757,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
- "clap 3.1.2",
+ "clap 3.1.3",
  "flockfile",
  "futures",
  "mockall 0.10.2",
@@ -2770,6 +2770,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tedge_config",
+ "tedge_users",
  "tedge_utils",
  "tempfile",
  "thiserror",
@@ -2784,7 +2785,7 @@ dependencies = [
 name = "tedge_apama_plugin"
 version = "0.5.4"
 dependencies = [
- "clap 3.1.2",
+ "clap 3.1.3",
  "roxmltree",
  "tempfile",
  "thiserror",
@@ -2796,7 +2797,7 @@ name = "tedge_apt_plugin"
 version = "0.5.4"
 dependencies = [
  "anyhow",
- "clap 3.1.2",
+ "clap 3.1.3",
  "csv",
  "hamcrest2",
  "reqwest",
@@ -2826,7 +2827,7 @@ dependencies = [
 name = "tedge_dummy_plugin"
 version = "0.5.4"
 dependencies = [
- "clap 3.1.2",
+ "clap 3.1.3",
  "thiserror",
 ]
 
@@ -2866,7 +2867,7 @@ dependencies = [
  "c8y_api",
  "c8y_smartrest",
  "c8y_translator",
- "clap 3.1.2",
+ "clap 3.1.3",
  "clock",
  "csv",
  "download",

--- a/crates/core/plugin_sm/src/plugin_manager.rs
+++ b/crates/core/plugin_sm/src/plugin_manager.rs
@@ -197,11 +197,15 @@ impl ExternalPlugins {
         let logger = log_file.buffer();
         let mut error_count = 0;
 
-        for (software_type, plugin) in self.plugin_map.iter() {
-            match plugin.list(logger).await {
-                Ok(software_list) => response.add_modules(software_type, software_list),
-                Err(_) => {
-                    error_count += 1;
+        if self.plugin_map.is_empty() {
+            response.add_modules("", vec![]);
+        } else {
+            for (software_type, plugin) in self.plugin_map.iter() {
+                match plugin.list(logger).await {
+                    Ok(software_list) => response.add_modules(software_type, software_list),
+                    Err(_) => {
+                        error_count += 1;
+                    }
                 }
             }
         }

--- a/crates/core/tedge_agent/Cargo.toml
+++ b/crates/core/tedge_agent/Cargo.toml
@@ -47,6 +47,8 @@ assert_cmd = "2.0"
 once_cell = "1.8"
 mqtt_tests = { path = "../../tests/mqtt_tests" }
 predicates = "2.0"
+tedge_users = { path = "../../common/tedge_users"}
+tedge_utils = { path = "../../common/tedge_utils"}
 tempfile = "3.2"
 tokio-test = "0.4"
 serial_test = "0.5"

--- a/crates/core/tedge_agent/src/error.rs
+++ b/crates/core/tedge_agent/src/error.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use agent_interface::SoftwareError;
 use flockfile::FlockfileError;
 use mqtt_channel::MqttError;
@@ -15,8 +17,8 @@ pub enum AgentError {
     #[error(transparent)]
     FromMqttClient(#[from] MqttError),
 
-    #[error("Couldn't load plugins from /etc/tedge/sm-plugins")]
-    NoPlugins,
+    #[error("Couldn't load plugins from {plugins_path}")]
+    NoPlugins { plugins_path: PathBuf },
 
     #[error(transparent)]
     FromSerdeJson(#[from] serde_json::Error),


### PR DESCRIPTION
Signed-off-by: initard <solo@softwareag.com>

## Proposed changes
- Closes #937

Fixing error message when the `sm-plugins` directory exists **but** it is empty. 

```shell
# you can test by making sm-plugins in /tmp
mkdir /tmp/sm-plugins
# run tedge_agent with --config-dir
./target/debug/tedge_agent --config-dir /tmp
```

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #937 

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments


