### PR TITLE
Issue #1544 Timeout unacknowledged config management operation requests

### DIFF
--- a/plugins/c8y_configuration_plugin/Cargo.toml
+++ b/plugins/c8y_configuration_plugin/Cargo.toml
@@ -35,7 +35,7 @@ tedge_config = { path = "../../crates/common/tedge_config" }
 tedge_utils = { path = "../../crates/common/tedge_utils", features = ["logging", "fs-notify"] }
 thin_edge_json = { path = "../../crates/core/thin_edge_json" }
 thiserror = "1.0"
-tokio = { version = "1.9", default_features = false, features = [ "fs", "io-util", "macros", "rt-multi-thread","signal"] }
+tokio = { version = "1.9", default_features = false, features = [ "fs", "io-util", "macros", "rt-multi-thread", "signal", "time"] }
 toml = "0.5"
 tracing = { version = "0.1", features = ["attributes", "log"] }
 
@@ -47,4 +47,5 @@ mqtt_tests = { path = "../../crates/tests/mqtt_tests" }
 serial_test = "0.8"
 tedge_test_utils = { path = "../../crates/tests/tedge_test_utils" }
 test-case = "2.2"
+tokio = { version = "1.9", default_features = false, features = ["test-util"] }
 toml = "0.5"

--- a/plugins/c8y_configuration_plugin/src/config.rs
+++ b/plugins/c8y_configuration_plugin/src/config.rs
@@ -1,7 +1,5 @@
-use crate::{
-    child_device::ChildDeviceResponsePayload, error::ConfigManagementError,
-    DEFAULT_PLUGIN_CONFIG_TYPE,
-};
+use crate::config_manager::DEFAULT_PLUGIN_CONFIG_TYPE;
+use crate::{child_device::ChildDeviceResponsePayload, error::ConfigManagementError};
 use c8y_api::smartrest::topic::C8yTopic;
 use mqtt_channel::{Message, MqttError, Topic};
 use serde::Deserialize;

--- a/plugins/c8y_configuration_plugin/src/config_manager.rs
+++ b/plugins/c8y_configuration_plugin/src/config_manager.rs
@@ -1,0 +1,357 @@
+use crate::config::PluginConfig;
+use crate::download::ConfigDownloadManager;
+use crate::operation::ConfigOperation;
+use crate::topic::ConfigOperationResponseTopic;
+use crate::upload::ConfigUploadManager;
+use crate::{
+    child_device::{get_child_id_from_child_topic, ConfigOperationResponse},
+    download::DownloadConfigFileStatusMessage,
+    upload::UploadConfigFileStatusMessage,
+};
+
+use anyhow::Result;
+use c8y_api::http_proxy::C8YHttpProxy;
+use c8y_api::smartrest::smartrest_deserializer::{
+    SmartRestConfigDownloadRequest, SmartRestConfigUploadRequest, SmartRestRequestGeneric,
+};
+use c8y_api::smartrest::smartrest_serializer::TryIntoOperationStatusMessage;
+use c8y_api::smartrest::topic::C8yTopic;
+use mqtt_channel::{Connection, Message, MqttError, SinkExt, StreamExt, Topic, TopicFilter};
+use tokio::sync::Mutex;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use tedge_utils::{notify::fs_notify_stream, paths::PathsError};
+use thin_edge_json::health::{health_check_topics, send_health_status};
+
+use tedge_utils::notify::{FsEvent, NotifyStream};
+use tracing::{error, info};
+
+pub const DEFAULT_PLUGIN_CONFIG_FILE_NAME: &str = "c8y-configuration-plugin.toml";
+pub const DEFAULT_OPERATION_DIR_NAME: &str = "c8y/";
+pub const DEFAULT_PLUGIN_CONFIG_TYPE: &str = "c8y-configuration-plugin";
+pub const CONFIG_CHANGE_TOPIC: &str = "tedge/configuration_change";
+
+pub struct ConfigManager {
+    plugin_config: PluginConfig,
+    mqtt_client: Arc<Mutex<Connection>>,
+    c8y_request_topics: TopicFilter,
+    health_check_topics: TopicFilter,
+    config_snapshot_response_topics: TopicFilter,
+    config_update_response_topics: TopicFilter,
+    fs_notification_stream: NotifyStream,
+    config_upload_manager: ConfigUploadManager,
+    config_download_manager: ConfigDownloadManager,
+}
+
+impl ConfigManager {
+    pub async fn new(
+        tedge_device_id: impl ToString,
+        mqtt_port: u16,
+        http_client: Arc<Mutex<dyn C8YHttpProxy>>,
+        local_http_host: impl ToString,
+        tmp_dir: PathBuf,
+        config_dir: PathBuf,
+    ) -> Result<Self, anyhow::Error> {
+        // `config_file_dir` expands to: /etc/tedge/c8y or `config-dir`/c8y
+        let config_file_dir = config_dir.join(DEFAULT_OPERATION_DIR_NAME);
+        let plugin_config =
+            PluginConfig::new(&config_file_dir.join(DEFAULT_PLUGIN_CONFIG_FILE_NAME));
+
+        let mqtt_client = Self::create_mqtt_client(mqtt_port).await?;
+        let mqtt_client = Arc::new(Mutex::new(mqtt_client));
+
+        let c8y_request_topics: TopicFilter = C8yTopic::SmartRestRequest.into();
+        let health_check_topics = health_check_topics("c8y-configuration-plugin");
+        let config_snapshot_response_topics: TopicFilter =
+            ConfigOperationResponseTopic::SnapshotResponse.into();
+        let config_update_response_topics: TopicFilter =
+            ConfigOperationResponseTopic::UpdateResponse.into();
+
+        // we watch `config_file_path` for any change to a file named `DEFAULT_PLUGIN_CONFIG_FILE_NAME`
+        let fs_notification_stream = fs_notify_stream(&[(
+            &config_file_dir,
+            Some(DEFAULT_PLUGIN_CONFIG_FILE_NAME.to_string()),
+            &[
+                FsEvent::Modified,
+                FsEvent::FileDeleted,
+                FsEvent::FileCreated,
+            ],
+        )])?;
+
+        let config_upload_manager = ConfigUploadManager::new(
+            tedge_device_id.to_string(),
+            mqtt_client.clone(),
+            http_client.clone(),
+            local_http_host.to_string(),
+            config_dir.clone(),
+        );
+
+        let config_download_manager = ConfigDownloadManager::new(
+            tedge_device_id.to_string(),
+            mqtt_client.clone(),
+            http_client.clone(),
+            local_http_host.to_string(),
+            config_dir.clone(),
+            tmp_dir.clone(),
+        );
+
+        let mut config_manager = ConfigManager {
+            plugin_config,
+            mqtt_client,
+            c8y_request_topics,
+            health_check_topics,
+            config_snapshot_response_topics,
+            config_update_response_topics,
+            fs_notification_stream,
+            config_upload_manager,
+            config_download_manager,
+        };
+
+        // Publish supported configuration types
+        config_manager.publish_supported_config_types().await?;
+
+        Ok(config_manager)
+    }
+
+    pub async fn run(&mut self) -> Result<(), anyhow::Error> {
+        self.get_pending_operations_from_cloud().await?;
+        loop {
+            let mut locked_mqtt_client = self.mqtt_client.lock().await;
+            tokio::select! {
+                message = locked_mqtt_client.received.next() => {
+                    drop(locked_mqtt_client);   //Unlock self.mqtt_client
+                    if let Some(message) = message {
+                        let topic = message.topic.name.clone();
+                        if let Err(err) = self.process_mqtt_message(
+                            message,
+                        )
+                        .await {
+                            error!("Processing the message received on {topic} failed with {err}");
+                        }
+                    } else {
+                        // message is None and the connection has been closed
+                        return Ok(())
+                    }
+                }
+                Some((path, mask)) = self.fs_notification_stream.rx.recv() => {
+                    match mask {
+                        FsEvent::Modified | FsEvent::FileDeleted | FsEvent::FileCreated => {
+                            match path.file_name() {
+                                Some(file_name) => {
+                                    // this if check is done to avoid matching on temporary files created by editors
+                                    if file_name.eq(DEFAULT_PLUGIN_CONFIG_FILE_NAME) {
+                                        let parent_dir_name = path.parent().and_then(|dir| dir.file_name()).ok_or(PathsError::ParentDirNotFound {path: path.as_os_str().into()})?;
+
+                                        if parent_dir_name.eq("c8y") {
+                                            let plugin_config = PluginConfig::new(&path);
+                                            let message = plugin_config.to_supported_config_types_message()?;
+                                            locked_mqtt_client.published.send(message).await?;
+                                        } else {
+                                            // this is a child device
+                                            let plugin_config = PluginConfig::new(&path);
+                                            let message = plugin_config.to_supported_config_types_message_for_child(&parent_dir_name.to_string_lossy())?;
+                                            locked_mqtt_client.published.send(message).await?;
+                                        }
+                                    }
+                                },
+                                None => {}
+                            }
+                        },
+                        _ => {
+                            // ignore other FsEvent(s)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn create_mqtt_client(mqtt_port: u16) -> Result<mqtt_channel::Connection, anyhow::Error> {
+        let mut topic_filter =
+            mqtt_channel::TopicFilter::new_unchecked(&C8yTopic::SmartRestRequest.to_string());
+        topic_filter.add_all(health_check_topics("c8y-configuration-plugin"));
+
+        topic_filter.add_all(ConfigOperationResponseTopic::SnapshotResponse.into());
+        topic_filter.add_all(ConfigOperationResponseTopic::UpdateResponse.into());
+
+        let mqtt_config = mqtt_channel::Config::default()
+            .with_session_name("c8y-configuration-plugin")
+            .with_port(mqtt_port)
+            .with_subscriptions(topic_filter);
+
+        let mqtt_client = mqtt_channel::Connection::new(&mqtt_config).await?;
+        Ok(mqtt_client)
+    }
+
+    async fn process_mqtt_message(&mut self, message: Message) -> Result<(), anyhow::Error> {
+        if self.health_check_topics.accept(&message) {
+            send_health_status(
+                &mut self.mqtt_client.lock().await.published,
+                "c8y-configuration-plugin",
+            )
+            .await;
+            return Ok(());
+        } else if self.config_snapshot_response_topics.accept(&message) {
+            info!("config snapshot response");
+            self.handle_child_device_config_operation_response(&message)
+                .await?;
+        } else if self.config_update_response_topics.accept(&message) {
+            info!("config update response");
+            self.handle_child_device_config_operation_response(&message)
+                .await?;
+        } else if self.c8y_request_topics.accept(&message) {
+            let payload = message.payload_str()?;
+            for smartrest_message in payload.split('\n') {
+                let result = match smartrest_message.split(',').next().unwrap_or_default() {
+                    "524" => {
+                        let maybe_config_download_request =
+                            SmartRestConfigDownloadRequest::from_smartrest(smartrest_message);
+                        if let Ok(config_download_request) = maybe_config_download_request {
+                            self.config_download_manager
+                                .handle_config_download_request(config_download_request)
+                                .await
+                        } else {
+                            error!(
+                                "Incorrect Download SmartREST payload: {}",
+                                smartrest_message
+                            );
+                            Ok(())
+                        }
+                    }
+                    "526" => {
+                        // retrieve config file upload smartrest request from payload
+                        let maybe_config_upload_request =
+                            SmartRestConfigUploadRequest::from_smartrest(smartrest_message);
+
+                        if let Ok(config_upload_request) = maybe_config_upload_request {
+                            // handle the config file upload request
+                            self.config_upload_manager
+                                .handle_config_upload_request(config_upload_request)
+                                .await
+                        } else {
+                            error!("Incorrect Upload SmartREST payload: {}", smartrest_message);
+                            Ok(())
+                        }
+                    }
+                    _ => {
+                        // Ignore operation messages not meant for this plugin
+                        Ok(())
+                    }
+                };
+
+                if let Err(err) = result {
+                    error!("Handling of operation: '{smartrest_message}' failed with {err}");
+                }
+            }
+        } else {
+            error!(
+                "Received unexpected message on topic: {}",
+                message.topic.name
+            );
+        }
+        Ok(())
+    }
+
+    pub async fn handle_child_device_config_operation_response(
+        &mut self,
+        message: &Message,
+    ) -> Result<(), anyhow::Error> {
+        match ConfigOperationResponse::try_from(message) {
+            Ok(config_response) => {
+                let smartrest_response = match &config_response {
+                    ConfigOperationResponse::Update { .. } => self
+                        .config_download_manager
+                        .handle_child_device_config_update_response(&config_response)?,
+                    ConfigOperationResponse::Snapshot { .. } => {
+                        self.config_upload_manager
+                            .handle_child_device_config_snapshot_response(&config_response)
+                            .await?
+                    }
+                };
+
+                self.mqtt_client
+                    .lock()
+                    .await
+                    .published
+                    .send(smartrest_response)
+                    .await?;
+                Ok(())
+            }
+            Err(err) => {
+                self.fail_pending_config_operation_in_c8y(message, err.to_string())
+                    .await
+            }
+        }
+    }
+
+    pub async fn fail_pending_config_operation_in_c8y(
+        &mut self,
+        message: &Message,
+        failure_reason: String,
+    ) -> Result<(), anyhow::Error> {
+        // Fail the operation in the cloud by sending EXECUTING and FAILED responses back to back
+        let config_operation = message.try_into()?;
+        let child_id = get_child_id_from_child_topic(&message.topic.name)?;
+
+        let c8y_child_topic =
+            Topic::new_unchecked(&C8yTopic::ChildSmartRestResponse(child_id).to_string());
+
+        let (executing_msg, failed_msg) = match config_operation {
+            ConfigOperation::Snapshot => {
+                let executing_msg = Message::new(
+                    &c8y_child_topic,
+                    UploadConfigFileStatusMessage::status_executing()?,
+                );
+                let failed_msg = Message::new(
+                    &c8y_child_topic,
+                    UploadConfigFileStatusMessage::status_failed(failure_reason)?,
+                );
+                (executing_msg, failed_msg)
+            }
+            ConfigOperation::Update => {
+                let executing_msg = Message::new(
+                    &c8y_child_topic,
+                    DownloadConfigFileStatusMessage::status_executing()?,
+                );
+                let failed_msg = Message::new(
+                    &c8y_child_topic,
+                    DownloadConfigFileStatusMessage::status_failed(failure_reason)?,
+                );
+                (executing_msg, failed_msg)
+            }
+        };
+        self.mqtt_client
+            .lock()
+            .await
+            .published
+            .send(executing_msg)
+            .await?;
+        self.mqtt_client
+            .lock()
+            .await
+            .published
+            .send(failed_msg)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn publish_supported_config_types(&mut self) -> Result<(), MqttError> {
+        let message = self.plugin_config.to_supported_config_types_message()?;
+        self.mqtt_client
+            .lock()
+            .await
+            .published
+            .send(message)
+            .await?;
+        Ok(())
+    }
+
+    async fn get_pending_operations_from_cloud(&mut self) -> Result<(), MqttError> {
+        // Get pending operations
+        let msg = Message::new(&C8yTopic::SmartRestResponse.to_topic()?, "500");
+        self.mqtt_client.lock().await.published.send(msg).await?;
+        Ok(())
+    }
+}

--- a/plugins/c8y_configuration_plugin/src/download.rs
+++ b/plugins/c8y_configuration_plugin/src/download.rs
@@ -1,14 +1,15 @@
 use crate::child_device::{
     try_cleanup_config_file_from_file_transfer_repositoy, ConfigOperationMessage,
 };
-use crate::{
-    child_device::ConfigOperationRequest, config::FileEntry, DEFAULT_PLUGIN_CONFIG_FILE_NAME,
+use crate::config_manager::{
+    CONFIG_CHANGE_TOPIC, DEFAULT_OPERATION_DIR_NAME, DEFAULT_PLUGIN_CONFIG_FILE_NAME,
 };
+use crate::{child_device::ConfigOperationRequest, config::FileEntry};
 use crate::{
     child_device::ConfigOperationResponse,
     error::{ChildDeviceConfigManagementError, ConfigManagementError},
 };
-use crate::{error, PluginConfig, CONFIG_CHANGE_TOPIC, DEFAULT_OPERATION_DIR_NAME};
+use crate::{error, PluginConfig};
 use agent_interface::OperationStatus;
 use c8y_api::http_proxy::C8YHttpProxy;
 use c8y_api::smartrest::error::SmartRestSerializerError;
@@ -25,255 +26,308 @@ use mqtt_channel::{Connection, Message, SinkExt, Topic};
 use serde_json::json;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::{fs, path::Path};
 use tedge_utils::file::{get_filename, get_metadata, PermissionEntry};
+use tokio::sync::Mutex;
 use tracing::{info, warn};
 
-#[allow(clippy::too_many_arguments)]
-pub async fn handle_config_download_request(
-    smartrest_request: SmartRestConfigDownloadRequest,
+pub struct ConfigDownloadManager {
+    tedge_device_id: String,
+    mqtt_client: Arc<Mutex<Connection>>,
+    http_client: Arc<Mutex<dyn C8YHttpProxy>>,
+    local_http_host: String,
+    config_dir: PathBuf,
     tmp_dir: PathBuf,
-    mqtt_client: &mut Connection,
-    http_client: &mut impl C8YHttpProxy,
-    local_http_host: &str,
-    tedge_device_id: &str,
-    config_dir: &Path,
-) -> Result<(), anyhow::Error> {
-    if smartrest_request.device == tedge_device_id {
-        handle_config_download_request_tedge_device(
-            smartrest_request,
-            tmp_dir,
-            mqtt_client,
-            http_client,
-            config_dir,
-        )
-        .await
-    } else {
-        handle_config_download_request_child_device(
-            smartrest_request,
+}
+
+impl ConfigDownloadManager {
+    pub fn new(
+        tedge_device_id: String,
+        mqtt_client: Arc<Mutex<Connection>>,
+        http_client: Arc<Mutex<dyn C8YHttpProxy>>,
+        local_http_host: String,
+        config_dir: PathBuf,
+        tmp_dir: PathBuf,
+    ) -> Self {
+        ConfigDownloadManager {
+            tedge_device_id,
             mqtt_client,
             http_client,
             local_http_host,
             config_dir,
             tmp_dir,
-        )
-        .await
+        }
     }
-}
 
-pub async fn handle_config_download_request_tedge_device(
-    smartrest_request: SmartRestConfigDownloadRequest,
-    tmp_dir: PathBuf,
-    mqtt_client: &mut Connection,
-    http_client: &mut impl C8YHttpProxy,
-    config_dir: &Path,
-) -> Result<(), anyhow::Error> {
-    let executing_message = DownloadConfigFileStatusMessage::executing()?;
-    mqtt_client.published.send(executing_message).await?;
-
-    let target_config_type = smartrest_request.config_type.clone();
-    let mut target_file_entry = FileEntry::default();
-
-    let config_file_path = config_dir
-        .join(DEFAULT_OPERATION_DIR_NAME)
-        .join(DEFAULT_PLUGIN_CONFIG_FILE_NAME);
-    let plugin_config = PluginConfig::new(&config_file_path);
-    let download_result = {
-        match plugin_config.get_file_entry_from_type(&target_config_type) {
-            Ok(file_entry) => {
-                target_file_entry = file_entry;
-                download_config_file(
-                    smartrest_request.url.as_str(),
-                    PathBuf::from(&target_file_entry.path),
-                    tmp_dir,
-                    target_file_entry.file_permissions,
-                    http_client,
-                )
+    pub async fn handle_config_download_request(
+        &self,
+        smartrest_request: SmartRestConfigDownloadRequest,
+    ) -> Result<(), anyhow::Error> {
+        if smartrest_request.device == self.tedge_device_id {
+            self.handle_config_download_request_tedge_device(smartrest_request)
                 .await
-            }
-            Err(err) => Err(err.into()),
-        }
-    };
-
-    match download_result {
-        Ok(_) => {
-            info!("The configuration download for '{target_config_type}' is successful.");
-
-            let successful_message = DownloadConfigFileStatusMessage::successful(None)?;
-            mqtt_client.published.send(successful_message).await?;
-
-            let notification_message =
-                get_file_change_notification_message(&target_file_entry.path, &target_config_type);
-            mqtt_client.published.send(notification_message).await?;
-            Ok(())
-        }
-        Err(err) => {
-            error!("The configuration download for '{target_config_type}' failed.",);
-
-            let failed_message = DownloadConfigFileStatusMessage::failed(err.to_string())?;
-            mqtt_client.published.send(failed_message).await?;
-            Err(err)
+        } else {
+            self.handle_config_download_request_child_device(smartrest_request)
+                .await
         }
     }
-}
 
-/// Map the c8y_DownloadConfigFile request into a tedge/commands/req/config_update command for the child device.
-/// The config file update is shared with the child device via the file transfer service.
-/// The configuration update is downloaded from Cumulocity and is uploaded to the file transfer service,
-/// so that it can be shared with a child device.
-/// A unique URL path for this config file, from the file transfer service, is shared with the child device in the command.
-/// The child device can use this URL to download the config file update from the file transfer service.
-pub async fn handle_config_download_request_child_device(
-    smartrest_request: SmartRestConfigDownloadRequest,
-    mqtt_client: &mut Connection,
-    http_client: &mut impl C8YHttpProxy,
-    local_http_host: &str,
-    config_dir: &Path,
-    tmp_dir: PathBuf,
-) -> Result<(), anyhow::Error> {
-    let child_id = smartrest_request.device;
-    let config_type = smartrest_request.config_type;
-
-    let plugin_config = PluginConfig::new(Path::new(&format!(
-        "{}/c8y/{child_id}/c8y-configuration-plugin.toml",
-        config_dir.display()
-    )));
-
-    match plugin_config.get_file_entry_from_type(&config_type) {
-        Ok(file_entry) => {
-            let config_management = ConfigOperationRequest::Update {
-                child_id: child_id.clone(),
-                file_entry,
-            };
-
-            if let Err(err) = download_config_file(
-                smartrest_request.url.as_str(),
-                config_management
-                    .file_transfer_repository_full_path()
-                    .into(),
-                tmp_dir,
-                PermissionEntry::new(None, None, None), //no need to change ownership of downloaded file
-                http_client,
-            )
+    pub async fn handle_config_download_request_tedge_device(
+        &self,
+        smartrest_request: SmartRestConfigDownloadRequest,
+    ) -> Result<(), anyhow::Error> {
+        let executing_message = DownloadConfigFileStatusMessage::executing()?;
+        self.mqtt_client
+            .lock()
             .await
-            {
-                // Fail the operation in the cloud if the file download itself fails
-                // by sending EXECUTING and FAILED responses back to back
+            .published
+            .send(executing_message)
+            .await?;
 
-                let c8y_child_topic =
-                    Topic::new_unchecked(&C8yTopic::ChildSmartRestResponse(child_id).to_string());
+        let target_config_type = smartrest_request.config_type.clone();
+        let mut target_file_entry = FileEntry::default();
 
-                let executing_msg = Message::new(
-                    &c8y_child_topic,
-                    DownloadConfigFileStatusMessage::status_executing()?,
-                );
-                mqtt_client.published.send(executing_msg).await?;
+        let config_file_path = self
+            .config_dir
+            .join(DEFAULT_OPERATION_DIR_NAME)
+            .join(DEFAULT_PLUGIN_CONFIG_FILE_NAME);
+        let plugin_config = PluginConfig::new(&config_file_path);
+        let download_result = {
+            match plugin_config.get_file_entry_from_type(&target_config_type) {
+                Ok(file_entry) => {
+                    target_file_entry = file_entry;
+                    self.download_config_file(
+                        smartrest_request.url.as_str(),
+                        PathBuf::from(&target_file_entry.path),
+                        target_file_entry.file_permissions,
+                    )
+                    .await
+                }
+                Err(err) => Err(err.into()),
+            }
+        };
 
-                let failure_reason = format!(
-                    "Downloading the config file update from {} failed with {}",
-                    smartrest_request.url, err
+        match download_result {
+            Ok(_) => {
+                info!("The configuration download for '{target_config_type}' is successful.");
+
+                let successful_message = DownloadConfigFileStatusMessage::successful(None)?;
+                self.mqtt_client
+                    .lock()
+                    .await
+                    .published
+                    .send(successful_message)
+                    .await?;
+
+                let notification_message = get_file_change_notification_message(
+                    &target_file_entry.path,
+                    &target_config_type,
                 );
-                let failed_msg = Message::new(
-                    &c8y_child_topic,
-                    DownloadConfigFileStatusMessage::status_failed(failure_reason)?,
-                );
-                mqtt_client.published.send(failed_msg).await?;
-            } else {
-                let config_update_req_msg = Message::new(
-                    &config_management.operation_request_topic(),
-                    config_management.operation_request_payload(local_http_host)?,
-                );
-                mqtt_client.published.send(config_update_req_msg).await?;
+                self.mqtt_client
+                    .lock()
+                    .await
+                    .published
+                    .send(notification_message)
+                    .await?;
+                Ok(())
+            }
+            Err(err) => {
+                error!("The configuration download for '{target_config_type}' failed.",);
+
+                let failed_message = DownloadConfigFileStatusMessage::failed(err.to_string())?;
+                self.mqtt_client
+                    .lock()
+                    .await
+                    .published
+                    .send(failed_message)
+                    .await?;
+                Err(err)
             }
         }
-        Err(ConfigManagementError::InvalidRequestedConfigType { config_type }) => {
-            warn!("Ignoring the config operation request for unknown config type: {config_type}");
-        }
-        Err(err) => return Err(err)?,
     }
 
-    Ok(())
-}
+    /// Map the c8y_DownloadConfigFile request into a tedge/commands/req/config_update command for the child device.
+    /// The config file update is shared with the child device via the file transfer service.
+    /// The configuration update is downloaded from Cumulocity and is uploaded to the file transfer service,
+    /// so that it can be shared with a child device.
+    /// A unique URL path for this config file, from the file transfer service, is shared with the child device in the command.
+    /// The child device can use this URL to download the config file update from the file transfer service.
+    pub async fn handle_config_download_request_child_device(
+        &self,
+        smartrest_request: SmartRestConfigDownloadRequest,
+    ) -> Result<(), anyhow::Error> {
+        let child_id = smartrest_request.device;
+        let config_type = smartrest_request.config_type;
 
-pub fn handle_child_device_config_update_response(
-    config_response: &ConfigOperationResponse,
-) -> Result<Message, ChildDeviceConfigManagementError> {
-    let c8y_child_topic = Topic::new_unchecked(&config_response.get_child_topic());
+        let plugin_config = PluginConfig::new(Path::new(&format!(
+            "{}/c8y/{child_id}/c8y-configuration-plugin.toml",
+            self.config_dir.display()
+        )));
 
-    let child_device_payload = config_response.get_payload();
+        match plugin_config.get_file_entry_from_type(&config_type) {
+            Ok(file_entry) => {
+                let config_management = ConfigOperationRequest::Update {
+                    child_id: child_id.clone(),
+                    file_entry,
+                };
 
-    if let Some(operation_status) = child_device_payload.status {
-        match operation_status {
-            OperationStatus::Successful => {
-                // Cleanup the downloaded file after the operation completes
-                try_cleanup_config_file_from_file_transfer_repositoy(config_response);
-                let successful_status_payload =
-                    DownloadConfigFileStatusMessage::status_successful(None)?;
-                Ok(Message::new(&c8y_child_topic, successful_status_payload))
-            }
-            OperationStatus::Failed => {
-                // Cleanup the downloaded file after the operation completes
-                try_cleanup_config_file_from_file_transfer_repositoy(config_response);
-                if let Some(error_message) = &child_device_payload.reason {
-                    let failed_status_payload =
-                        DownloadConfigFileStatusMessage::status_failed(error_message.clone())?;
-                    Ok(Message::new(&c8y_child_topic, failed_status_payload))
+                if let Err(err) = self
+                    .download_config_file(
+                        smartrest_request.url.as_str(),
+                        config_management
+                            .file_transfer_repository_full_path()
+                            .into(),
+                        PermissionEntry::new(None, None, None), //no need to change ownership of downloaded file
+                    )
+                    .await
+                {
+                    // Fail the operation in the cloud if the file download itself fails
+                    // by sending EXECUTING and FAILED responses back to back
+
+                    let c8y_child_topic = Topic::new_unchecked(
+                        &C8yTopic::ChildSmartRestResponse(child_id).to_string(),
+                    );
+
+                    let executing_msg = Message::new(
+                        &c8y_child_topic,
+                        DownloadConfigFileStatusMessage::status_executing()?,
+                    );
+                    self.mqtt_client
+                        .lock()
+                        .await
+                        .published
+                        .send(executing_msg)
+                        .await?;
+
+                    let failure_reason = format!(
+                        "Downloading the config file update from {} failed with {}",
+                        smartrest_request.url, err
+                    );
+                    let failed_msg = Message::new(
+                        &c8y_child_topic,
+                        DownloadConfigFileStatusMessage::status_failed(failure_reason)?,
+                    );
+                    self.mqtt_client
+                        .lock()
+                        .await
+                        .published
+                        .send(failed_msg)
+                        .await?;
                 } else {
-                    let default_error_message =
-                        String::from("No fail reason provided by child device.");
-                    let failed_status_payload =
-                        DownloadConfigFileStatusMessage::status_failed(default_error_message)?;
-                    Ok(Message::new(&c8y_child_topic, failed_status_payload))
+                    let config_update_req_msg = Message::new(
+                        &config_management.operation_request_topic(),
+                        config_management.operation_request_payload(&self.local_http_host)?,
+                    );
+                    self.mqtt_client
+                        .lock()
+                        .await
+                        .published
+                        .send(config_update_req_msg)
+                        .await?;
                 }
             }
-            OperationStatus::Executing => {
-                let executing_status_payload = DownloadConfigFileStatusMessage::status_executing()?;
-                Ok(Message::new(&c8y_child_topic, executing_status_payload))
+            Err(ConfigManagementError::InvalidRequestedConfigType { config_type }) => {
+                warn!(
+                    "Ignoring the config operation request for unknown config type: {config_type}"
+                );
+            }
+            Err(err) => return Err(err)?,
+        }
+
+        Ok(())
+    }
+
+    pub fn handle_child_device_config_update_response(
+        &self,
+        config_response: &ConfigOperationResponse,
+    ) -> Result<Message, ChildDeviceConfigManagementError> {
+        let c8y_child_topic = Topic::new_unchecked(&config_response.get_child_topic());
+
+        let child_device_payload = config_response.get_payload();
+
+        if let Some(operation_status) = child_device_payload.status {
+            match operation_status {
+                OperationStatus::Successful => {
+                    // Cleanup the downloaded file after the operation completes
+                    try_cleanup_config_file_from_file_transfer_repositoy(config_response);
+                    let successful_status_payload =
+                        DownloadConfigFileStatusMessage::status_successful(None)?;
+                    Ok(Message::new(&c8y_child_topic, successful_status_payload))
+                }
+                OperationStatus::Failed => {
+                    // Cleanup the downloaded file after the operation completes
+                    try_cleanup_config_file_from_file_transfer_repositoy(config_response);
+                    if let Some(error_message) = &child_device_payload.reason {
+                        let failed_status_payload =
+                            DownloadConfigFileStatusMessage::status_failed(error_message.clone())?;
+                        Ok(Message::new(&c8y_child_topic, failed_status_payload))
+                    } else {
+                        let default_error_message =
+                            String::from("No fail reason provided by child device.");
+                        let failed_status_payload =
+                            DownloadConfigFileStatusMessage::status_failed(default_error_message)?;
+                        Ok(Message::new(&c8y_child_topic, failed_status_payload))
+                    }
+                }
+                OperationStatus::Executing => {
+                    let executing_status_payload =
+                        DownloadConfigFileStatusMessage::status_executing()?;
+                    Ok(Message::new(&c8y_child_topic, executing_status_payload))
+                }
+            }
+        } else {
+            Err(ChildDeviceConfigManagementError::EmptyOperationStatus(
+                c8y_child_topic,
+            ))
+        }
+    }
+
+    async fn download_config_file(
+        &self,
+        download_url: &str,
+        file_path: PathBuf,
+        file_permissions: PermissionEntry,
+    ) -> Result<(), anyhow::Error> {
+        // Convert smartrest request to config download request struct
+        let mut config_download_request = ConfigDownloadRequest::try_new(
+            download_url,
+            file_path.clone(),
+            self.tmp_dir.clone(),
+            file_permissions,
+        )?;
+
+        if file_path.exists() {
+            // Confirm that the file has write access before any http request attempt
+            config_download_request.has_write_access()?;
+        } else if let Some(file_parent) = file_path.parent() {
+            if !file_parent.exists() {
+                fs::create_dir_all(file_parent)?;
             }
         }
-    } else {
-        Err(ChildDeviceConfigManagementError::EmptyOperationStatus(
-            c8y_child_topic,
-        ))
-    }
-}
 
-async fn download_config_file(
-    download_url: &str,
-    file_path: PathBuf,
-    tmp_dir: PathBuf,
-    file_permissions: PermissionEntry,
-    http_client: &mut impl C8YHttpProxy,
-) -> Result<(), anyhow::Error> {
-    // Convert smartrest request to config download request struct
-    let mut config_download_request =
-        ConfigDownloadRequest::try_new(download_url, file_path.clone(), tmp_dir, file_permissions)?;
-
-    if file_path.exists() {
-        // Confirm that the file has write access before any http request attempt
-        config_download_request.has_write_access()?;
-    } else if let Some(file_parent) = file_path.parent() {
-        if !file_parent.exists() {
-            fs::create_dir_all(file_parent)?;
+        // If the provided url is c8y, add auth
+        if self
+            .http_client
+            .lock()
+            .await
+            .url_is_in_my_tenant_domain(config_download_request.download_info.url())
+        {
+            let token = self.http_client.lock().await.get_jwt_token().await?;
+            config_download_request.download_info.auth = Some(Auth::new_bearer(&token.token()));
         }
+
+        // Download a file to tmp dir
+        let downloader = config_download_request.create_downloader();
+        downloader
+            .download(&config_download_request.download_info)
+            .await?;
+
+        // Move the downloaded file to the final destination
+        config_download_request.move_file()?;
+
+        Ok(())
     }
-
-    // If the provided url is c8y, add auth
-    if http_client.url_is_in_my_tenant_domain(config_download_request.download_info.url()) {
-        let token = http_client.get_jwt_token().await?;
-        config_download_request.download_info.auth = Some(Auth::new_bearer(&token.token()));
-    }
-
-    // Download a file to tmp dir
-    let downloader = config_download_request.create_downloader();
-    downloader
-        .download(&config_download_request.download_info)
-        .await?;
-
-    // Move the downloaded file to the final destination
-    config_download_request.move_file()?;
-
-    Ok(())
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/plugins/c8y_configuration_plugin/src/main.rs
+++ b/plugins/c8y_configuration_plugin/src/main.rs
@@ -1,5 +1,6 @@
 mod child_device;
 mod config;
+mod config_manager;
 mod download;
 mod error;
 mod operation;
@@ -9,50 +10,23 @@ mod upload;
 #[cfg(test)]
 mod tests;
 
-use crate::upload::handle_config_upload_request;
-use crate::{
-    child_device::ConfigOperationResponse,
-    download::{
-        handle_child_device_config_update_response, handle_config_download_request,
-        DownloadConfigFileStatusMessage,
-    },
-};
-use crate::{config::PluginConfig, upload::handle_child_device_config_snapshot_response};
+use crate::config::PluginConfig;
 
 use anyhow::Result;
 use c8y_api::http_proxy::{C8YHttpProxy, JwtAuthHttpProxy};
-use c8y_api::smartrest::smartrest_deserializer::{
-    SmartRestConfigDownloadRequest, SmartRestConfigUploadRequest, SmartRestRequestGeneric,
-};
-use c8y_api::smartrest::smartrest_serializer::TryIntoOperationStatusMessage;
-use c8y_api::smartrest::topic::C8yTopic;
-use child_device::get_child_id_from_child_topic;
 use clap::Parser;
-use mqtt_channel::{Connection, Message, MqttError, SinkExt, StreamExt, Topic, TopicFilter};
-use operation::ConfigOperation;
-use upload::UploadConfigFileStatusMessage;
+use config_manager::ConfigManager;
+use tokio::sync::Mutex;
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tedge_config::{
     ConfigRepository, ConfigSettingAccessor, DeviceIdSetting, IpAddress, MqttBindAddressSetting,
     MqttExternalBindAddressSetting, MqttPortSetting, TEdgeConfig, TmpPathSetting,
     DEFAULT_TEDGE_CONFIG_PATH,
 };
-use tedge_utils::{
-    file::{create_directory_with_user_group, create_file_with_user_group},
-    notify::fs_notify_stream,
-    paths::PathsError,
-};
-use thin_edge_json::health::{health_check_topics, send_health_status};
-use topic::ConfigOperationResponseTopic;
-
-use tedge_utils::notify::FsEvent;
+use tedge_utils::file::{create_directory_with_user_group, create_file_with_user_group};
 use tracing::{error, info};
-
-pub const DEFAULT_PLUGIN_CONFIG_FILE_NAME: &str = "c8y-configuration-plugin.toml";
-pub const DEFAULT_OPERATION_DIR_NAME: &str = "c8y/";
-pub const DEFAULT_PLUGIN_CONFIG_TYPE: &str = "c8y-configuration-plugin";
-pub const CONFIG_CHANGE_TOPIC: &str = "tedge/configuration_change";
 
 const AFTER_HELP_TEXT: &str = r#"On start, `c8y_configuration_plugin` notifies the cloud tenant of the managed configuration files, listed in the `CONFIG_FILE`, sending this list with a `119` on `c8y/s/us`.
 `c8y_configuration_plugin` subscribes then to `c8y/s/ds` listening for configuration operation requests (messages `524` and `526`).
@@ -84,23 +58,6 @@ pub struct ConfigPluginOpt {
 
     #[clap(long = "config-dir", default_value = DEFAULT_TEDGE_CONFIG_PATH)]
     pub config_dir: PathBuf,
-}
-
-async fn create_mqtt_client(mqtt_port: u16) -> Result<mqtt_channel::Connection, anyhow::Error> {
-    let mut topic_filter =
-        mqtt_channel::TopicFilter::new_unchecked(&C8yTopic::SmartRestRequest.to_string());
-    topic_filter.add_all(health_check_topics("c8y-configuration-plugin"));
-
-    topic_filter.add_all(ConfigOperationResponseTopic::SnapshotResponse.into());
-    topic_filter.add_all(ConfigOperationResponseTopic::UpdateResponse.into());
-
-    let mqtt_config = mqtt_channel::Config::default()
-        .with_session_name("c8y-configuration-plugin")
-        .with_port(mqtt_port)
-        .with_subscriptions(topic_filter);
-
-    let mqtt_client = mqtt_channel::Connection::new(&mqtt_config).await?;
-    Ok(mqtt_client)
 }
 
 pub async fn create_http_client(
@@ -139,298 +96,29 @@ async fn main() -> Result<(), anyhow::Error> {
     };
 
     let mqtt_port = tedge_config.query(MqttPortSetting)?.into();
-    let mut http_client = create_http_client(&tedge_config).await?;
+    let http_client = create_http_client(&tedge_config).await?;
+    let http_client: Arc<Mutex<dyn C8YHttpProxy>> = Arc::new(Mutex::new(http_client));
     let tmp_dir = tedge_config.query(TmpPathSetting)?.into();
 
     //TODO: Port number to be read from HttpPortSetting
     let local_http_host = format!("{}:8000", bind_address.to_string().as_str());
 
-    run(
+    let mut config_manager = ConfigManager::new(
         tedge_device_id,
         mqtt_port,
-        &mut http_client,
-        &local_http_host,
+        http_client,
+        local_http_host,
         tmp_dir,
-        &config_plugin_opt.config_dir,
+        config_plugin_opt.config_dir,
     )
-    .await
-}
+    .await?;
 
-async fn run(
-    tedge_device_id: String,
-    mqtt_port: u16,
-    http_client: &mut impl C8YHttpProxy,
-    local_http_host: &str,
-    tmp_dir: PathBuf,
-    config_dir: &Path,
-) -> Result<(), anyhow::Error> {
-    // `config_file_dir` expands to: /etc/tedge/c8y or `config-dir`/c8y
-    let config_file_dir = config_dir.join(DEFAULT_OPERATION_DIR_NAME);
-    let mut plugin_config =
-        PluginConfig::new(&config_file_dir.join(DEFAULT_PLUGIN_CONFIG_FILE_NAME));
-    let mut mqtt_client = create_mqtt_client(mqtt_port).await?;
-
-    // Publish supported configuration types
-    publish_supported_config_types(&mut mqtt_client, &plugin_config).await?;
-
-    // Get pending operations
-    let msg = Message::new(&C8yTopic::SmartRestResponse.to_topic()?, "500");
-    mqtt_client.published.send(msg).await?;
-
-    // we watch `config_file_path` for any change to a file named `DEFAULT_PLUGIN_CONFIG_FILE_NAME`
-    let mut fs_notification_stream = fs_notify_stream(&[(
-        &config_file_dir,
-        Some(DEFAULT_PLUGIN_CONFIG_FILE_NAME.to_string()),
-        &[
-            FsEvent::Modified,
-            FsEvent::FileDeleted,
-            FsEvent::FileCreated,
-        ],
-    )])?;
-
-    loop {
-        tokio::select! {
-            message = mqtt_client.received.next() => {
-            if let Some(message) = message {
-                let topic = message.topic.name.clone();
-                if let Err(err) = process_mqtt_message(
-                    message,
-                    &mut mqtt_client,
-                    http_client,
-                    local_http_host,
-                    tmp_dir.clone(),
-                    tedge_device_id.as_str(),
-                    config_dir
-                )
-                .await {
-                    error!("Processing the message received on {topic} failed with {err}");
-                }
-            } else {
-                // message is None and the connection has been closed
-                return Ok(())
-            }
-        }
-        Some((path, mask)) = fs_notification_stream.rx.recv() => {
-            match mask {
-                FsEvent::Modified | FsEvent::FileDeleted | FsEvent::FileCreated => {
-                    match path.file_name() {
-                        Some(file_name) => {
-                            // this if check is done to avoid matching on temporary files created by editors
-                            if file_name.eq(DEFAULT_PLUGIN_CONFIG_FILE_NAME) {
-                                let parent_dir_name = path.parent().and_then(|dir| dir.file_name()).ok_or(PathsError::ParentDirNotFound {path: path.as_os_str().into()})?;
-
-                                if parent_dir_name.eq("c8y") {
-                                    plugin_config = PluginConfig::new(&path);
-                                    let message = plugin_config.to_supported_config_types_message()?;
-                                    mqtt_client.published.send(message).await?;
-                                } else {
-                                    // this is a child device
-                                    plugin_config = PluginConfig::new(&path);
-                                    let message = plugin_config.to_supported_config_types_message_for_child(&parent_dir_name.to_string_lossy())?;
-                                    mqtt_client.published.send(message).await?;
-
-                                }
-                            }
-
-                        },
-                        None => {}
-                    }
-                },
-                _ => {
-                    // ignore other FsEvent(s)
-                }
-            }
-        }}
-    }
-}
-
-async fn process_mqtt_message(
-    message: Message,
-    mqtt_client: &mut Connection,
-    http_client: &mut impl C8YHttpProxy,
-    local_http_host: &str,
-    tmp_dir: PathBuf,
-    tedge_device_id: &str,
-    config_dir: &Path,
-) -> Result<(), anyhow::Error> {
-    let health_check_topics = health_check_topics("c8y-configuration-plugin");
-    let config_snapshot_response: TopicFilter =
-        ConfigOperationResponseTopic::SnapshotResponse.into();
-    let config_update_response: TopicFilter = ConfigOperationResponseTopic::UpdateResponse.into();
-    let c8y_request_topic: TopicFilter = C8yTopic::SmartRestRequest.into();
-
-    if health_check_topics.accept(&message) {
-        send_health_status(&mut mqtt_client.published, "c8y-configuration-plugin").await;
-        return Ok(());
-    } else if config_snapshot_response.accept(&message) {
-        info!("config snapshot response");
-        handle_child_device_config_operation_response(
-            &message,
-            mqtt_client,
-            http_client,
-            config_dir,
-        )
-        .await?;
-    } else if config_update_response.accept(&message) {
-        info!("config update response");
-        handle_child_device_config_operation_response(
-            &message,
-            mqtt_client,
-            http_client,
-            config_dir,
-        )
-        .await?;
-    } else if c8y_request_topic.accept(&message) {
-        let payload = message.payload_str()?;
-        for smartrest_message in payload.split('\n') {
-            let result = match smartrest_message.split(',').next().unwrap_or_default() {
-                "524" => {
-                    let maybe_config_download_request =
-                        SmartRestConfigDownloadRequest::from_smartrest(smartrest_message);
-                    if let Ok(config_download_request) = maybe_config_download_request {
-                        handle_config_download_request(
-                            config_download_request,
-                            tmp_dir.clone(),
-                            mqtt_client,
-                            http_client,
-                            local_http_host,
-                            tedge_device_id,
-                            config_dir,
-                        )
-                        .await
-                    } else {
-                        error!(
-                            "Incorrect Download SmartREST payload: {}",
-                            smartrest_message
-                        );
-                        Ok(())
-                    }
-                }
-                "526" => {
-                    // retrieve config file upload smartrest request from payload
-                    let maybe_config_upload_request =
-                        SmartRestConfigUploadRequest::from_smartrest(smartrest_message);
-
-                    if let Ok(config_upload_request) = maybe_config_upload_request {
-                        // handle the config file upload request
-                        handle_config_upload_request(
-                            config_upload_request,
-                            mqtt_client,
-                            http_client,
-                            local_http_host,
-                            tedge_device_id,
-                            config_dir,
-                        )
-                        .await
-                    } else {
-                        error!("Incorrect Upload SmartREST payload: {}", smartrest_message);
-                        Ok(())
-                    }
-                }
-                _ => {
-                    // Ignore operation messages not meant for this plugin
-                    Ok(())
-                }
-            };
-
-            if let Err(err) = result {
-                error!("Handling of operation: '{smartrest_message}' failed with {err}");
-            }
-        }
-    } else {
-        error!(
-            "Received unexpected message on topic: {}",
-            message.topic.name
-        );
-    }
-    Ok(())
-}
-
-pub async fn handle_child_device_config_operation_response(
-    message: &Message,
-    mqtt_client: &mut Connection,
-    http_client: &mut impl C8YHttpProxy,
-    config_dir: &Path,
-) -> Result<(), anyhow::Error> {
-    match ConfigOperationResponse::try_from(message) {
-        Ok(config_response) => {
-            let smartrest_response = match &config_response {
-                ConfigOperationResponse::Update { .. } => {
-                    handle_child_device_config_update_response(&config_response)?
-                }
-                ConfigOperationResponse::Snapshot { .. } => {
-                    handle_child_device_config_snapshot_response(
-                        &config_response,
-                        http_client,
-                        config_dir,
-                    )
-                    .await?
-                }
-            };
-
-            mqtt_client.published.send(smartrest_response).await?;
-            Ok(())
-        }
-        Err(err) => {
-            fail_pending_config_operation_in_c8y(message, err.to_string(), mqtt_client).await
-        }
-    }
-}
-
-pub async fn fail_pending_config_operation_in_c8y(
-    message: &Message,
-    failure_reason: String,
-    mqtt_client: &mut Connection,
-) -> Result<(), anyhow::Error> {
-    // Fail the operation in the cloud by sending EXECUTING and FAILED responses back to back
-    let config_operation = message.try_into()?;
-    let child_id = get_child_id_from_child_topic(&message.topic.name)?;
-
-    let c8y_child_topic =
-        Topic::new_unchecked(&C8yTopic::ChildSmartRestResponse(child_id).to_string());
-
-    let (executing_msg, failed_msg) = match config_operation {
-        ConfigOperation::Snapshot => {
-            let executing_msg = Message::new(
-                &c8y_child_topic,
-                UploadConfigFileStatusMessage::status_executing()?,
-            );
-            let failed_msg = Message::new(
-                &c8y_child_topic,
-                UploadConfigFileStatusMessage::status_failed(failure_reason)?,
-            );
-            (executing_msg, failed_msg)
-        }
-        ConfigOperation::Update => {
-            let executing_msg = Message::new(
-                &c8y_child_topic,
-                DownloadConfigFileStatusMessage::status_executing()?,
-            );
-            let failed_msg = Message::new(
-                &c8y_child_topic,
-                DownloadConfigFileStatusMessage::status_failed(failure_reason)?,
-            );
-            (executing_msg, failed_msg)
-        }
-    };
-    mqtt_client.published.send(executing_msg).await?;
-    mqtt_client.published.send(failed_msg).await?;
-
-    Ok(())
+    config_manager.run().await
 }
 
 fn init(cfg_dir: PathBuf) -> Result<(), anyhow::Error> {
     info!("Creating supported operation files");
     create_operation_files(&cfg_dir)?;
-    Ok(())
-}
-
-async fn publish_supported_config_types(
-    mqtt_client: &mut Connection,
-    plugin_config: &PluginConfig,
-) -> Result<(), MqttError> {
-    let message = plugin_config.to_supported_config_types_message()?;
-    mqtt_client.published.send(message).await?;
     Ok(())
 }
 

--- a/plugins/c8y_configuration_plugin/src/upload.rs
+++ b/plugins/c8y_configuration_plugin/src/upload.rs
@@ -3,8 +3,9 @@ use crate::{
         try_cleanup_config_file_from_file_transfer_repositoy, ConfigOperationMessage,
         ConfigOperationRequest, ConfigOperationResponse,
     },
+    config_manager::{DEFAULT_OPERATION_DIR_NAME, DEFAULT_PLUGIN_CONFIG_FILE_NAME},
     error::{ChildDeviceConfigManagementError, ConfigManagementError},
-    PluginConfig, DEFAULT_OPERATION_DIR_NAME, DEFAULT_PLUGIN_CONFIG_FILE_NAME,
+    PluginConfig,
 };
 use agent_interface::OperationStatus;
 use anyhow::Result;
@@ -21,8 +22,12 @@ use c8y_api::smartrest::{
 
 use mqtt_channel::{Connection, Message, SinkExt, Topic};
 use tedge_utils::file::{create_directory_with_user_group, create_file_with_user_group};
+use tokio::sync::Mutex;
 
-use std::path::Path;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tracing::{error, info, warn};
 
 pub struct UploadConfigFileStatusMessage {}
@@ -54,287 +59,307 @@ impl TryIntoOperationStatusMessage for UploadConfigFileStatusMessage {
     }
 }
 
-pub async fn handle_config_upload_request(
-    config_upload_request: SmartRestConfigUploadRequest,
-    mqtt_client: &mut Connection,
-    http_client: &mut impl C8YHttpProxy,
-    local_http_host: &str,
-    tedge_device_id: &str,
-    config_dir: &Path,
-) -> Result<()> {
-    if config_upload_request.device == tedge_device_id {
-        handle_config_upload_request_tedge_device(
-            config_upload_request,
+pub struct ConfigUploadManager {
+    tedge_device_id: String,
+    mqtt_client: Arc<Mutex<Connection>>,
+    http_client: Arc<Mutex<dyn C8YHttpProxy>>,
+    local_http_host: String,
+    config_dir: PathBuf,
+}
+
+impl ConfigUploadManager {
+    pub fn new(
+        tedge_device_id: String,
+        mqtt_client: Arc<Mutex<Connection>>,
+        http_client: Arc<Mutex<dyn C8YHttpProxy>>,
+        local_http_host: String,
+        config_dir: PathBuf,
+    ) -> Self {
+        ConfigUploadManager {
+            tedge_device_id,
             mqtt_client,
             http_client,
-            config_dir,
-        )
-        .await
-    } else {
-        handle_config_upload_request_child_device(
-            config_upload_request,
-            mqtt_client,
             local_http_host,
             config_dir,
-        )
-        .await
+        }
     }
-}
 
-pub async fn handle_config_upload_request_tedge_device(
-    config_upload_request: SmartRestConfigUploadRequest,
-    mqtt_client: &mut Connection,
-    http_client: &mut impl C8YHttpProxy,
-    config_dir: &Path,
-) -> Result<()> {
-    // set config upload request to executing
-    let msg = UploadConfigFileStatusMessage::executing()?;
-    mqtt_client.published.send(msg).await?;
-
-    let config_file_path = config_dir
-        .join(DEFAULT_OPERATION_DIR_NAME)
-        .join(DEFAULT_PLUGIN_CONFIG_FILE_NAME);
-    let plugin_config = PluginConfig::new(&config_file_path);
-
-    let upload_result = {
-        match plugin_config.get_file_entry_from_type(&config_upload_request.config_type) {
-            Ok(file_entry) => {
-                let config_file_path = file_entry.path;
-                upload_config_file(
-                    Path::new(config_file_path.as_str()),
-                    &config_upload_request.config_type,
-                    http_client,
-                )
+    pub async fn handle_config_upload_request(
+        &self,
+        config_upload_request: SmartRestConfigUploadRequest,
+    ) -> Result<()> {
+        if config_upload_request.device == self.tedge_device_id {
+            self.handle_config_upload_request_tedge_device(config_upload_request)
                 .await
+        } else {
+            self.handle_config_upload_request_child_device(config_upload_request)
+                .await
+        }
+    }
+
+    pub async fn handle_config_upload_request_tedge_device(
+        &self,
+        config_upload_request: SmartRestConfigUploadRequest,
+    ) -> Result<()> {
+        // set config upload request to executing
+        let msg = UploadConfigFileStatusMessage::executing()?;
+        self.mqtt_client.lock().await.published.send(msg).await?;
+
+        let config_file_path = self
+            .config_dir
+            .join(DEFAULT_OPERATION_DIR_NAME)
+            .join(DEFAULT_PLUGIN_CONFIG_FILE_NAME);
+        let plugin_config = PluginConfig::new(&config_file_path);
+
+        let upload_result = {
+            match plugin_config.get_file_entry_from_type(&config_upload_request.config_type) {
+                Ok(file_entry) => {
+                    let config_file_path = file_entry.path;
+                    self.upload_config_file(
+                        Path::new(config_file_path.as_str()),
+                        &config_upload_request.config_type,
+                    )
+                    .await
+                }
+                Err(err) => Err(err.into()),
             }
-            Err(err) => Err(err.into()),
+        };
+
+        let target_config_type = &config_upload_request.config_type;
+
+        match upload_result {
+            Ok(upload_event_url) => {
+                info!("The configuration upload for '{target_config_type}' is successful.");
+
+                let successful_message =
+                    UploadConfigFileStatusMessage::successful(Some(upload_event_url))?;
+                self.mqtt_client
+                    .lock()
+                    .await
+                    .published
+                    .send(successful_message)
+                    .await?;
+            }
+            Err(err) => {
+                error!("The configuration upload for '{target_config_type}' failed.",);
+
+                let failed_message = UploadConfigFileStatusMessage::failed(err.to_string())?;
+                self.mqtt_client
+                    .lock()
+                    .await
+                    .published
+                    .send(failed_message)
+                    .await?;
+            }
         }
-    };
 
-    let target_config_type = &config_upload_request.config_type;
-
-    match upload_result {
-        Ok(upload_event_url) => {
-            info!("The configuration upload for '{target_config_type}' is successful.");
-
-            let successful_message =
-                UploadConfigFileStatusMessage::successful(Some(upload_event_url))?;
-            mqtt_client.published.send(successful_message).await?;
-        }
-        Err(err) => {
-            error!("The configuration upload for '{target_config_type}' failed.",);
-
-            let failed_message = UploadConfigFileStatusMessage::failed(err.to_string())?;
-            mqtt_client.published.send(failed_message).await?;
-        }
+        Ok(())
     }
 
-    Ok(())
-}
+    pub async fn upload_config_file(
+        &self,
+        config_file_path: &Path,
+        config_type: &str,
+    ) -> Result<String> {
+        // upload config file
+        let upload_event_url = self
+            .http_client
+            .lock()
+            .await
+            .upload_config_file(config_file_path, config_type, None)
+            .await?;
 
-pub async fn upload_config_file(
-    config_file_path: &Path,
-    config_type: &str,
-    http_client: &mut impl C8YHttpProxy,
-) -> Result<String> {
-    // upload config file
-    let upload_event_url = http_client
-        .upload_config_file(config_file_path, config_type, None)
-        .await?;
-
-    Ok(upload_event_url)
-}
-
-/// Map the c8y_UploadConfigFile request into a tedge/commands/req/config_snapshot command for the child device.
-/// The child device is expected to upload the config fie snapshot to the file transfer service.
-/// A unique URL path for this config file, from the file transfer service, is shared with the child device in the command.
-/// The child device can use this URL to upload the config file snapshot to the file transfer service.
-pub async fn handle_config_upload_request_child_device(
-    config_upload_request: SmartRestConfigUploadRequest,
-    mqtt_client: &mut Connection,
-    local_http_host: &str,
-    config_dir: &Path,
-) -> Result<()> {
-    let child_id = config_upload_request.device;
-    let config_type = config_upload_request.config_type;
-
-    let plugin_config = PluginConfig::new(Path::new(&format!(
-        "{}/c8y/{child_id}/c8y-configuration-plugin.toml",
-        config_dir.display()
-    )));
-
-    match plugin_config.get_file_entry_from_type(&config_type) {
-        Ok(file_entry) => {
-            let config_management = ConfigOperationRequest::Snapshot {
-                child_id,
-                file_entry,
-            };
-
-            info!("Sending config snapshot request to child device");
-            let msg = Message::new(
-                &config_management.operation_request_topic(),
-                config_management.operation_request_payload(local_http_host)?,
-            );
-            mqtt_client.published.send(msg).await?;
-        }
-        Err(ConfigManagementError::InvalidRequestedConfigType { config_type }) => {
-            warn!("Ignoring the config management request for unknown config type: {config_type}");
-        }
-        Err(err) => return Err(err)?,
+        Ok(upload_event_url)
     }
 
-    Ok(())
-}
+    /// Map the c8y_UploadConfigFile request into a tedge/commands/req/config_snapshot command for the child device.
+    /// The child device is expected to upload the config fie snapshot to the file transfer service.
+    /// A unique URL path for this config file, from the file transfer service, is shared with the child device in the command.
+    /// The child device can use this URL to upload the config file snapshot to the file transfer service.
+    pub async fn handle_config_upload_request_child_device(
+        &self,
+        config_upload_request: SmartRestConfigUploadRequest,
+    ) -> Result<()> {
+        let child_id = config_upload_request.device;
+        let config_type = config_upload_request.config_type;
 
-pub async fn handle_child_device_config_snapshot_response(
-    config_response: &ConfigOperationResponse,
-    http_client: &mut impl C8YHttpProxy,
-    config_dir: &Path,
-) -> Result<Message, ChildDeviceConfigManagementError> {
-    let payload = config_response.get_payload();
-    let c8y_child_topic = Topic::new_unchecked(&config_response.get_child_topic());
+        let plugin_config = PluginConfig::new(Path::new(&format!(
+            "{}/c8y/{child_id}/c8y-configuration-plugin.toml",
+            self.config_dir.display()
+        )));
 
-    if let Some(operation_status) = payload.status {
-        match operation_status {
-            OperationStatus::Successful => {
-                match handle_child_device_successful_config_snapshot_response(
-                    config_response,
-                    http_client,
-                )
-                .await
-                {
-                    Ok(message) => Ok(message),
-                    Err(err) => {
+        match plugin_config.get_file_entry_from_type(&config_type) {
+            Ok(file_entry) => {
+                let config_management = ConfigOperationRequest::Snapshot {
+                    child_id,
+                    file_entry,
+                };
+
+                info!("Sending config snapshot request to child device");
+                let msg = Message::new(
+                    &config_management.operation_request_topic(),
+                    config_management.operation_request_payload(&self.local_http_host)?,
+                );
+                self.mqtt_client.lock().await.published.send(msg).await?;
+            }
+            Err(ConfigManagementError::InvalidRequestedConfigType { config_type }) => {
+                warn!(
+                    "Ignoring the config management request for unknown config type: {config_type}"
+                );
+            }
+            Err(err) => return Err(err)?,
+        }
+
+        Ok(())
+    }
+
+    pub async fn handle_child_device_config_snapshot_response(
+        &self,
+        config_response: &ConfigOperationResponse,
+    ) -> Result<Message, ChildDeviceConfigManagementError> {
+        let payload = config_response.get_payload();
+        let c8y_child_topic = Topic::new_unchecked(&config_response.get_child_topic());
+        let config_dir = self.config_dir.display();
+
+        if let Some(operation_status) = payload.status {
+            match operation_status {
+                OperationStatus::Successful => {
+                    match self
+                        .handle_child_device_successful_config_snapshot_response(config_response)
+                        .await
+                    {
+                        Ok(message) => Ok(message),
+                        Err(err) => {
+                            let failed_status_payload =
+                                UploadConfigFileStatusMessage::status_failed(err.to_string())?;
+                            Ok(Message::new(&c8y_child_topic, failed_status_payload))
+                        }
+                    }
+                }
+                OperationStatus::Failed => {
+                    if let Some(error_message) = &payload.reason {
+                        let failed_status_payload = UploadConfigFileStatusMessage::status_failed(
+                            error_message.to_string(),
+                        )?;
+                        Ok(Message::new(&c8y_child_topic, failed_status_payload))
+                    } else {
+                        let default_error_message =
+                            String::from("No fail reason provided by child device.");
                         let failed_status_payload =
-                            UploadConfigFileStatusMessage::status_failed(err.to_string())?;
+                            UploadConfigFileStatusMessage::status_failed(default_error_message)?;
                         Ok(Message::new(&c8y_child_topic, failed_status_payload))
                     }
                 }
-            }
-            OperationStatus::Failed => {
-                if let Some(error_message) = &payload.reason {
-                    let failed_status_payload =
-                        UploadConfigFileStatusMessage::status_failed(error_message.to_string())?;
-                    Ok(Message::new(&c8y_child_topic, failed_status_payload))
-                } else {
-                    let default_error_message =
-                        String::from("No fail reason provided by child device.");
-                    let failed_status_payload =
-                        UploadConfigFileStatusMessage::status_failed(default_error_message)?;
-                    Ok(Message::new(&c8y_child_topic, failed_status_payload))
+                OperationStatus::Executing => {
+                    // is cloud request pending?
+                    let executing_status_payload =
+                        UploadConfigFileStatusMessage::status_executing()?;
+                    Ok(Message::new(&c8y_child_topic, executing_status_payload))
                 }
             }
-            OperationStatus::Executing => {
-                // is cloud request pending?
-                let executing_status_payload = UploadConfigFileStatusMessage::status_executing()?;
-                Ok(Message::new(&c8y_child_topic, executing_status_payload))
+        } else {
+            if &config_response.get_config_type() == "c8y-configuration-plugin" {
+                // create directories
+                create_directory_with_user_group(
+                    format!("{}/c8y/{}", config_dir, config_response.get_child_id()),
+                    "tedge",
+                    "tedge",
+                    0o755,
+                )?;
+                create_directory_with_user_group(
+                    format!(
+                        "{}/operations/c8y/{}",
+                        config_dir,
+                        config_response.get_child_id()
+                    ),
+                    "tedge",
+                    "tedge",
+                    0o755,
+                )?;
+                create_file_with_user_group(
+                    format!(
+                        "{}/operations/c8y/{}/c8y_DownloadConfigFile",
+                        config_dir,
+                        config_response.get_child_id()
+                    ),
+                    "tedge",
+                    "tedge",
+                    0o755,
+                    None,
+                )?;
+                create_file_with_user_group(
+                    format!(
+                        "{}/operations/c8y/{}/c8y_UploadConfigFile",
+                        config_dir,
+                        config_response.get_child_id()
+                    ),
+                    "tedge",
+                    "tedge",
+                    0o755,
+                    None,
+                )?;
+                // copy to /etc/c8y
+                let path_from = &format!(
+                    "/var/tedge/file-transfer/{}/c8y-configuration-plugin",
+                    config_response.get_child_id()
+                );
+                let path_from = Path::new(path_from);
+                let path_to = &format!(
+                    "{}/c8y/{}/c8y-configuration-plugin.toml",
+                    config_dir,
+                    config_response.get_child_id()
+                );
+                let path_to = Path::new(path_to);
+                std::fs::rename(path_from, path_to)?;
             }
-        }
-    } else {
-        if &config_response.get_config_type() == "c8y-configuration-plugin" {
-            // create directories
-            create_directory_with_user_group(
-                format!(
-                    "{}/c8y/{}",
-                    config_dir.display(),
-                    config_response.get_child_id()
-                ),
-                "tedge",
-                "tedge",
-                0o755,
-            )?;
-            create_directory_with_user_group(
-                format!(
-                    "{}/operations/c8y/{}",
-                    config_dir.display(),
-                    config_response.get_child_id()
-                ),
-                "tedge",
-                "tedge",
-                0o755,
-            )?;
-            create_file_with_user_group(
-                format!(
-                    "{}/operations/c8y/{}/c8y_DownloadConfigFile",
-                    config_dir.display(),
-                    config_response.get_child_id()
-                ),
-                "tedge",
-                "tedge",
-                0o755,
-                None,
-            )?;
-            create_file_with_user_group(
-                format!(
-                    "{}/operations/c8y/{}/c8y_UploadConfigFile",
-                    config_dir.display(),
-                    config_response.get_child_id()
-                ),
-                "tedge",
-                "tedge",
-                0o755,
-                None,
-            )?;
-            // copy to /etc/c8y
-            let path_from = &format!(
-                "/var/tedge/file-transfer/{}/c8y-configuration-plugin",
-                config_response.get_child_id()
-            );
-            let path_from = Path::new(path_from);
-            let path_to = &format!(
+            // send 119
+            let child_plugin_config = PluginConfig::new(Path::new(&format!(
                 "{}/c8y/{}/c8y-configuration-plugin.toml",
-                config_dir.display(),
+                config_dir,
                 config_response.get_child_id()
-            );
-            let path_to = Path::new(path_to);
-            std::fs::rename(path_from, path_to)?;
-        }
-        // send 119
-        let child_plugin_config = PluginConfig::new(Path::new(&format!(
-            "{}/c8y/{}/c8y-configuration-plugin.toml",
-            config_dir.display(),
-            config_response.get_child_id()
-        )));
+            )));
 
-        // Publish supported configuration types for child devices
-        let message = child_plugin_config
-            .to_supported_config_types_message_for_child(&config_response.get_child_id())?;
+            // Publish supported configuration types for child devices
+            let message = child_plugin_config
+                .to_supported_config_types_message_for_child(&config_response.get_child_id())?;
+            Ok(message)
+        }
+    }
+
+    pub async fn handle_child_device_successful_config_snapshot_response(
+        &self,
+        config_response: &ConfigOperationResponse,
+    ) -> Result<Message, anyhow::Error> {
+        let c8y_child_topic = Topic::new_unchecked(&config_response.get_child_topic());
+
+        let uploaded_config_file_path = config_response.file_transfer_repository_full_path();
+
+        let c8y_upload_event_url = self
+            .http_client
+            .lock()
+            .await
+            .upload_config_file(
+                Path::new(&uploaded_config_file_path),
+                &config_response.get_config_type(),
+                Some(config_response.get_child_id()),
+            )
+            .await?;
+
+        // Cleanup the child uploaded file after uploading it to cloud
+        try_cleanup_config_file_from_file_transfer_repositoy(config_response);
+
+        info!("Marking the c8y_UploadConfigFile operation as successful with the Cumulocity URL for the uploaded file: {c8y_upload_event_url}");
+        let successful_status_payload =
+            UploadConfigFileStatusMessage::status_successful(Some(c8y_upload_event_url))?;
+        let message = Message::new(&c8y_child_topic, successful_status_payload);
+
         Ok(message)
     }
-}
-
-pub async fn handle_child_device_successful_config_snapshot_response(
-    config_response: &ConfigOperationResponse,
-    http_client: &mut impl C8YHttpProxy,
-) -> Result<Message, anyhow::Error> {
-    let c8y_child_topic = Topic::new_unchecked(&config_response.get_child_topic());
-
-    let uploaded_config_file_path = config_response.file_transfer_repository_full_path();
-
-    let c8y_upload_event_url = http_client
-        .upload_config_file(
-            Path::new(&uploaded_config_file_path),
-            &config_response.get_config_type(),
-            Some(config_response.get_child_id()),
-        )
-        .await?;
-
-    // Cleanup the child uploaded file after uploading it to cloud
-    try_cleanup_config_file_from_file_transfer_repositoy(config_response);
-
-    info!("Marking the c8y_UploadConfigFile operation as successful with the Cumulocity URL for the uploaded file: {c8y_upload_event_url}");
-    let successful_status_payload =
-        UploadConfigFileStatusMessage::status_successful(Some(c8y_upload_event_url))?;
-    let message = Message::new(&c8y_child_topic, successful_status_payload);
-
-    Ok(message)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use c8y_api::http_proxy::MockC8YHttpProxy;
-    use mockall::predicate;
     use mqtt_channel::Topic;
 
     #[test]
@@ -364,29 +389,5 @@ mod tests {
             message.payload_str().unwrap(),
             "502,c8y_UploadConfigFile,\"failed reason\"\n"
         );
-    }
-
-    #[tokio::test]
-    async fn test_upload_config_file() -> anyhow::Result<()> {
-        let config_path = Path::new("/some/temp/path");
-        let config_type = "config_type";
-
-        let mut http_client = MockC8YHttpProxy::new();
-
-        http_client
-            .expect_upload_config_file()
-            .with(
-                predicate::eq(config_path),
-                predicate::eq(config_type),
-                predicate::eq(None),
-            )
-            .return_once(|_path, _type, _child_id| Ok("http://server/config/file/url".to_string()));
-
-        assert_eq!(
-            upload_config_file(config_path, config_type, &mut http_client).await?,
-            "http://server/config/file/url"
-        );
-
-        Ok(())
     }
 }


### PR DESCRIPTION
## Proposed changes

If a child device does not respond to a config management operation request, fail that operation in the cloud with a timeout.
This PR is split into two parts:

[x] Make the plugin stateful so that the request-response mappings can be tracked
[] Timeout unacknowledged config management operation requests 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

#1544 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

