### PR TITLE
Have a single unix user used for all the thin-edge daemons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_watchdog"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "clap 3.1.6",

--- a/configuration/contrib/tedge_upgrade/upgrade_tedge_0.6.sh
+++ b/configuration/contrib/tedge_upgrade/upgrade_tedge_0.6.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# change the owenership of the below directories/files to `tedge` user,
+# as there is only `tedge` user exists.
+
+sudo chown tedge:tedge /etc/tedge/operations/c8y/c8y_*
+sudo chown tedge:tedge /etc/tedge/.agent
+sudo chown tedge:tedge /var/log/tedge/agent
+sudo chown tedge:tedge /run/lock/tedge_agent.lock
+sudo chown tedge:tedge /run/lock/tedge-mapper-c8y.lock

--- a/configuration/debian/tedge/postinst
+++ b/configuration/debian/tedge/postinst
@@ -2,11 +2,6 @@
 set -e
 
 ### Create groups
-# thin-edge.io compoments run within their own groups and users the following steps add new groups if they don't exist.
-if ! getent group tedge-users >/dev/null; then
-    addgroup --quiet tedge-users
-fi
-
 if ! getent group tedge >/dev/null; then
     addgroup --quiet --system tedge
 fi
@@ -22,11 +17,11 @@ if ! grep -q "/etc/tedge/mosquitto-conf" "/etc/mosquitto/mosquitto.conf"; then
     echo "include_dir /etc/tedge/mosquitto-conf" >>/etc/mosquitto/mosquitto.conf
 fi
 
-### Create file in /etc/sudoers.d directory. With this configuration, all users in the group tedge-users have the right to call the tedge command with sudo rights, which is required for system-wide configuration in "/etc/tedge"
-echo "%tedge-users   ALL = (ALL) /usr/bin/tedge" >/etc/sudoers.d/tedge-users
+### Create file in /etc/sudoers.d directory. With this configuration, all users in the group tedge have the right to call the tedge command with sudo rights, which is required for system-wide configuration in "/etc/tedge"
+echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge
 
 if [ -f "/etc/sudoers.d/010_pi-nopasswd" ]; then
-    echo "%tedge-users   ALL = (ALL) NOPASSWD: /usr/bin/tedge" >/etc/sudoers.d/tedge-users-nopasswd
+    echo "tedge   ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge-nopasswd
 fi
 
 # Initialize the tedge

--- a/configuration/debian/tedge/postinst
+++ b/configuration/debian/tedge/postinst
@@ -17,7 +17,7 @@ if ! grep -q "/etc/tedge/mosquitto-conf" "/etc/mosquitto/mosquitto.conf"; then
     echo "include_dir /etc/tedge/mosquitto-conf" >>/etc/mosquitto/mosquitto.conf
 fi
 
-### Create file in /etc/sudoers.d directory. With this configuration, all users in the group tedge have the right to call the tedge command with sudo rights, which is required for system-wide configuration in "/etc/tedge"
+### Create file in /etc/sudoers.d directory. With this configuration, the tedge user have the right to call the tedge command with sudo rights, which is required for system-wide configuration in "/etc/tedge"
 echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge
 
 if [ -f "/etc/sudoers.d/010_pi-nopasswd" ]; then

--- a/configuration/debian/tedge/postrm
+++ b/configuration/debian/tedge/postrm
@@ -7,19 +7,19 @@ remove_user_tedge() {
     fi
 }
 
-remove_tedge_users_group() {
-    if getent group tedge-users > /dev/null; then
-        groupdel tedge-users
+remove_tedge_group() {
+    if getent group tedge > /dev/null; then
+        groupdel tedge
     fi
 }
 
 remove_sudoers_file() {
-    if [ -f "/etc/sudoers.d/tedge-users" ]; then
-        rm /etc/sudoers.d/tedge-users
+    if [ -f "/etc/sudoers.d/tedge" ]; then
+        rm /etc/sudoers.d/tedge
     fi
 
-    if [ -f "/etc/sudoers.d/tedge-users-nopasswd" ]; then
-        rm /etc/sudoers.d/tedge-users-nopasswd
+    if [ -f "/etc/sudoers.d/tedge-nopasswd" ]; then
+        rm /etc/sudoers.d/tedge-nopasswd
     fi
 }
 
@@ -44,7 +44,7 @@ purge_var_log() {
 case "$1" in
     purge)
         remove_user_tedge
-        remove_tedge_users_group
+        remove_tedge_group
         remove_mosquitto_edit
         remove_sudoers_file
         purge_configs
@@ -53,7 +53,7 @@ case "$1" in
 
     remove)
         remove_user_tedge
-        remove_tedge_users_group
+        remove_tedge_group
         remove_mosquitto_edit
         remove_sudoers_file
     ;;

--- a/configuration/debian/tedge_agent/postinst
+++ b/configuration/debian/tedge_agent/postinst
@@ -2,26 +2,6 @@
 
 set -e
 
-### Create a group "tedge-agent" if not created before
-if ! getent group tedge-agent >/dev/null; then
-    addgroup --quiet --system tedge-agent
-fi
-
-### Create a user "tedge-agent" if not created before
-# Create user tedge-agent with no home(--no-create-home), no login(--shell) and in group tedge-agent(--ingroup)
-if ! getent passwd tedge-agent >/dev/null; then
-    adduser --quiet --system --no-create-home --ingroup tedge-agent --shell /usr/sbin/nologin tedge-agent
-    adduser tedge-agent tedge
-fi
-
-### Create file in /etc/sudoers.d directory
-# tedge-agent needs to execute some of its operations as a system user therefore it needs an entry in /etc/sudoers.
-echo "%tedge-agent   ALL = (ALL) NOPASSWD: /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge-agent
-
-if [ -f "/etc/sudoers.d/010_pi-nopasswd" ]; then
-    echo "%tedge-agent   ALL = (ALL) NOPASSWD: /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge-agent-nopasswd
-fi
-
 # Reenable the services only if systemctl is available
 if command -v systemctl >/dev/null; then
     ### Enable the sm services if the device is connected to c8y cloud
@@ -33,6 +13,6 @@ if command -v systemctl >/dev/null; then
 fi
 
 # Initialize the agent
-runuser -u tedge-agent -- tedge_agent --init
+runuser -u tedge -- tedge_agent --init
 
 #DEBHELPER#

--- a/configuration/debian/tedge_agent/postrm
+++ b/configuration/debian/tedge_agent/postrm
@@ -12,7 +12,7 @@ case "$1" in
        purge_agent_directory
     ;;
 
-    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
     ;;
 
     *)

--- a/configuration/debian/tedge_agent/postrm
+++ b/configuration/debian/tedge_agent/postrm
@@ -1,23 +1,6 @@
 #!/bin/sh
 set -e
 
-remove_tedge_agent_user() {
-    if getent passwd tedge-agent >/dev/null; then
-        pkill -u tedge-agent || true
-        deluser --quiet --system tedge-agent
-    fi
-}
-
-remove_sudoers_file() {
-    if [ -f "/etc/sudoers.d/tedge-agent" ]; then
-        rm /etc/sudoers.d/tedge-agent
-    fi
-
-    if [ -f "/etc/sudoers.d/tedge-agent-nopasswd" ]; then
-        rm /etc/sudoers.d/tedge-agent-nopasswd
-    fi
-}
-
 purge_agent_directory() {
     if [ -d "/etc/tedge/.agent" ]; then
         rm -rf /etc/tedge/.agent
@@ -26,14 +9,7 @@ purge_agent_directory() {
 
 case "$1" in
     purge)
-        remove_tedge_agent_user
-        remove_sudoers_file
-        purge_agent_directory
-    ;;
-
-    remove)
-        remove_tedge_agent_user
-        remove_sudoers_file
+       purge_agent_directory
     ;;
 
     upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/configuration/debian/tedge_mapper/postinst
+++ b/configuration/debian/tedge_mapper/postinst
@@ -2,19 +2,8 @@
 
 set -e
 
-### Create a group "tedge-mapper" if not created before
-if ! getent group tedge-mapper >/dev/null; then
-    addgroup --quiet --system tedge-mapper
-fi
-
-### Create a user "tedge-mapper" if not created before
-# Create user tedge-mapper with no home(--no-create-home), no login(--shell) and in group tedge(--ingroup)
-if ! getent passwd tedge-mapper >/dev/null; then
-    adduser --quiet --system --no-create-home --ingroup tedge-mapper --shell /usr/sbin/nologin tedge-mapper
-    adduser tedge-mapper tedge
-fi
 
 ### Initialize the sm mapper
-runuser -u tedge-mapper -- tedge_mapper --init c8y
-runuser -u tedge-mapper -- tedge_mapper --init az
+runuser -u tedge -- tedge_mapper --init c8y
+runuser -u tedge -- tedge_mapper --init az
 #DEBHELPER#

--- a/configuration/debian/tedge_mapper/postrm
+++ b/configuration/debian/tedge_mapper/postrm
@@ -1,13 +1,6 @@
 #!/bin/sh
 set -e
 
-remove_tedge_mapper_user() {
-    if getent passwd tedge-mapper >/dev/null; then
-        pkill -u tedge-mapper || true
-        deluser --quiet --system tedge-mapper
-    fi
-}
-
 purge_operations() {
     if [ -d "/etc/tedge/operations" ]; then
         rm -rf /etc/tedge/operations
@@ -16,12 +9,10 @@ purge_operations() {
 
 case "$1" in
     purge)
-        remove_tedge_mapper_user
-        purge_operations
+       purge_operations
     ;;
 
     remove)
-        remove_tedge_mapper_user
     ;;
 
     upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/configuration/init/systemd/tedge-agent.service
+++ b/configuration/init/systemd/tedge-agent.service
@@ -3,7 +3,7 @@ Description=tedge-agent is a thin-edge.io component to support operations.
 After=syslog.target network.target mosquitto.service
 
 [Service]
-User=tedge-agent
+User=tedge
 RuntimeDirectory=tedge_agent
 ExecStart=/usr/bin/tedge_agent
 Restart=on-failure

--- a/configuration/init/systemd/tedge-mapper-az.service
+++ b/configuration/init/systemd/tedge-mapper-az.service
@@ -3,7 +3,7 @@ Description=tedge-mapper-az checks Thin Edge JSON measurements and forwards to A
 After=syslog.target network.target mosquitto.service
 
 [Service]
-User=tedge-mapper
+User=tedge
 ExecStart=/usr/bin/tedge_mapper az
 Restart=on-failure
 RestartPreventExitStatus=255

--- a/configuration/init/systemd/tedge-mapper-c8y.service
+++ b/configuration/init/systemd/tedge-mapper-c8y.service
@@ -3,7 +3,7 @@ Description=tedge-mapper-c8y converts Thin Edge JSON measurements to Cumulocity 
 After=syslog.target network.target mosquitto.service
 
 [Service]
-User=tedge-mapper
+User=tedge
 ExecStart=/usr/bin/tedge_mapper c8y
 Restart=on-failure
 RestartPreventExitStatus=255

--- a/configuration/init/systemd/tedge-mapper-collectd.service
+++ b/configuration/init/systemd/tedge-mapper-collectd.service
@@ -3,7 +3,7 @@ Description=tedge-mapper-collectd converts Thin Edge JSON measurements to Cumulo
 After=syslog.target network.target mosquitto.service
 
 [Service]
-User=tedge-mapper
+User=tedge
 ExecStart=/usr/bin/tedge_mapper collectd
 Restart=on-failure
 RestartPreventExitStatus=255

--- a/crates/common/tedge_users/src/lib.rs
+++ b/crates/common/tedge_users/src/lib.rs
@@ -12,7 +12,6 @@ pub use windows::*;
 
 pub const ROOT_USER: &str = "root";
 pub const TEDGE_USER: &str = "tedge";
-pub const TEDGE_AGENT_USER: &str = "tedge-agent";
 pub const BROKER_USER: &str = "mosquitto";
 
 #[allow(dead_code)] // These errors are only raised from unix

--- a/crates/core/c8y_translator/fuzz/Cargo.lock
+++ b/crates/core/c8y_translator/fuzz/Cargo.lock
@@ -25,7 +25,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "c8y_translator"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clock",
  "json-writer",
@@ -56,7 +56,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clock"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "mockall",
  "time",
@@ -97,7 +97,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "json-writer"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "serde_json",
  "thiserror",
@@ -309,7 +309,7 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "thin_edge_json"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "clock",
  "json-writer",

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -226,18 +226,8 @@ impl SmAgent {
     #[instrument(skip(self), name = "sm-agent")]
     pub async fn init(&mut self, config_dir: PathBuf) -> Result<(), anyhow::Error> {
         let cfg_dir = config_dir.as_path().display().to_string();
-        create_directory_with_user_group(
-            &format!("{cfg_dir}/.agent"),
-            "tedge-agent",
-            "tedge-agent",
-            0o775,
-        )?;
-        create_directory_with_user_group(
-            "/var/log/tedge/agent",
-            "tedge-agent",
-            "tedge-agent",
-            0o775,
-        )?;
+        create_directory_with_user_group(&format!("{cfg_dir}/.agent"), "tedge", "tedge", 0o775)?;
+        create_directory_with_user_group("/var/log/tedge/agent", "tedge", "tedge", 0o775)?;
         info!("Initializing the tedge agent session");
         mqtt_channel::init_session(&self.config.mqtt_config).await?;
 

--- a/crates/core/tedge_mapper/src/az/mapper.rs
+++ b/crates/core/tedge_mapper/src/az/mapper.rs
@@ -33,8 +33,8 @@ impl TEdgeComponent for AzureMapper {
         let config_dir = cfg_dir.display().to_string();
         create_directory_with_user_group(
             &format!("{config_dir}/operations/az"),
-            "tedge-mapper",
-            "tedge-mapper",
+            "tedge",
+            "tedge",
             0o775,
         )?;
 

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -94,20 +94,20 @@ impl TEdgeComponent for CumulocityMapper {
 fn create_directories(config_dir: &str) -> Result<(), anyhow::Error> {
     create_directory_with_user_group(
         &format!("{config_dir}/operations/c8y"),
-        "tedge-mapper",
-        "tedge-mapper",
+        "tedge",
+        "tedge",
         0o775,
     )?;
     create_file_with_user_group(
         &format!("{config_dir}/operations/c8y/c8y_SoftwareUpdate"),
-        "tedge-mapper",
-        "tedge-mapper",
+        "tedge",
+        "tedge",
         0o644,
     )?;
     create_file_with_user_group(
         &format!("{config_dir}/operations/c8y/c8y_Restart"),
-        "tedge-mapper",
-        "tedge-mapper",
+        "tedge",
+        "tedge",
         0o644,
     )?;
     Ok(())

--- a/docs/src/howto-guides/002_installation.md
+++ b/docs/src/howto-guides/002_installation.md
@@ -103,19 +103,6 @@ Eg:
 dpkg -i tedge_mapper_0.5.0_armhf.deb
 ```
 
-### Add your user to `tedge-users` group
-
-During the installation process, a `tedge-users` group is automatically created,
-in order to ease the administration of who can use the `sudo tedge` command on the device.
-Indeed, the `tedge` command needs to be run using `sudo`.
-So, unless all the users are granted sudo privileges, you have to add a user to the `tedge-users` group for that user to be able to use `tedge`.
-
-Run this command to add a user to the group.
-
-```shell
-sudo adduser <user> tedge-users
-```
-
 ## Next steps
 
 1. [Connect your device to Cumulocity IoT](../tutorials/connect-c8y.md)


### PR DESCRIPTION
## Proposed changes

This PR captures code changes for

- Removing the `tedge-agent` and tedge-mapper` users and groups
- Now all the directories and files that are required by the `thin-edge.io` services are owned by `tedge` user.
- The `thin-edge.io services tedge-agent, tedge-mapper az/c8y/collectd` will run under `tedge` user.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

