### PR TITLE
#759 tedge disconnect falsely returns exit code 0 when disabling or stopping of a component fails

### DIFF
--- a/crates/core/tedge/src/cli/disconnect/error.rs
+++ b/crates/core/tedge/src/cli/disconnect/error.rs
@@ -2,6 +2,9 @@ use std::path::PathBuf;
 
 #[derive(thiserror::Error, Debug)]
 pub enum DisconnectBridgeError {
+    #[error("Bridge file does not exist.")]
+    BridgeFileDoesNotExist,
+
     #[error(transparent)]
     Configuration(#[from] crate::ConfigError),
 
@@ -11,9 +14,9 @@ pub enum DisconnectBridgeError {
     #[error(transparent)]
     IoError(#[from] std::io::Error),
 
+    #[error("Service operation failed.")]
+    ServiceFailed,
+
     #[error(transparent)]
     SystemServiceError(#[from] crate::system_services::SystemServiceError),
-
-    #[error("Bridge file does not exist.")]
-    BridgeFileDoesNotExist,
 }


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Return non zero exit code when one or more service component fails to stop or get disabled during `tedge disconnect` call.
## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#759 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

