### PR TITLE
Replace actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -19,11 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        # https://github.com/actions-rs/toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.58.1
-          override: true
+        uses: dtolnay/rust-toolchain@1.58.1
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -59,12 +55,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        # https://github.com/actions-rs/toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.58.1
         with:
-          toolchain: 1.58.1
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -28,11 +28,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        # https://github.com/actions-rs/toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.58.1
-          override: true
+        uses: dtolnay/rust-toolchain@1.58.1
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -84,10 +80,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.58.1
-          override: true
+        uses: dtolnay/rust-toolchain@1.58.1
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -100,12 +93,7 @@ jobs:
         # The tests could fail if GitHub blocks external connections.
         # It seems like they rarely do.
       - name: Cargo test features
-        uses: actions-rs/cargo@v1
-        # https://github.com/marketplace/actions/rust-cargo
-        with:
-          command: test
-          args: --verbose --features integration-test,requires-sudo -- \
-            --skip sending_and_receiving_a_message
+        run: cargo test --verbose --features integration-test,requires-sudo -- --skip sending_and_receiving_a_message
 
 ##################################################################################
 
@@ -129,12 +117,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Enable toolchain via github action
-        # https://github.com/actions-rs/toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.58.1
         with:
-          toolchain: 1.58.1
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -51,10 +51,7 @@ jobs:
     if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true' }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
+      - uses: dtolnay/rust-toolchain@nightly
       - name: Run cargo-udeps
         uses: aig787/cargo-udeps-action@v1
         with:
@@ -139,11 +136,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.58.1
         with:
-          toolchain: 1.58.1
           components: rustfmt, clippy
-          override: true
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -191,10 +186,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.58.1
-          override: true
+        uses: dtolnay/rust-toolchain@1.58.1
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -230,10 +222,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.58.1
-          override: true
+        uses: dtolnay/rust-toolchain@1.58.1
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -262,11 +251,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.58.1
         with:
-          toolchain: 1.58.1
-          target: armv7-unknown-linux-gnueabihf
-          override: true
+          targets: armv7-unknown-linux-gnueabihf
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -290,12 +277,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: enable toolchain via github action
-        # https://github.com/actions-rs/toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@1.58.1
         with:
-          toolchain: 1.58.1
           target: armv7-unknown-linux-gnueabihf
-          override: true
 
       - name: Enable cache
         # https://github.com/marketplace/actions/rust-cache
@@ -319,10 +303,7 @@ jobs:
 #        uses: actions/checkout@v3
 #
 #      - name: Install rust v1.58.1
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: 1.58.1
-#          override: true
+#        uses: dtolnay/rust-toolchain@1.58.1
 #
 #      - name: Enable cache
 #        # https://github.com/marketplace/actions/rust-cache


### PR DESCRIPTION
As actions-rs/toolchain is unmaintained, switch over to dtolnay/rust-toolchain for our workflow implementation.