### PR TITLE
Fix: Flush the file buffer after writing to the file

### DIFF
--- a/crates/common/tedge_utils/src/fs.rs
+++ b/crates/common/tedge_utils/src/fs.rs
@@ -43,6 +43,8 @@ pub async fn atomically_write_file_async(
         return Err(err);
     }
 
+    file.flush().await?;
+
     if let Err(err) = tokio_fs::rename(tempfile.as_ref(), dest).await {
         let () = tokio_fs::remove_file(tempfile).await?;
         return Err(err);

--- a/crates/common/tedge_utils/src/fs.rs
+++ b/crates/common/tedge_utils/src/fs.rs
@@ -18,6 +18,8 @@ pub fn atomically_write_file_sync(
         return Err(err);
     }
 
+    file.flush()?;
+
     if let Err(err) = std_fs::rename(tempfile.as_ref(), dest) {
         let _ = std_fs::remove_file(tempfile);
         return Err(err);


### PR DESCRIPTION
## Proposed changes

This _may_(!!!) solve #1241.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

#1241 

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

