### PR TITLE
Add Raspberry Pi OS 11 to level 2 support

### DIFF
--- a/docs/src/supported-platforms.md
+++ b/docs/src/supported-platforms.md
@@ -17,4 +17,5 @@ Level 2 platforms are not officially supported and tested yet, but we know from 
 * Ubuntu 20.04 in WSL (only for development, not for running thin-edge.io due to missing systemd)
 * AMD64 Debian 10
 * ARMv6 Raspberry Pi OS 10 (needs to be built for this specific target, please refer to [Issue-161](https://github.com/thin-edge/thin-edge.io/issues/161))
-
+* ARMv7 Raspberry Pi OS 11
+* ARMv8 Raspberry Pi OS 11


### PR DESCRIPTION
## Proposed changes
The first step to update our supported platform described in https://github.com/thin-edge/thin-edge.io/issues/1024.
To add Raspberry Pi OS 11 (bullseye) as level 2 support.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1024

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

