### PR TITLE
Fix --init of tedge_agent run by root

### DIFF
--- a/configuration/debian/tedge_agent/postinst
+++ b/configuration/debian/tedge_agent/postinst
@@ -7,7 +7,7 @@ set -e
 # to monitor the installation of the new version up to completion.
 if command -v systemctl >/dev/null; then
     if ! systemctl is-active --quiet tedge-agent; then
-         sudo -u tedge -- tedge_agent --init
+         sudo -- tedge_agent --init
     fi
 fi
 


### PR DESCRIPTION
## Proposed changes
`tedge_agent --init` must run as root, introduced by https://github.com/thin-edge/thin-edge.io/commit/fe705ffdf2b18e09492df0ab613a69f8b5bca72f.

However, my commit https://github.com/thin-edge/thin-edge.io/commit/ccf9bf2f626caec5d303980b02432535f5896d66 brought back it to run as `tedge`. This PR fixes it.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#1466 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

