### PR TITLE
Enable Resolve v2 for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "plugins/tedge_apama_plugin",
     "plugins/log_request_plugin",
 ]
+resolver = "2"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
The v2 resolver allows for more fine-grained inclusion of dependency
features. Previously dev-dependency features got merged with 'normal'
dependency features. This may not always be desirable.

For more information see
https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html

## Types of changes

What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

This should be a non-breaking change as, as far as I could tell no crates had 'hidden' feature dependencies. However, since it is the default since the 2021 edition it makes sense to enable it now so as to reduce potential future workload.
