### PR TITLE
fix tedge typo in docs

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,6 +1,7 @@
 [default.extend-words]
 mosquitto = "mosquitto"
 hda = "hda"
+tegde = "tedge"
 
 [files]
 extend-exclude = [ "**certificate.txt", "**test_root_cert*.txt" ]

--- a/docs/src/references/c8y-configuration-management.md
+++ b/docs/src/references/c8y-configuration-management.md
@@ -111,7 +111,7 @@ $ ls -l /etc/tedge/operations/c8y/child-2
 
 The `c8y_configuration_plugin` has to be run as a daemon on the device, the latter being connected to Cumulocity.
 
-On start of `tegde_mapper c8y` and on `/etc/tedge/operations/c8y` directory updates,
+On start of `tedge_mapper c8y` and on `/etc/tedge/operations/c8y` directory updates,
 one can observe on the MQTT bus of the thin-edge device
 the messages sent to Cumulocity to declare the capabilities of the main and child devices.
 Here, the capabilities to upload and download configuration files


### PR DESCRIPTION
Signed-off-by: reubenmiller <reuben.miller@softwareag.com>

## Proposed changes

* Fix small typo of `tedge` in the Cumulocity Device Configuration Management docs
* Add `typos` rule to automatically detect common `tedge` typo

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
