### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,6 +2947,7 @@ dependencies = [
  "async-stream",
  "futures",
  "inotify",
+ "maplit",
  "nix",
  "strum_macros",
  "tedge_test_utils",


### PR DESCRIPTION
I forgot to update the Cargo.lock file when filing the PR.
This patch fixes this.

Fixes: 73f74d9a38ded5b72e8b0acc9dce49fced3ea53c ("tedge_utils: Move "maplit" to dev-dependencies")
