### PR TITLE
#1124 runtime_start_two_mappers pysys test fix

### DIFF
--- a/tests/PySys/tedge_mapper_c8y/runtime_start_two_mappers/run.py
+++ b/tests/PySys/tedge_mapper_c8y/runtime_start_two_mappers/run.py
@@ -1,6 +1,5 @@
 from pysys.basetest import BaseTest
 
-
 """
 Validate tedge_mapper can't be started twice.
 
@@ -20,7 +19,8 @@ class RuntimeMultiMappers(BaseTest):
         tedge_mapper = "/usr/bin/tedge_mapper"
         self.sudo = "/usr/bin/sudo"
 
-        tedge_mapper1 = self.startProcess(
+        # starting the first tedge mapper instance
+        _ = self.startProcess(
             command=self.sudo,
             arguments=["systemctl", "start", "tedge-mapper-c8y"],
             stdouterr="tedge_mapper1",
@@ -28,14 +28,17 @@ class RuntimeMultiMappers(BaseTest):
 
         self.wait(0.1)
 
-        tedge_mapper2 = self.startProcess(
+        # starting the second tedge mapper instance
+        # and expecting this one to crash
+        _ = self.startProcess(
             command=self.sudo,
-            arguments=["-u", "tedge-mapper", tedge_mapper, "c8y"],
+            arguments=["-u", "tedge", tedge_mapper, "c8y"],
             stdouterr="tedge_mapper2",
             expectedExitStatus="==1",
         )
 
-        stop = self.startProcess(
+        # stopping the first tedge mapper instance
+        _ = self.startProcess(
             command=self.sudo,
             arguments=["systemctl", "stop", "tedge-mapper-c8y"],
             stdouterr="tedge_mapper1",


### PR DESCRIPTION
## Proposed changes
  
  - the test was still using tedge-mapper user but #1085 renamed all users to `tedge`

Signed-off-by: initard <solo@softwareag.com>



<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Paste Link to the issue
- Closes #1124

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

