### PR TITLE
Fix install array expansion

### DIFF
--- a/ci/installation_scripts/clean_up_rpi.sh
+++ b/ci/installation_scripts/clean_up_rpi.sh
@@ -11,5 +11,5 @@ sudo systemctl stop apama
 source ./ci/package_list.sh
 
 # Purge packages
-sudo apt --assume-yes purge "${RELEASE_PACKAGES[*]}"
-sudo DEBIAN_FRONTEND=noninteractive apt --assume-yes purge "${EXTERNAL_ARM_PACKAGES[*]}"
+sudo apt --assume-yes purge "${RELEASE_PACKAGES[@]}"
+sudo DEBIAN_FRONTEND=noninteractive apt --assume-yes purge "${EXTERNAL_ARM_PACKAGES[@]}"

--- a/ci/installation_scripts/install_for_amd64.sh
+++ b/ci/installation_scripts/install_for_amd64.sh
@@ -9,7 +9,7 @@ PKG_DIR=$1
 source ./ci/package_list.sh
 
 # Install pre-required packages
-sudo apt-get --assume-yes install "${EXTERNAL_AMD64_PACKAGES[*]}"
+sudo apt-get --assume-yes install "${EXTERNAL_AMD64_PACKAGES[@]}"
 
 # Install thin-edge packages
 for PACKAGE in "${RELEASE_PACKAGES[@]}"

--- a/ci/installation_scripts/install_for_arm.sh
+++ b/ci/installation_scripts/install_for_arm.sh
@@ -9,7 +9,7 @@ PKG_DIR=$1
 source ./ci/package_list.sh
 
 # Install pre-required packages
-sudo apt-get --assume-yes install "${EXTERNAL_ARM_PACKAGES[*]}"
+sudo apt-get --assume-yes install "${EXTERNAL_ARM_PACKAGES[@]}"
 
 # Install thin-edge packages
 for PACKAGE in "${RELEASE_PACKAGES[@]}"


### PR DESCRIPTION

I messed up b3f1da8cf607cb1c6668d30ae1121a19305cf9e9, 12912211adc50d6ea99d4e2d1c4c1bf71a3cb5c0 and c147d91f6aedfcef6574fd105557e6661220ee3d as reported by @PradeepKiruvale in [here](https://github.com/thin-edge/thin-edge.io/commit/a2c58baddcf685cde414fb66847e6e981921d6c7).

This fixes it (hopefully).

@PradeepKiruvale please test these patches whether they fix your issue! 