### PR TITLE
Directory for custom fragments /etc/tedge/device does not exist

### DIFF
--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -118,6 +118,13 @@ fn create_directories(config_dir: &Path) -> Result<(), anyhow::Error> {
         0o644,
         None,
     )?;
+    // Create directory for device custom fragments
+    create_directory_with_user_group(
+        format!("{}/device", config_dir.display()),
+        "tedge",
+        "tedge",
+        0o775,
+    )?;
     Ok(())
 }
 

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -76,6 +76,7 @@ impl TEdgeComponent for CumulocityMapper {
             device_type,
             operations,
             http_proxy,
+            cfg_dir,
         )?);
 
         let mut mapper = create_mapper(

--- a/docs/src/howto-guides/022_c8y_fragments.md
+++ b/docs/src/howto-guides/022_c8y_fragments.md
@@ -19,7 +19,9 @@ sudo tedge config set device.type VALUE
 
 ## Custom fragments
 
-If you wish to add more fragments to Cumulocity, you can do so by populating `/etc/tedge/device/inventory.json`
+If you wish to add more fragments to Cumulocity, you can do so by populating `{base_config_dir}/device/inventory.json`.
+The default `base_config_dir` is `/etc/tedge`.
+See the link for more information about setting a custom [base_config_dir.](../references/thin-edge-config-files.md)
 
 An example `inventory.json` looks something like this:
 


### PR DESCRIPTION
## Proposed changes

This PR includes the code to create the `/etc/tedge/device` directory when the `tedge-mapper-c8y` is initialized.

It also fixes some issues related to reading the fragment `inventory.json` file from the custom path when config files are stored in the `custom config` direction.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1365

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

