### PR TITLE
Create child upon directory creation

### DIFF
--- a/crates/core/tedge_mapper/src/c8y/converter.rs
+++ b/crates/core/tedge_mapper/src/c8y/converter.rs
@@ -432,7 +432,12 @@ where
                         .or_insert_with(Operations::default);
 
                     add_or_remove_operation(message, child_op)?;
-                    Ok(Some(create_supported_operations(&message.ops_dir)?))
+                    let path = message.ops_dir.to_path_buf().join(&message.operation_name);
+                    if path.is_dir() {
+                        Ok(Some(create_supported_operations(&path)?))
+                    } else {
+                        Ok(Some(create_supported_operations(&message.ops_dir)?))
+                    }
                 }
             }
             None => Ok(None),
@@ -462,7 +467,6 @@ fn add_or_remove_operation(
             let ops_dir = message.ops_dir.clone();
             let op_name = message.operation_name.clone();
             let op = get_operation(ops_dir.join(op_name))?;
-
             ops.add_operation(op);
         }
         EventType::Remove => {


### PR DESCRIPTION
Signed-off-by: Pradeep Kumar K J <pradeepkumar.kj@softwareag.com>

## Proposed changes

When a directory for the child device supported operation is created in `/etc/tedge/operations/c8y` then the mapper should send the `114` smartest message to the c8y cloud to create a new child device.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

