### PR TITLE
Fix mqtt message threshhold in test

### DIFF
--- a/tests/PySys/tedge_mapper_c8y/tedge_mapper_c8y_packet_threshold_size/run.py
+++ b/tests/PySys/tedge_mapper_c8y/tedge_mapper_c8y_packet_threshold_size/run.py
@@ -68,7 +68,13 @@ class TedgeMapperC8yThresholdPacketSize(BaseTest):
         )
 
     def validate(self):
-        self.assertGrep('tedge_sub.out', "The input size 20489 is too big. The threshold is 16384.", contains=True)
+        self.assertGrep(
+            "tedge_sub.out",
+            "The size of the message received on tedge/measurements is 20489 "
+            # Note: 2**16 would bei 18384 but the C8y limit is a bit smaller
+            + "which is greater than the threshold size of 16184.",
+            contains=True,
+        )
 
     def mapper_cleanup(self):
         self.log.info("mapper_cleanup")


### PR DESCRIPTION
Signed-off-by: Michael Abel <info@abel-ikt.de>

## Proposed changes

Adjust mqtt message threshhold in test to the value that is actually supported by C8y

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

