### PR TITLE
Remove unused deps

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -20,6 +20,21 @@ jobs:
         # https://github.com/13rac1/block-fixup-merge-action
         uses: 13rac1/block-fixup-merge-action@v2.0.0
 
+  udeps:
+    name: Check for unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Run cargo-udeps
+        uses: aig787/cargo-udeps-action@v1
+        with:
+          version: 'latest'
+          args: '--all-features'
+
   # JOB to run change detection
   changes:
     name: Filter changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,7 +2069,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "tedge_utils",
  "tempfile",
  "test-case",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2969,7 +2969,6 @@ dependencies = [
  "certificate",
  "serde",
  "tedge_test_utils",
- "tedge_users",
  "tedge_utils",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,7 +3051,6 @@ name = "tedge_utils"
 version = "0.7.2"
 dependencies = [
  "assert_matches",
- "futures",
  "nix",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tedge_utils",
  "tempfile",
  "test-case",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,7 +3017,6 @@ dependencies = [
  "serial_test",
  "tedge_config",
  "tedge_test_utils",
- "tedge_users",
  "tedge_utils",
  "test-case",
  "thin_edge_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3050,7 +3050,6 @@ dependencies = [
 name = "tedge_utils"
 version = "0.7.2"
 dependencies = [
- "anyhow",
  "assert_matches",
  "futures",
  "nix",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2913,7 +2913,6 @@ dependencies = [
  "clap 3.1.18",
  "flockfile",
  "futures",
- "mockall 0.10.2",
  "mqtt_channel",
  "mqtt_tests",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,7 +1528,6 @@ dependencies = [
  "serial_test",
  "tedge_test_utils",
  "test-case",
- "thiserror",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,7 +2875,6 @@ dependencies = [
  "base64",
  "certificate",
  "clap 3.1.18",
- "futures",
  "hyper",
  "mockito",
  "mqtt_tests",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,6 @@ version = "0.7.2"
 dependencies = [
  "anyhow",
  "assert_matches",
- "async-trait",
  "log",
  "serial_test",
  "tedge_test_utils",

--- a/crates/common/download/Cargo.toml
+++ b/crates/common/download/Cargo.toml
@@ -14,9 +14,8 @@ nix = "0.23"
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tedge_utils = { path = "../tedge_utils" }
 thiserror = "1.0"
-tokio = "1.12"
+tokio = { version = "1.12", features = ["fs"] }
 url = "2.2"
 
 [dev-dependencies]

--- a/crates/common/download/Cargo.toml
+++ b/crates/common/download/Cargo.toml
@@ -15,7 +15,6 @@ reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tedge_utils = { path = "../tedge_utils" }
-tempfile = "3.2"
 thiserror = "1.0"
 tokio = "1.12"
 url = "2.2"

--- a/crates/common/logged_command/Cargo.toml
+++ b/crates/common/logged_command/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 rust-version = "1.58.1"
 
 [dependencies]
-async-trait = "0.1"
 log = "0.4"
 thiserror = "1.0"
 tokio = { version = "1.8", features = [ "fs", "io-util", "macros", "process", "rt" ] }

--- a/crates/common/logged_command/Cargo.toml
+++ b/crates/common/logged_command/Cargo.toml
@@ -7,7 +7,6 @@ rust-version = "1.58.1"
 
 [dependencies]
 log = "0.4"
-thiserror = "1.0"
 tokio = { version = "1.8", features = [ "fs", "io-util", "macros", "process", "rt" ] }
 
 

--- a/crates/common/tedge_config/Cargo.toml
+++ b/crates/common/tedge_config/Cargo.toml
@@ -9,7 +9,6 @@ rust-version = "1.58.1"
 certificate = { path = "../certificate" }
 serde = { version = "1.0", features = ["derive"] }
 tedge_utils = { path = "../tedge_utils" }
-tedge_users = { path = "../tedge_users" }
 tempfile = "3.2"
 thiserror = "1.0"
 toml = "0.5"

--- a/crates/common/tedge_utils/Cargo.toml
+++ b/crates/common/tedge_utils/Cargo.toml
@@ -13,7 +13,6 @@ default = []
 logging = ["tracing", "tracing-subscriber"]
 
 [dependencies]
-futures = "0.3"
 nix = "0.23.1"
 tempfile = "3.2"
 thiserror = "1.0"

--- a/crates/common/tedge_utils/Cargo.toml
+++ b/crates/common/tedge_utils/Cargo.toml
@@ -13,7 +13,6 @@ default = []
 logging = ["tracing", "tracing-subscriber"]
 
 [dependencies]
-anyhow = "1.0"
 futures = "0.3"
 nix = "0.23.1"
 tempfile = "3.2"

--- a/crates/core/plugin_sm/Cargo.toml
+++ b/crates/core/plugin_sm/Cargo.toml
@@ -13,7 +13,6 @@ download = { path = "../../common/download" }
 logged_command = { path = "../../common/logged_command" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tedge_utils = { path = "../../common/tedge_utils" }
 time = { version = "0.3", features = ["formatting"] }
 thiserror = "1.0"
 tokio = { version = "1.8", features = ["process", "rt"] }

--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -17,7 +17,6 @@ anyhow = "1.0"
 base64 = "0.13"
 certificate = { path = "../../common/certificate" }
 clap = { version = "3", features = ["cargo", "derive"] }
-futures = "0.3"
 hyper = { version = "0.14", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls", "stream"] }
 rpassword = "5.0"

--- a/crates/core/tedge_agent/Cargo.toml
+++ b/crates/core/tedge_agent/Cargo.toml
@@ -28,7 +28,6 @@ async-trait = "0.1"
 clap = { version = "3.0", features = ["cargo", "derive"] }
 flockfile = { path = "../../common/flockfile" }
 futures = "0.3"
-mockall = "0.10"
 mqtt_channel = { path = "../../common/mqtt_channel" }
 plugin_sm = { path = "../plugin_sm" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -47,7 +47,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "3.0", features = ["cargo", "derive"] }
 tedge_config = { path = "../../common/tedge_config" }
-tedge_users = { path = "../../common/tedge_users" }
 tedge_utils = { path = "../../common/tedge_utils", features = ["logging"] }
 thin_edge_json = { path = "../thin_edge_json" }
 thiserror = "1.0"

--- a/crates/tests/tedge_test_utils/Cargo.toml
+++ b/crates/tests/tedge_test_utils/Cargo.toml
@@ -7,6 +7,9 @@ rust-version = "1.58.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata.cargo-udeps.ignore]
+normal = ["anyhow"]
+
 [dependencies]
 anyhow = "1.0"
 tempfile = "3.3"


### PR DESCRIPTION
## Proposed changes

This PR removes unused dependencies from all crates in the repository.

It also adds a `cargo-udeps` job in the CI pipeline (in the "pull-request-checks" workflow) to check whether there are any unused dependencies.

For me, `cargo-udeps` does not report any unused dependencies on the tip of this branch, but I might have some things missed (or removed too much), depending on the compilation targets and so on.
So lets see what CI tells us about this.

We might even need to discuss whether we want such a job in the pipeline or not!

(This is just a drive-by PR that I happened to write because I found unused stuff while casually browsing the repository... I don't consider this to be too important :wink:)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
