### PR TITLE
Fix workflows: Add collectd to purge and to install again

### DIFF
--- a/.github/workflows/integration-test-workflow.yml
+++ b/.github/workflows/integration-test-workflow.yml
@@ -46,7 +46,7 @@ jobs:
         continue-on-error: true
 
       - name: purge
-        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto libmosquitto1 collectd-core collectd
+        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto libmosquitto1 collectd-core
 
       - name: install mosquitto
         run: sudo apt-get --assume-yes install mosquitto
@@ -55,7 +55,7 @@ jobs:
         run: sudo apt-get --assume-yes install libmosquitto1
 
       - name: install collectd-core
-        run: sudo apt-get --assume-yes install collectd-core collectd
+        run: sudo apt-get --assume-yes install collectd-core
 
       - name: install tedge package
         run: sudo dpkg -i ./debian-package_unpack/tedge_0.*_amd64.deb
@@ -190,7 +190,7 @@ jobs:
       # mosquitto-clients is required for system test only, but has dependency on libmosquitto1.
       # therefore, we need to purge it here, and mosquitto-clients is required only for RPi.
       - name: purge
-        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto-clients mosquitto libmosquitto1 collectd-core
+        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto-clients mosquitto libmosquitto1 collectd-core collectd
 
       - name: install mosquitto
         run: sudo apt-get --assume-yes install mosquitto
@@ -202,7 +202,7 @@ jobs:
         run: sudo apt-get --assume-yes install mosquitto-clients
 
       - name: install collectd-core
-        run: sudo apt-get --assume-yes install collectd-core
+        run: sudo apt-get --assume-yes install collectd-core collectd
 
       - name: install tedge package
         run: sudo dpkg -i ./debian-package_unpack/tedge_0.*_armhf.deb
@@ -214,7 +214,7 @@ jobs:
         run: sudo dpkg -i ./debian-package_unpack/tedge_agent_*_armhf.deb
 
       - name: install tedge plugin packages
-        run: sudo dpkg -i ./debian-package_unpack/tedge_*_plugin_*_armhf.deb  
+        run: sudo dpkg -i ./debian-package_unpack/tedge_*_plugin_*_armhf.deb
 
       - name: run tedge help
         run: tedge --help

--- a/.github/workflows/integration-test-workflow.yml
+++ b/.github/workflows/integration-test-workflow.yml
@@ -46,7 +46,7 @@ jobs:
         continue-on-error: true
 
       - name: purge
-        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto libmosquitto1 collectd-core
+        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto libmosquitto1 collectd-core collectd
 
       - name: install mosquitto
         run: sudo apt-get --assume-yes install mosquitto
@@ -55,7 +55,7 @@ jobs:
         run: sudo apt-get --assume-yes install libmosquitto1
 
       - name: install collectd-core
-        run: sudo apt-get --assume-yes install collectd-core
+        run: sudo apt-get --assume-yes install collectd-core collectd
 
       - name: install tedge package
         run: sudo dpkg -i ./debian-package_unpack/tedge_0.*_amd64.deb

--- a/.github/workflows/system-test-offsite.yml
+++ b/.github/workflows/system-test-offsite.yml
@@ -52,10 +52,10 @@ jobs:
           path: /home/pi/examples
 
       - name: purge packages
-        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto-clients mosquitto libmosquitto1 collectd-core
+        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto-clients mosquitto libmosquitto1 collectd-core collectd
 
       - name: install packages
-        run: sudo apt-get --assume-yes install mosquitto-clients mosquitto libmosquitto1 collectd-core
+        run: sudo apt-get --assume-yes install mosquitto-clients mosquitto libmosquitto1 collectd-core collectd
 
       - name: install packages
         run: sudo dpkg -i ./debian-package_unpack/*.deb


### PR DESCRIPTION
## Proposed changes

Fix package installation and deinstallation in the integration test workflow.
Probably a side effect of installing collectd on that Pis earlier

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)