### PR TITLE
Disable the pull request limit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  # Disable the pull request limit for dependabot
+  open-pull-requests-limit: 0
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
The thin-edge.io project has quite a lot of dependencies - I counted 73
from the current commit, via this very un-scientific method:

```console
cargo tree --depth 1 | \
    grep -v "^[a-z]"  | \
    grep -v "^$" | \
    grep -v "dev-dependencies" | \
    cut -d " " -f 2 | \
    sort -u | \
    wc -l
```

And because they might only get more in the future rather than less,
this patch disables the dependabot pull request limit, letting
dependabot open as many pull requests as necessary to keep our
dependencies up to date.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Repository infrastructure

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
