### PR TITLE
Remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,7 +2943,6 @@ dependencies = [
 name = "tedge_utils"
 version = "0.7.3"
 dependencies = [
- "anyhow",
  "assert_matches",
  "async-stream",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,12 +1507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,7 +2941,6 @@ dependencies = [
  "async-stream",
  "futures",
  "inotify",
- "maplit",
  "nix",
  "strum_macros",
  "tedge_test_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,7 +1642,6 @@ dependencies = [
  "mqtt_tests",
  "rumqttc",
  "serial_test",
- "tedge_utils",
  "thiserror",
  "tokio",
 ]

--- a/crates/common/mqtt_channel/Cargo.toml
+++ b/crates/common/mqtt_channel/Cargo.toml
@@ -12,7 +12,6 @@ async-trait = "0.1"
 futures = "0.3"
 fastrand = "1.8"
 rumqttc = "0.10"
-tedge_utils = { path = "../tedge_utils" }
 thiserror = "1.0"
 tokio = { version = "1.12", features = ["rt", "time"] }
 

--- a/crates/common/tedge_utils/Cargo.toml
+++ b/crates/common/tedge_utils/Cargo.toml
@@ -11,13 +11,12 @@ description = "tedge_utils provide utilities for thin-edge.io components"
 # No features on by default
 default = []
 logging = ["tracing", "tracing-subscriber"]
-fs-notify = ["inotify", "async-stream", "maplit", "strum_macros", "try-traits"]
+fs-notify = ["inotify", "async-stream", "strum_macros", "try-traits"]
 
 [dependencies]
 async-stream = { version = "0.3", optional = true }
 futures = "0.3"
 inotify = { version = "0.10", optional = true }
-maplit = { version = "1.0", optional = true }
 nix = "0.24"
 strum_macros = { version = "0.24", optional = true }
 tempfile = "3.2"
@@ -30,6 +29,7 @@ users = "0.11.0"
 
 [dev-dependencies]
 assert_matches = "1.5"
+maplit = "1.0"
 tedge_test_utils = { path = "../../tests/tedge_test_utils" }
 tokio = { version = "1.12", features = [ "rt-multi-thread"] }
 whoami = "1.2.1"

--- a/crates/common/tedge_utils/Cargo.toml
+++ b/crates/common/tedge_utils/Cargo.toml
@@ -14,7 +14,6 @@ logging = ["tracing", "tracing-subscriber"]
 fs-notify = ["inotify", "async-stream", "maplit", "strum_macros", "try-traits"]
 
 [dependencies]
-anyhow = "1.0"
 async-stream = { version = "0.3", optional = true }
 futures = "0.3"
 inotify = { version = "0.10", optional = true }


### PR DESCRIPTION
Removes unused dependencies from `tedge_utils` and `mqtt_channel`.

Followup for #1313