### PR TITLE
Update rumqttd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,7 +2311,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.20.6",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2381,23 +2381,24 @@ dependencies = [
 
 [[package]]
 name = "rumqttd"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1b0c1bb4e345c681c0a13174ce78df48885b0855c06f6eadbad53efb8b5e3b"
+checksum = "916b8c94b0703befa41eb45cb0b684e7050755be1a70ebd38cfe77faa879a829"
 dependencies = [
  "argh",
  "bytes",
  "confy",
  "futures-util",
+ "jackiechan",
  "jemallocator",
  "log",
- "mqttbytes",
  "pretty_env_logger",
- "rumqttlog",
+ "rustls-pemfile 0.3.0",
+ "segments",
  "serde",
  "thiserror",
  "tokio",
- "tokio-rustls 0.22.0",
+ "tokio-rustls 0.23.4",
  "warp",
 ]
 
@@ -2457,6 +2458,15 @@ dependencies = [
  "ring",
  "sct 0.7.0",
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
+dependencies = [
+ "base64",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,7 +1656,6 @@ dependencies = [
  "once_cell",
  "rumqttc",
  "rumqttd",
- "rumqttlog",
  "tokio",
 ]
 
@@ -2400,24 +2399,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.23.4",
  "warp",
-]
-
-[[package]]
-name = "rumqttlog"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031d0d6fc69b8f36267870724b7a28e4a9396d0b3f722f84b5631c56c0840244"
-dependencies = [
- "byteorder",
- "bytes",
- "fnv",
- "jackiechan",
- "log",
- "memmap",
- "mqttbytes",
- "segments",
- "serde",
- "thiserror",
 ]
 
 [[package]]

--- a/crates/tests/mqtt_tests/Cargo.toml
+++ b/crates/tests/mqtt_tests/Cargo.toml
@@ -13,6 +13,6 @@ fastrand = "1.8"
 futures = "0.3"
 once_cell = "1.8"
 rumqttc = "0.10"
-rumqttd = "0.9"
+rumqttd = "0.11"
 rumqttlog = "0.9"
 tokio = { version = "1.9", default_features = false, features = [] }

--- a/crates/tests/mqtt_tests/Cargo.toml
+++ b/crates/tests/mqtt_tests/Cargo.toml
@@ -14,5 +14,4 @@ futures = "0.3"
 once_cell = "1.8"
 rumqttc = "0.10"
 rumqttd = "0.11"
-rumqttlog = "0.9"
 tokio = { version = "1.9", default_features = false, features = [] }

--- a/crates/tests/mqtt_tests/src/test_mqtt_server.rs
+++ b/crates/tests/mqtt_tests/src/test_mqtt_server.rs
@@ -111,7 +111,7 @@ fn spawn_broker(port: u16) {
 }
 
 fn get_rumqttd_config(port: u16) -> Config {
-    let router_config = rumqttlog::Config {
+    let router_config = librumqttd::rumqttlog::Config {
         id: 0,
         dir: "/tmp/rumqttd".into(),
         max_segment_size: 10240,


### PR DESCRIPTION
## Proposed changes

Closes #1265
Supersedes #1265 

The dependabot update from #1265 is included in this PR. The update did not work in #1265 because the interface of the `librumqttd::Config` type changed, so its usage had to be adapted.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
