### PR TITLE
Vision statement for thin-edge core

### DIFF
--- a/design/thin-edge-core.md
+++ b/design/thin-edge-core.md
@@ -258,3 +258,21 @@ The key points to be highlighted are that:
   built as an assemblage of Rust actors. They can be used without any modifications.
 * Building a tuned thin-edge executable requires a Rust compiler but not a deep expertise in Rust.
   What has to be done is mostly to list the actors to be included and to connect message producers and consumers.
+
+## What kind of component for my use case?
+
+What are the pros & cons of Rust-based and MQTT-based components?
+When use one or the other?
+
+| MQTT-based thin-edge executable                                                | Rust-based thin-edge actor                                              |
+|--------------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| Coarse grain component used to build IIoT agents                               | Fine grain component used to build MQTT-based thin-edge executables     |
+| Process running on the local network                                           | Actor running inside a process                                          |
+| Interact over MQTT and HTTP using JSON messages                                | Interact over in-memory channels using statically typed messages        |
+| Can be written in any language                                                 | Must be written in Rust                                                 |
+| Deployed over hosts and containers on the edge local network                   | Integrated into an executable in combination with other actors          |
+| Required to enable interactions over several devices and cloud end-points      | Leverage a thin-edge-json actor to interact with MQTT-based executables |                        
+| Facilitate prototyping and interactivity                                       | Build for robustness and frugality                                      |
+| Might lead to a resource greedy agent with too many daemon processes           | Help to optimize resource utilisation within a single process           |
+| Might lead to deployment and dependency issues with loosely-coupled components | Dependencies and compatibilities are checked at compile-time            |
+| The `tedge` command is an MQTT-based executable                                | The `tedge` command is an assemblage of Rust-based thin-edge actors     | 

--- a/design/thin-edge-core.md
+++ b/design/thin-edge-core.md
@@ -1,0 +1,50 @@
+# Thin-edge Core Vision
+
+A typical IoT application has to address:
+
+* __sophisticated business-cases__, with applications involving several vendors, actors and users;
+* __very diverse integration needs__ over operating systems, protocols, data sources, processing tools, actuators, cloud end-points;
+* __constraint environments__ with low-resources devices, large-scale deployments, high exposure to security risks,
+  prohibitive manual operations, long-term supports;
+* __safety related requirements__ with devices operating machines in hazardous contexts.
+  
+The forces behind these requirements are pushing in opposite directions.
+
+* On one side, from the use-case and integration perspective, one needs a dynamic and open setting with a large set of features that can be easily extended and combined.
+  [NodeRed](https://nodered.org/) is the archetype of such tools facilitating connections of components.
+* On the other side, to meet resource and security constraints, one needs a minimal system specifically built for a task with cherry-picked components.
+  On the extreme side this leads to the idea of [unikernel](https://en.wikipedia.org/wiki/Unikernel) with sealed, single-purpose software images.
+  
+Can these two poles be reconciled?
+
+The approach of thin-edge is to ease the development of IoT applications on edge devices with a smooth transition between:
+* prototyping use-cases - when the aim is to easily onboard devices for IIoT,
+* production use-cases - when the need is to deploy a hardened specific software on a large fleet of devices,
+* as well as intermediate use-cases - when the application is build by several vendors with components written using different programming languages;
+  or when a manufacturer assembles his tools on the devices while letting open to his customers the option to add their own modules. 
+
+To achieve this goal, the foundations of thin-edge address the hardened case first.
+* The core of thin-edge and its components are written using the *Rust* programming languages.
+* The set of components used by an application is defined at *build time*.
+* These components cooperate using a streaming, asynchronous message passing, *internal* API.
+* Connections to the outside are delegated to specific bridge components
+  that abstract the actual protocol (MQTT, HTTP, Modbus, OPC UA)
+  while making these external channels accessible to the other components.
+* The *internal* messages exchanged by the components are *predefined* and cover the domain of telemetry and IoT
+  (measurements, events, alarms, operation requests, operation outcomes ...). 
+  Messages sent to the outside are freely defined by the respective bridge components.
+* The core of thin-edge provides the tools to configure the components as well as the internal message routes.
+* An executable for an IoT application is statically defined by an assemblage of components and their configuration.
+  
+To open this static core, thin-edge provides bridge components opening channels to external end-points and message buses.
+* Notably, thin-edge provides an MQTT component to connect external processes
+  that are not necessarily part of the core, can be written using any programming languages
+  and can run on other devices. 
+* This MQTT bus works as an extension of the channels used internally by the core components.
+  For that purpose, the internal thin-edge messages are serialized over MQTT using the thin-edge JSON schema.
+* On top of this MQTT bus, thin-edge provides plugins to connect specific application,
+  *e.g.* `collectd` or Apama.
+* Most of the extensions of thin-edge will be provided by such bridge components:
+  * to handle specific south-bound protocols as Modbus or OPC UA,
+  * to trigger operations on the devices through a command line interface,
+  * and, last but not least, to connect to specific cloud end-point with mapper components.

--- a/design/thin-edge-core.md
+++ b/design/thin-edge-core.md
@@ -1,7 +1,7 @@
 # Thin-edge Design Principles
 
 __Thin-edge makes it easy the integration of cloud services, edge computing and operational technologies,
-with the foundations to develop business-specific IIoT gateways
+with the foundations to develop business-specific IIoT agents
 from a catalog of generic and use-case specific components assembled
 on top of a framework that enables connectivity and interoperability.__
 
@@ -39,14 +39,14 @@ with two levels of building blocks that combine along an IIoT specific API.
   as well as the rules to combine them into hardened executables.
 * To ease incremental developments,
   thin-edge give the developers the freedom to combine both MQTT and Rust-based components
-  into purpose-specific gateways.
+  into purpose-specific agents.
 * To make feasible the interoperability of components provided by different tiers,
   thin-edge comes with an extensible data model for IIoT -
   cloud connectivity, telemetry data, device management, child devices, ...
 
 ## Design Principles
 
-* Thin-edge provides the tools to develop an IIoT gateway by assembling components
+* Thin-edge provides the tools to develop an IIoT agent by assembling components
   that have been implemented independently,
   possibly by different vendors and using different programming languages.
 * There are two levels of components:
@@ -70,7 +70,7 @@ with two levels of building blocks that combine along an IIoT specific API.
     and to add missing features without having to implement a full-fledged Rust component. 
 * To enable interactions between the MQTT-components, thin-edge provides an MQTT bus made of:
     * a local MQTT server,
-    * an MQTT bridge that relays messages between the gateway and the cloud end-points,
+    * an MQTT bridge that relays messages between the agent and the cloud end-points,
     * an MQTT API that defines topics and message payloads
       * to exchange telemetry data,
       * to monitor components health,
@@ -90,13 +90,13 @@ with two levels of building blocks that combine along an IIoT specific API.
 
 Thin-edge is shipped with a batteries-included executable, the `tedge` command, that eases on-boarding
 with support for various IoT clouds, monitoring tools, software-management plugins, OT protocols ...
-On top of `tedge`, an IoT-application developer can easily build a purpose-specific IoT gateway
+On top of `tedge`, an IoT-application developer can easily build a purpose-specific IIoT agent
 to connect his devices to the cloud and local resources. 
-This IoT gateway is made of independent processes that interact over MQTT using JSON messages,
+This IIoT agent is made of independent processes that interact over MQTT using JSON messages,
 and that are deployed over the devices on the edge as well as the OT network.
 The IoT-application developer can implement and deploy his own components,
 using his programming language of choice,
-and leveraging the thin-edge MQTT API to interact with the components of the gateway.
+and leveraging the thin-edge MQTT API to interact with the components of the agent.
 
 ```
                         #
@@ -207,7 +207,7 @@ The main motivation for this internal design is the ability to build specific ex
 tuned for a specific use-case, consuming less memory and offering a reduced attack surface.
 
 An application developer can easily reassemble cherry-picked thin-edge actors into a highly tuned executable,
-keeping only the feature actually required on the IIoT gateways,
+keeping only the feature actually required on the IIoT agents,
 and possibly adding Rust actors that have been implemented specification for his application.
 
 ```

--- a/design/thin-edge-core.md
+++ b/design/thin-edge-core.md
@@ -1,33 +1,49 @@
-# Thin-edge Core Vision
+# Thin-edge Design Principles
 
+__Thin-edge makes it easy the integration of cloud services, edge computing and operational technologies,
+with the foundations to develop business-specific IIoT gateways
+from a catalog of generic and use-case specific components assembled
+on top of a framework that enables connectivity and interoperability.__
+
+With IIoT, there is a fantastic opportunity for innovative use-cases and business models
+that are more reactive, flexible, and efficient.
+However, the challenges are many and each require a different expertise.
 A typical IoT application has to address:
 
-* __sophisticated business-cases__, with applications involving several vendors, actors and users;
-* __very diverse integration needs__ over operating systems, protocols, data sources, processing tools, actuators, cloud end-points;
-* __constraint environments__ with low-resources devices, high exposure to security risks, prohibitive manual operations;
-* __particular non-functional requirements__ safety of devices operating machines in hazardous contexts,
-  scalability over large fleet of devices, long-term supports of scattered devices.
+* __sophisticated business-cases__, with applications involving several vendors, actors and users
+  and combining connectivity, device management, telemetry, monitoring, analytics;
+* __very diverse integration needs__ over operating systems, protocols, data sources, processing tools,
+  actuators, cloud end-points, legacy systems;
+* __constraint environments__ with low-resources devices, high exposure to security risks,
+  prohibitive manual operations, restricted upgrades;
+* __business-critical or even safety-critical requirements__ with large fleet of devices
+  operating in hazardous contexts and requesting long-term support.
   
-The forces behind these requirements are pushing in opposite directions.
+Furthermore, the forces behind these requirements are pushing in opposite directions.
 
-* On one side, to address the diversity of use-cases and integration requirements, one needs a large open set of features that can be easily extended and combined.
+* On one side, to address the diversity of use-cases and integration requirements,
+  one needs a large open set of features that can be easily extended and combined.
   [NodeRed](https://nodered.org/) is the archetype of such tools facilitating connections of components.
-* On the other side, to meet resource and security constraints, one needs a minimal system specifically built for a task with cherry-picked components.
-  On the extreme side, this leads to the idea of [unikernel](https://en.wikipedia.org/wiki/Unikernel) with sealed, single-purpose software images.
+* On the other side, to meet resource and security constraints,
+  one needs a minimal system specifically built for a task with cherry-picked components.
+  Taken to the extreme, this leads to the idea of [unikernel](https://en.wikipedia.org/wiki/Unikernel)
+  with sealed, single-purpose software images.
   
-What makes thin-edge unique is its approach to reconcile these two poles with two levels of building blocks.
-* To maximize flexibility and interoperability, thin-edge provides the tools to build an agent from independent executables that interact over MQTT using JSON messages.
-* To minimize resources and vulnerabilities, thin-edge features fine-grain Rust components as well as the rules to combine them into purpose-specific agents.
-* To make feasible the assemblage of fine-grain and MQTT-based components into IIoT agents,
-  thin-edge comes with an extensible data model for IIoT - cloud connectivity, telemetry data, device management, child devices, ... -
-  and defines the rules to exchange related messages over MQTT as well as between fine-grain components and at the boundary between the internal and MQTT worlds.
-
-With this approach, thin-edge eases the development of IoT applications on edge devices with a smooth transition between:
-* prototyping use-cases - when the need is to easily onboard devices for IIoT with batteries-included tools,
-* production use-cases - when the need is to deploy a hardened specific software on a large fleet of devices,  
-* IIoT agent development - when the aim is to implement an application-specific agent that integrates tools and services provided by independent vendors.
-* Hardware specific software - when a manufacturer assembles his tools on the devices while letting open to his customers the option to add their own modules. 
-
+What makes thin-edge unique is its approach to reconcile these two poles
+with two levels of building blocks that combine along an IIoT specific API.
+* To maximize flexibility and interoperability,
+  thin-edge provides the tools to build an agent from independent executables
+  that interact over MQTT and HTTP using JSON messages.
+* To minimize resources and vulnerabilities,
+  thin-edge features fine-grain Rust components
+  as well as the rules to combine them into hardened executables.
+* To ease incremental developments,
+  thin-edge give the developers the freedom to combine both MQTT and Rust-based components
+  into purpose-specific gateways.
+* To make feasible the interoperability of components provided by different tiers,
+  thin-edge comes with an extensible data model for IIoT -
+  cloud connectivity, telemetry data, device management, child devices, ...
+  
 ## Design Principles
 
 To achieve this goal, the foundations of thin-edge address the hardened case first.

--- a/design/thin-edge-core.md
+++ b/design/thin-edge-core.md
@@ -4,24 +4,31 @@ A typical IoT application has to address:
 
 * __sophisticated business-cases__, with applications involving several vendors, actors and users;
 * __very diverse integration needs__ over operating systems, protocols, data sources, processing tools, actuators, cloud end-points;
-* __constraint environments__ with low-resources devices, large-scale deployments, high exposure to security risks,
-  prohibitive manual operations, long-term supports;
-* __safety related requirements__ with devices operating machines in hazardous contexts.
+* __constraint environments__ with low-resources devices, high exposure to security risks, prohibitive manual operations;
+* __particular non-functional requirements__ safety of devices operating machines in hazardous contexts,
+  scalability over large fleet of devices, long-term supports of scattered devices.
   
 The forces behind these requirements are pushing in opposite directions.
 
-* On one side, from the use-case and integration perspective, one needs a dynamic and open setting with a large set of features that can be easily extended and combined.
+* On one side, to address the diversity of use-cases and integration requirements, one needs a large open set of features that can be easily extended and combined.
   [NodeRed](https://nodered.org/) is the archetype of such tools facilitating connections of components.
 * On the other side, to meet resource and security constraints, one needs a minimal system specifically built for a task with cherry-picked components.
-  On the extreme side this leads to the idea of [unikernel](https://en.wikipedia.org/wiki/Unikernel) with sealed, single-purpose software images.
+  On the extreme side, this leads to the idea of [unikernel](https://en.wikipedia.org/wiki/Unikernel) with sealed, single-purpose software images.
   
-Can these two poles be reconciled?
+What makes thin-edge unique is its approach to reconcile these two poles with two levels of building blocks.
+* To maximize flexibility and interoperability, thin-edge provides the tools to build an agent from independent executables that interact over MQTT using JSON messages.
+* To minimize resources and vulnerabilities, thin-edge features fine-grain Rust components as well as the rules to combine them into purpose-specific agents.
+* To make feasible the assemblage of fine-grain and MQTT-based components into IIoT agents,
+  thin-edge comes with an extensible data model for IIoT - cloud connectivity, telemetry data, device management, child devices, ... -
+  and defines the rules to exchange related messages over MQTT as well as between fine-grain components and at the boundary between the internal and MQTT worlds.
 
-The approach of thin-edge is to ease the development of IoT applications on edge devices with a smooth transition between:
-* prototyping use-cases - when the aim is to easily onboard devices for IIoT,
-* production use-cases - when the need is to deploy a hardened specific software on a large fleet of devices,
-* as well as intermediate use-cases - when the application is build by several vendors with components written using different programming languages;
-  or when a manufacturer assembles his tools on the devices while letting open to his customers the option to add their own modules. 
+With this approach, thin-edge eases the development of IoT applications on edge devices with a smooth transition between:
+* prototyping use-cases - when the need is to easily onboard devices for IIoT with batteries-included tools,
+* production use-cases - when the need is to deploy a hardened specific software on a large fleet of devices,  
+* IIoT agent development - when the aim is to implement an application-specific agent that integrates tools and services provided by independent vendors.
+* Hardware specific software - when a manufacturer assembles his tools on the devices while letting open to his customers the option to add their own modules. 
+
+## Design Principles
 
 To achieve this goal, the foundations of thin-edge address the hardened case first.
 * The core of thin-edge and its components are written using the *Rust* programming languages.
@@ -48,8 +55,7 @@ To open this static core, thin-edge provides bridge components opening channels 
   * to handle specific south-bound protocols as Modbus or OPC UA,
   * to trigger operations on the devices through a command line interface,
   * and, last but not least, to connect to specific cloud end-point with mapper components.
-
-
+  
 ## Building an application with thin-edge
 
 A thin-edge IoT application is built using two kinds of building blocks:


### PR DESCRIPTION
Signed-off-by: Didier Wenzek <didier.wenzek@free.fr>

## Proposed changes

Here a proposal for a vision statement for the core of thin-edge. 

The purpose of this statement is to set a frame around the discussions on what has been [our vision so far](https://github.com/thin-edge/thin-edge.io/tree/main/docs/src/architecture), [how to improve it](https://github.com/thin-edge/thin-edge.io/discussions/801) and the [direction proposed by @TheNeikos and @matthiasbeyer](https://github.com/thin-edge/thin-edge.io/pull/948).

The focus is on what and why, letting the how to other discussions.

* Up to now, the focus has been set on flexibility and openness with a large set of features. Do we have to move to a smaller and statically defined core? Where is the balance point?
* What are the criteria to decide for an approach or another.
* What are the key ideas that make the backbone of the project ?
* Is MQTT part of the core or not ?
* Do we need to specify and maintain a thin-edge Json schema?

On purpose:
* The proposal is written as if an agreement has already been reached. Feel free to comment.
* Put aside the `docs` folder even if I think this vision should be a key element of the documentation. So we can merge it even, if not implemented yet.

## Types of changes

- [x] Design Documentation

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
