### PR TITLE
Change the restart temporary file location from /run/tedge_agent to /tmp

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_defaults.rs
+++ b/crates/common/tedge_config/src/tedge_config_defaults.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 const DEFAULT_ETC_PATH: &str = "/etc";
 const DEFAULT_PORT: u16 = 1883;
-const DEFAULT_TMP_PATH: &str = "/tmp";
+pub const DEFAULT_TMP_PATH: &str = "/tmp";
 pub const DEFAULT_LOG_PATH: &str = "/var/log";
 pub const DEFAULT_RUN_PATH: &str = "/run";
 const DEFAULT_DEVICE_TYPE: &str = "thin-edge.io";

--- a/crates/core/tedge_agent/src/restart_operation_handler.rs
+++ b/crates/core/tedge_agent/src/restart_operation_handler.rs
@@ -4,18 +4,18 @@ pub mod restart_operation {
     use std::{fs::File, fs::OpenOptions, io::Read, io::Write, path::Path};
     use time::OffsetDateTime;
 
-    const SLASH_RUN_PATH_TEDGE_AGENT_RESTART: &str = "tedge_agent/tedge_agent_restart";
+    const TEDGE_AGENT_RESTART: &str = "tedge_agent_restart";
     const SLASH_PROC_UPTIME: &str = "/proc/uptime";
 
-    /// creates an empty file in /run
-    /// the file name defined by `SLASH_RUN_PATH_TEDGE_AGENT_RESTART`
+    /// creates an empty file in /tmp
+    /// the file name defined by `TEDGE_AGENT_RESTART`
     ///
     /// # Example
     /// ```
-    /// RestartOperationHelper::create_slash_run_file()?;
+    /// RestartOperationHelper::create_tmp_restart_file()?;
     /// ```
-    pub fn create_slash_run_file(run_dir: &Path) -> Result<(), AgentError> {
-        let path = &run_dir.join(SLASH_RUN_PATH_TEDGE_AGENT_RESTART);
+    pub fn create_tmp_restart_file(tmp_dir: &Path) -> Result<(), AgentError> {
+        let path = &tmp_dir.join(TEDGE_AGENT_RESTART);
         let path = Path::new(path);
 
         let mut file = match OpenOptions::new()
@@ -34,14 +34,14 @@ pub mod restart_operation {
         Ok(())
     }
 
-    pub fn slash_run_file_exists(run_dir: &Path) -> bool {
-        let path = &run_dir.join(SLASH_RUN_PATH_TEDGE_AGENT_RESTART);
-        std::path::Path::new(path).exists()
+    pub fn tmp_restart_file_exists(run_dir: &Path) -> bool {
+        let path = &run_dir.join(TEDGE_AGENT_RESTART);
+        Path::new(path).exists()
     }
 
     /// returns the datetime of `SLASH_RUN_PATH_TEDGE_AGENT_RESTART` "modified at".
     fn get_restart_file_datetime(run_dir: &Path) -> Result<time::OffsetDateTime, AgentError> {
-        let mut file = File::open(&run_dir.join(SLASH_RUN_PATH_TEDGE_AGENT_RESTART))?;
+        let mut file = File::open(&run_dir.join(TEDGE_AGENT_RESTART))?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
 
@@ -97,7 +97,7 @@ pub mod restart_operation {
     pub fn has_rebooted(run_dir: &Path) -> Result<bool, AgentError> {
         // there is no slash run file after the reboot, so we assume success.
         // this is true for most of the cases as "/run/" is normally cleared after a reboot.
-        if !slash_run_file_exists(run_dir) {
+        if !tmp_restart_file_exists(run_dir) {
             return Ok(true);
         }
 


### PR DESCRIPTION
## Proposed changes
tedge_agent creates `tedge_agent_restart` file in order to keep the timestamp of restart operation executed. However, the file was supposed to be created /run/tedge_agent directory, which is created by systemd.

In addition, to create a file directly under /run requires root.

To remove the implicit dependency on systemd, change the directory to create the file from /run/tedge_agent to /tmp.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#975 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

