### PR TITLE
Update rustc: 1.58.1 -> 1.63.0

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.58.1
+        uses: dtolnay/rust-toolchain@1.62.1
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.58.1
+        uses: dtolnay/rust-toolchain@1.62.1
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.62.1
+        uses: dtolnay/rust-toolchain@1.63.0
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.62.1
+        uses: dtolnay/rust-toolchain@1.63.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.62.1
+        uses: dtolnay/rust-toolchain@1.63.0
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.62.1
+        uses: dtolnay/rust-toolchain@1.63.0
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.58.1
+        uses: dtolnay/rust-toolchain@1.62.1
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.58.1
+        uses: dtolnay/rust-toolchain@1.62.1
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/hosted-post-merge_version_update.yml
+++ b/.github/workflows/hosted-post-merge_version_update.yml
@@ -20,7 +20,7 @@ jobs:
       - name: enable toolchain via github action
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.62.1
+          toolchain: 1.63.0
           components: cargo
           override: true
 

--- a/.github/workflows/hosted-post-merge_version_update.yml
+++ b/.github/workflows/hosted-post-merge_version_update.yml
@@ -20,7 +20,7 @@ jobs:
       - name: enable toolchain via github action
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.58.1
+          toolchain: 1.62.1
           components: cargo
           override: true
 

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.58.1
+        uses: dtolnay/rust-toolchain@1.62.1
         with:
           components: rustfmt, clippy
 
@@ -180,7 +180,7 @@ jobs:
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
         with:
-          toolchain: 1.58.1
+          toolchain: 1.62.1
           command: clippy
           args: --version
 
@@ -188,7 +188,7 @@ jobs:
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
         with:
-          toolchain: 1.58.1
+          toolchain: 1.62.1
           command: clippy
           args: --all-features
 
@@ -220,7 +220,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.58.1
+        uses: dtolnay/rust-toolchain@1.62.1
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -258,7 +258,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.58.1
+        uses: dtolnay/rust-toolchain@1.62.1
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -289,7 +289,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.58.1
+        uses: dtolnay/rust-toolchain@1.62.1
         with:
           targets: armv7-unknown-linux-gnueabihf
 
@@ -317,7 +317,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.58.1
+        uses: dtolnay/rust-toolchain@1.62.1
         with:
           target: armv7-unknown-linux-gnueabihf
 
@@ -342,8 +342,8 @@ jobs:
 #      - name: Checkout
 #        uses: actions/checkout@v3
 #
-#      - name: Install rust v1.58.1
-#        uses: dtolnay/rust-toolchain@1.58.1
+#      - name: Install rust v1.62.1
+#        uses: dtolnay/rust-toolchain@1.62.1
 #
 #      - name: Enable cache
 #        # https://github.com/marketplace/actions/rust-cache

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -168,7 +168,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.62.1
+        uses: dtolnay/rust-toolchain@1.63.0
         with:
           components: rustfmt, clippy
 
@@ -180,7 +180,7 @@ jobs:
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
         with:
-          toolchain: 1.62.1
+          toolchain: 1.63.0
           command: clippy
           args: --version
 
@@ -188,7 +188,7 @@ jobs:
         uses: actions-rs/cargo@v1
         # https://github.com/marketplace/actions/rust-cargo
         with:
-          toolchain: 1.62.1
+          toolchain: 1.63.0
           command: clippy
           args: --all-features
 
@@ -220,7 +220,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.62.1
+        uses: dtolnay/rust-toolchain@1.63.0
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -258,7 +258,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.62.1
+        uses: dtolnay/rust-toolchain@1.63.0
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -289,7 +289,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.62.1
+        uses: dtolnay/rust-toolchain@1.63.0
         with:
           targets: armv7-unknown-linux-gnueabihf
 
@@ -317,7 +317,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: dtolnay/rust-toolchain@1.62.1
+        uses: dtolnay/rust-toolchain@1.63.0
         with:
           target: armv7-unknown-linux-gnueabihf
 
@@ -342,8 +342,8 @@ jobs:
 #      - name: Checkout
 #        uses: actions/checkout@v3
 #
-#      - name: Install rust v1.62.1
-#        uses: dtolnay/rust-toolchain@1.62.1
+#      - name: Install rust v1.63.0
+#        uses: dtolnay/rust-toolchain@1.63.0
 #
 #      - name: Enable cache
 #        # https://github.com/marketplace/actions/rust-cache

--- a/.github/workflows/update-tedge-ref-docs.yml
+++ b/.github/workflows/update-tedge-ref-docs.yml
@@ -6,36 +6,36 @@ on:
   # runs automatically on 00:00 UTC on 1st of every month
   schedule:
   - cron: "0 0 1 * *"
-     
+
 jobs:
     build-tedge-create-ref-docs:
       runs-on: Ubuntu-20.04
-      
+
       steps:
         - name: Checkout
           uses: actions/checkout@v3
         - run: |
            git config --global user.email "info@thin-edge.io"
            git config --global user.name "Versioneer"
-           
+
         - name: enable toolchain via github action
           # https://github.com/actions-rs/toolchain
           uses: actions-rs/toolchain@v1
           with:
-            toolchain: 1.58.1
+            toolchain: 1.62.1
             override: true
 
         - name: Enable cache
           # https://github.com/marketplace/actions/rust-cache
           uses: Swatinem/rust-cache@v1
-        
+
         - name: Build tedge
           uses: actions-rs/cargo@v1
           # https://github.com/marketplace/actions/rust-cargo
           with:
             command: build
             args: --release -p tedge
-     
+
         - name: run the update script
           run: ./docs/gen-ref-docs.sh
         - name: Create Pull Request

--- a/.github/workflows/update-tedge-ref-docs.yml
+++ b/.github/workflows/update-tedge-ref-docs.yml
@@ -22,7 +22,7 @@ jobs:
           # https://github.com/actions-rs/toolchain
           uses: actions-rs/toolchain@v1
           with:
-            toolchain: 1.62.1
+            toolchain: 1.63.0
             override: true
 
         - name: Enable cache

--- a/crates/common/mqtt_channel/src/messages.rs
+++ b/crates/common/mqtt_channel/src/messages.rs
@@ -48,7 +48,7 @@ impl Message {
     pub fn payload_bytes(&self) -> &[u8] {
         self.payload
             .strip_suffix(&[0])
-            .unwrap_or_else(|| self.payload.as_slice())
+            .unwrap_or(self.payload.as_slice())
     }
 }
 


### PR DESCRIPTION
## Proposed changes

In #1279 we had a brief discussion whether to update rustc in our CI or not.

IMO there's no reason why we shouldn't, so here goes a PR to update rustc in all workflows.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
