### PR TITLE
.toml format for c8y-log-plugin and c8y-configuration-plugin is different

### DIFF
--- a/plugins/c8y_configuration_plugin/src/main.rs
+++ b/plugins/c8y_configuration_plugin/src/main.rs
@@ -213,13 +213,13 @@ fn init(cfg_dir: PathBuf) -> Result<(), anyhow::Error> {
 fn create_operation_files(config_dir: &str) -> Result<(), anyhow::Error> {
     create_directory_with_user_group(&format!("{config_dir}/c8y"), "root", "root", 0o1777)?;
     let example_config = r#"# Add the configurations to be managed by c8y-configuration-plugin
-    files = [
-        #    { path = '/etc/tedge/tedge.toml' },
-        #    { path = '/etc/tedge/mosquitto-conf/c8y-bridge.conf', type = 'c8y-bridge.conf' },
-        #    { path = '/etc/tedge/mosquitto-conf/tedge-mosquitto.conf', type = 'tedge-mosquitto.conf' },
-        #    { path = '/etc/mosquitto/mosquitto.conf', type = 'mosquitto.conf' },
-        #    { path = '/etc/tedge/c8y/example.txt', type = 'example', user = 'tedge', group = 'tedge', mode = 0o444 }
-    ]"#;
+files = [
+#    { path = '/etc/tedge/tedge.toml' },
+#    { path = '/etc/tedge/mosquitto-conf/c8y-bridge.conf', type = 'c8y-bridge.conf' },
+#    { path = '/etc/tedge/mosquitto-conf/tedge-mosquitto.conf', type = 'tedge-mosquitto.conf' },
+#    { path = '/etc/mosquitto/mosquitto.conf', type = 'mosquitto.conf' },
+#    { path = '/etc/tedge/c8y/example.txt', type = 'example', user = 'tedge', group = 'tedge', mode = 0o444 }
+]"#;
 
     create_file_with_user_group(
         &format!("{config_dir}/c8y/c8y-configuration-plugin.toml"),

--- a/plugins/c8y_configuration_plugin/src/main.rs
+++ b/plugins/c8y_configuration_plugin/src/main.rs
@@ -213,6 +213,7 @@ fn init(cfg_dir: PathBuf) -> Result<(), anyhow::Error> {
 fn create_operation_files(config_dir: &str) -> Result<(), anyhow::Error> {
     create_directory_with_user_group(&format!("{config_dir}/c8y"), "root", "root", 0o1777)?;
     let example_config = r#"# Add the configurations to be managed by c8y-configuration-plugin
+
 files = [
 #    { path = '/etc/tedge/tedge.toml' },
 #    { path = '/etc/tedge/mosquitto-conf/c8y-bridge.conf', type = 'c8y-bridge.conf' },

--- a/plugins/c8y_log_plugin/src/main.rs
+++ b/plugins/c8y_log_plugin/src/main.rs
@@ -226,9 +226,9 @@ fn create_init_logs_directories_and_files(
     // creating c8y-log-plugin.toml
     let logs_path = format!("{logs_dir}/tedge/agent/software-*");
     let data = format!(
-        "files = [
-    {{ type = \"software-management\", path = \"{logs_path}\" }},
-]"
+        r#"files = [
+    {{ type = "software-management", path = "{logs_path}" }},
+]"#
     );
 
     create_file_with_user_group(

--- a/plugins/c8y_log_plugin/src/main.rs
+++ b/plugins/c8y_log_plugin/src/main.rs
@@ -225,17 +225,18 @@ fn create_init_logs_directories_and_files(
 
     // creating c8y-log-plugin.toml
     let logs_path = format!("{logs_dir}/tedge/agent/software-*");
-    let data = toml::toml! {
-        files = [
-            { type = "software-management", path = logs_path }
-        ]
-    };
+    let data = format!(
+        "files = [
+            {{ type = \"software-management\", path = \"{logs_path}\" }},
+        ]"
+    );
+
     create_file_with_user_group(
         &format!("{config_dir}/{DEFAULT_PLUGIN_CONFIG_FILE}"),
         "root",
         "root",
         0o644,
-        Some(&data.to_string()),
+        Some(&data),
     )?;
 
     Ok(())

--- a/plugins/c8y_log_plugin/src/main.rs
+++ b/plugins/c8y_log_plugin/src/main.rs
@@ -227,8 +227,8 @@ fn create_init_logs_directories_and_files(
     let logs_path = format!("{logs_dir}/tedge/agent/software-*");
     let data = format!(
         "files = [
-            {{ type = \"software-management\", path = \"{logs_path}\" }},
-        ]"
+    {{ type = \"software-management\", path = \"{logs_path}\" }},
+]"
     );
 
     create_file_with_user_group(


### PR DESCRIPTION
## Proposed changes

Fix the style of `c8y-log-plugin.toml` content style as below.

`files = [
            { type = "software-management", path = "/var/log/tedge/agent/software-*" },
        ]`

The `toml::toml!()` outputs the content as `[[files]]`. So, to avoid this syntax replace the `toml::toml!` with `format!`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
(https://github.com/thin-edge/thin-edge.io/issues/1209)

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

