### PR TITLE
Retry when retrieving the C8Y ID fails

### DIFF
--- a/ci/ci_smoke_test_c8y.sh
+++ b/ci/ci_smoke_test_c8y.sh
@@ -76,7 +76,7 @@ PATH=$PATH:/usr/sbin
 
 python3 -m venv ~/env-c8y-api
 source ~/env-c8y-api/bin/activate
-pip3 install c8y-api
+pip3 install c8y-api retry-decorator
 export C8YDEVICEID=$(python3 ./ci/find_device_id.py --tenant $C8YTENANT --user $C8YUSERNAME --device $C8YDEVICE --url $C8YURL)
 
 # after calling the script, the ID should be a numeric value

--- a/ci/configure_bridge.sh
+++ b/ci/configure_bridge.sh
@@ -37,7 +37,7 @@ cat /etc/mosquitto/mosquitto.conf
 
 python3 -m venv ~/env-c8y-api
 source ~/env-c8y-api/bin/activate
-pip3 install c8y-api
+pip3 install c8y-api retry-decorator
 
 # Delete the device (ignore error)
 set +e

--- a/ci/find_device_id.py
+++ b/ci/find_device_id.py
@@ -8,21 +8,27 @@ For example:
     python3 ci/find_device_id.py --tenant t493319102 --user octocat
       --device devraspberrypi --url thin-edge-io.eu-latest.cumulocity.com
 
+Hint: Make sure to use the local interpreter with python3 and avoid
+the dot-slash notation when using a Python environment.
+
+Also export the C8Y password into variable C8YPASS
 """
 
 import argparse
 import os
 import sys
 from c8y_api import CumulocityApi
+from retry_decorator import retry
 
 
+@retry(Exception, tries=5, timeout_secs=2)
 def get_device_id(c8y, name):
     """retrive the current device ID"""
 
     devices = c8y.device_inventory.get_all(name=name)
     if len(devices) == 1:
         return devices[0].id
-    return None
+    raise SystemError("Failed to retrive ID")
 
 
 def main():

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,4 +6,4 @@ junitparser == 2.2.0
 junit2html == 30.0.6
 psutil == 5.9.0
 c8y-api == 1.1.1
-
+retry-decorator == 1.1.1


### PR DESCRIPTION
## Proposed changes

Increase CI stability by retrying a few times to when retrieving the C8Y ID.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
//comment