### PR TITLE
Parse timezone with negative offset

### DIFF
--- a/crates/core/c8y_api/src/smartrest/smartrest_deserializer.rs
+++ b/crates/core/c8y_api/src/smartrest/smartrest_deserializer.rs
@@ -159,6 +159,17 @@ impl SmartRestUpdateSoftwareModule {
     }
 }
 
+fn fix_timezone_offset(time: &str) -> String {
+    let str_size = time.len();
+    let split = time.split(['+', '-']).last();
+    match split {
+        Some(value) if !value.contains(':') => {
+            time[0..str_size - 2].to_string() + ":" + &time[str_size - 2..str_size]
+        }
+        _ => time.to_string(),
+    }
+}
+
 fn to_datetime<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
 where
     D: Deserializer<'de>,
@@ -171,15 +182,19 @@ where
     // so we add a ':'
     let mut date_string: String = Deserialize::deserialize(deserializer)?;
 
-    let str_size = date_string.len();
-    // check if `date_string` does not have a colon.
-    let date_string_end = &date_string.split('+').last();
-    date_string = match date_string_end {
-        Some(string) if !string.contains(':') => {
-            date_string[0..str_size - 2].to_string() + ":" + &date_string[str_size - 2..str_size]
+    if date_string.contains('T') {
+        let mut split = date_string.split('T');
+        let mut date_part = split.next().unwrap().to_string(); // safe.
+
+        let maybe_time_part = split.next();
+
+        if let Some(time_part) = maybe_time_part {
+            let time_part = fix_timezone_offset(time_part);
+            date_part.push('T');
+            date_part.push_str(&time_part);
         }
-        _ => date_string,
-    };
+        date_string = date_part;
+    }
 
     match OffsetDateTime::parse(&date_string, &format_description::well_known::Rfc3339) {
         Ok(result) => Ok(result),
@@ -554,6 +569,8 @@ mod tests {
     #[test_case("2021-09-21T11:40:27+02:00", "2021-09-22T11:40:27+02:00"; "with colon both")]
     #[test_case("2021-09-21T11:40:27+02:00", "2021-09-22T11:40:27+0200"; "with colon date from")]
     #[test_case("2021-09-21T11:40:27+0200", "2021-09-22T11:40:27+02:00"; "with colon date to")]
+    #[test_case("2021-09-21T11:40:27-0000", "2021-09-22T11:40:27-02:00"; "with negative timezone offset")]
+    #[test_case("2021-09-21T11:40:27Z", "2021-09-22T11:40:00Z"; "utc timezone")]
     fn deserialize_smartrest_log_file_request_operation(date_from: &str, date_to: &str) {
         let smartrest = String::from(&format!(
             "522,DeviceSerial,syslog,{},{},ERROR,1000",


### PR DESCRIPTION
## Proposed changes

Fixed a bug where only positive timezone offset (UTC+n) was formatted to rfc3339 expected format.
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #1633

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

