### PR TITLE
Clippy: Remove let unit

### DIFF
--- a/crates/common/certificate/src/lib.rs
+++ b/crates/common/certificate/src/lib.rs
@@ -110,7 +110,7 @@ impl KeyCertPair {
         id: &str,
         not_before: OffsetDateTime,
     ) -> Result<KeyCertPair, CertificateError> {
-        let () = KeyCertPair::check_identifier(id, config.max_cn_size)?;
+        KeyCertPair::check_identifier(id, config.max_cn_size)?;
         let mut distinguished_name = rcgen::DistinguishedName::new();
         distinguished_name.push(rcgen::DnType::CommonName, id);
         distinguished_name.push(rcgen::DnType::OrganizationName, &config.organization_name);

--- a/crates/common/download/examples/simple_download.rs
+++ b/crates/common/download/examples/simple_download.rs
@@ -14,10 +14,10 @@ async fn main() -> Result<()> {
     let downloader = Downloader::new("test_download", &None, "/tmp");
 
     // Call `download` method to get data from url.
-    let () = downloader.download(&url_data).await?;
+    downloader.download(&url_data).await?;
 
     // Call cleanup method to remove downloaded file if no longer necessary.
-    let () = downloader.cleanup().await?;
+    downloader.cleanup().await?;
 
     Ok(())
 }

--- a/crates/common/download/src/download.rs
+++ b/crates/common/download/src/download.rs
@@ -219,7 +219,7 @@ mod tests {
         let url = DownloadInfo::new(&target_url);
 
         let downloader = Downloader::new(&name, &version, target_dir_path.path());
-        let () = downloader.download(&url).await?;
+        downloader.download(&url).await?;
 
         let log_content = std::fs::read(downloader.filename())?;
 

--- a/crates/common/flockfile/src/unix.rs
+++ b/crates/common/flockfile/src/unix.rs
@@ -56,7 +56,7 @@ impl Flockfile {
             }
         };
 
-        let () = match flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock) {
+        match flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock) {
             Ok(()) => (),
             Err(err) => {
                 return Err(FlockfileError::FromNix { path, source: err });

--- a/crates/common/json_writer/src/lib.rs
+++ b/crates/common/json_writer/src/lib.rs
@@ -41,7 +41,7 @@ impl JsonWriter {
 
     pub fn write_key(&mut self, key: &str) -> Result<(), JsonWriterError> {
         self.maybe_separate();
-        let () = serde_json::to_writer(&mut self.buffer, key)?;
+        serde_json::to_writer(&mut self.buffer, key)?;
         self.buffer.push(b':');
         self.needs_separator = false;
         Ok(())
@@ -49,7 +49,7 @@ impl JsonWriter {
 
     pub fn write_str(&mut self, s: &str) -> Result<(), JsonWriterError> {
         self.maybe_separate();
-        let () = serde_json::to_writer(&mut self.buffer, s)?;
+        serde_json::to_writer(&mut self.buffer, s)?;
         self.needs_separator = true;
         Ok(())
     }
@@ -58,7 +58,7 @@ impl JsonWriter {
         self.maybe_separate();
         match value.classify() {
             FpCategory::Normal | FpCategory::Zero | FpCategory::Subnormal => {
-                let () = serde_json::to_writer(&mut self.buffer, &value)?;
+                serde_json::to_writer(&mut self.buffer, &value)?;
                 self.needs_separator = true;
                 Ok(())
             }

--- a/crates/common/mqtt_channel/src/tests.rs
+++ b/crates/common/mqtt_channel/src/tests.rs
@@ -99,7 +99,7 @@ mod tests {
         ]
         .into_iter()
         {
-            let () = broker.publish(topic, payload).await?;
+            broker.publish(topic, payload).await?;
             assert_eq!(
                 MaybeMessage::Next(message(topic, payload)),
                 next_message(&mut messages).await
@@ -113,7 +113,7 @@ mod tests {
         ]
         .into_iter()
         {
-            let () = broker.publish(topic, payload).await?;
+            broker.publish(topic, payload).await?;
             assert_eq!(MaybeMessage::Timeout, next_message(&mut messages).await);
         }
 

--- a/crates/common/tedge_config/src/tedge_config_repository.rs
+++ b/crates/common/tedge_config/src/tedge_config_repository.rs
@@ -32,10 +32,10 @@ impl ConfigRepository<TEdgeConfig> for TEdgeConfigRepository {
 
         // Create `$HOME/.tedge` or `/etc/tedge` directory in case it does not exist yet
         if !self.config_location.tedge_config_root_path.exists() {
-            let () = fs::create_dir(self.config_location.tedge_config_root_path())?;
+            fs::create_dir(self.config_location.tedge_config_root_path())?;
         }
 
-        let () = atomically_write_file_sync(
+        atomically_write_file_sync(
             self.config_location.temporary_tedge_config_file_path(),
             self.config_location.tedge_config_file_path(),
             toml.as_bytes(),

--- a/crates/common/tedge_utils/src/file.rs
+++ b/crates/common/tedge_utils/src/file.rs
@@ -74,19 +74,19 @@ impl PermissionEntry {
     pub fn apply(&self, path: &Path) -> Result<(), FileError> {
         match (&self.user, &self.group) {
             (Some(user), Some(group)) => {
-                let () = change_user_and_group(path, user, group)?;
+                change_user_and_group(path, user, group)?;
             }
             (Some(user), None) => {
-                let () = change_user(path, user)?;
+                change_user(path, user)?;
             }
             (None, Some(group)) => {
-                let () = change_group(path, group)?;
+                change_group(path, group)?;
             }
             (None, None) => {}
         }
 
         if let Some(mode) = &self.mode {
-            let () = change_mode(path, *mode)?;
+            change_mode(path, *mode)?;
         }
 
         Ok(())
@@ -95,7 +95,7 @@ impl PermissionEntry {
     fn create_directory(&self, dir: &Path) -> Result<(), FileError> {
         match fs::create_dir(dir) {
             Ok(_) => {
-                let () = self.apply(dir)?;
+                self.apply(dir)?;
                 Ok(())
             }
             Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
@@ -119,7 +119,7 @@ impl PermissionEntry {
             .open(file)
         {
             Ok(mut f) => {
-                let () = self.apply(file)?;
+                self.apply(file)?;
                 if let Some(default_content) = default_content {
                     f.write(default_content.as_bytes()).map_err(|e| {
                         FileError::WriteContentFailed {
@@ -342,7 +342,7 @@ mod tests {
         assert!(format!("{:o}", perm.mode()).contains("644"));
 
         let permission_set = PermissionEntry::new(None, None, Some(0o444));
-        let () = permission_set.apply(Path::new(file_path.as_str())).unwrap();
+        permission_set.apply(Path::new(file_path.as_str())).unwrap();
 
         let meta = fs::metadata(file_path.as_str()).unwrap();
         let perm = meta.permissions();

--- a/crates/common/tedge_utils/src/fs.rs
+++ b/crates/common/tedge_utils/src/fs.rs
@@ -41,14 +41,14 @@ pub async fn atomically_write_file_async(
         .await?;
 
     if let Err(err) = file.write_all(content).await {
-        let () = tokio_fs::remove_file(tempfile).await?;
+        tokio_fs::remove_file(tempfile).await?;
         return Err(err);
     }
 
     file.flush().await?;
 
     if let Err(err) = tokio_fs::rename(tempfile.as_ref(), dest).await {
-        let () = tokio_fs::remove_file(tempfile).await?;
+        tokio_fs::remove_file(tempfile).await?;
         return Err(err);
     }
 
@@ -69,7 +69,7 @@ mod tests {
 
         let content = "test_data";
 
-        let () = atomically_write_file_async(&temp_path, &destination_path, content.as_bytes())
+        atomically_write_file_async(&temp_path, &destination_path, content.as_bytes())
             .await
             .unwrap();
 

--- a/crates/common/tedge_utils/src/fs_notify.rs
+++ b/crates/common/tedge_utils/src/fs_notify.rs
@@ -536,8 +536,8 @@ mod tests {
             ttd_clone.file("file_b").with_raw_content("content");
         });
 
-        let () = fs_notify_handler.await.unwrap();
-        let () = file_handler.await.unwrap();
+        fs_notify_handler.await.unwrap();
+        file_handler.await.unwrap();
     }
 
     #[tokio::test]
@@ -568,7 +568,7 @@ mod tests {
             ttd_clone.file("file_c").delete(); // should match CREATE, DELETE
         });
 
-        let () = fs_notify_handler.await.unwrap();
-        let () = file_handler.await.unwrap();
+        fs_notify_handler.await.unwrap();
+        file_handler.await.unwrap();
     }
 }

--- a/crates/core/c8y_api/src/http_proxy.rs
+++ b/crates/core/c8y_api/src/http_proxy.rs
@@ -157,8 +157,7 @@ impl C8yMqttJwtTokenRetriever {
 #[async_trait]
 impl C8yJwtTokenRetriever for C8yMqttJwtTokenRetriever {
     async fn get_jwt_token(&mut self) -> Result<SmartRestJwtResponse, SMCumulocityMapperError> {
-        let () = self
-            .mqtt_con
+        self.mqtt_con
             .published
             .publish(mqtt_channel::Message::new(
                 &Topic::new_unchecked("c8y/s/uat"),
@@ -237,7 +236,7 @@ impl JwtAuthHttpProxy {
         let mut mqtt_con = Connection::new(&mqtt_config).await?;
 
         // Ignore errors on this connection
-        let () = mqtt_con.errors.close();
+        mqtt_con.errors.close();
 
         let jwt_token_retriver = Box::new(C8yMqttJwtTokenRetriever::new(mqtt_con));
 

--- a/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
+++ b/crates/core/c8y_smartrest/src/smartrest_deserializer.rs
@@ -57,7 +57,7 @@ impl Default for SmartRestUpdateSoftware {
 impl SmartRestUpdateSoftware {
     pub fn from_smartrest(&self, smartrest: &str) -> Result<Self, SmartRestDeserializerError> {
         let mut message_id = smartrest.to_string();
-        let () = message_id.truncate(3);
+        message_id.truncate(3);
 
         let mut rdr = ReaderBuilder::new()
             .has_headers(false)
@@ -461,7 +461,7 @@ mod tests {
                 url: Some("url1".into()),
                 file_path: None,
             }));
-        let () = expected_thin_edge_json.add_update(SoftwareModuleUpdate::remove(SoftwareModule {
+        expected_thin_edge_json.add_update(SoftwareModuleUpdate::remove(SoftwareModule {
             module_type: Some("".to_string()),
             name: "software2".to_string(),
             version: None,

--- a/crates/core/c8y_translator/src/json.rs
+++ b/crates/core/c8y_translator/src/json.rs
@@ -50,7 +50,7 @@ fn from_thin_edge_json_with_timestamp(
     maybe_child_id: Option<&str>,
 ) -> Result<String, CumulocityJsonError> {
     let mut serializer = serializer::C8yJsonSerializer::new(timestamp, maybe_child_id);
-    let () = parse_str(input, &mut serializer)?;
+    parse_str(input, &mut serializer)?;
     Ok(serializer.into_string()?)
 }
 

--- a/crates/core/plugin_sm/src/operation_logs.rs
+++ b/crates/core/plugin_sm/src/operation_logs.rs
@@ -108,10 +108,10 @@ impl OperationLogs {
         for (key, value) in log_tracker.iter_mut() {
             if key.starts_with("software-list") {
                 // only allow one update list file in logs
-                let () = remove_old_logs(value, &self.log_dir, 1)?;
+                remove_old_logs(value, &self.log_dir, 1)?;
             } else {
                 // allow most recent five
-                let () = remove_old_logs(value, &self.log_dir, 5)?;
+                remove_old_logs(value, &self.log_dir, 5)?;
             }
         }
 

--- a/crates/core/plugin_sm/tests/plugin.rs
+++ b/crates/core/plugin_sm/tests/plugin.rs
@@ -410,7 +410,7 @@ mod tests {
     fn get_dummy_plugin_tmp_path() -> PathBuf {
         let path = PathBuf::from_str("/tmp/.tedge_dummy_plugin").unwrap();
         if !&path.exists() {
-            let () = fs::create_dir(&path).unwrap();
+            fs::create_dir(&path).unwrap();
         }
         path
     }

--- a/crates/core/tedge/src/cli/certificate/create.rs
+++ b/crates/core/tedge/src/cli/certificate/create.rs
@@ -28,7 +28,7 @@ impl Command for CreateCertCmd {
 
     fn execute(&self) -> anyhow::Result<()> {
         let config = NewCertificateConfig::default();
-        let () = self.create_test_certificate(&config)?;
+        self.create_test_certificate(&config)?;
         Ok(())
     }
 }

--- a/crates/core/tedge/src/cli/certificate/remove.rs
+++ b/crates/core/tedge/src/cli/certificate/remove.rs
@@ -18,7 +18,7 @@ impl Command for RemoveCertCmd {
     }
 
     fn execute(&self) -> anyhow::Result<()> {
-        let () = self.remove_certificate()?;
+        self.remove_certificate()?;
         Ok(())
     }
 }

--- a/crates/core/tedge/src/cli/certificate/show.rs
+++ b/crates/core/tedge/src/cli/certificate/show.rs
@@ -16,7 +16,7 @@ impl Command for ShowCertCmd {
     }
 
     fn execute(&self) -> anyhow::Result<()> {
-        let () = self.show_certificate()?;
+        self.show_certificate()?;
         Ok(())
     }
 }

--- a/crates/core/tedge/src/cli/config/commands/set.rs
+++ b/crates/core/tedge/src/cli/config/commands/set.rs
@@ -18,7 +18,7 @@ impl Command for SetConfigCommand {
 
     fn execute(&self) -> anyhow::Result<()> {
         let mut config = self.config_repository.load()?;
-        let () = (self.config_key.set)(&mut config, self.value.to_string())?;
+        (self.config_key.set)(&mut config, self.value.to_string())?;
         self.config_repository.store(&config)?;
         Ok(())
     }

--- a/crates/core/tedge/src/cli/config/commands/unset.rs
+++ b/crates/core/tedge/src/cli/config/commands/unset.rs
@@ -17,7 +17,7 @@ impl Command for UnsetConfigCommand {
 
     fn execute(&self) -> anyhow::Result<()> {
         let mut config = self.config_repository.load()?;
-        let () = (self.config_key.unset)(&mut config)?;
+        (self.config_key.unset)(&mut config)?;
         self.config_repository.store(&config)?;
         Ok(())
     }

--- a/crates/core/tedge/src/cli/connect/c8y_direct_connection.rs
+++ b/crates/core/tedge/src/cli/connect/c8y_direct_connection.rs
@@ -29,7 +29,7 @@ pub fn create_device_with_direct_connection(
 
     let mut client_config = ClientConfig::new();
 
-    let () = load_root_certs(
+    load_root_certs(
         &mut client_config.root_store,
         bridge_config.bridge_root_cert_path.clone(),
     )?;

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -242,7 +242,7 @@ where
     TEdgeConfig: ConfigSettingAccessor<T>,
 {
     let value = config.query(setting)?;
-    let () = config.update(setting, value)?;
+    config.update(setting, value)?;
     Ok(())
 }
 
@@ -402,17 +402,14 @@ fn new_bridge(
     }
 
     println!("Checking if configuration for requested bridge already exists.\n");
-    let () = bridge_config_exists(config_location, bridge_config)?;
+    bridge_config_exists(config_location, bridge_config)?;
 
     println!("Validating the bridge certificates.\n");
-    let () = bridge_config.validate()?;
+    bridge_config.validate()?;
 
     if bridge_config.cloud_name.eq("c8y") {
         println!("Creating the device in Cumulocity cloud.\n");
-        let () = c8y_direct_connection::create_device_with_direct_connection(
-            bridge_config,
-            device_type,
-        )?;
+        c8y_direct_connection::create_device_with_direct_connection(bridge_config, device_type)?;
     }
 
     println!("Saving configuration for requested bridge.\n");
@@ -522,12 +519,12 @@ fn write_bridge_config_to_file(
         get_common_mosquitto_config_file_path(config_location, common_mosquitto_config);
     let mut common_draft = DraftFile::new(&common_config_path)?;
     common_mosquitto_config.serialize(&mut common_draft)?;
-    let () = common_draft.persist()?;
+    common_draft.persist()?;
 
     let config_path = get_bridge_config_file_path(config_location, bridge_config);
     let mut config_draft = DraftFile::new(config_path)?;
     bridge_config.serialize(&mut config_draft)?;
-    let () = config_draft.persist()?;
+    config_draft.persist()?;
 
     Ok(())
 }

--- a/crates/core/tedge/src/system_services/manager.rs
+++ b/crates/core/tedge/src/system_services/manager.rs
@@ -33,7 +33,7 @@ pub trait SystemServiceManager: Debug {
         service: SystemService,
     ) -> Result<bool, SystemServiceError> {
         if self.is_service_running(service)? {
-            let () = self.restart_service(service)?;
+            self.restart_service(service)?;
             Ok(true)
         } else {
             Ok(false)

--- a/crates/core/tedge_agent/src/restart_operation_handler.rs
+++ b/crates/core/tedge_agent/src/restart_operation_handler.rs
@@ -12,7 +12,7 @@ pub mod restart_operation {
     ///
     /// # Example
     /// ```
-    /// let () = RestartOperationHelper::create_slash_run_file()?;
+    /// RestartOperationHelper::create_slash_run_file()?;
     /// ```
     pub fn create_slash_run_file(run_dir: &Path) -> Result<(), AgentError> {
         let path = &run_dir.join(SLASH_RUN_PATH_TEDGE_AGENT_RESTART);

--- a/crates/core/tedge_agent/src/state.rs
+++ b/crates/core/tedge_agent/src/state.rs
@@ -41,7 +41,7 @@ impl StateRepository for AgentStateRepository {
 
         // Create in path given through `config-dir` or `/etc/tedge` directory in case it does not exist yet
         if !self.state_repo_root.exists() {
-            let () = fs::create_dir(&self.state_repo_root).await?;
+            fs::create_dir(&self.state_repo_root).await?;
         }
 
         let mut temppath = self.state_repo_path.clone();
@@ -58,7 +58,7 @@ impl StateRepository for AgentStateRepository {
             operation_id: None,
             operation: None,
         };
-        let () = self.store(&state).await?;
+        self.store(&state).await?;
 
         Ok(state)
     }

--- a/crates/core/tedge_mapper/src/az/converter.rs
+++ b/crates/core/tedge_mapper/src/az/converter.rs
@@ -41,10 +41,10 @@ impl Converter for AzureConverter {
     }
 
     async fn try_convert(&mut self, input: &Message) -> Result<Vec<Message>, Self::Error> {
-        let () = self.size_threshold.validate(input)?;
+        self.size_threshold.validate(input)?;
         let default_timestamp = self.add_timestamp.then(|| self.clock.now());
         let mut serializer = ThinEdgeJsonSerializer::new_with_timestamp(default_timestamp);
-        let () = thin_edge_json::parser::parse_str(input.payload_str()?, &mut serializer)?;
+        thin_edge_json::parser::parse_str(input.payload_str()?, &mut serializer)?;
 
         let payload = serializer.into_string()?;
         Ok(vec![(Message::new(&self.mapper_config.out_topic, payload))])

--- a/crates/core/tedge_mapper/src/c8y/converter.rs
+++ b/crates/core/tedge_mapper/src/c8y/converter.rs
@@ -99,7 +99,7 @@ where
         .try_into()
         .expect("topics that mapper should subscribe to");
 
-        let () = topic_filter.add_all(CumulocityMapper::subscriptions(&operations).unwrap());
+        topic_filter.add_all(CumulocityMapper::subscriptions(&operations).unwrap());
 
         let mapper_config = MapperConfig {
             in_topic_filter: topic_filter,
@@ -153,7 +153,7 @@ where
         .try_into()
         .expect("topics that mapper should subscribe to");
 
-        let () = topic_filter.add_all(CumulocityMapper::subscriptions(&operations).unwrap());
+        topic_filter.add_all(CumulocityMapper::subscriptions(&operations).unwrap());
 
         let mapper_config = MapperConfig {
             in_topic_filter: topic_filter,
@@ -348,7 +348,7 @@ where
     async fn try_convert(&mut self, message: &Message) -> Result<Vec<Message>, ConversionError> {
         match &message.topic {
             topic if topic.name.starts_with("tedge/measurements") => {
-                let () = self.size_threshold.validate(message)?;
+                self.size_threshold.validate(message)?;
                 self.try_convert_measurement(message)
             }
             topic
@@ -933,10 +933,10 @@ mod tests {
         let operation_logs = OperationLogs::try_new(log_dir.path().to_path_buf()).unwrap();
 
         let now = std::time::Instant::now();
-        let () = super::execute_operation("5", "sleep", "sleep_one", &operation_logs)
+        super::execute_operation("5", "sleep", "sleep_one", &operation_logs)
             .await
             .unwrap();
-        let () = super::execute_operation("5", "sleep", "sleep_two", &operation_logs)
+        super::execute_operation("5", "sleep", "sleep_two", &operation_logs)
             .await
             .unwrap();
 

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -225,7 +225,7 @@ mod tests {
         });
 
         // publish `payload` to `pub_topic`
-        let () = broker.publish(pub_topic, payload).await?;
+        broker.publish(pub_topic, payload).await?;
 
         // check the `messages` returned contain `expected_msg`
         assert_received_all_expected(&mut messages, TEST_TIMEOUT_SECS, &[expected_msg]).await;

--- a/crates/core/thin_edge_json/src/measurement.rs
+++ b/crates/core/thin_edge_json/src/measurement.rs
@@ -88,9 +88,9 @@ pub trait MeasurementVisitor {
         name: &str,
         value: f64,
     ) -> Result<(), Self::Error> {
-        let () = self.visit_start_group(group)?;
-        let () = self.visit_measurement(name, value)?;
-        let () = self.visit_end_group()?;
+        self.visit_start_group(group)?;
+        self.visit_measurement(name, value)?;
+        self.visit_end_group()?;
         Ok(())
     }
 }

--- a/crates/core/thin_edge_json/src/parser.rs
+++ b/crates/core/thin_edge_json/src/parser.rs
@@ -21,7 +21,7 @@ pub fn parse_str<T: MeasurementVisitor>(
 
     let parser = ThinEdgeJsonParser { visitor };
 
-    let () = deserializer
+    deserializer
         .deserialize_map(parser)
         .map_err(|error| map_error(error, input))?;
     Ok(())
@@ -105,8 +105,7 @@ where
                     )
                     .map_err(|err| de::Error::custom(invalid_timestamp(timestamp_str, err)))?;
 
-                    let () = self
-                        .visitor
+                    self.visitor
                         .visit_timestamp(timestamp)
                         .map_err(de::Error::custom)?;
                 }
@@ -117,7 +116,7 @@ where
                         visitor: self.visitor,
                     };
 
-                    let () = map.next_value_seed(parser)?;
+                    map.next_value_seed(parser)?;
                     measurements_count += 1;
                 }
             }
@@ -156,8 +155,7 @@ where
             return Err(de::Error::custom("Expect single-value measurement"));
         }
 
-        let () = self
-            .visitor
+        self.visitor
             .visit_start_group(self.key.as_ref())
             .map_err(de::Error::custom)?;
 
@@ -170,7 +168,7 @@ where
                 visitor: self.visitor,
             };
 
-            let () = map.next_value_seed(parser)?;
+            map.next_value_seed(parser)?;
             measurements_count += 1;
         }
 
@@ -178,7 +176,7 @@ where
             return Err(de::Error::custom(invalid_empty_measurement(&self.key)));
         }
 
-        let () = self.visitor.visit_end_group().map_err(de::Error::custom)?;
+        self.visitor.visit_end_group().map_err(de::Error::custom)?;
 
         Ok(())
     }
@@ -204,8 +202,7 @@ where
             return Err(de::Error::custom(invalid_json_number(&self.key)));
         }
 
-        let () = self
-            .visitor
+        self.visitor
             .visit_measurement(self.key.as_ref(), value)
             .map_err(de::Error::custom)?;
 
@@ -319,7 +316,7 @@ mod tests {
 
         let mut builder = ThinEdgeJsonBuilder::default();
 
-        let () = parse_str(input, &mut builder)?;
+        parse_str(input, &mut builder)?;
 
         let output = builder.done()?;
 

--- a/crates/core/thin_edge_json/src/serialize.rs
+++ b/crates/core/thin_edge_json/src/serialize.rs
@@ -67,7 +67,7 @@ impl ThinEdgeJsonSerializer {
 
         if !self.timestamp_present {
             if let Some(default_timestamp) = self.default_timestamp {
-                let () = self.visit_timestamp(default_timestamp)?;
+                self.visit_timestamp(default_timestamp)?;
             }
         }
 

--- a/crates/tests/tedge_test_utils/src/fs.rs
+++ b/crates/tests/tedge_test_utils/src/fs.rs
@@ -36,7 +36,7 @@ impl TempTedgeDir {
         let path = root.join(&self.current_file_path).join(directory_name);
 
         if !path.exists() {
-            let () = fs::create_dir(&path).unwrap();
+            fs::create_dir(&path).unwrap();
         };
 
         TempTedgeDir {

--- a/plugins/c8y_configuration_plugin/src/config.rs
+++ b/plugins/c8y_configuration_plugin/src/config.rs
@@ -173,7 +173,7 @@ impl PluginConfig {
     fn to_smartrest_payload(&self) -> String {
         let mut config_types = self.get_all_file_types();
         // Sort because hashset doesn't guarantee the order
-        let () = config_types.sort();
+        config_types.sort();
         let supported_config_types = config_types.join(",");
         format!("119,{supported_config_types}")
     }

--- a/plugins/c8y_configuration_plugin/src/download.rs
+++ b/plugins/c8y_configuration_plugin/src/download.rs
@@ -26,7 +26,7 @@ pub async fn handle_config_download_request(
     http_client: &mut impl C8YHttpProxy,
 ) -> Result<(), anyhow::Error> {
     let executing_message = DownloadConfigFileStatusMessage::executing()?;
-    let () = mqtt_client.published.send(executing_message).await?;
+    mqtt_client.published.send(executing_message).await?;
 
     let target_config_type = smartrest_request.config_type.clone();
     let mut target_file_entry = FileEntry::default();
@@ -53,18 +53,18 @@ pub async fn handle_config_download_request(
             info!("The configuration download for '{target_config_type}' is successful.");
 
             let successful_message = DownloadConfigFileStatusMessage::successful(None)?;
-            let () = mqtt_client.published.send(successful_message).await?;
+            mqtt_client.published.send(successful_message).await?;
 
             let notification_message =
                 get_file_change_notification_message(&target_file_entry.path, &target_config_type);
-            let () = mqtt_client.published.send(notification_message).await?;
+            mqtt_client.published.send(notification_message).await?;
             Ok(())
         }
         Err(err) => {
             error!("The configuration download for '{target_config_type}' failed.",);
 
             let failed_message = DownloadConfigFileStatusMessage::failed(err.to_string())?;
-            let () = mqtt_client.published.send(failed_message).await?;
+            mqtt_client.published.send(failed_message).await?;
             Err(err)
         }
     }
@@ -82,7 +82,7 @@ async fn download_config_file(
         ConfigDownloadRequest::try_new(download_url, file_path, tmp_dir, file_permissions)?;
 
     // Confirm that the file has write access before any http request attempt
-    let () = config_download_request.has_write_access()?;
+    config_download_request.has_write_access()?;
 
     // If the provided url is c8y, add auth
     if http_client.url_is_in_my_tenant_domain(config_download_request.download_info.url()) {
@@ -92,12 +92,12 @@ async fn download_config_file(
 
     // Download a file to tmp dir
     let downloader = config_download_request.create_downloader();
-    let () = downloader
+    downloader
         .download(&config_download_request.download_info)
         .await?;
 
     // Move the downloaded file to the final destination
-    let () = config_download_request.move_file()?;
+    config_download_request.move_file()?;
 
     Ok(())
 }
@@ -190,7 +190,7 @@ impl ConfigDownloadRequest {
             self.file_permissions.clone()
         };
 
-        let () = file_permissions.apply(&self.file_path)?;
+        file_permissions.apply(&self.file_path)?;
 
         Ok(())
     }

--- a/plugins/c8y_configuration_plugin/src/main.rs
+++ b/plugins/c8y_configuration_plugin/src/main.rs
@@ -78,7 +78,7 @@ pub async fn create_http_client(
     tedge_config: &TEdgeConfig,
 ) -> Result<JwtAuthHttpProxy, anyhow::Error> {
     let mut http_proxy = JwtAuthHttpProxy::try_new(tedge_config).await?;
-    let () = http_proxy.init().await?;
+    http_proxy.init().await?;
     Ok(http_proxy)
 }
 
@@ -127,14 +127,14 @@ async fn run(
     // Publish supported configuration types
     let msg = plugin_config.to_supported_config_types_message()?;
     debug!("Plugin init message: {:?}", msg);
-    let () = mqtt_client.published.send(msg).await?;
+    mqtt_client.published.send(msg).await?;
 
     // Get pending operations
     let msg = Message::new(
         &Topic::new_unchecked(C8yTopic::SmartRestResponse.as_str()),
         "500",
     );
-    let () = mqtt_client.published.send(msg).await?;
+    mqtt_client.published.send(msg).await?;
 
     let fs_notification_stream = fs_notify_stream(&[(
         config_dir,
@@ -250,7 +250,7 @@ async fn process_mqtt_message(
 
 fn init(cfg_dir: PathBuf) -> Result<(), anyhow::Error> {
     info!("Creating supported operation files");
-    let () = create_operation_files(&cfg_dir)?;
+    create_operation_files(&cfg_dir)?;
     Ok(())
 }
 

--- a/plugins/c8y_configuration_plugin/src/upload.rs
+++ b/plugins/c8y_configuration_plugin/src/upload.rs
@@ -51,7 +51,7 @@ pub async fn handle_config_upload_request(
 ) -> Result<()> {
     // set config upload request to executing
     let msg = UploadConfigFileStatusMessage::executing()?;
-    let () = mqtt_client.published.send(msg).await?;
+    mqtt_client.published.send(msg).await?;
 
     let upload_result = {
         match plugin_config.get_file_entry_from_type(&config_upload_request.config_type) {
@@ -76,13 +76,13 @@ pub async fn handle_config_upload_request(
 
             let successful_message =
                 UploadConfigFileStatusMessage::successful(Some(upload_event_url))?;
-            let () = mqtt_client.published.send(successful_message).await?;
+            mqtt_client.published.send(successful_message).await?;
         }
         Err(err) => {
             error!("The configuration upload for '{target_config_type}' failed.",);
 
             let failed_message = UploadConfigFileStatusMessage::failed(err.to_string())?;
-            let () = mqtt_client.published.send(failed_message).await?;
+            mqtt_client.published.send(failed_message).await?;
         }
     }
 

--- a/plugins/c8y_log_plugin/src/config.rs
+++ b/plugins/c8y_log_plugin/src/config.rs
@@ -74,7 +74,7 @@ impl LogPluginConfig {
     // 118,typeA,typeB,...
     fn to_smartrest_payload(&self) -> String {
         let mut config_types = self.get_all_file_types();
-        let () = config_types.sort();
+        config_types.sort();
         let supported_config_types = config_types.join(",");
         format!("118,{supported_config_types}")
     }

--- a/plugins/c8y_log_plugin/src/logfile_request.rs
+++ b/plugins/c8y_log_plugin/src/logfile_request.rs
@@ -217,7 +217,7 @@ async fn execute_logfile_request_operation(
     http_client: &mut JwtAuthHttpProxy,
 ) -> Result<(), anyhow::Error> {
     let executing = LogfileRequest::executing()?;
-    let () = mqtt_client.published.send(executing).await?;
+    mqtt_client.published.send(executing).await?;
 
     let log_content = new_read_logs(smartrest_request, plugin_config)?;
 
@@ -226,7 +226,7 @@ async fn execute_logfile_request_operation(
         .await?;
 
     let successful = LogfileRequest::successful(Some(upload_event_url))?;
-    let () = mqtt_client.published.send(successful).await?;
+    mqtt_client.published.send(successful).await?;
 
     info!("Log request processed.");
     Ok(())
@@ -249,7 +249,7 @@ pub async fn handle_logfile_request_operation(
         Err(error) => {
             let error_message = format!("Handling of operation failed with {}", error);
             let failed_msg = LogfileRequest::failed(error_message)?;
-            let () = mqtt_client.published.send(failed_msg).await?;
+            mqtt_client.published.send(failed_msg).await?;
             Err(error)
         }
     }
@@ -438,7 +438,7 @@ mod tests {
 
         let data = "this is the first line.\nthis is the second line.\nthis is the third line.\nthis is the forth line.\nthis is the fifth line.";
 
-        let () = log_file.write_all(data.as_bytes()).unwrap();
+        log_file.write_all(data.as_bytes()).unwrap();
 
         let line_counter = 0;
         let max_lines = 4;
@@ -491,7 +491,7 @@ mod tests {
 
             let data = &format!("this is the first line of {file_name}.\nthis is the second line of {file_name}.\nthis is the third line of {file_name}.\nthis is the forth line of {file_name}.\nthis is the fifth line of {file_name}.");
 
-            let () = log_file.write_all(data.as_bytes()).unwrap();
+            log_file.write_all(data.as_bytes()).unwrap();
 
             let new_mtime = FileTime::from_unix_time(m_time, 0);
             set_file_mtime(file_path, new_mtime).unwrap();

--- a/plugins/c8y_log_plugin/src/main.rs
+++ b/plugins/c8y_log_plugin/src/main.rs
@@ -79,7 +79,7 @@ pub async fn create_http_client(
     tedge_config: &TEdgeConfig,
 ) -> Result<JwtAuthHttpProxy, anyhow::Error> {
     let mut http_proxy = JwtAuthHttpProxy::try_new(tedge_config).await?;
-    let () = http_proxy.init().await?;
+    http_proxy.init().await?;
     Ok(http_proxy)
 }
 
@@ -93,7 +93,7 @@ async fn run(
 
     let health_check_topics = health_check_topics("c8y-log-plugin");
     let config_file_path = config_dir.join(config_file_name);
-    let () = handle_dynamic_log_type_update(&plugin_config, mqtt_client).await?;
+    handle_dynamic_log_type_update(&plugin_config, mqtt_client).await?;
 
     let fs_notification_stream = fs_notify_stream(&[(
         config_dir,
@@ -116,7 +116,7 @@ async fn run(
                 match mask {
                     FileEvent::Created | FileEvent::Deleted | FileEvent::Modified => {
                         plugin_config = read_log_config(&config_file_path);
-                        let () = handle_dynamic_log_type_update(&plugin_config, mqtt_client).await?;
+                        handle_dynamic_log_type_update(&plugin_config, mqtt_client).await?;
                     }
                 }
             }
@@ -134,7 +134,7 @@ pub async fn process_mqtt_message(
 ) -> Result<(), anyhow::Error> {
     if is_c8y_bridge_up(&message) {
         let plugin_config = read_log_config(config_file);
-        let () = handle_dynamic_log_type_update(&plugin_config, mqtt_client).await?;
+        handle_dynamic_log_type_update(&plugin_config, mqtt_client).await?;
     } else if health_check_topics.accept(&message) {
         send_health_status(&mut mqtt_client.published, "c8y-log-plugin").await;
     } else if let Ok(payload) = message.payload_str() {
@@ -192,7 +192,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let logs_dir = PathBuf::from(logs_dir.to_string());
 
     if config_plugin_opt.init {
-        let () = init(&config_plugin_opt.config_dir, &logs_dir)?;
+        init(&config_plugin_opt.config_dir, &logs_dir)?;
         return Ok(());
     }
 
@@ -200,7 +200,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut mqtt_client = create_mqtt_client(&tedge_config).await?;
     let mut http_client = create_http_client(&tedge_config).await?;
 
-    let () = run(
+    run(
         &config_dir,
         DEFAULT_PLUGIN_CONFIG_FILE,
         &mut mqtt_client,
@@ -212,7 +212,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
 fn init(config_dir: &Path, logs_dir: &Path) -> Result<(), anyhow::Error> {
     info!("Creating supported operation files");
-    let () = create_init_logs_directories_and_files(config_dir, logs_dir)?;
+    create_init_logs_directories_and_files(config_dir, logs_dir)?;
     Ok(())
 }
 

--- a/plugins/tedge_apt_plugin/src/main.rs
+++ b/plugins/tedge_apt_plugin/src/main.rs
@@ -173,15 +173,13 @@ fn get_installer(
 
         (None, Some(file_path)) => {
             let mut package = PackageMetadata::try_new(file_path)?;
-            let () =
-                package.validate_package(&[&format!("Package: {}", &module), "Debian package"])?;
-
+            package.validate_package(&[&format!("Package: {}", &module), "Debian package"])?;
             Ok((format!("{}", package.file_path().display()), Some(package)))
         }
 
         (Some(version), Some(file_path)) => {
             let mut package = PackageMetadata::try_new(file_path)?;
-            let () = package.validate_package(&[
+            package.validate_package(&[
                 &format!("Version: {}", &version),
                 &format!("Package: {}", &module),
                 "Debian package",


### PR DESCRIPTION
## Proposed changes

It seems that clippy failures were merged at some point... I don't know.

This fixes a clippy lint over all crates in the repository, namingly the [let-unit-value](https://rust-lang.github.io/rust-clippy/master/#let_unit_value) lint.

Nothing more was done in this patchset.

## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

