### PR TITLE
Issue #1480: Prevent c8y-config-plugin crashing on bad input

### DIFF
--- a/plugins/c8y_configuration_plugin/src/config.rs
+++ b/plugins/c8y_configuration_plugin/src/config.rs
@@ -3,7 +3,7 @@ use crate::{
     DEFAULT_PLUGIN_CONFIG_TYPE,
 };
 use c8y_api::smartrest::topic::C8yTopic;
-use mqtt_channel::{Message, Topic};
+use mqtt_channel::{Message, MqttError, Topic};
 use serde::Deserialize;
 use std::borrow::Borrow;
 use std::collections::HashSet;
@@ -152,7 +152,7 @@ impl PluginConfig {
         self
     }
 
-    pub fn to_supported_config_types_message(&self) -> Result<Message, anyhow::Error> {
+    pub fn to_supported_config_types_message(&self) -> Result<Message, MqttError> {
         let topic = C8yTopic::SmartRestResponse.to_topic()?;
         Ok(Message::new(&topic, self.to_smartrest_payload()))
     }
@@ -160,7 +160,7 @@ impl PluginConfig {
     pub fn to_supported_config_types_message_for_child(
         &self,
         child_id: &str,
-    ) -> Result<Message, anyhow::Error> {
+    ) -> Result<Message, MqttError> {
         let topic_str = &format!("c8y/s/us/{child_id}");
         let topic = Topic::new(topic_str)?;
         Ok(Message::new(&topic, self.to_smartrest_payload()))


### PR DESCRIPTION
## Proposed changes

- [x] Log failures while processing messges and file watcher events instead of propagating the error eventually crashing the plugin
- [ ] Convert errors into SmartREST 502 failure messages

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

