### PR TITLE
Remove "serde" module in "clock" crate

### DIFF
--- a/crates/common/clock/Cargo.toml
+++ b/crates/common/clock/Cargo.toml
@@ -11,4 +11,3 @@ time = "0.3.7"
 
 [features]
 default = []
-with-serde = ["time/serde-well-known"]

--- a/crates/common/clock/src/lib.rs
+++ b/crates/common/clock/src/lib.rs
@@ -1,9 +1,6 @@
 use mockall::automock;
 use time::OffsetDateTime;
 
-#[cfg(feature = "with-serde")]
-pub mod serde;
-
 pub type Timestamp = OffsetDateTime;
 
 #[automock]

--- a/crates/common/clock/src/serde/mod.rs
+++ b/crates/common/clock/src/serde/mod.rs
@@ -1,1 +1,0 @@
-pub mod rfc3339;

--- a/crates/common/clock/src/serde/rfc3339.rs
+++ b/crates/common/clock/src/serde/rfc3339.rs
@@ -1,6 +1,0 @@
-/// Re-exported module
-///
-/// Use this module in combination with serde's [`#[with]`][with] attribute.
-///
-/// [with]: https://serde.rs/field-attrs.html#with
-pub use time::serde::rfc3339::option;

--- a/crates/core/thin_edge_json/Cargo.toml
+++ b/crates/core/thin_edge_json/Cargo.toml
@@ -8,12 +8,12 @@ rust-version = "1.58.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clock = { path = "../../common/clock", features = ["with-serde"] }
+clock = { path = "../../common/clock" }
 json-writer = { path = "../../common/json_writer" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 thiserror = "1.0"
-time = { version = "0.3", features = ["formatting", "local-offset", "parsing", "serde"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "parsing", "serde", "serde-well-known"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/core/thin_edge_json/src/alarm.rs
+++ b/crates/core/thin_edge_json/src/alarm.rs
@@ -25,7 +25,7 @@ pub struct ThinEdgeAlarmData {
     pub text: Option<String>,
 
     #[serde(default)]
-    #[serde(with = "clock::serde::rfc3339::option")]
+    #[serde(with = "time::serde::rfc3339::option")]
     pub time: Option<Timestamp>,
 }
 

--- a/crates/core/thin_edge_json/src/event.rs
+++ b/crates/core/thin_edge_json/src/event.rs
@@ -22,7 +22,7 @@ pub struct ThinEdgeEventData {
     pub text: Option<String>,
 
     #[serde(default)]
-    #[serde(with = "clock::serde::rfc3339::option")]
+    #[serde(with = "time::serde::rfc3339::option")]
     pub time: Option<Timestamp>,
 
     #[serde(flatten)]


### PR DESCRIPTION
## Proposed changes

I found that the "serde" module was only a reexport of the "serde" module of the "time" crate which did not add any further functionality.
Thus, its usage can be replaced by using the "time" crate directly. As the functionality was only used in the "thin_edge_json" crate, and that crate already imports "time", I consider this PR a reduction in code-complexity.

## Types of changes


- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
