### PR TITLE
Closes #1486 Set port 8000 as default HTTP port for tedge-agent

### DIFF
--- a/configuration/debian/tedge_agent/postrm
+++ b/configuration/debian/tedge_agent/postrm
@@ -13,10 +13,17 @@ purge_agent_lock() {
    fi
 }
 
+purge_var_data_directory() {
+    if [ -d "/var/tedge" ]; then
+        rm -rf /var/tedge
+    fi
+}
+
 case "$1" in
     purge)
        purge_agent_directory
        purge_agent_lock
+       purge_var_data_directory
     ;;
 
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/configuration/init/systemd/tedge-agent.service
+++ b/configuration/init/systemd/tedge-agent.service
@@ -3,7 +3,7 @@ Description=tedge-agent is a thin-edge.io component to support operations.
 After=syslog.target network.target mosquitto.service
 
 [Service]
-User=root
+User=tedge
 RuntimeDirectory=tedge_agent
 ExecStart=/usr/bin/tedge_agent
 Restart=on-failure

--- a/crates/core/tedge_agent/src/http_rest.rs
+++ b/crates/core/tedge_agent/src/http_rest.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::error::FileTransferError;
 
-const HTTP_FILE_TRANSFER_PORT: u16 = 80;
+const HTTP_FILE_TRANSFER_PORT: u16 = 8000;
 
 #[derive(Debug, Clone)]
 pub struct HttpConfig {

--- a/docs/src/references/tedge-file-transfer-service.md
+++ b/docs/src/references/tedge-file-transfer-service.md
@@ -6,15 +6,17 @@ as the storage on thin-edge devices are typically very limited.
 
 Files can be uploaded, downloaded and deleted from this repository via the following HTTP endpoints:
 
-* Upload: PUT http://{tedge-ip}/tedge/file-transfer/{path}/{to}/{resource}
-* Download: GET http://{tedge-ip}/tedge/file-transfer/{path}/{to}/{resource}
-* Delete: DELETE http://{tedge-ip}/tedge/file-transfer/{path}/{to}/{resource}
+* Upload: PUT http://{tedge-ip}:8000/tedge/file-transfer/{path}/{to}/{resource}
+* Download: GET http://{tedge-ip}:8000/tedge/file-transfer/{path}/{to}/{resource}
+* Delete: DELETE http://{tedge-ip}:8000/tedge/file-transfer/{path}/{to}/{resource}
 
 The `tedge-ip` is derived from the following tedge configurations:
 
 * mqtt.bind_address
 * mqtt.external.bind_address
-* mqtt.external.bind_interface
+
+If the `mqtt.external.bind_address` is configured, then the `tedge-ip` is set to that value,
+else the `mqtt.bind_address` is used with the default value of `127.0.0.1`.
 
 The files uploaded to this repository are stored at `/var/tedge/file-transfer` directory.
 The `{path}/{to}/{resource}` specified in the URL is replicated under this directory.

--- a/plugins/c8y_configuration_plugin/src/main.rs
+++ b/plugins/c8y_configuration_plugin/src/main.rs
@@ -126,7 +126,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut http_client = create_http_client(&tedge_config).await?;
     let tmp_dir = tedge_config.query(TmpPathSetting)?.into();
 
-    let local_http_host = format!("{}:80", bind_address.to_string().as_str());
+    //TODO: Port number to be read from HttpPortSetting
+    let local_http_host = format!("{}:8000", bind_address.to_string().as_str());
 
     run(
         tedge_device_id,


### PR DESCRIPTION
## Proposed changes

Change default HTTP port of `tedge-agent` from 80 to 8000 so that it doesn't always have to run as root.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

