### PR TITLE
Fix tedge-apt-plugin list to show the correct version

### DIFF
--- a/plugins/tedge_apt_plugin/src/main.rs
+++ b/plugins/tedge_apt_plugin/src/main.rs
@@ -254,7 +254,7 @@ fn get_name_and_version(line: &str) -> (&str, &str) {
         .first()
         .unwrap_or(&"unknown name")
         .split_once('/')
-        .unwrap_or((&"unknown name", &"others"))
+        .unwrap_or(("unknown name", "others"))
         .0;
     let version = if line.contains("upgradable from:") {
         // e.g. tedge/tedge-main 0.8.1-127-gb7d7d599 arm64 [upgradable from: 0.8.1]


### PR DESCRIPTION
## Proposed changes
When upgradable version is available, the plugin took the upgradable version instead of the actual installed version.

This implementation relies on the output format of `apt list --manual-installed`

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#1664 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

