### PR TITLE
Restart of tedge-mapper-c8y is recreating deleted child devices

### DIFF
--- a/crates/core/tedge_mapper/src/c8y/converter.rs
+++ b/crates/core/tedge_mapper/src/c8y/converter.rs
@@ -274,20 +274,22 @@ where
     ) -> Result<Vec<Message>, ConversionError> {
         if topic.name.starts_with("tedge/alarms") {
             let mut mqtt_messages: Vec<Message> = Vec::new();
-            let topic_split: Vec<&str> = topic.name.split('/').collect();
-            if topic_split.len() == 5 {
-                let child_id = topic_split[4];
-                // Create a child device, if it does not exists already
-                if !child_id.is_empty() && !self.children.contains(child_id) {
-                    self.children.insert(child_id.to_string());
-                    mqtt_messages.push(Message::new(
-                        &Topic::new_unchecked(SMARTREST_PUBLISH_TOPIC),
-                        format!("101,{child_id},{child_id},thin-edge.io-child"),
-                    ));
-                }
-            }
             self.size_threshold.validate(message)?;
             let mut messages = self.alarm_converter.try_convert_alarm(message)?;
+            if !messages.is_empty() {
+                let topic_split: Vec<&str> = topic.name.split('/').collect();
+                if topic_split.len() == 5 {
+                    let child_id = topic_split[4];
+                    // Create a child device, if it does not exists already
+                    if !child_id.is_empty() && !self.children.contains(child_id) {
+                        self.children.insert(child_id.to_string());
+                        mqtt_messages.push(Message::new(
+                            &Topic::new_unchecked(SMARTREST_PUBLISH_TOPIC),
+                            format!("101,{child_id},{child_id},thin-edge.io-child"),
+                        ));
+                    }
+                }
+            }
             mqtt_messages.append(&mut messages);
             Ok(mqtt_messages)
         } else if topic.name.starts_with(INTERNAL_ALARMS_TOPIC) {

--- a/crates/core/tedge_mapper/src/c8y/converter.rs
+++ b/crates/core/tedge_mapper/src/c8y/converter.rs
@@ -277,10 +277,11 @@ where
             self.size_threshold.validate(message)?;
             let mut messages = self.alarm_converter.try_convert_alarm(message)?;
             if !messages.is_empty() {
+                // When there is some messages to be sent on behalf of a child device,
+                // this child device must be declared first, if not done yet
                 let topic_split: Vec<&str> = topic.name.split('/').collect();
                 if topic_split.len() == 5 {
                     let child_id = topic_split[4];
-                    // Create a child device, if it does not exists already
                     if !child_id.is_empty() && !self.children.contains(child_id) {
                         self.children.insert(child_id.to_string());
                         mqtt_messages.push(Message::new(

--- a/crates/core/tedge_mapper/src/c8y/tests.rs
+++ b/crates/core/tedge_mapper/src/c8y/tests.rs
@@ -683,7 +683,7 @@ async fn test_sync_child_alarms() {
     let alarm_message = Message::new(&Topic::new_unchecked(alarm_topic), alarm_payload);
 
     // During the sync phase, alarms are not converted immediately, but only cached to be synced later
-    assert_eq!(converter.convert(&alarm_message).await.len(), 1);
+    assert!(converter.convert(&alarm_message).await.is_empty());
 
     let non_alarm_topic = "tedge/measurements/external_sensor";
     let non_alarm_payload = r#"{"temp": 1}"#;


### PR DESCRIPTION
## Proposed changes

With the existing logic, when the `tedge-mapper-c8y` is restarted, the `child/external` device creation message is formed and pushed into the vector even during the sync logic as well, because the sync logic receives messages from `tedge/alarms`.  This will create the devices that were not requested now but were part of the previous requests.

As a fix, Create an `external/child device` only after the alarm messages are synced if the device is not created already.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1340

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

