### PR TITLE
[955] over write the apt plugin exit code

### DIFF
--- a/plugins/tedge_apt_plugin/src/main.rs
+++ b/plugins/tedge_apt_plugin/src/main.rs
@@ -235,7 +235,14 @@ fn run_cmd(cmd: &str, args: &str) -> Result<ExitStatus, InternalError> {
 
 fn main() {
     // On usage error, the process exits with a status code of 1
-    let apt = AptCli::parse();
+
+    let apt = match AptCli::try_parse() {
+        Ok(aptcli) => aptcli,
+        Err(_e) => {
+            // re-write the clap exit_status from 2 to 1, if parse fails
+            std::process::exit(1)
+        }
+    };
 
     match run(apt.operation) {
         Ok(status) if status.success() => {


### PR DESCRIPTION
## Proposed changes
This PR addresses the apt plugin exit code when the plugin fails due to no args or wrong args.
`Clap` returns `exit code 2` on failure when there are wrong args, but this has to be `1` as per the plugin specification.
So, we overwrite the exit code to `1`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

