### PR TITLE
Fix fragments tests to work with `tedge` installed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,6 +2879,7 @@ dependencies = [
  "agent_interface",
  "anyhow",
  "assert-json-diff",
+ "assert_cmd",
  "assert_matches",
  "async-trait",
  "batcher",

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -28,6 +28,7 @@ stop-on-upgrade = false
 
 [dependencies]
 agent_interface = { path = "../agent_interface"}
+assert_cmd = "2.0"
 anyhow = "1.0"
 async-trait = "0.1"
 batcher = { path = "../../common/batcher" }

--- a/crates/core/tedge_mapper/src/c8y/fragments.rs
+++ b/crates/core/tedge_mapper/src/c8y/fragments.rs
@@ -35,8 +35,16 @@ impl C8yAgentFragment {
         Ok(jsond)
     }
 }
+
 pub fn get_tedge_version() -> Result<String, ConversionError> {
-    let process = Command::new("tedge").arg("--version").output();
+    let process = if cfg!(test) {
+        assert_cmd::Command::cargo_bin("tedge")
+            .unwrap()
+            .arg("--version")
+            .output()
+    } else {
+        Command::new("tedge").arg("--version").output()
+    };
 
     match process {
         Ok(process) => {
@@ -50,7 +58,7 @@ pub fn get_tedge_version() -> Result<String, ConversionError> {
         }
         Err(err) => {
             warn!("{}\ntedge version not found.", err);
-            Ok("0.0.0".to_string())
+            Ok("unknown".to_string())
         }
     }
 }

--- a/crates/core/tedge_mapper/src/c8y/tests.rs
+++ b/crates/core/tedge_mapper/src/c8y/tests.rs
@@ -1314,12 +1314,17 @@ async fn mapper_updating_the_default_inventory_fragments() {
     let (_tmp_dir, sm_mapper) = start_c8y_mapper(broker.port, &cfg_dir).await.unwrap();
 
     publish_a_fake_jwt_token(broker).await;
-    let expected_fragment_content = r#"{
-        "c8y_Agent": {
+
+    let version = env!("CARGO_PKG_VERSION");
+
+    let expected_fragment_content = &format!(
+        r#"{{
+        "c8y_Agent": {{
             "name": "thin-edge.io",
             "url": "https://thin-edge.io",
-            "version": "0.0.0"
-        }"#;
+            "version": "{version}"
+        }}"#
+    );
 
     mqtt_tests::assert_received_all_expected(
         &mut inventory_message,
@@ -1338,18 +1343,23 @@ async fn mapper_updating_the_inventory_fragments_from_file() {
     // Verify the fragment message that is published
     let broker = mqtt_tests::test_mqtt_broker();
     let cfg_dir = TempTedgeDir::new();
-    let content = r#"{
-        "c8y_Agent": {
+
+    let version = env!("CARGO_PKG_VERSION");
+
+    let content = &format!(
+        r#"{{
+        "c8y_Agent": {{
             "name": "thin-edge.io",
             "url": "https://thin-edge.io",
-            "version": "0.0.0"
-        },
-        "c8y_Firmware": {
+            "version": "{version}"
+        }},
+        "c8y_Firmware": {{
             "name": "raspberrypi-bootloader",
             "url": "31aab9856861b1a587e2094690c2f6e272712cb1",
             "version": "1.20140107-1"
-        }
-    }"#;
+        }}
+    }}"#
+    );
     create_inventroy_json_file_with_content(&cfg_dir, content);
     let mut inventory_message = broker
         .messages_published_on("c8y/inventory/managedObjects/update/test-device")


### PR DESCRIPTION
## Proposed changes

This test was passing because the pipeline did not have tedge installed. But when tedge is installed, locally, the version field defaults to the version of tedge on your system. This tests fixes this issue to use tedge from cargo_bin. Additionally env! is used to get the current version of the binaries, which can be used to compare to tedge --version.

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

