### PR TITLE
File permission API to change ownership of directory even if it already exists

### DIFF
--- a/configuration/debian/tedge_agent/postrm
+++ b/configuration/debian/tedge_agent/postrm
@@ -13,6 +13,12 @@ purge_agent_lock() {
    fi
 }
 
+purge_agent_logs() {
+    if [ -d "/var/log/tedge/agent" ]; then
+        rm -rf /var/log/tedge/agent
+    fi
+}
+
 purge_var_data_directory() {
     if [ -d "/var/tedge" ]; then
         rm -rf /var/tedge
@@ -24,6 +30,7 @@ case "$1" in
        purge_agent_directory
        purge_agent_lock
        purge_var_data_directory
+       purge_agent_logs
     ;;
 
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)


### PR DESCRIPTION
## Proposed changes

When `tedge-agent` starts, the `/var/log/tedge/agent` directory is first created as `root` by the `operations_log` manager in `SmAgent::try_new` which is later changed to `tedge` in `SmAgent::init`. This fix makes such ownership changes of existing files possible.

The log directory could have been created as `tedge` at the beginning itself. Avoiding that for now, just to minimize the changes required for this bug fix. This will be fixed properly after the 0.7.6 release.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

