### PR TITLE
Update sha1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
  "base64",
  "pem",
  "rcgen",
- "sha-1 0.9.8",
+ "sha-1 0.10.0",
  "thiserror",
  "time",
  "x509-parser",

--- a/crates/common/certificate/Cargo.toml
+++ b/crates/common/certificate/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.58.1"
 
 [dependencies]
 rcgen = { version = "0.9", features = ["pem", "zeroize"] }
-sha-1 = "0.9"
+sha-1 = "0.10"
 thiserror = "1.0"
 time = "0.3"
 x509-parser = "0.13"

--- a/crates/common/certificate/src/lib.rs
+++ b/crates/common/certificate/src/lib.rs
@@ -312,7 +312,7 @@ mod tests {
         // just decode the key contents
         let b64_bytes =
             base64::decode(&cert_cont[header_len..cert_cont.len() - footer_len]).unwrap();
-        let expected_thumbprint = format!("{:x}", sha1::Sha1::digest(b64_bytes.as_ref()));
+        let expected_thumbprint = format!("{:x}", sha1::Sha1::digest(b64_bytes));
 
         // compare the two thumbprints
         assert_eq!(thumbprint, expected_thumbprint.to_uppercase());


### PR DESCRIPTION
## Proposed changes

Closes #1269 
Superseeds #1269

This is basically #1269 plus a fix that makes the (test)code compile again, as the dependency update was nontrivial (but trivial enough to work out with this simple fix).

I actually took the commit from dependabot from #1269 because of the nice commit message the bot generates :tada: 


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
