### PR TITLE
tedge connect c8y fails to connect to cumulocity cloud on yocto

### DIFF
--- a/crates/core/tedge/src/cli/connect/c8y_direct_connection.rs
+++ b/crates/core/tedge/src/cli/connect/c8y_direct_connection.rs
@@ -1,4 +1,5 @@
 use super::{BridgeConfig, ConnectError};
+use crate::cli::connect::CONNECTION_TIMEOUT;
 use certificate::parse_root_certificate::create_tls_config;
 use rumqttc::tokio_rustls::rustls::{AlertDescription, Error};
 use rumqttc::{
@@ -19,6 +20,7 @@ pub fn create_device_with_direct_connection(
 
     let mut mqtt_options = MqttOptions::new(bridge_config.remote_clientid.clone(), host[0], 8883);
     mqtt_options.set_keep_alive(std::time::Duration::from_secs(5));
+    mqtt_options.set_connection_timeout(CONNECTION_TIMEOUT.as_secs());
 
     let tls_config = create_tls_config(
         bridge_config.bridge_root_cert_path.clone().into(),

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -14,6 +14,7 @@ const WAIT_FOR_CHECK_SECONDS: u64 = 2;
 const C8Y_CONFIG_FILENAME: &str = "c8y-bridge.conf";
 const AZURE_CONFIG_FILENAME: &str = "az-bridge.conf";
 pub(crate) const RESPONSE_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);
 const MOSQUITTO_RESTART_TIMEOUT_SECONDS: u64 = 5;
 const MQTT_TLS_PORT: u16 = 8883;
 const TEDGE_BRIDGE_CONF_DIR_PATH: &str = "mosquitto-conf";
@@ -260,6 +261,7 @@ fn check_device_status_c8y(tedge_config: &TEdgeConfig) -> Result<DeviceStatus, C
     );
 
     options.set_keep_alive(RESPONSE_TIMEOUT);
+    options.set_connection_timeout(CONNECTION_TIMEOUT.as_secs());
 
     let (mut client, mut connection) = rumqttc::Client::new(options, 10);
     let mut acknowledged = false;

--- a/crates/core/tedge/src/cli/connect/jwt_token.rs
+++ b/crates/core/tedge/src/cli/connect/jwt_token.rs
@@ -1,4 +1,4 @@
-use crate::cli::connect::{ConnectError, RESPONSE_TIMEOUT};
+use crate::cli::connect::{ConnectError, CONNECTION_TIMEOUT, RESPONSE_TIMEOUT};
 use rumqttc::QoS::AtLeastOnce;
 use rumqttc::{Event, Incoming, MqttOptions, Outgoing, Packet};
 
@@ -9,6 +9,7 @@ pub(crate) fn get_connected_c8y_url(port: u16, host: String) -> Result<String, C
 
     let mut options = MqttOptions::new(CLIENT_ID, host, port);
     options.set_keep_alive(RESPONSE_TIMEOUT);
+    options.set_connection_timeout(CONNECTION_TIMEOUT.as_secs());
 
     let (mut client, mut connection) = rumqttc::Client::new(options, 10);
     let mut acknowledged = false;


### PR DESCRIPTION
Signed-off-by: Pradeep Kumar K J <pkj@softwareag.com>

## Proposed changes
On `yocto` the `tedge connect c8y` was failing because the MQTT connections were timing out.
So, the `MQTT connection timeout` has been increased in the below MQTT client's connection.

- Direct connection to create the device in the c8y cloud
- Jwt token retrieval for verification of the connection

The default value was `5sec` now increased to `60sec`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/1595

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

