### PR TITLE
Remove flockfile for tedge_agent before running --init in postint script

### DIFF
--- a/configuration/debian/tedge_agent/postinst
+++ b/configuration/debian/tedge_agent/postinst
@@ -2,12 +2,18 @@
 
 set -e
 
-# Initialize the agent __only__ if not when agent is running
+# Initialize the agent __only__ if not when agent is running.
 # Indeed, during an OTA self-update, the previous version of the  `agent` is kept running
 # to monitor the installation of the new version up to completion.
 if command -v systemctl >/dev/null; then
-    if ! systemctl is-active --quiet tedge-agent; then
-         sudo -- tedge_agent --init
+    if ! systemctl is-active --quiet tedge-agent ; then
+         # Flock file should be removed as `tedge_agent --init` must run as root
+         # although the flockfile is owned by `tedge`.
+         if [ -f "/run/lock/tedge_agent.lock" ]; then
+                rm /run/lock/tedge_agent.lock
+         fi
+         # It must be run as root to create the directory `/var/tedge`.
+         tedge_agent --init
     fi
 fi
 


### PR DESCRIPTION
## Proposed changes
tedge_agent is supposed to run by the `tedge` user, therefore, the flockfile is owned by the `tedge` user. However, due to the directory creation of `/var/tedge`, `tedge_agent --init` must be run as root in the postinst script. If the flockfile owned by `tedge` user exists, the `tedge_agent --init` will fail.

To fix this issue, the postinst script should remove the flock file if it exists before the initialization.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#1551 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

