### PR TITLE
#759 Move 'logged_command' to a crate as it going to be used by other components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,6 +1391,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "logged_command"
+version = "0.6.1"
+dependencies = [
+ "anyhow",
+ "assert_matches",
+ "async-trait",
+ "log",
+ "serial_test 0.6.0",
+ "tempfile",
+ "test-case",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,7 +1573,7 @@ dependencies = [
  "futures",
  "mqtt_tests",
  "rumqttc",
- "serial_test",
+ "serial_test 0.5.1",
  "thiserror",
  "tokio",
 ]
@@ -1945,9 +1960,10 @@ dependencies = [
  "async-trait",
  "csv",
  "download",
+ "logged_command",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 0.5.1",
  "tedge_utils",
  "tempfile",
  "test-case",
@@ -2444,6 +2460,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,7 +2622,18 @@ checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static",
  "parking_lot 0.11.2",
- "serial_test_derive",
+ "serial_test_derive 0.5.1",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
+dependencies = [
+ "lazy_static",
+ "parking_lot 0.11.2",
+ "serial_test_derive 0.6.0",
 ]
 
 [[package]]
@@ -2611,6 +2644,19 @@ checksum = "b2acd6defeddb41eb60bb468f8825d0cfd0c2a76bc03bfd235b6a1dc4f6a1ad5"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.15",
+ "syn 1.0.88",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2881bccd7d60fb32dfa3d7b3136385312f8ad75e2674aab2852867a09790cae8"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "rustversion",
  "syn 1.0.88",
 ]
 
@@ -2788,7 +2834,7 @@ dependencies = [
  "predicates 2.1.1",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 0.5.1",
  "tedge_config",
  "tedge_users",
  "tedge_utils",
@@ -2822,7 +2868,7 @@ dependencies = [
  "hamcrest2",
  "reqwest",
  "serde",
- "serial_test",
+ "serial_test 0.5.1",
  "tedge_utils",
  "test-case",
  "thiserror",
@@ -2899,7 +2945,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 0.5.1",
  "tedge_config",
  "tedge_users",
  "tedge_utils",

--- a/crates/common/logged_command/Cargo.toml
+++ b/crates/common/logged_command/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "logged_command"
+version = "0.6.1"
+authors = ["thin-edge.io team <info@thin-edge.io>"]
+edition = "2021"
+rust-version = "1.58.1"
+
+[dependencies]
+async-trait = "0.1"
+log = "0.4"
+thiserror = "1.0"
+tokio = { version = "1.8", features = [ "fs", "io-util", "macros", "process", "rt" ] }
+
+
+[dev-dependencies]
+anyhow = "1.0"
+assert_matches = "1.5"
+serial_test = "0.6"
+tempfile = "3.2"
+test-case = "2.0"

--- a/crates/common/logged_command/src/lib.rs
+++ b/crates/common/logged_command/src/lib.rs
@@ -1,0 +1,3 @@
+mod logged_command;
+
+pub use crate::logged_command::{LoggedCommand, LoggingChild};

--- a/crates/common/logged_command/src/logged_command.rs
+++ b/crates/common/logged_command/src/logged_command.rs
@@ -1,8 +1,13 @@
-use std::ffi::OsStr;
-use std::process::{Output, Stdio};
-use tokio::fs::File;
-use tokio::io::{AsyncWriteExt, BufWriter};
-use tokio::process::{Child, Command};
+use log::error;
+use std::{
+    ffi::OsStr,
+    process::{Output, Stdio},
+};
+use tokio::{
+    fs::File,
+    io::{AsyncWriteExt, BufWriter},
+    process::{Child, Command},
+};
 
 pub struct LoggingChild {
     command_line: String,
@@ -16,7 +21,7 @@ impl LoggingChild {
     ) -> Result<Output, std::io::Error> {
         let outcome = self.inner_child.wait_with_output().await;
         if let Err(err) = LoggedCommand::log_outcome(&self.command_line, &outcome, logger).await {
-            tracing::log::error!("Fail to log the command execution: {}", err);
+            error!("Fail to log the command execution: {}", err);
         }
 
         outcome
@@ -80,7 +85,7 @@ impl LoggedCommand {
         let outcome = self.command.output().await;
 
         if let Err(err) = LoggedCommand::log_outcome(&self.command_line, &outcome, logger).await {
-            tracing::log::error!("Fail to log the command execution: {}", err);
+            error!("Fail to log the command execution: {}", err);
         }
 
         outcome

--- a/crates/core/plugin_sm/Cargo.toml
+++ b/crates/core/plugin_sm/Cargo.toml
@@ -10,6 +10,7 @@ agent_interface = { path = "../agent_interface" }
 async-trait = "0.1"
 csv = "1.1"
 download = { path = "../../common/download" }
+logged_command = { path = "../../common/logged_command" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tedge_utils = { path = "../../common/tedge_utils" }

--- a/crates/core/plugin_sm/src/lib.rs
+++ b/crates/core/plugin_sm/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod log_file;
-pub mod logged_command;
 pub mod plugin;
 pub mod plugin_manager;

--- a/crates/core/plugin_sm/src/plugin.rs
+++ b/crates/core/plugin_sm/src/plugin.rs
@@ -1,8 +1,8 @@
-use crate::logged_command::LoggedCommand;
 use agent_interface::*;
 use async_trait::async_trait;
 use csv::ReaderBuilder;
 use download::Downloader;
+use logged_command::LoggedCommand;
 use serde::Deserialize;
 use std::path::Path;
 use std::{path::PathBuf, process::Output};


### PR DESCRIPTION
## Proposed changes

Extract `logged_command` to a crate as it is now used by other components.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
