### PR TITLE
tedge preinst script uses tedge user that doesn't exist yet

### DIFF
--- a/configuration/debian/tedge/postinst
+++ b/configuration/debian/tedge/postinst
@@ -1,27 +1,9 @@
 #!/bin/sh
 set -e
 
-### Create groups
-if ! getent group tedge >/dev/null; then
-    addgroup --quiet --system tedge
-fi
-
-### Create users
-# Create user tedge with no additional info(--gecos "") no home(--no-create-home), no login(--shell) and in group tedge(--ingroup)
-if ! getent passwd tedge >/dev/null; then
-    adduser --quiet --system --gecos "" --no-create-home --disabled-login --shell /sbin/nologin --ingroup tedge tedge
-fi
-
 ### Add include to mosquitto.conf so tedge specific conf will be loaded
 if ! grep -q "/etc/tedge/mosquitto-conf" "/etc/mosquitto/mosquitto.conf"; then
     echo "include_dir /etc/tedge/mosquitto-conf" >>/etc/mosquitto/mosquitto.conf
-fi
-
-### Create file in /etc/sudoers.d directory. With this configuration, the tedge user have the right to call the tedge command with sudo rights, which is required for system-wide configuration in "/etc/tedge"
-echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge
-
-if [ -f "/etc/sudoers.d/010_pi-nopasswd" ]; then
-    echo "tedge   ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge-nopasswd
 fi
 
 # Initialize the tedge

--- a/configuration/debian/tedge/postrm
+++ b/configuration/debian/tedge/postrm
@@ -51,14 +51,7 @@ case "$1" in
         purge_var_log
     ;;
 
-    remove)
-        remove_user_tedge
-        remove_tedge_group
-        remove_mosquitto_edit
-        remove_sudoers_file
-    ;;
-
-    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
     ;;
 
     *)

--- a/configuration/debian/tedge/preinst
+++ b/configuration/debian/tedge/preinst
@@ -1,6 +1,25 @@
 #!/bin/sh
 set -e
 
+### Create groups
+if ! getent group tedge >/dev/null; then
+    addgroup --quiet --system tedge
+fi
+
+### Create users
+# Create user tedge with no additional info(--gecos "") no home(--no-create-home), no login(--shell) and in group tedge(--ingroup)
+if ! getent passwd tedge >/dev/null; then
+    adduser --quiet --system --gecos "" --no-create-home --disabled-login --shell /sbin/nologin --ingroup tedge tedge
+fi
+
+### Create file in /etc/sudoers.d directory. With this configuration, the tedge user have the right to call the tedge command with sudo rights, which is required for system-wide configuration in "/etc/tedge"
+echo "tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge
+
+if [ -f "/etc/sudoers.d/010_pi-nopasswd" ]; then
+    echo "tedge   ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init" >/etc/sudoers.d/tedge-nopasswd
+fi
+
+
 # change the owenership of the below directories/files to `tedge` user,
 # as there is only `tedge` user exists.
 

--- a/configuration/debian/tedge_agent/postrm
+++ b/configuration/debian/tedge_agent/postrm
@@ -7,9 +7,16 @@ purge_agent_directory() {
     fi
 }
 
+purge_agent_lock() {
+   if [ -f "/run/lock/tedge_agent.lock" ]; then
+       rm -rf /run/lock/tedge_agent.lock
+   fi
+}
+
 case "$1" in
     purge)
        purge_agent_directory
+       purge_agent_lock
     ;;
 
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/configuration/debian/tedge_mapper/postrm
+++ b/configuration/debian/tedge_mapper/postrm
@@ -7,15 +7,28 @@ purge_operations() {
     fi
 }
 
+purge_mapper_lock() {
+   if [ -f "/run/lock/tedge-mapper-c8y.lock" ]; then
+       rm -rf /run/lock/tedge-mapper-c8y.lock
+   fi
+
+   if [ -f "/run/lock/tedge-mapper-az.lock" ]; then
+       rm -rf /run/lock/tedge-mapper-az.lock
+   fi
+
+   if [ -f "/run/lock/tedge-mapper-collectd.lock" ]; then
+       rm -rf /run/lock/tedge-mapper-collectd.lock
+   fi
+
+}
+
 case "$1" in
     purge)
-       purge_operations
+        purge_operations
+        purge_mapper_lock
     ;;
 
-    remove)
-    ;;
-
-    upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
     ;;
 
     *)


### PR DESCRIPTION
Signed-off-by: Pradeep Kumar K J <pradeepkumar.kj@softwareag.com>

## Proposed changes

- Create `tedge` user in `preinst` script rather than in `postinst` script.
- Remove `tedge` user only during `purge` not on `remove`, because the files/directories created using `tedge` user are deleted only on `purge`.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

