### PR TITLE
Use cargo-make as the main task runner for the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,5 @@ tests/PySys/**/Output/
 **/*venv*
 
 # Other files
-Makefile.toml
 .vimspector.json
 .env

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,33 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.clean]
+command = "cargo"
+args = ["clean"]
+
+[tasks.format]
+install_crate = "rustfmt"
+command = "cargo"
+args = ["fmt"]
+
+[tasks.clippy]
+install_crate = "cargo-clippy"
+command = "cargo"
+args = ["clippy"]
+
+[tasks.build]
+command = "cargo"
+args = ["build"]
+dependencies = ["format", "clippy", "clean"]
+
+
+[tasks.test]
+command = "cargo"
+args = ["test"]
+dependencies = ["format", "clippy", "clean"]
+
+[tasks.flow]
+dependencies = [
+    "build",
+    "test"
+]


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->
Hi, unfortunately I did not have time to finish this ticket. All I added was a basic Makefile.toml, where I defined some tasks.  

There is also a makefile.toml that Lukasz created a while back, which I am pasting below.

```toml
[env]
CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true

[config]
default_to_workspace = false

[tasks.format]
install_crate = "rustfmt"
command = "cargo"
args = ["fmt", "--", "--check"]

[tasks.clippy]
install_crate = "clippy"
command = "cargo"
args = ["clippy"]

[tasks.tarpaulin]
install_crate = "cargo-tarpaulin"
command = "cargo"
args = ["tarpaulin"]

[tasks.audit]
install_crate = "cargo-audit"
command = "cargo"
args = ["audit"]

[tasks.outdated]
install_crate = "cargo-outdated"
command = "cargo"
args = ["outdated"]

[tasks.msrv]
install_crate = "cargo-msrv"
command = "cargo"
args = ["msrv", "--minimum", "1.54.0"]

[tasks.clean]
command = "cargo"
args = ["clean"]

[tasks.build]
command = "cargo"
args = ["build", "--release"]
dependencies = []

[tasks.test]
command = "cargo"
args = ["test", "--verbose"]
dependencies = []

[tasks.test-apt-plugin]
env = { "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER" = "sudo -E" }
command = "cargo"
args = ["test", "-p", "tedge_apt_plugin", "--features", "sudo-runner"]
dependencies = []

[tasks.run-mosquitto]
command = "mosquitto"
args = ["-p", "55555"]

[tasks.test-mosquitto-available-run]
command = "cargo"
args = ["test", "-p", "tedge_mapper", "--features", "mosquitto-available"]
dependencies = []

[tasks.test-mosquitto-available]
run_task = { name = ["run-mosquitto", "test-mosquitto-available-run"], parallel = true }


[tasks.test-mosquitto-available-all]
dependencies = ["test-mosquitto-available", "post-test-mosquitto-available"]

[tasks.post-test-mosquitto-available]
command = "killall"
args = ["mosquitto"]

[tasks.commit-all]
dependencies = [
    "format",
    "clippy",
    "build",
    "tarpaulin",
    "audit",
    "outdated",
    "msrv",
    "test",
    "test-apt-plugin"
]

[tasks.commit-tests]
dependencies = [
    "format",
    "clippy",
    "test"
]

[tasks.commit-build-tests]
dependencies = [
    "format",
    "clippy",
    "build",
    "test"
]
```

Lukasz' version is already quite complete.

What I think is missing is:

- [ ] adding a cross compilation task
- [ ] using this makefile in the pipeline

## Paste Link to the issue
- #1659

