### PR TITLE
Switch to all in one workflow strategy for GitHub Actions

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1375,6 +1375,8 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./results
+        destination_dir: results
+        commit_message: Results for ci pipeline run ${{ github.run_number }}
 
     - name: Final Result
       # This will fail if there are errors in the reports

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1295,12 +1295,15 @@ jobs:
     # This is here a limitation of the amount of workflows
     # that trigger each other (GitHub Bug).
     # It would be nicer to use the postprocess trigger instead
-    - name: Repository Dispatch
-      uses: peter-evans/repository-dispatch@v1
-      with:
-          token: ${{ secrets.SECRET_THEGHTOKEN  }}
-          event-type: postprocess
-          repository: abelikt/thin-edge.io_analytics
+
+# Disabled until analytics VM is available
+#
+#    - name: Repository Dispatch
+#      uses: peter-evans/repository-dispatch@v1
+#      with:
+#          token: ${{ secrets.SECRET_THEGHTOKEN  }}
+#          event-type: postprocess
+#          repository: abelikt/thin-edge.io_analytics
 
     - name: download result a
       uses: actions/download-artifact@v3

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1,7 +1,7 @@
 name: ci_pipeline
 
 # All in one ci pipeline
-#  Note that the jobs system-test_offsite_{abcd} , install-and-use-rpi_mythic{abcd}
+#  Note that the jobs system-test_offsite_{abcd} , install-and-use-rpi_m32sd10{abcd}
 #  are there four times and are almost identical. They only differ in a character
 #  a,b,c,d that we use to select a runner.
 #
@@ -532,8 +532,8 @@ jobs:
 
 #################################################################################
 
-  install-and-use-rpi_mythica:
-    runs-on: [self-hosted, Linux, ARM, offsite_mythica]
+  install-and-use-rpi_m32sd10a:
+    runs-on: [self-hosted, Linux, ARM, offsite_m32sd10a]
     needs: [build_matrix_arm]
 
     steps:
@@ -621,7 +621,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: mythica
+          C8YDEVICE: m32sd10a
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -633,7 +633,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: mythica
+          C8YDEVICE: m32sd10a
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -653,8 +653,8 @@ jobs:
 
 #################################################################################
 
-  install-and-use-rpi_mythicb:
-    runs-on: [self-hosted, Linux, ARM, offsite_mythicc]
+  install-and-use-rpi_m32sd10b:
+    runs-on: [self-hosted, Linux, ARM, offsite_m32sd10b]
     needs: [build_matrix_arm]
 
     steps:
@@ -743,7 +743,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: mythicb
+          C8YDEVICE: m32sd10b
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -755,7 +755,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: mythicb
+          C8YDEVICE: m32sd10b
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -775,8 +775,8 @@ jobs:
 
 #################################################################################
 
-  install-and-use-rpi_mythicc:
-    runs-on: [self-hosted, Linux, ARM, offsite_mythicb]
+  install-and-use-rpi_m32sd10c:
+    runs-on: [self-hosted, Linux, ARM, offsite_m32sd10c]
     needs: [build_matrix_arm]
 
     steps:
@@ -865,7 +865,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: mythicc
+          C8YDEVICE: m32sd10c
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -877,7 +877,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: mythicc
+          C8YDEVICE: m32sd10c
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -897,8 +897,8 @@ jobs:
 
 #################################################################################
 
-  install-and-use-rpi_mythicd:
-    runs-on: [self-hosted, Linux, ARM, offsite_mythicd]
+  install-and-use-rpi_m32sd10d:
+    runs-on: [self-hosted, Linux, ARM, offsite_m32sd10d]
     needs: [build_matrix_arm]
 
     steps:
@@ -986,7 +986,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: mythicd
+          C8YDEVICE: m32sd10d
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -998,7 +998,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: mythicd
+          C8YDEVICE: m32sd10d
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -1019,8 +1019,8 @@ jobs:
 #################################################################################
 
   system-test_offsite_a:
-    runs-on: [self-hosted, Linux, ARM, offsite_mythica]
-    needs: [install-and-use-rpi_mythica]
+    runs-on: [self-hosted, Linux, ARM, offsite_m32sd10a]
+    needs: [install-and-use-rpi_m32sd10a]
 
     steps:
 
@@ -1034,7 +1034,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythica
+            C8YDEVICE: m32sd10a
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1047,7 +1047,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythica
+            C8YDEVICE: m32sd10a
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1060,7 +1060,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythica
+            C8YDEVICE: m32sd10a
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1073,7 +1073,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythica
+            C8YDEVICE: m32sd10a
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1083,14 +1083,14 @@ jobs:
       # https://github.com/marketplace/actions/upload-a-build-artifact
       uses: actions/upload-artifact@v2
       with:
-        name: results_pysys_offsite_mythica
+        name: results_pysys_offsite_m32sd10a
         path: tests/
 
 #################################################################################
 
   system-test_offsite_b:
-    runs-on: [self-hosted, Linux, ARM, offsite_mythicb]
-    needs: [install-and-use-rpi_mythicb]
+    runs-on: [self-hosted, Linux, ARM, offsite_m32sd10b]
+    needs: [install-and-use-rpi_m32sd10b]
 
     steps:
 
@@ -1104,7 +1104,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicb
+            C8YDEVICE: m32sd10b
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1117,7 +1117,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicb
+            C8YDEVICE: m32sd10b
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1130,7 +1130,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicb
+            C8YDEVICE: m32sd10b
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1143,7 +1143,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicb
+            C8YDEVICE: m32sd10b
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1153,14 +1153,14 @@ jobs:
       # https://github.com/marketplace/actions/upload-a-build-artifact
       uses: actions/upload-artifact@v2
       with:
-        name: results_pysys_offsite_mythicb
+        name: results_pysys_offsite_m32sd10b
         path: tests/
 
 #################################################################################
 
   system-test_offsite_c:
-    runs-on: [self-hosted, Linux, ARM, offsite_mythicc]
-    needs: [install-and-use-rpi_mythicc]
+    runs-on: [self-hosted, Linux, ARM, offsite_m32sd10c]
+    needs: [install-and-use-rpi_m32sd10c]
 
     steps:
 
@@ -1174,7 +1174,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicc
+            C8YDEVICE: m32sd10c
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1187,7 +1187,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicc
+            C8YDEVICE: m32sd10c
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1200,7 +1200,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicc
+            C8YDEVICE: m32sd10c
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1213,7 +1213,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicc
+            C8YDEVICE: m32sd10c
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1223,14 +1223,14 @@ jobs:
       # https://github.com/marketplace/actions/upload-a-build-artifact
       uses: actions/upload-artifact@v2
       with:
-        name: results_pysys_offsite_mythicc
+        name: results_pysys_offsite_m32sd10c
         path: tests/
 
 #################################################################################
 
   system-test_offsite_d:
-    runs-on: [self-hosted, Linux, ARM, offsite_mythicd]
-    needs: [install-and-use-rpi_mythicd]
+    runs-on: [self-hosted, Linux, ARM, offsite_m32sd10d]
+    needs: [install-and-use-rpi_m32sd10d]
 
     steps:
 
@@ -1244,7 +1244,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicd
+            C8YDEVICE: m32sd10d
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1257,7 +1257,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicd
+            C8YDEVICE: m32sd10d
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1270,7 +1270,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicd
+            C8YDEVICE: m32sd10d
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1283,7 +1283,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: mythicd
+            C8YDEVICE: m32sd10d
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1293,7 +1293,7 @@ jobs:
       # https://github.com/marketplace/actions/upload-a-build-artifact
       uses: actions/upload-artifact@v2
       with:
-        name: results_pysys_offsite_mythicd
+        name: results_pysys_offsite_m32sd10d
         path: tests/
 
 #############################################################################
@@ -1324,29 +1324,29 @@ jobs:
       uses: actions/download-artifact@v3
       # https://github.com/marketplace/actions/download-a-build-artifact
       with:
-        name: results_pysys_offsite_mythica
-        path: results/results_pysys_offsite_mythica
+        name: results_pysys_offsite_m32sd10a
+        path: results/results_pysys_offsite_m32sd10a
 
     - name: download result b
       uses: actions/download-artifact@v3
       # https://github.com/marketplace/actions/download-a-build-artifact
       with:
-        name: results_pysys_offsite_mythicb
-        path: results/results_pysys_offsite_mythicb
+        name: results_pysys_offsite_m32sd10b
+        path: results/results_pysys_offsite_m32sd10b
 
     - name: download result c
       uses: actions/download-artifact@v3
       # https://github.com/marketplace/actions/download-a-build-artifact
       with:
-        name: results_pysys_offsite_mythicc
-        path: results/results_pysys_offsite_mythicc
+        name: results_pysys_offsite_m32sd10c
+        path: results/results_pysys_offsite_m32sd10c
 
     - name: download result d
       uses: actions/download-artifact@v3
       # https://github.com/marketplace/actions/download-a-build-artifact
       with:
-        name: results_pysys_offsite_mythicd
-        path: results/results_pysys_offsite_mythicd
+        name: results_pysys_offsite_m32sd10d
+        path: results/results_pysys_offsite_m32sd10d
 
     - name: Build report
       run: ./ci/report/build.sh
@@ -1363,7 +1363,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: system-test-report-matrix_${{ github.run_number }}
-        path: results/report-matrix.html
+        path: results/report-matrix.htm
 
     - name: Run ls on analysis folder
       run: |

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1,0 +1,1364 @@
+name: ci_pipeline
+
+# All in one ci pipeline
+#  Note that the jobs system-test_offsite_{abcd} , install-and-use-rpi_mythic{abcd}
+#  are there four times and are almost identical. They only differ in a character
+#  a,b,c,d that we use to select a runner.
+#
+# TODO: Reduce complexity by moving functionality to bash scripts
+# TODO: Think about automated generation of this workflow, there is
+#   duplicated code, especially in the later sections
+# TODO: Smoke testing on Azure is disabled, we should check if it works out
+#   with 4 runners in parallel or enable only one
+
+on:
+  push:
+    branches: [main, continuous_integration]
+  workflow_dispatch:
+    branches: [main, continuous_integration]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-fmt:
+    name: Run cargo fmt
+    runs-on: Ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cargo fmt --version
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: fmt
+          args: --version
+
+      - name: Cargo fmt
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: fmt
+          args: -- --check
+
+  python-black:
+    name: Python static checks
+    runs-on: Ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run black
+        uses: rickstaa/action-black@v1
+        with:
+          black_args: ". --check"
+
+  cargo-clippy:
+    name: Run cargo clippy
+    runs-on: Ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: enable toolchain via github action
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.58.1
+          components: rustfmt, clippy
+          override: true
+
+      - name: Enable cache
+        # https://github.com/marketplace/actions/rust-cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Cargo clippy --version
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          toolchain: 1.58.1
+          command: clippy
+          args: --version
+
+      - name: Cargo clippy
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          toolchain: 1.58.1
+          command: clippy
+
+  cargo-test:
+    name: Run cargo test
+    runs-on: Ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: enable toolchain via github action
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.58.1
+          override: true
+
+      - name: Enable cache
+        # https://github.com/marketplace/actions/rust-cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Cargo version
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: version
+
+      - name: Cargo build dummy plugin
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: build
+          args: -p tedge_dummy_plugin
+
+      - name: Cargo test
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: test
+          args: --no-fail-fast
+
+
+###############################################################################
+
+  build_amd64:
+    name: Build tedge and mapper Debian packages for amd64
+    runs-on: Ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: enable toolchain via github action
+        # https://github.com/actions-rs/toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.58.1
+          override: true
+
+      - name: Enable cache
+        # https://github.com/marketplace/actions/rust-cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Install cargo-deb
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: install
+          args: cargo-deb --version 1.34.2
+
+      - name: Build tedge debian package
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge
+
+      - name: Build tedge_mapper debian package
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge_mapper
+
+      - name: Build tedge_apt_plugin debian package
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge_apt_plugin
+
+      - name: Build tedge_apama_plugin debian package
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge_apama_plugin
+
+      - name: Build tedge_agent debian package
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge_agent
+
+      - name: Build tedge_logfile_request_plugin debian package
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge_logfile_request_plugin
+
+      - name: build sawtooth-publisher for amd64
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: build
+          args: --release -p sawtooth_publisher
+
+      - name: Upload artifacts as zip
+        # https://github.com/marketplace/actions/upload-a-build-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: debian-packages-amd64
+          path: target/debian/*.deb
+
+      - name: upload amd64 sawtooth-publisher as zip
+        # https://github.com/marketplace/actions/upload-a-build-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: sawtooth_publisher_amd64
+          path: target/release/sawtooth_publisher
+
+      - name: Build tedge_dummy_plugin
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: build
+          args: --release -p tedge_dummy_plugin
+
+      - name: upload dummy-plugin
+        # https://github.com/marketplace/actions/upload-a-build-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: tedge_dummy_plugin_amd64
+          path: target/release/tedge_dummy_plugin
+
+  build_matrix_arm:
+    name: Build tedge and mapper Debian for armv7
+    runs-on: Ubuntu-20.04
+    strategy:
+      matrix:
+        # Add only arm targets here as we use a custom strip binary!
+        target:
+          [
+            aarch64-unknown-linux-gnu,
+            aarch64-unknown-linux-musl,
+            arm-unknown-linux-gnueabihf,
+            armv7-unknown-linux-gnueabihf,
+            armv7-unknown-linux-musleabihf,
+          ]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: enable toolchain via github action
+        # https://github.com/actions-rs/toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.58.1
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: Enable cache
+        # https://github.com/marketplace/actions/rust-cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: install cargo-deb
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: install
+          args: cargo-deb --version 1.34.2
+
+      - name: install cargo-strip
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: install
+          args: cargo-strip
+
+      - name: build cross release for target
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          use-cross: true
+          command: build
+          args: --release --target=${{ matrix.target }}
+
+      - name: apt update
+        run: sudo apt update
+
+      # armv7 uses `arm-linux-gnueabihf-strip`; aarch64 uses `aarch64-linux-gnu-strip`
+      # It appears `aarch64-linux-gnu-strip` seems to work explicitly on other arm bins but not other way around.
+      - name: Install binutils to add `strip` for striping arm binaries
+        run: sudo apt-get --assume-yes install binutils-arm-linux-gnueabihf binutils-aarch64-linux-gnu
+
+      - name: Strip tedge
+        run: arm-linux-gnueabihf-strip target/${{ matrix.target }}/release/tedge || aarch64-linux-gnu-strip target/${{ matrix.target }}/release/tedge
+
+      - name: Strip tedge_mapper
+        run: arm-linux-gnueabihf-strip target/${{ matrix.target }}/release/tedge_mapper || aarch64-linux-gnu-strip target/${{ matrix.target }}/release/tedge_mapper
+
+      - name: Strip tedge_agent
+        run: arm-linux-gnueabihf-strip target/${{ matrix.target }}/release/tedge_agent || aarch64-linux-gnu-strip target/${{ matrix.target }}/release/tedge_agent
+
+      - name: Strip tedge_apt_plugin
+        run: arm-linux-gnueabihf-strip target/${{ matrix.target }}/release/tedge_apt_plugin || aarch64-linux-gnu-strip target/${{ matrix.target }}/release/tedge_apt_plugin
+
+      - name: Strip tedge_apama_plugin
+        run: arm-linux-gnueabihf-strip target/${{ matrix.target }}/release/tedge_apama_plugin || aarch64-linux-gnu-strip target/${{ matrix.target }}/release/tedge_apama_plugin
+
+      - name: Strip tedge_logfile_request_plugin
+        run: arm-linux-gnueabihf-strip target/${{ matrix.target }}/release/tedge_logfile_request_plugin || aarch64-linux-gnu-strip target/${{ matrix.target }}/release/tedge_logfile_request_plugin
+
+      - name: build tedge debian package for target
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge --no-strip --no-build --target=${{ matrix.target }}
+
+      - name: build tedge_mapper debian package for target
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge_mapper --no-strip --no-build --target=${{ matrix.target }}
+
+      - name: build tedge_agent debian package for target
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge_agent --no-strip --no-build --target=${{ matrix.target }}
+
+      - name: build tedge_apt_plugin debian package for target
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge_apt_plugin --no-strip --no-build --target=${{ matrix.target }}
+
+      - name: build tedge_apama_plugin debian package for target
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge_apama_plugin --no-strip --no-build --target=${{ matrix.target }}
+
+      - name: build tedge_logfile_request_plugin debian package for target
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: deb
+          args: -p tedge_logfile_request_plugin --no-strip --no-build --target=${{ matrix.target }}
+
+      - name: build sawtooth publisher
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          use-cross: true
+          command: build
+          args: --release -p sawtooth_publisher --target=${{ matrix.target }}
+
+      - name: Strip workaround sawtooth_publisher
+        run: arm-linux-gnueabihf-strip target/${{ matrix.target }}/release/sawtooth_publisher || aarch64-linux-gnu-strip target/${{ matrix.target }}/release/sawtooth_publisher
+
+      - name: upload debian packages as zip
+        # https://github.com/marketplace/actions/upload-a-build-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: debian-packages-${{ matrix.target }}
+          path: target/${{ matrix.target }}/debian/*.deb
+
+      - name: upload sawtooth publisher as zip
+        # https://github.com/marketplace/actions/upload-a-build-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: sawtooth_publisher_${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/sawtooth_publisher
+
+      - name: Build tedge_dummy_plugin
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: build
+          args: --release -p tedge_dummy_plugin
+
+      - name: Strip workaround for tedge_dummy_plugin
+        run: arm-linux-gnueabihf-strip target/${{ matrix.target }}/release/tedge_dummy_plugin || aarch64-linux-gnu-strip target/${{ matrix.target }}/release/tedge_dummy_plugin
+
+      - name: Upload dummy-plugin
+        # https://github.com/marketplace/actions/upload-a-build-artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: tedge_dummy_plugin_${{ matrix.target }}
+          path: target/${{ matrix.target }}/release/tedge_dummy_plugin
+
+#################################################################################
+
+  install-and-use-amd64:
+    runs-on: Ubuntu-20.04
+    needs: [build_amd64]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: debian-packages-amd64
+          path: debian-package_unpack
+
+      - name: Workaround Stop collectd mapper
+        run: sudo systemctl stop tedge-mapper-collectd
+        continue-on-error: true
+
+      - name: disconnect c8y
+        run: sudo tedge disconnect c8y
+        # We need to continue when there is no tedge already installed
+        continue-on-error: true
+
+      - name: disconnect az
+        run: sudo tedge disconnect az
+        # We need to continue when there is no tedge already installed
+        continue-on-error: true
+
+      - name: purge
+        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto libmosquitto1 collectd-core
+
+      - name: install mosquitto
+        run: sudo apt-get --assume-yes install mosquitto
+
+      - name: install libmosquitto1
+        run: sudo apt-get --assume-yes install libmosquitto1
+
+      - name: install collectd-core
+        run: sudo apt-get --assume-yes install collectd-core
+
+      - name: install tedge package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_0.*_amd64.deb
+
+      - name: install tedge mapper package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_mapper_*_amd64.deb
+
+      - name: install tedge agent package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_agent_*_amd64.deb
+
+      - name: install tedge plugin packages
+        run: sudo dpkg -i ./debian-package_unpack/tedge_*_plugin_*_amd64.deb
+
+
+      - name: run tedge help
+        run: tedge --help
+
+        # For Analytics: replace the default config file with tedge custom config file
+      - name: configure collectd
+        run: sudo cp "/etc/tedge/contrib/collectd/collectd.conf" "/etc/collectd/collectd.conf"
+
+  cargo-test-features:
+    name: Run cargo test features
+    runs-on: Ubuntu-20.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: install-and-use-amd64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: enable toolchain via github action
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.58.1
+          override: true
+
+      - name: Enable cache
+        # https://github.com/marketplace/actions/rust-cache
+        uses: Swatinem/rust-cache@v1
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: debian-packages-amd64
+          path: debian-package_unpack
+
+      - name: install mosquitto
+        run: sudo apt-get --assume-yes install mosquitto
+
+      - name: install libmosquitto1
+        run: sudo apt-get --assume-yes install libmosquitto1
+
+      - name: install collectd-core
+        run: sudo apt-get --assume-yes install collectd-core
+
+      - name: install tedge package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_0.*_amd64.deb
+
+      - name: install tedge mapper package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_mapper_*_amd64.deb
+
+      - name: install tedge agent package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_agent_*_amd64.deb
+
+      - name: install tedge plugin packages
+        run: sudo dpkg -i ./debian-package_unpack/tedge_*_plugin_*_amd64.deb
+
+      - name: Cargo test features (compile)
+        # Compile in advance to avoid that cargo compiles during the test run
+        # this seems to have an impact on some tests as the timing differs
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: test
+          args: --verbose --no-run --features integration-test
+
+      - name: Cargo build dummy plugin
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p tedge_dummy_plugin
+
+        # To run the test for features here is kind of experimental
+        # they could fail if GitHub blocks external connections.
+        # It seems like they rarely do.
+      - name: Cargo test features
+        uses: actions-rs/cargo@v1
+        # https://github.com/marketplace/actions/rust-cargo
+        with:
+          command: test
+          args: --verbose --features integration-test,requires-sudo -- \
+            --skip sending_and_receiving_a_message
+
+#################################################################################
+
+  install-and-use-rpi_mythica:
+    runs-on: [self-hosted, Linux, ARM, offsite_mythica]
+    needs: [build_matrix_arm]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: debian-packages-armv7-unknown-linux-gnueabihf
+          path: debian-package_unpack
+
+      - name: Workaround Stop collectd mapper
+        run: sudo systemctl stop tedge-mapper-collectd
+        continue-on-error: true
+
+      - name: disconnect c8y
+        run: sudo tedge disconnect c8y
+        # We need to continue when there is no tedge already installed
+        continue-on-error: true
+
+      - name: disconnect az
+        run: sudo tedge disconnect az
+        # We need to continue when there is no tedge already installed
+        continue-on-error: true
+
+      - name: Stop apama
+        run: sudo systemctl stop apama
+        continue-on-error: true
+
+      - name: purge
+        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto-clients mosquitto libmosquitto1 collectd-core collectd
+
+      - name: install mosquitto
+        run: sudo apt-get --assume-yes install mosquitto
+
+      - name: install libmosquitto1
+        run: sudo apt-get --assume-yes install libmosquitto1
+
+      - name: install mosquitto-clients
+        run: sudo apt-get --assume-yes install mosquitto-clients
+
+      - name: install collectd-core
+        run: sudo apt-get --assume-yes install collectd-core collectd
+
+      - name: install tedge package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_0.*_armhf.deb
+
+      - name: install tedge mapper package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_mapper_*_armhf.deb
+
+      - name: install tedge agent package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_agent_*_armhf.deb
+
+      - name: install tedge plugin packages
+        run: sudo dpkg -i ./debian-package_unpack/tedge_*_plugin_*_armhf.deb
+
+      - name: run tedge help
+        run: tedge --help
+
+      - name: configure collectd
+        run: sudo cp "/etc/tedge/contrib/collectd/collectd.conf" "/etc/collectd/collectd.conf"
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: sawtooth_publisher_armv7-unknown-linux-gnueabihf
+          path: /home/pi/examples
+
+      - name: chmod publisher
+        run: chmod +x /home/pi/examples/sawtooth_publisher
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: tedge_dummy_plugin_armv7-unknown-linux-gnueabihf
+          path: /home/pi/tedge_dummy_plugin
+
+      - name: chmod dummy_plugin
+        run: chmod +x /home/pi/tedge_dummy_plugin/tedge_dummy_plugin
+
+      - name: Configure Bridge
+        run: ./ci/configure_bridge.sh
+        env:
+          C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+          C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+          C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+          C8YDEVICE: offsite_mythica
+          TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+          EXAMPLEDIR: /home/pi/examples
+          C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+      - name: Run smoke test for Cumulocity
+        run: ./ci/ci_smoke_test_c8y.sh
+        env:
+          C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+          C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+          C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+          C8YDEVICE: offsite_mythica
+          TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+          EXAMPLEDIR: /home/pi/examples
+          C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+# Run tests for Azure
+# Enable this, when we have decided about how many runners we use
+#
+#      - name: Run Smoke Test for Azure
+#        run: ./ci/ci_smoke_test_az.sh
+#        env:
+#          SASKEYQUEUE: ${{ secrets.SASKEYQUEUE }}
+#          SASKEYIOTHUB: ${{ secrets.SASKEYIOTHUB }}
+#          AZUREENDPOINT: ${{ secrets.AZUREENDPOINT }}
+#          AZUREEVENTHUB: ${{ secrets.AZUREEVENTHUB }}
+#          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+#################################################################################
+
+  install-and-use-rpi_mythicb:
+    runs-on: [self-hosted, Linux, ARM, offsite_mythicc]
+    needs: [build_matrix_arm]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: debian-packages-armv7-unknown-linux-gnueabihf
+          path: debian-package_unpack
+
+      - name: Workaround Stop collectd mapper
+        run: sudo systemctl stop tedge-mapper-collectd
+        continue-on-error: true
+
+      - name: disconnect c8y
+        run: sudo tedge disconnect c8y
+        # We need to continue when there is no tedge already installed
+        continue-on-error: true
+
+      - name: disconnect az
+        run: sudo tedge disconnect az
+        # We need to continue when there is no tedge already installed
+        continue-on-error: true
+
+      - name: Stop apama
+        run: sudo systemctl stop apama
+        continue-on-error: true
+
+      - name: purge
+        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto-clients mosquitto libmosquitto1 collectd-core collectd
+
+      - name: install mosquitto
+        run: sudo apt-get --assume-yes install mosquitto
+
+      - name: install libmosquitto1
+        run: sudo apt-get --assume-yes install libmosquitto1
+
+      - name: install mosquitto-clients
+        run: sudo apt-get --assume-yes install mosquitto-clients
+
+      - name: install collectd-core
+        run: sudo apt-get --assume-yes install collectd-core collectd
+
+      - name: install tedge package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_0.*_armhf.deb
+
+      - name: install tedge mapper package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_mapper_*_armhf.deb
+
+      - name: install tedge agent package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_agent_*_armhf.deb
+
+      - name: install tedge plugin packages
+        run: sudo dpkg -i ./debian-package_unpack/tedge_*_plugin_*_armhf.deb
+
+      - name: run tedge help
+        run: tedge --help
+
+        # replace the default config file with tedge custom config file
+      - name: configure collectd
+        run: sudo cp "/etc/tedge/contrib/collectd/collectd.conf" "/etc/collectd/collectd.conf"
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: sawtooth_publisher_armv7-unknown-linux-gnueabihf
+          path: /home/pi/examples
+
+      - name: chmod publisher
+        run: chmod +x /home/pi/examples/sawtooth_publisher
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: tedge_dummy_plugin_armv7-unknown-linux-gnueabihf
+          path: /home/pi/tedge_dummy_plugin
+
+      - name: chmod dummy_plugin
+        run: chmod +x /home/pi/tedge_dummy_plugin/tedge_dummy_plugin
+
+      - name: Configure Bridge
+        run: ./ci/configure_bridge.sh
+        env:
+          C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+          C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+          C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+          C8YDEVICE: offsite_mythicb
+          TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+          EXAMPLEDIR: /home/pi/examples
+          C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+      - name: Run smoke test for Cumulocity
+        run: ./ci/ci_smoke_test_c8y.sh
+        env:
+          C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+          C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+          C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+          C8YDEVICE: offsite_mythicb
+          TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+          EXAMPLEDIR: /home/pi/examples
+          C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+# Run tests for Azure
+# Enable this, when we have decided about how many runners we use
+#
+#      - name: Run Smoke Test for Azure
+#        run: ./ci/ci_smoke_test_az.sh
+#        env:
+#          SASKEYQUEUE: ${{ secrets.SASKEYQUEUE }}
+#          SASKEYIOTHUB: ${{ secrets.SASKEYIOTHUB }}
+#          AZUREENDPOINT: ${{ secrets.AZUREENDPOINT }}
+#          AZUREEVENTHUB: ${{ secrets.AZUREEVENTHUB }}
+#          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+#################################################################################
+
+  install-and-use-rpi_mythicc:
+    runs-on: [self-hosted, Linux, ARM, offsite_mythicb]
+    needs: [build_matrix_arm]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: debian-packages-armv7-unknown-linux-gnueabihf
+          path: debian-package_unpack
+
+      - name: Workaround Stop collectd mapper
+        run: sudo systemctl stop tedge-mapper-collectd
+        continue-on-error: true
+
+      - name: disconnect c8y
+        run: sudo tedge disconnect c8y
+        # We need to continue when there is no tedge already installed
+        continue-on-error: true
+
+      - name: disconnect az
+        run: sudo tedge disconnect az
+        # We need to continue when there is no tedge already installed
+        continue-on-error: true
+
+      - name: Stop apama
+        run: sudo systemctl stop apama
+        continue-on-error: true
+
+      - name: purge
+        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto-clients mosquitto libmosquitto1 collectd-core collectd
+
+      - name: install mosquitto
+        run: sudo apt-get --assume-yes install mosquitto
+
+      - name: install libmosquitto1
+        run: sudo apt-get --assume-yes install libmosquitto1
+
+      - name: install mosquitto-clients
+        run: sudo apt-get --assume-yes install mosquitto-clients
+
+      - name: install collectd-core
+        run: sudo apt-get --assume-yes install collectd-core collectd
+
+      - name: install tedge package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_0.*_armhf.deb
+
+      - name: install tedge mapper package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_mapper_*_armhf.deb
+
+      - name: install tedge agent package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_agent_*_armhf.deb
+
+      - name: install tedge plugin packages
+        run: sudo dpkg -i ./debian-package_unpack/tedge_*_plugin_*_armhf.deb
+
+      - name: run tedge help
+        run: tedge --help
+
+        # replace the default config file with tedge custom config file
+      - name: configure collectd
+        run: sudo cp "/etc/tedge/contrib/collectd/collectd.conf" "/etc/collectd/collectd.conf"
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: sawtooth_publisher_armv7-unknown-linux-gnueabihf
+          path: /home/pi/examples
+
+      - name: chmod publisher
+        run: chmod +x /home/pi/examples/sawtooth_publisher
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: tedge_dummy_plugin_armv7-unknown-linux-gnueabihf
+          path: /home/pi/tedge_dummy_plugin
+
+      - name: chmod dummy_plugin
+        run: chmod +x /home/pi/tedge_dummy_plugin/tedge_dummy_plugin
+
+      - name: Configure Bridge
+        run: ./ci/configure_bridge.sh
+        env:
+          C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+          C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+          C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+          C8YDEVICE: offsite_mythicc
+          TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+          EXAMPLEDIR: /home/pi/examples
+          C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+      - name: Run smoke test for Cumulocity
+        run: ./ci/ci_smoke_test_c8y.sh
+        env:
+          C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+          C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+          C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+          C8YDEVICE: offsite_mythicc
+          TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+          EXAMPLEDIR: /home/pi/examples
+          C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+# Run tests for Azure
+# Enable this, when we have decided about how many runners we use
+#
+#      - name: Run Smoke Test for Azure
+#        run: ./ci/ci_smoke_test_az.sh
+#        env:
+#          SASKEYQUEUE: ${{ secrets.SASKEYQUEUE }}
+#          SASKEYIOTHUB: ${{ secrets.SASKEYIOTHUB }}
+#          AZUREENDPOINT: ${{ secrets.AZUREENDPOINT }}
+#          AZUREEVENTHUB: ${{ secrets.AZUREEVENTHUB }}
+#          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+#################################################################################
+
+  install-and-use-rpi_mythicd:
+    runs-on: [self-hosted, Linux, ARM, offsite_mythicd]
+    needs: [build_matrix_arm]
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: debian-packages-armv7-unknown-linux-gnueabihf
+          path: debian-package_unpack
+
+      - name: Workaround Stop collectd mapper
+        run: sudo systemctl stop tedge-mapper-collectd
+        continue-on-error: true
+
+      - name: disconnect c8y
+        run: sudo tedge disconnect c8y
+        # We need to continue when there is no tedge already installed
+        continue-on-error: true
+
+      - name: disconnect az
+        run: sudo tedge disconnect az
+        # We need to continue when there is no tedge already installed
+        continue-on-error: true
+
+      - name: Stop apama
+        run: sudo systemctl stop apama
+        continue-on-error: true
+
+      - name: purge
+        run: sudo dpkg -P tedge_agent tedge_logfile_request_plugin tedge_mapper tedge_apt_plugin tedge_apama_plugin tedge mosquitto-clients mosquitto libmosquitto1 collectd-core collectd
+
+      - name: install mosquitto
+        run: sudo apt-get --assume-yes install mosquitto
+
+      - name: install libmosquitto1
+        run: sudo apt-get --assume-yes install libmosquitto1
+
+      - name: install mosquitto-clients
+        run: sudo apt-get --assume-yes install mosquitto-clients
+
+      - name: install collectd-core
+        run: sudo apt-get --assume-yes install collectd-core collectd
+
+      - name: install tedge package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_0.*_armhf.deb
+
+      - name: install tedge mapper package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_mapper_*_armhf.deb
+
+      - name: install tedge agent package
+        run: sudo dpkg -i ./debian-package_unpack/tedge_agent_*_armhf.deb
+
+      - name: install tedge plugin packages
+        run: sudo dpkg -i ./debian-package_unpack/tedge_*_plugin_*_armhf.deb
+
+      - name: run tedge help
+        run: tedge --help
+
+      - name: configure collectd
+        run: sudo cp "/etc/tedge/contrib/collectd/collectd.conf" "/etc/collectd/collectd.conf"
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: sawtooth_publisher_armv7-unknown-linux-gnueabihf
+          path: /home/pi/examples
+
+      - name: chmod publisher
+        run: chmod +x /home/pi/examples/sawtooth_publisher
+
+      - uses: actions/download-artifact@v3
+        # https://github.com/marketplace/actions/download-a-build-artifact
+        with:
+          name: tedge_dummy_plugin_armv7-unknown-linux-gnueabihf
+          path: /home/pi/tedge_dummy_plugin
+
+      - name: chmod dummy_plugin
+        run: chmod +x /home/pi/tedge_dummy_plugin/tedge_dummy_plugin
+
+      - name: Configure Bridge
+        run: ./ci/configure_bridge.sh
+        env:
+          C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+          C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+          C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+          C8YDEVICE: offsite_mythicd
+          TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+          EXAMPLEDIR: /home/pi/examples
+          C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+      - name: Run smoke test for Cumulocity
+        run: ./ci/ci_smoke_test_c8y.sh
+        env:
+          C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+          C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+          C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+          C8YDEVICE: offsite_mythicd
+          TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+          EXAMPLEDIR: /home/pi/examples
+          C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+# Run tests for Azure
+# Enable this, when we have decided about how many runners we use
+#
+#      - name: Run Smoke Test for Azure
+#        run: ./ci/ci_smoke_test_az.sh
+#        env:
+#          SASKEYQUEUE: ${{ secrets.SASKEYQUEUE }}
+#          SASKEYIOTHUB: ${{ secrets.SASKEYIOTHUB }}
+#          AZUREENDPOINT: ${{ secrets.AZUREENDPOINT }}
+#          AZUREEVENTHUB: ${{ secrets.AZUREEVENTHUB }}
+#          IOTHUBNAME: ${{ secrets.IOTHUBNAME }}
+
+#################################################################################
+
+  system-test_offsite_a:
+    runs-on: [self-hosted, Linux, ARM, offsite_mythica]
+    needs: [install-and-use-rpi_mythica]
+
+    steps:
+
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: Run all Tests
+      run:  bash  ./ci/ci_run_all_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythica
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+
+    - name: Run all plugin tests
+      run:  bash  ./ci/ci_run_all_plugin_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythica
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+
+    - name: Run all sm tests
+      run:  bash  ./ci/ci_run_all_sm_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythica
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+
+    - name: Run all statistics tests
+      run:  bash  ./ci/ci_run_statistics.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythica
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+
+    - name: upload results as zip
+      # https://github.com/marketplace/actions/upload-a-build-artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: results_pysys_offsite_mythica
+        path: tests/
+
+#################################################################################
+
+  system-test_offsite_b:
+    runs-on: [self-hosted, Linux, ARM, offsite_mythicb]
+    needs: [install-and-use-rpi_mythicb]
+
+    steps:
+
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: Run all Tests
+      run:  bash  ./ci/ci_run_all_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicb
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+
+    - name: Run all plugin tests
+      run:  bash  ./ci/ci_run_all_plugin_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicb
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+
+    - name: Run all sm tests
+      run:  bash  ./ci/ci_run_all_sm_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicb
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+
+    - name: Run all statistics tests
+      run:  bash  ./ci/ci_run_statistics.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicb
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+
+    - name: upload results as zip
+      # https://github.com/marketplace/actions/upload-a-build-artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: results_pysys_offsite_mythicb
+        path: tests/
+
+#################################################################################
+
+  system-test_offsite_c:
+    runs-on: [self-hosted, Linux, ARM, offsite_mythicc]
+    needs: [install-and-use-rpi_mythicc]
+
+    steps:
+
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: Run all Tests
+      run:  bash  ./ci/ci_run_all_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicc
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+
+    - name: Run all plugin tests
+      run:  bash  ./ci/ci_run_all_plugin_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicc
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+
+    - name: Run all sm tests
+      run:  bash  ./ci/ci_run_all_sm_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicc
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+
+    - name: Run all statistics tests
+      run:  bash  ./ci/ci_run_statistics.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicc
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+
+    - name: upload results as zip
+      # https://github.com/marketplace/actions/upload-a-build-artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: results_pysys_offsite_mythicc
+        path: tests/
+
+#################################################################################
+
+  system-test_offsite_d:
+    runs-on: [self-hosted, Linux, ARM, offsite_mythicd]
+    needs: [install-and-use-rpi_mythicd]
+
+    steps:
+
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: Run all Tests
+      run:  bash  ./ci/ci_run_all_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicd
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+
+    - name: Run all plugin tests
+      run:  bash  ./ci/ci_run_all_plugin_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicd
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+
+    - name: Run all sm tests
+      run:  bash  ./ci/ci_run_all_sm_tests.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicd
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+
+    - name: Run all statistics tests
+      run:  bash  ./ci/ci_run_statistics.sh
+      continue-on-error: true
+      env:
+            C8YPASS: ${{ secrets.SECRET_C8YPASS }}
+            C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
+            C8YDEVICE: offsite_mythicd
+            C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
+            C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
+            TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
+            EXAMPLEDIR: /home/pi/examples
+
+    - name: upload results as zip
+      # https://github.com/marketplace/actions/upload-a-build-artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: results_pysys_offsite_mythicd
+        path: tests/
+
+#############################################################################
+
+  system-test_postprocessing:
+    needs: [system-test_offsite_a, system-test_offsite_b, system-test_offsite_c, system-test_offsite_d]
+    runs-on: Ubuntu-20.04
+    steps:
+
+    - name: checkout
+      uses: actions/checkout@v2
+
+    # Trigger repo dispatch here.
+    # This is here a limitation of the amount of workflows
+    # that trigger each other (GitHub Bug).
+    # It would be nicer to use the postprocess trigger instead
+    - name: Repository Dispatch
+      uses: peter-evans/repository-dispatch@v1
+      with:
+          token: ${{ secrets.SECRET_THEGHTOKEN  }}
+          event-type: postprocess
+          repository: abelikt/thin-edge.io_analytics
+
+    - name: download result a
+      uses: actions/download-artifact@v3
+      # https://github.com/marketplace/actions/download-a-build-artifact
+      with:
+        name: results_pysys_offsite_mythica
+        path: results/results_pysys_offsite_mythica
+
+    - name: download result b
+      uses: actions/download-artifact@v3
+      # https://github.com/marketplace/actions/download-a-build-artifact
+      with:
+        name: results_pysys_offsite_mythicb
+        path: results/results_pysys_offsite_mythicb
+
+    - name: download result c
+      uses: actions/download-artifact@v3
+      # https://github.com/marketplace/actions/download-a-build-artifact
+      with:
+        name: results_pysys_offsite_mythicc
+        path: results/results_pysys_offsite_mythicc
+
+    - name: download result d
+      uses: actions/download-artifact@v3
+      # https://github.com/marketplace/actions/download-a-build-artifact
+      with:
+        name: results_pysys_offsite_mythicd
+        path: results/results_pysys_offsite_mythicd
+
+    - name: Build report
+      run: ./ci/report/build.sh
+
+    - name: upload report as zip
+      # https://github.com/marketplace/actions/upload-a-build-artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: report_matrix_${{ github.run_number }}
+        path: results/report.zip
+
+    - name: upload report as html
+      # https://github.com/marketplace/actions/upload-a-build-artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: system-test-report-matrix_${{ github.run_number }}
+        path: results/report-matrix.html
+
+    - name: Run ls on analysis folder
+      run: |
+        ls -l ./results
+
+    - name: Deploy to GitHub Pages
+      # peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./results
+
+    - name: Final Result
+      # This will fail if there are errors in the reports
+      run: |
+        python3 ./ci/report/final_result.py ./results/all_reports.xml

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -13,9 +13,9 @@ name: ci_pipeline
 
 on:
   push:
-    branches: [main, continuous_integration]
+    branches: [main]
   workflow_dispatch:
-    branches: [main, continuous_integration]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -622,7 +622,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: offsite_mythica
+          C8YDEVICE: mythica
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -634,7 +634,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: offsite_mythica
+          C8YDEVICE: mythica
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -744,7 +744,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: offsite_mythicb
+          C8YDEVICE: mythicb
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -756,7 +756,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: offsite_mythicb
+          C8YDEVICE: mythicb
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -866,7 +866,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: offsite_mythicc
+          C8YDEVICE: mythicc
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -878,7 +878,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: offsite_mythicc
+          C8YDEVICE: mythicc
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -987,7 +987,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: offsite_mythicd
+          C8YDEVICE: mythicd
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -999,7 +999,7 @@ jobs:
           C8YPASS: ${{ secrets.SECRET_C8YPASS }}
           C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
           C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
-          C8YDEVICE: offsite_mythicd
+          C8YDEVICE: mythicd
           TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
           EXAMPLEDIR: /home/pi/examples
           C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
@@ -1034,7 +1034,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythica
+            C8YDEVICE: mythica
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1046,7 +1046,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythica
+            C8YDEVICE: mythica
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1058,7 +1058,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythica
+            C8YDEVICE: mythica
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1070,7 +1070,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythica
+            C8YDEVICE: mythica
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1100,7 +1100,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicb
+            C8YDEVICE: mythicb
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1112,7 +1112,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicb
+            C8YDEVICE: mythicb
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1124,7 +1124,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicb
+            C8YDEVICE: mythicb
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1136,7 +1136,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicb
+            C8YDEVICE: mythicb
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1166,7 +1166,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicc
+            C8YDEVICE: mythicc
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1178,7 +1178,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicc
+            C8YDEVICE: mythicc
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1190,7 +1190,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicc
+            C8YDEVICE: mythicc
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1202,7 +1202,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicc
+            C8YDEVICE: mythicc
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1232,7 +1232,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicd
+            C8YDEVICE: mythicd
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
@@ -1244,7 +1244,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicd
+            C8YDEVICE: mythicd
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1256,7 +1256,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicd
+            C8YDEVICE: mythicd
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/
             EXAMPLEDIR: /home/pi/examples
@@ -1268,7 +1268,7 @@ jobs:
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
-            C8YDEVICE: offsite_mythicd
+            C8YDEVICE: mythicd
             C8YTENANT: ${{secrets.SECRET_C8YTENANT}}
             C8YURL: https://thin-edge-io.eu-latest.cumulocity.com
             TEBASEDIR: /home/pi/actions-runner/_work/thin-edge.io/thin-edge.io/

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -461,7 +461,6 @@ jobs:
   cargo-test-features:
     name: Run cargo test features
     runs-on: Ubuntu-20.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     needs: install-and-use-amd64
 
     steps:

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1030,6 +1030,7 @@ jobs:
     - name: Run all Tests
       run:  bash  ./ci/ci_run_all_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1042,6 +1043,7 @@ jobs:
     - name: Run all plugin tests
       run:  bash  ./ci/ci_run_all_plugin_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1054,6 +1056,7 @@ jobs:
     - name: Run all sm tests
       run:  bash  ./ci/ci_run_all_sm_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1066,6 +1069,7 @@ jobs:
     - name: Run all statistics tests
       run:  bash  ./ci/ci_run_statistics.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1096,6 +1100,7 @@ jobs:
     - name: Run all Tests
       run:  bash  ./ci/ci_run_all_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1108,6 +1113,7 @@ jobs:
     - name: Run all plugin tests
       run:  bash  ./ci/ci_run_all_plugin_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1120,6 +1126,7 @@ jobs:
     - name: Run all sm tests
       run:  bash  ./ci/ci_run_all_sm_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1132,6 +1139,7 @@ jobs:
     - name: Run all statistics tests
       run:  bash  ./ci/ci_run_statistics.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1162,6 +1170,7 @@ jobs:
     - name: Run all Tests
       run:  bash  ./ci/ci_run_all_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1174,6 +1183,7 @@ jobs:
     - name: Run all plugin tests
       run:  bash  ./ci/ci_run_all_plugin_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1186,6 +1196,7 @@ jobs:
     - name: Run all sm tests
       run:  bash  ./ci/ci_run_all_sm_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1198,6 +1209,7 @@ jobs:
     - name: Run all statistics tests
       run:  bash  ./ci/ci_run_statistics.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1228,6 +1240,7 @@ jobs:
     - name: Run all Tests
       run:  bash  ./ci/ci_run_all_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1240,6 +1253,7 @@ jobs:
     - name: Run all plugin tests
       run:  bash  ./ci/ci_run_all_plugin_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1252,6 +1266,7 @@ jobs:
     - name: Run all sm tests
       run:  bash  ./ci/ci_run_all_sm_tests.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}
@@ -1264,6 +1279,7 @@ jobs:
     - name: Run all statistics tests
       run:  bash  ./ci/ci_run_statistics.sh
       continue-on-error: true
+      if: true
       env:
             C8YPASS: ${{ secrets.SECRET_C8YPASS }}
             C8YUSERNAME: ${{ secrets.SECRET_C8YUSERNAME }}

--- a/ci/ci_run_all_plugin_tests.sh
+++ b/ci/ci_run_all_plugin_tests.sh
@@ -31,13 +31,15 @@ cd tests/PySys/
 sudo tedge config set software.plugin.default apt
 
 set +e
-pysys.py run --record -v DEBUG 'apt_*' -XmyPlatform='container'
+# Dont use -v DEBUG here, it will print the enviroment vars with passwords in them
+pysys.py run --record 'apt_*' -XmyPlatform='container'
 set -e
 
 mv __pysys_junit_xml pysys_junit_xml_apt
 
 set +e
-pysys.py run --record -v DEBUG 'apama_*' -XmyPlatform='container'
+# Dont use -v DEBUG here, it will print the enviroment vars with passwords in them
+pysys.py run --record 'apama_*' -XmyPlatform='container'
 set -e
 
 mv __pysys_junit_xml pysys_junit_xml_apama
@@ -46,7 +48,8 @@ sudo cp ../../plugins/tedge_docker_plugin/tedge_docker_plugin.sh /etc/tedge/sm-p
 sudo chmod +x /etc/tedge/sm-plugins/docker
 
 set +e
-pysys.py run --record -v DEBUG 'docker_*' -XmyPlatform='container' -Xdockerplugin='dockerplugin'
+# Dont use -v DEBUG here, it will print the enviroment vars with passwords in them
+pysys.py run --record 'docker_*' -XmyPlatform='container' -Xdockerplugin='dockerplugin'
 set -e
 
 mv __pysys_junit_xml pysys_junit_xml_docker

--- a/ci/ci_run_all_sm_tests.sh
+++ b/ci/ci_run_all_sm_tests.sh
@@ -53,7 +53,8 @@ cd tests/PySys/
 # Run all software management tests, including the ones for the
 # fake- and the  docker plugin
 set +e
-pysys.py run --record -v DEBUG 'SoftwareManagement.*' -XmyPlatform='container' -Xdockerplugin='dockerplugin' -Xfakeplugin='fakeplugin'
+# Dont use -v DEBUG here, it will print the enviroment vars with passwords in them
+pysys.py run --record 'SoftwareManagement.*' -XmyPlatform='container' -Xdockerplugin='dockerplugin' -Xfakeplugin='fakeplugin'
 set -e
 
 deactivate

--- a/ci/ci_run_all_tests.sh
+++ b/ci/ci_run_all_tests.sh
@@ -41,7 +41,8 @@ export C8YDEVICEID=$(python3 ./ci/find_device_id.py --tenant $C8YTENANT --user $
 cd tests/PySys/
 
 set +e
-pysys.py run --exclude analytics --record -v DEBUG
+# Dont use -v DEBUG here, it will print the enviroment vars with passwords in them
+pysys.py run --exclude analytics --record
 set -e
 
 deactivate

--- a/ci/report/build.sh
+++ b/ci/report/build.sh
@@ -9,4 +9,4 @@ source ~/env-builder/bin/activate
 pip3 install junitparser
 pip3 install junit2html
 
-./ci/report/report_builder.py --folder ./results abelikt ci_pipeline.yml
+./ci/report/report_builder.py --folder ./results thin-edge ci_pipeline.yml

--- a/ci/report/build.sh
+++ b/ci/report/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Call this file to generate a report from a GitHub Workflow
+
+set -e
+
+python3 -m venv ~/env-builder
+source ~/env-builder/bin/activate
+pip3 install junitparser
+pip3 install junit2html
+
+./ci/report/report_builder.py --folder ./results abelikt ci_pipeline.yml

--- a/ci/report/build_local.sh
+++ b/ci/report/build_local.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Call this file to generate a report locally
+
+set -e
+
+python3 -m venv ~/env-builder
+source ~/env-builder/bin/activate
+pip3 install junitparser
+pip3 install junit2html
+
+./ci/report/report_builder.py --folder ./results abelikt ci_pipeline.yml --download

--- a/ci/report/build_local.sh
+++ b/ci/report/build_local.sh
@@ -9,4 +9,4 @@ source ~/env-builder/bin/activate
 pip3 install junitparser
 pip3 install junit2html
 
-./ci/report/report_builder.py --folder ./results abelikt ci_pipeline.yml --download
+./ci/report/report_builder.py --folder ./results thin-edge ci_pipeline.yml --download

--- a/ci/report/download_workflow_artifact.py
+++ b/ci/report/download_workflow_artifact.py
@@ -1,0 +1,235 @@
+#!/usr/bin/python3
+"""Download latest thin-edge build artifacts from GitHub.
+
+In order to run it often, you need a GitHub token set to $THEGHTOKEN.
+See https://github.com/settings/tokens to generate a token with repo, workflow scope.
+
+See also here
+https://docs.github.com/en/rest/reference/actions#download-an-artifact
+"""
+
+import argparse
+import json
+import os
+import os.path
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+def download_artifact(
+    url: str, name: str, token: str, user: str, workflowname: str, output: str = None
+) -> None:
+    """Download the artifact and store it as a zip file"""
+    failhard = False
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    auth = HTTPBasicAuth(user, token)
+
+    assert workflowname.endswith(".yml")
+
+    workflowname = os.path.splitext(workflowname)[0]
+
+    print(f"Will try to download file {name}.zip")
+
+    if output:
+        # artifact_filename = os.path.splitext(os.path.basename(output))[0] + ".zip"
+        artifact_filename = os.path.join(os.path.abspath(output), name + ".zip")
+    else:
+        artifact_filename = f"{workflowname}_{name}.zip"
+
+    if os.path.exists(artifact_filename):
+        print(f"Skipped {artifact_filename} as it is already there")
+        if failhard:
+            raise SystemError("File already there!")
+        return
+
+    req = requests.get(url, auth=auth, headers=headers, stream=True)
+    req.raise_for_status()
+
+    with open(os.path.expanduser(artifact_filename), "wb") as thefile:
+        for chunk in req.iter_content(chunk_size=128):
+            thefile.write(chunk)
+        print(f"Downloaded {name}.zip as {artifact_filename}")
+
+
+def get_artifacts_for_runid(
+    runid: int,
+    token: str,
+    user: str,
+    myfilter: str,
+    workflowname: str,
+    output: str = None,
+) -> None:
+    """Download artifacts for a given runid"""
+
+    print("Getting artifacts of workflow")
+
+    url = f"https://api.github.com/repos/{user}/thin-edge.io/actions/runs/{runid}/artifacts"
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    auth = HTTPBasicAuth(user, token)
+
+    req = requests.get(url, auth=auth, headers=headers)
+    req.raise_for_status()
+
+    text = json.loads(req.text)
+
+    try:
+        artifacts = text["artifacts"]
+    except KeyError as err:
+        print("Issue in response:")
+        raise err
+
+    print(f"Found {len(artifacts)} artifacts")
+
+    for artifact in artifacts:
+        try:
+            artifact_name = artifact["name"]
+            artifact_url = artifact["archive_download_url"]
+        except KeyError as err:
+            print("Issue in response:")
+            raise err
+
+        print("Found:", artifact_name)
+        if myfilter is None:
+            download_artifact(
+                artifact_url, artifact_name, token, user, workflowname, output
+            )
+        elif artifact_name.startswith(myfilter):
+            download_artifact(
+                artifact_url, artifact_name, token, user, workflowname, output
+            )
+        else:
+            pass  # skip that file
+
+
+def get_workflow(token: str, user: str, name: str) -> int:
+    """
+    Derive the last run ID of a GitHub workflow.
+
+    :param token: GitHub token
+    :param user: GitHub user name
+    :param name: Name of the workflow
+    :return: ID of the workflow
+    """
+
+    print(f"Getting id of last execution of workflow {name}")
+
+    assert name.endswith(".yml")
+
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    auth = HTTPBasicAuth(user, token)
+    index = 0  # Hint: 0 and 1 seem to have an identical meaning when we request
+    param = {"per_page": 1, "page": index}
+
+    # first request:
+    url = f"https://api.github.com/repos/{user}/thin-edge.io/actions/workflows/{name}"
+    req = requests.get(url, params=param, auth=auth, headers=headers)
+    req.raise_for_status()
+
+    stuff = json.loads(req.text)
+
+    # print(json.dumps(stuff, indent='  '))
+
+    wfid = stuff.get("id")
+    if not wfid:
+        raise SystemError(stuff)
+
+    # print(stuff.get('id'))
+
+    print(f"ID of workflow {name} is {wfid}")
+
+    return wfid
+
+
+def get_valid_run(wfid: int, token: str, user: str, state: str, ignore: bool) -> int:
+    """Download the last valid run of workflow that is in requested state"""
+
+    index = 0  # Hint: 0 and 1 seem to have an identical meaning when we request
+    found = False
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    auth = HTTPBasicAuth(user, token)
+
+    url = f"https://api.github.com/repos/{user}/thin-edge.io/actions/workflows/{wfid}/runs"
+
+    print("Getting execution of workflow")
+
+    while not found:
+        param = {"per_page": 1, "page": index}
+        req = requests.get(url, params=param, auth=auth, headers=headers)
+        req.raise_for_status()
+
+        response = json.loads(req.text)
+
+        if not response.get("workflow_runs"):
+            print("GOT ERROR:")
+            print(json.dumps(response, indent="  "))
+            raise SystemError
+
+        try:
+            workflow = response["workflow_runs"][0]
+            workflowname = workflow["name"]
+            wfrunid = int(workflow["id"])
+            wfrun = workflow["run_number"]
+            conclusion = workflow["conclusion"]
+            status = workflow["status"]
+            creation = workflow["created_at"]
+        except KeyError as err:
+            print("Issue in response:")
+            raise err
+
+        print("Workflow   : ", workflowname)
+        print("Conclusion : ", conclusion)
+        print("ID         : ", wfrunid)
+        print("Run        : ", wfrun)
+        print("Status     :", status)
+        print("Creation   :", creation)
+
+        filename = f"{workflowname}_{wfrun}.json"
+        with open(filename, "w") as thefile:
+            thefile.write(json.dumps(response, indent="  "))
+
+        if (state == conclusion) or ignore:
+            found = True
+        else:
+            print(f"Workflow conclusion was {conclusion}. Trying an older one ...")
+            index += 1
+
+    return wfrunid
+
+
+def main():
+    """main entry point"""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("username", type=str, help="GitHub Username")
+    parser.add_argument("workflowname", type=str, help="Name of workflow")
+    parser.add_argument(
+        "--filter", type=str, help="Download only files starting with ..."
+    )
+    parser.add_argument("-o", "--output", type=str, help="File to store the result to.")
+    parser.add_argument(
+        "-i", "--ignore", action="store_true", help="Ignore run conclusion"
+    )
+    args = parser.parse_args()
+
+    username = args.username
+    workflowname = os.path.basename(args.workflowname)
+    myfilter = args.filter
+    output = args.output
+    ignore = args.ignore
+
+    token = None
+
+    try:
+        token = os.environ["THEGHTOKEN"]
+    except KeyError:
+        print("Warning: Environment variable THEGHTOKEN not set")
+
+    wfid = get_workflow(token, username, workflowname)
+
+    runid = get_valid_run(wfid, token, username, "success", ignore)
+
+    get_artifacts_for_runid(runid, token, username, myfilter, workflowname, output)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/report/final_result.py
+++ b/ci/report/final_result.py
@@ -1,0 +1,33 @@
+#!/bin/python3
+
+"""Parse final xml and return an error if there are failures.
+"""
+
+import sys
+from xml.dom.minidom import parse
+
+dom = parse(sys.argv[1])
+
+errors = 0
+failures = 0
+
+for nodes in dom.childNodes:
+    l = nodes.attributes.length
+
+    for node in range(l):
+        attr = nodes.attributes.item(node)
+
+        print(f" {attr.name} : {attr.value}")
+        if attr.name == "failures":
+            failures = int(attr.value)
+        if attr.name == "errors":
+            errors = int(attr.value)
+
+print(f"Recorded {errors} errors and {failures} failures in {sys.argv[1]}")
+
+if errors == 0 and failures == 0:
+    print("Passed, no errors.")
+    sys.exit(0)
+else:
+    print("Failed, there are errors in the test run.")
+    sys.exit(1)

--- a/ci/report/report_builder.py
+++ b/ci/report/report_builder.py
@@ -25,9 +25,9 @@ import shutil
 
 runners_cfg = [
     {
-        "name": "results_pysys_offsite_mythica",
+        "name": "results_pysys_offsite_m32sd10a",
         "repo": "thin-edge",
-        "archive": "results_pysys_offsite_mythica.zip",
+        "archive": "results_pysys_offsite_m32sd10a.zip",
         "tests": [
             "all",
             "apt",
@@ -37,9 +37,9 @@ runners_cfg = [
         ],
     },
     {
-        "name": "results_pysys_offsite_mythicb",
+        "name": "results_pysys_offsite_m32sd10b",
         "repo": "thin-edge",
-        "archive": "results_pysys_offsite_mythicb.zip",
+        "archive": "results_pysys_offsite_m32sd10b.zip",
         "tests": [
             "all",
             "apt",
@@ -49,9 +49,9 @@ runners_cfg = [
         ],
     },
     {
-        "name": "results_pysys_offsite_mythicc",
+        "name": "results_pysys_offsite_m32sd10c",
         "repo": "thin-edge",
-        "archive": "results_pysys_offsite_mythicc.zip",
+        "archive": "results_pysys_offsite_m32sd10c.zip",
         "tests": [
             "all",
             "apt",
@@ -61,9 +61,9 @@ runners_cfg = [
         ],
     },
     {
-        "name": "results_pysys_offsite_mythicd",
+        "name": "results_pysys_offsite_m32sd10d",
         "repo": "thin-edge",
-        "archive": "results_pysys_offsite_mythicd.zip",
+        "archive": "results_pysys_offsite_m32sd10d.zip",
         "tests": [
             "all",
             "apt",

--- a/ci/report/report_builder.py
+++ b/ci/report/report_builder.py
@@ -10,8 +10,8 @@ source ~/env-builder/bin/activate
 pip3 install junitparser
 pip3 install junit2html python3 -m venv ~/env-pysys
 
-./report_builder.py abelikt ci_pipeline.yml
-./report_builder.py abelikt ci_pipeline.yml --download
+./report_builder.py thin-edge ci_pipeline.yml
+./report_builder.py thin-edge ci_pipeline.yml --download
 
 TODO Export configuration to separate config file
 
@@ -26,7 +26,7 @@ import shutil
 runners_cfg = [
     {
         "name": "results_pysys_offsite_mythica",
-        "repo": "abelikt",
+        "repo": "thin-edge",
         "archive": "results_pysys_offsite_mythica.zip",
         "tests": [
             "all",
@@ -38,7 +38,7 @@ runners_cfg = [
     },
     {
         "name": "results_pysys_offsite_mythicb",
-        "repo": "abelikt",
+        "repo": "thin-edge",
         "archive": "results_pysys_offsite_mythicb.zip",
         "tests": [
             "all",
@@ -50,7 +50,7 @@ runners_cfg = [
     },
     {
         "name": "results_pysys_offsite_mythicc",
-        "repo": "abelikt",
+        "repo": "thin-edge",
         "archive": "results_pysys_offsite_mythicc.zip",
         "tests": [
             "all",
@@ -62,7 +62,7 @@ runners_cfg = [
     },
     {
         "name": "results_pysys_offsite_mythicd",
-        "repo": "abelikt",
+        "repo": "thin-edge",
         "archive": "results_pysys_offsite_mythicd.zip",
         "tests": [
             "all",

--- a/ci/report/report_builder.py
+++ b/ci/report/report_builder.py
@@ -1,0 +1,207 @@
+#!/usr/bin/python3
+
+"""
+Build a complete report for all our runners
+
+Exemplary call
+
+python3 -m venv ~/env-builder
+source ~/env-builder/bin/activate
+pip3 install junitparser
+pip3 install junit2html python3 -m venv ~/env-pysys
+
+./report_builder.py abelikt ci_pipeline.yml
+./report_builder.py abelikt ci_pipeline.yml --download
+
+TODO Export configuration to separate config file
+
+"""
+
+import argparse
+import os
+import subprocess
+import shutil
+
+
+runners_cfg = [
+    {
+        "name": "results_pysys_offsite_mythica",
+        "repo": "abelikt",
+        "archive": "results_pysys_offsite_mythica.zip",
+        "tests": [
+            "all",
+            "apt",
+            "apama",
+            "docker",
+            "sm",
+        ],
+    },
+    {
+        "name": "results_pysys_offsite_mythicb",
+        "repo": "abelikt",
+        "archive": "results_pysys_offsite_mythicb.zip",
+        "tests": [
+            "all",
+            "apt",
+            "apama",
+            "docker",
+            "sm",
+        ],
+    },
+    {
+        "name": "results_pysys_offsite_mythicc",
+        "repo": "abelikt",
+        "archive": "results_pysys_offsite_mythicc.zip",
+        "tests": [
+            "all",
+            "apt",
+            "apama",
+            "docker",
+            "sm",
+        ],
+    },
+    {
+        "name": "results_pysys_offsite_mythicd",
+        "repo": "abelikt",
+        "archive": "results_pysys_offsite_mythicd.zip",
+        "tests": [
+            "all",
+            "apt",
+            "apama",
+            "docker",
+            "sm",
+        ],
+    },
+]
+
+
+def download_results(repo, workflow):
+    """Download and unzip results from test workflows"""
+
+    scriptfolder = os.path.dirname(os.path.realpath(__file__))
+
+    cmd = (
+        f"{scriptfolder}/download_workflow_artifact.py {repo} {workflow}"
+        + " -o ./ --filter results --ignore"
+    )
+    print(cmd)
+    subprocess.run(cmd, shell=True, check=True)
+
+
+def unpack_reports(runner):
+    """Unpack reports mentioned in the runner configuration"""
+
+    assert os.path.exists(runner["archive"])
+    name = runner["name"]
+    archive = runner["archive"]
+    cmd = f"unzip -q -o -d {name} {archive}"
+    print(cmd)
+    subprocess.run(cmd, shell=True, check=True)
+
+
+def postprocess_runner(runner):
+    """Postprocess results from a runner.
+    Fails if a test foler is missing that is mentioned in the runner
+    configuration.
+    """
+
+    name = runner["name"]
+    tests = runner["tests"]
+
+    print(f"Processing: {name} ")
+
+    tags = ["all", "apt", "apama", "docker", "sm", "analytics"]
+    files = ""
+
+    for tag in tags:
+        if tag in tests:
+            folder = f"{name}/PySys/pysys_junit_xml_{tag}"
+            if os.path.exists(folder):
+                files += f"{name}/PySys/pysys_junit_xml_{tag}/*.xml "
+            else:
+                raise SystemError("Folder Expected", folder)
+
+    cmd = f"junitparser merge {files} { name }.xml"
+    print(cmd)
+    subprocess.run(cmd, shell=True, check=True)
+
+
+def postprocess(runners):
+    """Create a combined reports from all sources"""
+
+    files = ""
+
+    for runner in runners:
+        name = runner["name"] + ".xml"
+        files += " " + name
+
+    print("Files:  ", files)
+
+    # Print summary matrix
+    cmd = f"junit2html --summary-matrix {files}"
+    print(cmd)
+    subprocess.run(cmd, shell=True, check=True)
+
+    # Merge all reports
+    cmd = f"junitparser merge {files} all_reports.xml"
+    print(cmd)
+    subprocess.run(cmd, shell=True, check=True)
+
+    # Build report matrix
+    cmd = f"junit2html --report-matrix report-matrix.html {files}"
+    print(cmd)
+    subprocess.run(cmd, shell=True, check=True)
+
+    # Zip everything
+    cmd = "zip report.zip *.html *.json"
+    print(cmd)
+    subprocess.run(cmd, shell=True, check=True)
+
+
+def main(runners, repo, workflow, folder, download_reports=True):
+    """Main entry point to build the reports"""
+
+    if download_reports:
+        # delete folder contents
+        shutil.rmtree(folder, ignore_errors=True)
+        os.mkdir(folder)
+    else:
+        # reuse folder with downloaded zip files
+        pass
+
+    os.chdir(folder)
+
+    if download_reports:
+        download_results(repo, workflow)
+
+        for runner in runners:
+            unpack_reports(runner)
+
+    for runner in runners:
+        postprocess_runner(runner)
+
+    postprocess(runners)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("repo", type=str, help="GitHub repository")
+    parser.add_argument("workflow", type=str, help="Name of workflow")
+    parser.add_argument(
+        "--folder",
+        type=str,
+        help="Working folder (Default ./report )",
+        default="./report",
+    )
+    parser.add_argument("--download", action="store_true", help="Download reports")
+
+    args = parser.parse_args()
+
+    main(
+        runners_cfg,
+        args.repo,
+        args.workflow,
+        folder=args.folder,
+        download_reports=args.download,
+    )


### PR DESCRIPTION
## Proposed changes

Switch to all in one workflow strategy for GitHub Actions.
See  https://github.com/thin-edge/thin-edge.io/issues/1038

Note: Docu is still missing (Runners, configuration, etc)
Note: The configuration of Runners is not finalized yet

**Note: I'll present this in the next arch rampup**

Here is an example how it would look on Michaels CI:

https://github.com/abelikt/thin-edge.io/actions/runs/2108411912

This is the report that is automatically generated from it:

https://abelikt.github.io/thin-edge.io/report-matrix.html

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/1038

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

comment
