### PR TITLE
fix debian upgrade path

### DIFF
--- a/configuration/debian/tedge-agent/postinst
+++ b/configuration/debian/tedge-agent/postinst
@@ -53,4 +53,9 @@ if command -v systemctl >/dev/null; then
     fi
 fi
 
+if [ -f /var/lib/dpkg/info/tedge_agent.postrm ]; then
+    # Prevent purge from deleting files related to the package
+    rm -f /var/lib/dpkg/info/tedge_agent.postrm
+fi
+
 # Do not use DEBHELPER: for OTA self-update one needs a fine-control over the deb options

--- a/configuration/debian/tedge-mapper/postinst
+++ b/configuration/debian/tedge-mapper/postinst
@@ -30,3 +30,8 @@ if command -v systemctl >/dev/null; then
         systemctl start tedge-mapper-collectd.service
     fi
 fi
+
+if [ -f /var/lib/dpkg/info/tedge_mapper.postrm ]; then
+    # Prevent purge from deleting files related to the package
+    rm -f /var/lib/dpkg/info/tedge_mapper.postrm
+fi

--- a/crates/core/tedge_agent/Cargo.toml
+++ b/crates/core/tedge_agent/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/thin-edge/thin-edge.io"
 [package.metadata.deb]
 pre-depends = "tedge-mapper"
 replaces = "tedge_agent"
+conflicts = "tedge_agent (<= 0.8.1)"
+breaks = "tedge_agent (<= 0.8.1)"
+provides = "tedge_agent"
 maintainer-scripts = "../../../configuration/debian/tedge-agent"
 assets = [
     ["../../../configuration/init/systemd/tedge-agent.service", "/lib/systemd/system/tedge-agent.service", "644"],

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/thin-edge/thin-edge.io"
 [package.metadata.deb]
 pre-depends = "tedge"
 replaces = "tedge_mapper"
+conflicts = "tedge_mapper (<= 0.8.1)"
+breaks = "tedge_mapper (<= 0.8.1)"
+provides = "tedge_mapper"
 maintainer-scripts = "../../../configuration/debian/tedge-mapper"
 assets = [
     ["../../../configuration/init/systemd/tedge-mapper-az.service", "/lib/systemd/system/tedge-mapper-az.service", "644"],

--- a/crates/core/tedge_watchdog/Cargo.toml
+++ b/crates/core/tedge_watchdog/Cargo.toml
@@ -14,6 +14,8 @@ repository = "https://github.com/thin-edge/thin-edge.io"
 [package.metadata.deb]
 pre-depends = "tedge"
 replaces = "tedge_watchdog"
+conflicts = "tedge_watchdog (<= 0.8.1)"
+breaks = "tedge_watchdog (<= 0.8.1)"
 maintainer-scripts = "../../../configuration/debian/tedge-watchdog"
 assets = [
     ["../../../configuration/init/systemd/tedge-watchdog.service", "/lib/systemd/system/tedge-watchdog.service", "644"],

--- a/plugins/c8y_configuration_plugin/Cargo.toml
+++ b/plugins/c8y_configuration_plugin/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/thin-edge/thin-edge.io"
 
 [package.metadata.deb]
 replaces = "c8y_configuration_plugin"
+conflicts = "c8y_configuration_plugin (<= 0.8.1)"
+breaks = "c8y_configuration_plugin (<= 0.8.1)"
 maintainer-scripts = "../../configuration/debian/c8y-configuration-plugin"
 assets = [
     ["../../configuration/init/systemd/c8y-configuration-plugin.service", "/lib/systemd/system/c8y-configuration-plugin.service", "644"],

--- a/plugins/c8y_log_plugin/Cargo.toml
+++ b/plugins/c8y_log_plugin/Cargo.toml
@@ -12,6 +12,8 @@ repository = "https://github.com/thin-edge/thin-edge.io"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [package.metadata.deb]
 replaces = "c8y_log_plugin"
+conflicts = "c8y_log_plugin (<= 0.8.1)"
+breaks = "c8y_log_plugin (<= 0.8.1)"
 maintainer-scripts = "../../configuration/debian/c8y-log-plugin"
 assets = [
     ["../../configuration/init/systemd/c8y-log-plugin.service", "/lib/systemd/system/c8y-log-plugin.service", "644"],

--- a/plugins/tedge_apama_plugin/Cargo.toml
+++ b/plugins/tedge_apama_plugin/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/thin-edge/thin-edge.io"
 
 [package.metadata.deb]
 replaces = "tedge_apama_plugin"
+conflicts = "tedge_apama_plugin (<= 0.8.1)"
+breaks = "tedge_apama_plugin (<= 0.8.1)"
 assets = [
     ["target/release/tedge-apama-plugin", "/etc/tedge/sm-plugins/apama", "755"],
 ]

--- a/plugins/tedge_apt_plugin/Cargo.toml
+++ b/plugins/tedge_apt_plugin/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/thin-edge/thin-edge.io"
 
 [package.metadata.deb]
 replaces = "tedge_apt_plugin"
+conflicts = "tedge_apt_plugin (<= 0.8.1)"
+breaks = "tedge_apt_plugin (<= 0.8.1)"
 assets = [
     ["target/release/tedge-apt-plugin", "/etc/tedge/sm-plugins/apt", "755"],
 ]

--- a/plugins/tedge_dummy_plugin/Cargo.toml
+++ b/plugins/tedge_dummy_plugin/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/thin-edge/thin-edge.io"
 
 [package.metadata.deb]
 replaces = "tedge_dummy_plugin"
+conflicts = "tedge_dummy_plugin (<= 0.8.1)"
+breaks = "tedge_dummy_plugin (<= 0.8.1)"
 
 [dependencies]
 clap = { version = "3", features = ["derive"] }


### PR DESCRIPTION
Signed-off-by: Reuben Miller <reuben.miller@softwareag.com>

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

PR #1625 broke the upgrade path (installing from older versions). The installation of some packages (namely `tedge-mapper` and `tedge-agent`) would fail in the `postinst` maintainer scripts due to the flocks not being released. Upon further investigation it was found out that the maintainer scripts from the previous package were not being run which resulted in the related services not being stopped before the new `postinst` script from the renamed packages were executed.

The following changes were done to address the installation errors:

* Add `Breaks` and `Conflicts` Debian package relationships to the old renamed package to prevent both versions from being **installed** at the same time. This way all the maintainer scripts are properly executed
* Add `Provides` Debian package relationship for `tedge-mapper` and `tedge-agent` to avoid break packages which depend on them before those packages are updated
* Remove `postrm` maintainer scripts for older`tedge_mapper` and `tedge_agent` packages to prevent the related configuration files from being removed when the older packages are purged (as the older packages are not removed automatically during `dpkg --install`!). This change is unfortunate as it "feels very hacky" but I think it is unavoidable.
* `get-thin-edge_io.sh` when installing the packages with the new Debian conform names, then it will purge the old packages so that the user is not left with double the amount of packages (e.g. `tedge-mapper` and `tedge_mapper`). A purge is needed because due to the `Conflict` the older package is still marked as `ic` under `dpkg` which means it only has it's configuration installed. But since the `postrm` files have been removed, it is save to purge the older packages.


**Background into further research**

The proper way to transition a packages is documented by Debian under [Renaming Packages](https://wiki.debian.org/RenamingPackages), but unfortunately there are too many blockers (see below):

* Requires creation of a new meta package (transitioning package) which is just to handle the package renaming. This package would have to be hosted somewhere (or added to the releases package, but that would be way too confusing for users as there would be one transition package per package!)
* Since the packages are installed via `dpkg`, both the transition package and the new package need to be installed in the same command. This would be unfortunately unusable when updating from the cloud
* Building the transition package is problematic due to the original problem of having non-confirm Debian package names (e.g. using forbidden char `_` in the name). A lot of the tools don't function properly due to this.

Below are the links to the Debian reference documents

* https://wiki.debian.org/PackageTransition
* https://wiki.debian.org/RenamingPackages


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

