### PR TITLE
fs_notify generates events on wrong directory paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,8 +1379,7 @@ dependencies = [
 [[package]]
 name = "inotify"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf888f9575c290197b2c948dc9e9ff10bd1a39ad1ea8585f734585fa6b9d3f9"
+source = "git+https://github.com/hannobraun/inotify-rs?branch=master#9ec50c55bb2b0db444f4602e1bd8c358b6df2615"
 dependencies = [
  "bitflags",
  "futures-core",
@@ -2965,7 +2964,6 @@ dependencies = [
  "download",
  "flockfile",
  "futures",
- "inotify",
  "logged_command",
  "mockall",
  "mockito",

--- a/crates/common/tedge_utils/Cargo.toml
+++ b/crates/common/tedge_utils/Cargo.toml
@@ -16,7 +16,7 @@ fs-notify = ["inotify", "async-stream", "strum_macros", "try-traits"]
 [dependencies]
 async-stream = { version = "0.3", optional = true }
 futures = "0.3"
-inotify = { version = "0.10", optional = true }
+inotify =  { git = "https://github.com/hannobraun/inotify-rs", branch = "master", optional = true }
 nix = "0.24"
 strum_macros = { version = "0.24", optional = true }
 tempfile = "3.2"

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -39,7 +39,6 @@ csv = "1.1"
 download = { path = "../../common/download" }
 flockfile = { path = "../../common/flockfile" }
 futures = "0.3"
-inotify = "0.10.0"
 logged_command = { path = "../../common/logged_command" }
 mockall = "0.11"
 mqtt_channel = { path = "../../common/mqtt_channel" }

--- a/crates/tests/tedge_test_utils/src/fs.rs
+++ b/crates/tests/tedge_test_utils/src/fs.rs
@@ -12,7 +12,7 @@ pub struct TempTedgeDir {
 }
 
 pub struct TempTedgeFile {
-    file_path: PathBuf,
+    pub file_path: PathBuf,
 }
 
 impl Default for TempTedgeDir {

--- a/plugins/c8y_configuration_plugin/src/main.rs
+++ b/plugins/c8y_configuration_plugin/src/main.rs
@@ -322,7 +322,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial_test::serial]
     async fn test_message_dispatch() -> anyhow::Result<()> {
-        let test_config_path = "/some/test/config";
+        let test_config_path = "/tmp"; //Pass some existing path
         let test_config_type = "c8y-configuration-plugin";
 
         let broker = mqtt_tests::test_mqtt_broker();


### PR DESCRIPTION
## Proposed changes

This PR fixes the issue related to raising the events for the wrong `directory` when  `watching multiple directories`.
Uses the `inotify` fix that helps to extract the exact path on which the event has been raised.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1453

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

