### PR TITLE
fixing panic when wrong command set in template #983

### DIFF
--- a/crates/core/c8y_smartrest/src/operations.rs
+++ b/crates/core/c8y_smartrest/src/operations.rs
@@ -25,7 +25,7 @@ pub struct OnMessageExec {
 #[serde(rename_all = "lowercase")]
 pub struct Operation {
     #[serde(skip)]
-    name: String,
+    pub name: String,
     exec: Option<OnMessageExec>,
 }
 

--- a/crates/core/tedge_mapper/src/c8y/error.rs
+++ b/crates/core/tedge_mapper/src/c8y/error.rs
@@ -41,8 +41,12 @@ pub enum CumulocityMapperError {
     #[error(transparent)]
     FromIo(#[from] std::io::Error),
 
-    #[error("Operation execution failed: {0}")]
-    ExecuteFailed(String),
+    #[error("Operation execution failed: {error_message}. Command: {command}. Operation name: {operation_name}")]
+    ExecuteFailed {
+        error_message: String,
+        command: String,
+        operation_name: String,
+    },
 
     #[error("An unknown operation template: {0}")]
     UnknownOperation(String),


### PR DESCRIPTION
## Proposed changes
- Closes #983 

- tedge-mapper was previously leaving operations hanging dead in the
      cloud if the wrong command path was set inside the template file
      in /etc/tedge/operations/<cloud>/operation_name
- this will fix handles the error, (removing the unwrap)
- it also ensures that operation status is updated to executing and
      then to failed.
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

