### PR TITLE
Temporarily disable integration tests that need the apt plugin

### DIFF
--- a/.github/workflows/integration-test-workflow.yml
+++ b/.github/workflows/integration-test-workflow.yml
@@ -109,7 +109,16 @@ jobs:
         # https://github.com/marketplace/actions/rust-cargo
         with:
           command: test
-          args: --verbose --features integration-test,requires-sudo -- --skip sending_and_receiving_a_message
+          args: --verbose --features integration-test,requires-sudo -- \
+            --skip sending_and_receiving_a_message \
+            --skip tests::install_from_local_file_success::version_with_path \
+            --skip tests::install_from_local_file_success::path_with_version \
+            --skip tests::install_from_local_file_success::path \
+            --skip tests::install_from_local_file_fail::wrong_path_with_wrong_version \
+            --skip tests::install_from_local_file_fail::wrong_path_with_right_version \
+            --skip tests::install_from_local_file_fail::wrong_path \
+            --skip tests::install_from_local_file_fail::right_path_with_wrong_version
+
 
   install-and-use-rpi:
     runs-on: [self-hosted, Linux, ARM, onsite]


### PR DESCRIPTION
Signed-off-by: Michael Abel <info@abel-ikt.de>

## Proposed changes

These tests rely on a working tedge apt plugin.
However, in the current integration-test-workflow.yml the plugin is not installed (currently on purpose).

Until the release, I propose to run the tests manually and disable them temporarily to avoid issues in CI.
Afterwards, we should prepare the right environment for the tests afterwards.

Soon after the release should do one of these:
a) Install the plugin in the workflow
b) Move the tests to a test-job where we have tedge installed (yet to be created) (e.g. a integration- or system-test crate)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Test-Smell : Ignored test (anti-feature); to be repaired soon.

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1000

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


