### PR TITLE
Remove "default" from the name of some tedge config settigs

### DIFF
--- a/crates/common/tedge_config/src/settings.rs
+++ b/crates/common/tedge_config/src/settings.rs
@@ -288,37 +288,39 @@ impl ConfigSetting for SoftwarePluginDefaultSetting {
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct TmpPathDefaultSetting;
+pub struct TmpPathSetting;
 
-impl ConfigSetting for TmpPathDefaultSetting {
+impl ConfigSetting for TmpPathSetting {
     const KEY: &'static str = "tmp.path";
 
     const DESCRIPTION: &'static str = concat!(
-        "The default temporary path to be used for downloads on the device",
+        "The temporary directory path to be used for downloads on the device",
         "Example: /tmp"
     );
 
     type Value = FilePath;
 }
 
-pub struct LogPathDefaultSetting;
+pub struct LogPathSetting;
 
-impl ConfigSetting for LogPathDefaultSetting {
+impl ConfigSetting for LogPathSetting {
     const KEY: &'static str = "logs.path";
 
-    const DESCRIPTION: &'static str =
-        concat!("The default path to be used for logs", "Example: /var/log");
+    const DESCRIPTION: &'static str = concat!(
+        "The directory path to be used for logs",
+        "Example: /var/log"
+    );
 
     type Value = FilePath;
 }
 
-pub struct RunPathDefaultSetting;
+pub struct RunPathSetting;
 
-impl ConfigSetting for RunPathDefaultSetting {
+impl ConfigSetting for RunPathSetting {
     const KEY: &'static str = "run.path";
 
     const DESCRIPTION: &'static str = concat!(
-        "The default path to be used for runtime information",
+        "The directory path to be used for runtime information",
         "Example: /run"
     );
 

--- a/crates/common/tedge_config/src/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config.rs
@@ -509,8 +509,8 @@ where
     }
 }
 
-impl ConfigSettingAccessor<TmpPathDefaultSetting> for TEdgeConfig {
-    fn query(&self, _setting: TmpPathDefaultSetting) -> ConfigSettingResult<FilePath> {
+impl ConfigSettingAccessor<TmpPathSetting> for TEdgeConfig {
+    fn query(&self, _setting: TmpPathSetting) -> ConfigSettingResult<FilePath> {
         Ok(self
             .data
             .tmp
@@ -519,23 +519,19 @@ impl ConfigSettingAccessor<TmpPathDefaultSetting> for TEdgeConfig {
             .unwrap_or_else(|| self.config_defaults.default_tmp_path.clone()))
     }
 
-    fn update(
-        &mut self,
-        _setting: TmpPathDefaultSetting,
-        value: FilePath,
-    ) -> ConfigSettingResult<()> {
+    fn update(&mut self, _setting: TmpPathSetting, value: FilePath) -> ConfigSettingResult<()> {
         self.data.tmp.dir_path = Some(value);
         Ok(())
     }
 
-    fn unset(&mut self, _setting: TmpPathDefaultSetting) -> ConfigSettingResult<()> {
+    fn unset(&mut self, _setting: TmpPathSetting) -> ConfigSettingResult<()> {
         self.data.tmp.dir_path = None;
         Ok(())
     }
 }
 
-impl ConfigSettingAccessor<LogPathDefaultSetting> for TEdgeConfig {
-    fn query(&self, _setting: LogPathDefaultSetting) -> ConfigSettingResult<FilePath> {
+impl ConfigSettingAccessor<LogPathSetting> for TEdgeConfig {
+    fn query(&self, _setting: LogPathSetting) -> ConfigSettingResult<FilePath> {
         Ok(self
             .data
             .logs
@@ -544,23 +540,19 @@ impl ConfigSettingAccessor<LogPathDefaultSetting> for TEdgeConfig {
             .unwrap_or_else(|| self.config_defaults.default_logs_path.clone()))
     }
 
-    fn update(
-        &mut self,
-        _setting: LogPathDefaultSetting,
-        value: FilePath,
-    ) -> ConfigSettingResult<()> {
+    fn update(&mut self, _setting: LogPathSetting, value: FilePath) -> ConfigSettingResult<()> {
         self.data.logs.dir_path = Some(value);
         Ok(())
     }
 
-    fn unset(&mut self, _setting: LogPathDefaultSetting) -> ConfigSettingResult<()> {
+    fn unset(&mut self, _setting: LogPathSetting) -> ConfigSettingResult<()> {
         self.data.logs.dir_path = None;
         Ok(())
     }
 }
 
-impl ConfigSettingAccessor<RunPathDefaultSetting> for TEdgeConfig {
-    fn query(&self, _setting: RunPathDefaultSetting) -> ConfigSettingResult<FilePath> {
+impl ConfigSettingAccessor<RunPathSetting> for TEdgeConfig {
+    fn query(&self, _setting: RunPathSetting) -> ConfigSettingResult<FilePath> {
         Ok(self
             .data
             .run
@@ -569,16 +561,12 @@ impl ConfigSettingAccessor<RunPathDefaultSetting> for TEdgeConfig {
             .unwrap_or_else(|| self.config_defaults.default_run_path.clone()))
     }
 
-    fn update(
-        &mut self,
-        _setting: RunPathDefaultSetting,
-        value: FilePath,
-    ) -> ConfigSettingResult<()> {
+    fn update(&mut self, _setting: RunPathSetting, value: FilePath) -> ConfigSettingResult<()> {
         self.data.run.dir_path = Some(value);
         Ok(())
     }
 
-    fn unset(&mut self, _setting: RunPathDefaultSetting) -> ConfigSettingResult<()> {
+    fn unset(&mut self, _setting: RunPathSetting) -> ConfigSettingResult<()> {
         self.data.run.dir_path = None;
         Ok(())
     }

--- a/crates/common/tedge_config/tests/test_tedge_config.rs
+++ b/crates/common/tedge_config/tests/test_tedge_config.rs
@@ -101,10 +101,7 @@ path = "/some/value"
         FilePath::from("key.pem")
     );
 
-    assert_eq!(
-        config.query(TmpPathDefaultSetting)?,
-        FilePath::from("/some/value")
-    );
+    assert_eq!(config.query(TmpPathSetting)?, FilePath::from("/some/value"));
 
     assert_eq!(
         config.query(MqttBindAddressSetting)?,

--- a/crates/core/tedge/src/cli/config/config_key.rs
+++ b/crates/core/tedge/src/cli/config/config_key.rs
@@ -57,9 +57,9 @@ impl ConfigKey {
             config_key!(MqttExternalCertfileSetting),
             config_key!(MqttExternalKeyfileSetting),
             config_key!(SoftwarePluginDefaultSetting),
-            config_key!(TmpPathDefaultSetting),
-            config_key!(LogPathDefaultSetting),
-            config_key!(RunPathDefaultSetting),
+            config_key!(TmpPathSetting),
+            config_key!(LogPathSetting),
+            config_key!(RunPathSetting),
         ]
     }
 }

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -20,9 +20,9 @@ use serde_json::json;
 use std::process;
 use std::{convert::TryInto, fmt::Debug, path::PathBuf, sync::Arc};
 use tedge_config::{
-    ConfigRepository, ConfigSettingAccessor, ConfigSettingAccessorStringExt, LogPathDefaultSetting,
-    MqttBindAddressSetting, MqttPortSetting, RunPathDefaultSetting, SoftwarePluginDefaultSetting,
-    TEdgeConfigLocation, TmpPathDefaultSetting, DEFAULT_LOG_PATH, DEFAULT_RUN_PATH,
+    ConfigRepository, ConfigSettingAccessor, ConfigSettingAccessorStringExt, LogPathSetting,
+    MqttBindAddressSetting, MqttPortSetting, RunPathSetting, SoftwarePluginDefaultSetting,
+    TEdgeConfigLocation, TmpPathSetting, DEFAULT_LOG_PATH, DEFAULT_RUN_PATH,
 };
 use tedge_utils::file::create_directory_with_user_group;
 use tokio::sync::Mutex;
@@ -139,11 +139,11 @@ impl SmAgentConfig {
             .tedge_config_root_path()
             .to_path_buf();
 
-        let tedge_download_dir = tedge_config.query_string(TmpPathDefaultSetting)?.into();
+        let tedge_download_dir = tedge_config.query_string(TmpPathSetting)?.into();
 
-        let tedge_log_dir: String = tedge_config.query_string(LogPathDefaultSetting)?.into();
+        let tedge_log_dir: String = tedge_config.query_string(LogPathSetting)?.into();
         let tedge_log_dir = PathBuf::from(&format!("{tedge_log_dir}/{AGENT_LOG_PATH}"));
-        let tedge_run_dir = tedge_config.query_string(RunPathDefaultSetting)?.into();
+        let tedge_run_dir = tedge_config.query_string(RunPathSetting)?.into();
 
         Ok(SmAgentConfig::default()
             .with_sm_home(tedge_config_path)

--- a/crates/core/tedge_mapper/src/main.rs
+++ b/crates/core/tedge_mapper/src/main.rs
@@ -86,7 +86,7 @@ async fn main() -> anyhow::Result<()> {
     // Run only one instance of a mapper
     let _flock = check_another_instance_is_not_running(
         &mapper_opt.name.to_string(),
-        &config.query(RunPathDefaultSetting)?.into(),
+        &config.query(RunPathSetting)?.into(),
     )?;
 
     if mapper_opt.init {


### PR DESCRIPTION
## Proposed changes
While I was implementing to get the query of `tmp.path`, I got confused by the name `TmpPathDefaultSetting` because the default is `/tmp`, but I use the variable because I don't want to hardcode `/tmp`. I believe that it's wrongly named.

This PR just removes "Default" from 
* TmpPathDefaultSetting
* LogPathDefaultSetting
* RunPathDefaultSetting

Note) SoftwarePluginDefaultSetting should stay as it is, as this is meant to have what the "default" plugin.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

