### PR TITLE
Sporadic test failures in c8y tests

### DIFF
--- a/crates/tests/mqtt_tests/src/test_mqtt_server.rs
+++ b/crates/tests/mqtt_tests/src/test_mqtt_server.rs
@@ -120,7 +120,7 @@ fn get_rumqttd_config(port: u16) -> Config {
     };
 
     let connections_settings = ConnectionSettings {
-        connection_timeout_ms: 1,
+        connection_timeout_ms: 10,
         max_client_id_len: 256,
         throttle_delay_ms: 0,
         max_payload_size: 268435455,


### PR DESCRIPTION
## Proposed changes

Increase the `connection_timeout_ms` setting of the `rumqttd` broker. 

Before it was set to `1ms` as observed that the tests were failing because the `rumqttd` broker was closing the client connection if the connection was idle for 1ms.

Now increased it to `10ms` the tests are not failing anymore. Now the broker will close the client connection only if the connection is idle for 10ms.

Ran the tests in the loop for 500 iterations, and found that the tests are not failing anymore.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

