### PR TITLE
Finalize config management reference documentation

### DIFF
--- a/docs/src/references/c8y-configuration-management.md
+++ b/docs/src/references/c8y-configuration-management.md
@@ -73,7 +73,11 @@ The `c8y_configuration_plugin` configuration is stored by default under `/etc/te
 This [TOML](https://toml.io/en/) file defines the list of files to be managed from the cloud tenant.
 Each configuration file is defined by a record with:
 * The full `path` to the file.
-* An optional configuration `type`. If not provided, the `path` is used a `type`.
+* An optional configuration `type`. If not provided, the `path` is used as `type`.
+* Optional unix file ownership: `user`, `group` and octal `mode`.  
+  These are only used when a configuration file pushed from the cloud doesn't exist on the device.
+  When a configuration file is already present on the device, this plugin never changes file ownership,
+  ignoring these parameters.
 
 ```shell
 $ cat /etc/tedge/c8y/c8y-configuration-plugin.toml
@@ -81,7 +85,7 @@ files = [
     { path = '/etc/tedge/tedge.toml', type = 'tedge.toml' },
     { path = '/etc/tedge/mosquitto-conf/c8y-bridge.conf' },
     { path = '/etc/tedge/mosquitto-conf/tedge-mosquitto.conf' },
-    { path = '/etc/mosquitto/mosquitto.conf', type = 'mosquitto'}
+    { path = '/etc/mosquitto/mosquitto.conf', type = 'mosquitto', user = 'mosquitto', group = 'mosquitto', mode = 0o644 }
   ]
 ```
 
@@ -159,9 +163,3 @@ Note that:
 * Since the type of configuration file is used as an MQTT topic name, the characters `#` and `+` cannot be used in a type name.
   If such a character is used in a type name (or in the path of a configuration file without explicit type),
   then the whole plugin configuration `/etc/tedge/c8y/c8y-configuration-plugin.toml` is considered ill-formed.
-
-## Internals
-
-Points that still need to be addressed:
-
-* What if the target file doesn't exist? Is this is an error? If not what user, group and mod are to be used?

--- a/docs/src/references/c8y-configuration-management.md
+++ b/docs/src/references/c8y-configuration-management.md
@@ -13,8 +13,9 @@ Thin-edge provides an operation plugin to
   that will be managed from the cloud tenant.
 * Notably, __the plugin configuration itself is managed from the cloud__,
   meaning, the device owner can update from the cloud the list of files to be managed.
-* By default, __the managed files are represented on the cloud by their full path on the device__.
-  Optionally, the device owner can assign an alias to each target path.  
+* Cumulocity manages the configuration files accordingly to their type,
+  a name that is chosen by the device owner to categorise each configuration.
+  By default, the full path of a configuration file on the device is used as its type.
 * When files are downloaded from the cloud to the device,
   __these files are stored in a temporary directory first__.
   They are atomically moved to their target path, only after a fully successful download.
@@ -72,20 +73,22 @@ The `c8y_configuration_plugin` configuration is stored by default under `/etc/te
 This [TOML](https://toml.io/en/) file defines the list of files to be managed from the cloud tenant.
 Each configuration file is defined by a record with:
 * The full `path` to the file.
+* An optional configuration `type`. If not provided, the `path` is used a `type`.
 
 ```shell
 $ cat /etc/tedge/c8y/c8y-configuration-plugin.toml
 files = [
-    { path = '/etc/tedge/tedge.toml' },
+    { path = '/etc/tedge/tedge.toml', type = 'thin-edge.toml' },
     { path = '/etc/tedge/mosquitto-conf/c8y-bridge.conf' },
     { path = '/etc/tedge/mosquitto-conf/tedge-mosquitto.conf' },
-    { path = '/etc/mosquitto/mosquitto.conf' }
+    { path = '/etc/mosquitto/mosquitto.conf', type = 'mosquitto'}
   ]
 ```
 
 Note that:
 * The file `/etc/tedge/c8y/c8y-configuration-plugin.toml` itself doesn't need to be listed.
   This is implied, so the list can *always* be configured from the cloud.
+  The `type` for this self configuration file is `c8y-configuration-plugin`.
 * If the file `/etc/tedge/c8y/c8y-configuration-plugin.toml`
   is not found, empty, ill-formed or not-readable
   then only `c8y-configuration-plugin.toml` is managed from the cloud.
@@ -151,5 +154,4 @@ the `c8y_configuration_plugin` service notifies this update over MQTT.
 
 Points that still need to be addressed:
 
-* Ability to give a type name to a configuration file.
 * What if the target file doesn't exist? Is this is an error? If not what user, group and mod are to be used?

--- a/docs/src/references/c8y-configuration-management.md
+++ b/docs/src/references/c8y-configuration-management.md
@@ -78,7 +78,7 @@ Each configuration file is defined by a record with:
 ```shell
 $ cat /etc/tedge/c8y/c8y-configuration-plugin.toml
 files = [
-    { path = '/etc/tedge/tedge.toml', type = 'thin-edge.toml' },
+    { path = '/etc/tedge/tedge.toml', type = 'tedge.toml' },
     { path = '/etc/tedge/mosquitto-conf/c8y-bridge.conf' },
     { path = '/etc/tedge/mosquitto-conf/tedge-mosquitto.conf' },
     { path = '/etc/mosquitto/mosquitto.conf', type = 'mosquitto'}
@@ -147,8 +147,18 @@ The `c8y_configuration_plugin` reports progress and errors on its `stderr`.
 When a configuration file is successfully downloaded from the cloud,
 the `c8y_configuration_plugin` service notifies this update over MQTT.
 
-* Each message provides the path to the freshly updated file as in `{ "changedFile": "/etc/tedge/tedge.toml" }`.
-* The messages are published on `tedge/configuration_change`.
+* The notification messages are published on the topic `tedge/configuration_change/{type}`,
+  where `{type}` is the type of the configuration file that have been updated,
+  for instance `tedge/configuration_change/tedge.toml`
+* Each message provides the path to the freshly updated file as in `{ "path": "/etc/tedge/tedge.toml" }`.
+
+Note that:
+* If no specific type has been assigned to a configuration file, then the path to this file is used as its type.
+  Update notifications for that file are then published on the topic `tedge/configuration_change/{path}`,
+  for instance `tedge/configuration_change//etc/tedge/mosquitto-conf/c8y-bridge.conf`.
+* Since the type of configuration file is used as an MQTT topic name, the characters `#` and `+` cannot be used in a type name.
+  If such a character is used in a type name (or in the path of a configuration file without explicit type),
+  then the whole plugin configuration `/etc/tedge/c8y/c8y-configuration-plugin.toml` is considered ill-formed.
 
 ## Internals
 


### PR DESCRIPTION
## Proposed changes

Update the reference documentation accordingly to https://github.com/thin-edge/thin-edge.io/pull/1145:
* Optional configuration `type`
* Changes of the notification topic.
* Ownership of new configuration file. 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

