### PR TITLE
Add output to `tedge cert create` and `tedge cert remove` commands

### DIFF
--- a/crates/core/tedge/src/cli/certificate/create.rs
+++ b/crates/core/tedge/src/cli/certificate/create.rs
@@ -29,6 +29,7 @@ impl Command for CreateCertCmd {
     fn execute(&self) -> anyhow::Result<()> {
         let config = NewCertificateConfig::default();
         self.create_test_certificate(&config)?;
+        eprintln!("Certificate was successfully created");
         Ok(())
     }
 }

--- a/docs/src/howto-guides/003_registration.md
+++ b/docs/src/howto-guides/003_registration.md
@@ -8,6 +8,10 @@ To create new certificate you can use [`tedge cert create`](../references/tedge-
 sudo tedge cert create --device-id alpha
 ```
 
+```
+Certificate was successfully created
+```
+
 > Note: `tedge cert` requires `sudo` privilege. This command provides no output on success.
 
 [`sudo tedge cert create`](../references/tedge-cert.md) will create certificate in a default location (`/etc/tedge/device-certs/`).
@@ -57,6 +61,10 @@ Follow the instruction to remove the existing certificate and issue [`tedge cert
 
 ```shell
 sudo tedge cert remove
+```
+
+```
+Certificate was successfully removed
 ```
 
 and try [`tedge cert create`](../references/tedge-cert.md) once again.

--- a/docs/src/references/thin-edge-config-files.md
+++ b/docs/src/references/thin-edge-config-files.md
@@ -97,6 +97,7 @@ To create/remove/upload the certificate, one can use the below command.
 
 ```shell
 sudo tedge cert create --device-id thinedge
+Certificate was successfully created
 
 # Find the certificates that are created as below.
 

--- a/docs/src/tutorials/connect-azure.md
+++ b/docs/src/tutorials/connect-azure.md
@@ -33,6 +33,10 @@ Indeed, this certificate aims to authenticate that this device is the device wit
 sudo tedge cert create --device-id my-device
 ```
 
+```
+Certificate was successfully created
+```
+
 ## Show certificate details
 
 You can then check the content of that certificate.

--- a/docs/src/tutorials/connect-c8y.md
+++ b/docs/src/tutorials/connect-c8y.md
@@ -74,6 +74,10 @@ Indeed, this certificate aims to authenticate that this device is actually the d
 sudo tedge cert create --device-id my-device
 ```
 
+```
+Certificate was successfully created
+```
+
 You can then check the content of that certificate.
 
 ```shell


### PR DESCRIPTION
## Proposed changes

Added output to `tedge cert create` and `tedge cert remove` commands:

- `tedge cert create`
  - `Certificate was successfully created.` if certificate was successfully created
- `tedge cert remove`
  - `Certificate was successfully removed.` if certificate was removed
  - `There is no certificate to remove.` if there is no certificate

The documentation was also updated to include the added output.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

The change was made because I think it would be good for all the CLI commands that could possibly be invoked by the human, to print human-readable output describing what happened, even if just one sentence, it's better than nothing.

E.g. `tedge cert remove` returned `Ok` for both `cert removed` and `no cert` cases, but it had no output, so the user wouldn't know what actually happened. Alternatively `no cert` case could return an error, but I'd argue it makes more sense as a success case because the end result is the same as with `cert removed` case: there is no cert and a new one can be created.

As for the implementation, i separated the logic and printing between 2 impls, but e.g. `cli/certificate/show.rs` just does the printing in the 2nd impl, and if it's fine, then I could also move the print there and avoid some boilerplate.

Lastly, sorry if I'm bikeshedding too hard 😅


