### PR TITLE
Add workflow to block fixup commits

### DIFF
--- a/.github/workflows/block-fixup-commits.yml
+++ b/.github/workflows/block-fixup-commits.yml
@@ -1,0 +1,13 @@
+on: [pull_request]
+
+name: Block fixup commits
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0
+


### PR DESCRIPTION
## Proposed changes

This patch adds a workflow that blocks merging commits that were made with
`git commit --fixup` or `git commit --squash` during the development of
a PR.

For example as happened from https://github.com/thin-edge/thin-edge.io/pull/934 (no offense of course)!


## Types of changes

- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
