### PR TITLE
Make systemd watchdog backend only build for linux

### DIFF
--- a/crates/core/tedge_watchdog/src/dummy_watchdog.rs
+++ b/crates/core/tedge_watchdog/src/dummy_watchdog.rs
@@ -1,0 +1,3 @@
+pub async fn start_watchdog(_config_dir: PathBuf) -> Result<(), anyhow::Error> {
+    anyhow::Error::from(crate::error::WatchdogError::WatchdogNotAvailable)
+}

--- a/crates/core/tedge_watchdog/src/error.rs
+++ b/crates/core/tedge_watchdog/src/error.rs
@@ -4,6 +4,10 @@ use tedge_config::{ConfigSettingError, TEdgeConfigError};
 
 #[derive(Debug, thiserror::Error)]
 pub enum WatchdogError {
+    #[cfg(not(target_os = "linux"))]
+    #[error("The watchdog is not available on this platform")]
+    WatchdogNotAvailable,
+
     #[error("Fail to run `{cmd}`: {from}")]
     CommandExecError { cmd: String, from: std::io::Error },
 

--- a/crates/core/tedge_watchdog/src/main.rs
+++ b/crates/core/tedge_watchdog/src/main.rs
@@ -3,7 +3,18 @@ use std::path::PathBuf;
 use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 
 mod error;
+
+// on linux, we use systemd
+#[cfg(target_os = "linux")]
 mod systemd_watchdog;
+#[cfg(target_os = "linux")]
+use systemd_watchdog as watchdog;
+
+// on non-linux, we do nothing for now
+#[cfg(not(target_os = "linux"))]
+mod dummy_watchdog;
+#[cfg(not(target_os = "linux"))]
+use dummy_watchdog as watchdog;
 
 #[derive(Debug, clap::Parser)]
 #[clap(
@@ -31,5 +42,5 @@ async fn main() -> Result<(), anyhow::Error> {
     let watchdog_opt = WatchdogOpt::parse();
     tedge_utils::logging::initialise_tracing_subscriber(watchdog_opt.debug);
 
-    systemd_watchdog::start_watchdog(watchdog_opt.config_dir).await
+    watchdog::start_watchdog(watchdog_opt.config_dir).await
 }


### PR DESCRIPTION
Following the discussion in #1278 and as suggested by @albinsuresh:

This patch ensures that the systemd watchdog backend is only used when
building for linux.

Right now, there is no other watchdog implementation. Thus, there is a
"dummy_watchdog" module introduced that does nothing. This might be
removed and replaced by something specific, if we ever build
thin-edge.io for other targets, such as Apple, FreeBSD or others.

---

I'm going to request review by multiple people, so everyone knows about this and has the chance of saying something if this is not the right approach (because we might possibly need more like this in the future).