### PR TITLE
Retry unauthorized HTTP request with a renewed JWT token

### DIFF
--- a/crates/core/c8y_api/src/http_proxy.rs
+++ b/crates/core/c8y_api/src/http_proxy.rs
@@ -188,7 +188,7 @@ impl C8yJwtTokenRetriever for C8yMqttJwtTokenRetriever {
 /// - Keep the connection info to c8y and the internal Id of the device
 /// - Handle JWT requests
 pub struct JwtAuthHttpProxy {
-    jwt_token_retriver: Box<dyn C8yJwtTokenRetriever>,
+    jwt_token_retriever: Box<dyn C8yJwtTokenRetriever>,
     http_con: reqwest::Client,
     end_point: C8yEndPoint,
     child_devices: HashMap<String, String>,
@@ -196,13 +196,13 @@ pub struct JwtAuthHttpProxy {
 
 impl JwtAuthHttpProxy {
     pub fn new(
-        jwt_token_retriver: Box<dyn C8yJwtTokenRetriever>,
+        jwt_token_retriever: Box<dyn C8yJwtTokenRetriever>,
         http_con: reqwest::Client,
         c8y_host: &str,
         device_id: &str,
     ) -> JwtAuthHttpProxy {
         JwtAuthHttpProxy {
-            jwt_token_retriver,
+            jwt_token_retriever,
             http_con,
             end_point: C8yEndPoint {
                 c8y_host: c8y_host.into(),
@@ -244,10 +244,10 @@ impl JwtAuthHttpProxy {
         // Ignore errors on this connection
         mqtt_con.errors.close();
 
-        let jwt_token_retriver = Box::new(C8yMqttJwtTokenRetriever::new(mqtt_con));
+        let jwt_token_retriever = Box::new(C8yMqttJwtTokenRetriever::new(mqtt_con));
 
         Ok(JwtAuthHttpProxy::new(
-            jwt_token_retriver,
+            jwt_token_retriever,
             http_con,
             &c8y_host,
             &device_id,
@@ -390,7 +390,7 @@ impl C8YHttpProxy for JwtAuthHttpProxy {
     }
 
     async fn get_jwt_token(&mut self) -> Result<SmartRestJwtResponse, SMCumulocityMapperError> {
-        self.jwt_token_retriver.get_jwt_token().await
+        self.jwt_token_retriever.get_jwt_token().await
     }
 
     async fn send_event(
@@ -540,14 +540,14 @@ mod tests {
             .create();
 
         // An JwtAuthHttpProxy ...
-        let mut jwt_token_retriver = Box::new(MockC8yJwtTokenRetriever::new());
-        jwt_token_retriver
+        let mut jwt_token_retriever = Box::new(MockC8yJwtTokenRetriever::new());
+        jwt_token_retriever
             .expect_get_jwt_token()
             .returning(|| Ok(SmartRestJwtResponse::default()));
 
         let http_client = reqwest::ClientBuilder::new().build().unwrap();
         let mut http_proxy = JwtAuthHttpProxy::new(
-            jwt_token_retriver,
+            jwt_token_retriever,
             http_client,
             mockito::server_url().as_str(),
             device_id,
@@ -583,14 +583,14 @@ mod tests {
             .create();
 
         // An JwtAuthHttpProxy ...
-        let mut jwt_token_retriver = Box::new(MockC8yJwtTokenRetriever::new());
-        jwt_token_retriver
+        let mut jwt_token_retriever = Box::new(MockC8yJwtTokenRetriever::new());
+        jwt_token_retriever
             .expect_get_jwt_token()
             .returning(|| Ok(SmartRestJwtResponse::default()));
 
         let http_client = reqwest::ClientBuilder::new().build().unwrap();
         let mut http_proxy = JwtAuthHttpProxy::new(
-            jwt_token_retriver,
+            jwt_token_retriever,
             http_client,
             mockito::server_url().as_str(),
             device_id,
@@ -657,15 +657,15 @@ mod tests {
             .create();
 
         // An JwtAuthHttpProxy ...
-        let mut jwt_token_retriver = Box::new(MockC8yJwtTokenRetriever::new());
-        jwt_token_retriver
+        let mut jwt_token_retriever = Box::new(MockC8yJwtTokenRetriever::new());
+        jwt_token_retriever
             .expect_get_jwt_token()
             .returning(|| Ok(SmartRestJwtResponse::default()));
 
         let http_client = reqwest::ClientBuilder::new().build().unwrap();
 
         let mut http_proxy = JwtAuthHttpProxy::new(
-            jwt_token_retriver,
+            jwt_token_retriever,
             http_client,
             mockito::server_url().as_str(),
             device_id,


### PR DESCRIPTION
Signed-off-by: Didier Wenzek <didier.wenzek@free.fr>

## Proposed changes

Address the two root causes of [Unauthorized request](https://github.com/thin-edge/thin-edge.io/issues/1562):i

* Re-open the MQTT connection for each JWT token request.
* When an HTTP request to Cumulocity is rejected as unauthorized, then renew the JWT token and retry.
Do this only once, since there is no point to get yet another fresh token if rejected twice in a row.

For the first point, the alternative is to keep the MQTT connection open and to have a background task that consumes all the JWT token - requested by the process or not, and to cache the latest one. However, this alternative introduces more complexity and opening an MQTT connection before each HTTP request should not be a performance issue for the current use-cases.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

See https://github.com/thin-edge/thin-edge.io/issues/1562

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

