### PR TITLE
Avoid to have two platform options in PySys ...

### DIFF
--- a/ci/ci_run_all_sm_tests.sh
+++ b/ci/ci_run_all_sm_tests.sh
@@ -53,7 +53,7 @@ cd tests/PySys/
 # Run all software management tests, including the ones for the
 # fake- and the  docker plugin
 set +e
-pysys.py run --record -v DEBUG 'SoftwareManagement.*' -XmyPlatform='smcontainer' -Xdockerplugin='dockerplugin' -Xfakeplugin='fakeplugin'
+pysys.py run --record -v DEBUG 'SoftwareManagement.*' -XmyPlatform='container' -Xdockerplugin='dockerplugin' -Xfakeplugin='fakeplugin'
 set -e
 
 deactivate

--- a/tests/PySys/Readme.md
+++ b/tests/PySys/Readme.md
@@ -97,11 +97,11 @@ Better run them in a VM or a container.
 
 To run the tests:
 
-    pysys.py run 'sm-apt*' -XmyPlatform='smcontainer'
+    pysys.py run 'sm-apt*' -XmyPlatform='container'
 
 To run the tests with another tenant url:
 
-    pysys.py run 'sm-apt*' -XmyPlatform='smcontainer' -Xtenant_url='thin-edge-io.eu-latest.cumulocity.com'
+    pysys.py run 'sm-apt*' -XmyPlatform='container' -Xtenant_url='thin-edge-io.eu-latest.cumulocity.com'
 
 
 ### Apt Plugin Tests
@@ -119,7 +119,7 @@ To run the tests:
 Some of the tests desire a configured fakeplugin to simulate fruits.
 To run the tests on a platform with fake plugin:
 
-    pysys.py run -v DEBUG 'sm-fake*' -Xfakeplugin=fakeplugin -XmyPlatform=smcontainer
+    pysys.py run -v DEBUG 'sm-fake*' -Xfakeplugin=fakeplugin -XmyPlatform=container
 
 See file software-management-end-to-end/dummy-plugin-configuration/Info.md
 on how to setup and configure the fake plugin.

--- a/tests/PySys/software_management_end_to_end/environment_sm_management.py
+++ b/tests/PySys/software_management_end_to_end/environment_sm_management.py
@@ -12,11 +12,11 @@ Better run them in a VM or a container.
 
 To run the tests:
 
-    pysys.py run 'sm-apt*' -XmyPlatform='smcontainer'
+    pysys.py run 'sm-apt*' -XmyPlatform='container'
 
 To run the tests with another tenant url:
 
-    pysys.py run 'sm-apt*' -XmyPlatform='smcontainer' -Xtenant_url='thin-edge-io.eu-latest.cumulocity.com'
+    pysys.py run 'sm-apt*' -XmyPlatform='container' -Xtenant_url='thin-edge-io.eu-latest.cumulocity.com'
 
 
 
@@ -71,7 +71,7 @@ class SoftwareManagement(EnvironmentC8y):
 
     # Static class member that can be overridden by a command line argument
     # E.g.:
-    # pysys.py run 'sm-apt*' -XmyPlatform='smcontainer'
+    # pysys.py run 'sm-apt*' -XmyPlatform='container'
 
     myPlatform = None
 
@@ -94,10 +94,10 @@ class SoftwareManagement(EnvironmentC8y):
     def setup(self):
         """Setup Environment"""
 
-        if self.myPlatform != "smcontainer":
+        if self.myPlatform != "container":
             self.skipTest(
                 "Testing the apt plugin is not supported on this platform."+\
-                    "Use parameter -XmyPlatform='smcontainer' to enable it")
+                    "Use parameter -XmyPlatform='container' to enable it")
 
         # Database with package IDs taken from the thin-edge.io
         # TODO make this somehow not hard-coded

--- a/tests/PySys/software_management_end_to_end/sm_fake_install_remove/run.py
+++ b/tests/PySys/software_management_end_to_end/sm_fake_install_remove/run.py
@@ -14,7 +14,7 @@ This test is currently skipped as it needs a specialized setup with the
 dummy-plugin set up to install fruits.
 
 To run it do this:
-    pysys.py run -v DEBUG 'sm-fake*' -Xfakeplugin=fakeplugin -XmyPlatform=smcontainer
+    pysys.py run -v DEBUG 'sm-fake*' -Xfakeplugin=fakeplugin -XmyPlatform=container
 
 """
 

--- a/tests/PySys/software_management_end_to_end/sm_fake_install_remove_multiple/run.py
+++ b/tests/PySys/software_management_end_to_end/sm_fake_install_remove_multiple/run.py
@@ -14,7 +14,7 @@ This test is currently skipped as it needs a specialized setup with the
 dummy-plugin set up to install fruits.
 
 To run it do this:
-    pysys.py run -v DEBUG 'sm-fake*' -Xfakeplugin=fakeplugin -XmyPlatform=smcontainer
+    pysys.py run -v DEBUG 'sm-fake*' -Xfakeplugin=fakeplugin -XmyPlatform=container
 
 """
 

--- a/tests/PySys/software_management_end_to_end/sm_mixed_install_remove_multiple/run.py
+++ b/tests/PySys/software_management_end_to_end/sm_mixed_install_remove_multiple/run.py
@@ -15,7 +15,7 @@ This test is currently skipped as it needs a specialized setup with the
 dummy-plugin set up to install fruits.
 
 To run it do this:
-    pysys.py run -v DEBUG 'sm-fake*' -Xfakeplugin=fakeplugin -XmyPlatform=smcontainer
+    pysys.py run -v DEBUG 'sm-fake*' -Xfakeplugin=fakeplugin -XmyPlatform=container
 
 """
 


### PR DESCRIPTION
## Proposed changes

Reduce complexity by only selecting platform "container" to select everything that modifies the OS by installing software, etc.
Also reduces the danger to miss tests by test-filters.

Signed-off-by: Michael Abel <info@abel-ikt.de>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


