### PR TITLE
Fix stalled Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "logged_command"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "assert_matches",


### PR DESCRIPTION
Signed-off-by: Didier Wenzek <didier.wenzek@free.fr>

## Proposed changes

`Cargo.lock` has not been properly updated by the patch version bump https://github.com/thin-edge/thin-edge.io/pull/1108

