### PR TITLE
Fix a method to split SmartREST messages and improve failure reason

### DIFF
--- a/crates/core/c8y_api/src/smartrest/message.rs
+++ b/crates/core/c8y_api/src/smartrest/message.rs
@@ -52,16 +52,86 @@ pub fn sanitize_for_smartrest(input: Vec<u8>, max_size: usize) -> String {
         .collect()
 }
 
-/// Get the last line of input.
+/// Generate a failure reason of operation with the following format.
+/// <Last line of input>
+/// (line break)
+/// <All records on input>
+///
+/// If the input has only one line, returns the line only.
 /// If the input is empty or contains invalid UTF-8, it returns an empty String.
-/// The last line is ensured to be SmartREST compatible.
-pub fn get_last_line_for_smartrest(input: Vec<u8>, max_size: usize) -> String {
+/// The output is ensured to be SmartREST compatible.
+pub fn get_failure_reason_for_smartrest(input: Vec<u8>, max_size: usize) -> String {
     let input_string = String::from_utf8(input).unwrap_or_else(|err| {
         error!("The input contains invalid UTF-8: {err}");
         String::default()
     });
     let last_line = input_string.lines().last().unwrap_or_default();
-    sanitize_for_smartrest(last_line.as_bytes().to_vec(), max_size)
+    let failure_reason = match input_string.lines().count() {
+        0 | 1 => last_line.to_string(),
+        _ => format!("{}\n\n{}", last_line, input_string.as_str()),
+    };
+    sanitize_for_smartrest(failure_reason.as_bytes().to_vec(), max_size)
+}
+
+/// Split MQTT message payload to multiple SmartREST messages.
+///
+/// ```
+/// use c8y_api::smartrest::message::collect_smartrest_messages;
+/// let data = "511,device,echo hello\n511,device,\"echo hello\necho world\"";
+/// let messages = collect_smartrest_messages(data);
+/// assert_eq!(messages[0], "511,device,echo hello");
+/// assert_eq!(messages[1], "511,device,\"echo hello\necho world\"");
+/// ```
+pub fn collect_smartrest_messages(data: &str) -> Vec<String> {
+    let mut stack: Vec<char> = Vec::new();
+    let mut smartrest_messages: Vec<String> = Vec::new();
+    let mut is_inside = false; // Inside an outermost double quote block or not.
+    let mut maybe_escaped = false; // The previous char is backslash or not.
+
+    for c in data.chars() {
+        if c == '\\' {
+            stack.push(c);
+            maybe_escaped = true;
+        } else if c == '"' {
+            if maybe_escaped {
+                stack.pop(); // Remove the literal backslash to avoid the backslash also escaped.
+                stack.push(c);
+            } else {
+                stack.push(c);
+                if is_inside {
+                    // End of the outermost block
+                    is_inside = false;
+                } else {
+                    // Beginning of the outermost block
+                    is_inside = true;
+                }
+            }
+            maybe_escaped = false;
+        } else if c == '\n' {
+            if is_inside {
+                // Still inside of the SmartREST message
+                stack.push(c);
+            } else {
+                // End of the SmartREST message
+                let message = stack.iter().collect();
+                smartrest_messages.push(message);
+                stack.clear();
+            }
+            maybe_escaped = false;
+        } else {
+            stack.push(c);
+            maybe_escaped = false;
+        }
+    }
+
+    // The last message doesn't end with `\n`.
+    if !stack.is_empty() {
+        let message = stack.iter().collect();
+        smartrest_messages.push(message);
+        stack.clear();
+    }
+
+    smartrest_messages
 }
 
 #[cfg(test)]
@@ -121,7 +191,7 @@ mod tests {
     fn invalid_utf8_is_contained_last_line() {
         let invalid_sparkle_heart = vec![0, 159, 146, 150];
         let last_line =
-            get_last_line_for_smartrest(invalid_sparkle_heart, MAX_PAYLOAD_LIMIT_IN_BYTES);
+            get_failure_reason_for_smartrest(invalid_sparkle_heart, MAX_PAYLOAD_LIMIT_IN_BYTES);
         assert_eq!(last_line, "".to_string());
     }
 
@@ -145,13 +215,15 @@ mod tests {
         assert_eq!(stripped, expected_output.to_string());
     }
 
-    #[test_case("foo\r\nbar\n\nbaz\n", "baz"; "standard")]
+    #[test_case("baz\n", "baz"; "one line")]
     #[test_case("baz", "baz"; "no new line")]
+    #[test_case("foo\r\nbar\n\nbaz\n", "baz\n\nfoo\r\n"; "multiline")]
     #[test_case("", ""; "empty")]
     #[test_case("おはよう\nこんにちは\n", "こんに"; "no ascii")]
-    fn return_last_line_of_vec_u8(input: &str, expected_output: &str) {
+    #[test_case("あ\nい\nう\nえ\nお\n", "お\n\nあ\n"; "no ascii2")]
+    fn return_formatted_text_for_failure_reason_from_vec_u8(input: &str, expected_output: &str) {
         let vec_u8 = input.as_bytes().to_vec();
-        let last_line = get_last_line_for_smartrest(vec_u8, 10);
+        let last_line = get_failure_reason_for_smartrest(vec_u8, 10);
         assert_eq!(last_line.as_str(), expected_output);
     }
 
@@ -161,5 +233,55 @@ mod tests {
             vec.push(u8::from(i))
         }
         vec
+    }
+
+    #[test]
+    fn split_single_smartrest_message() {
+        let data = r#"528,DeviceSerial,softwareA,1.0,url1,install,softwareB,2.0,url2,install"#;
+        let message = collect_smartrest_messages(data);
+        assert_eq!(
+            message[0],
+            r#"528,DeviceSerial,softwareA,1.0,url1,install,softwareB,2.0,url2,install"#
+        );
+    }
+
+    #[test]
+    fn split_multiple_smartrest_messages() {
+        let data = r#"511,device,echo hello
+511,device,"echo hello
+echo world"
+511,device,"echo \"hello\""
+511,device,"echo \"hello\"; echo \"world\""
+511,device,echo hello; echo world
+511,device,"echo hello,world"
+511,device,"echo \\"hello\\""
+528,DeviceSerial,softwareA,1.0,url1,install,softwareB,2.0,url2,install
+524,DeviceSerial,http://www.my.url,type
+524,DeviceSerial,"something",http://www.my.url,type
+511,device,511,rina0005,echo \\\"#;
+
+        let messages = collect_smartrest_messages(data);
+
+        assert_eq!(messages[0], r#"511,device,echo hello"#);
+        assert_eq!(
+            messages[1],
+            r#"511,device,"echo hello
+echo world""#
+        );
+        assert_eq!(messages[2], r#"511,device,"echo "hello"""#);
+        assert_eq!(messages[3], r#"511,device,"echo "hello"; echo "world"""#);
+        assert_eq!(messages[4], r#"511,device,echo hello; echo world"#);
+        assert_eq!(messages[5], r#"511,device,"echo hello,world""#);
+        assert_eq!(messages[6], r#"511,device,"echo \"hello\"""#);
+        assert_eq!(
+            messages[7],
+            r#"528,DeviceSerial,softwareA,1.0,url1,install,softwareB,2.0,url2,install"#
+        );
+        assert_eq!(messages[8], r#"524,DeviceSerial,http://www.my.url,type"#);
+        assert_eq!(
+            messages[9],
+            r#"524,DeviceSerial,"something",http://www.my.url,type"#
+        );
+        assert_eq!(messages[10], r#"511,device,511,rina0005,echo \\\"#);
     }
 }


### PR DESCRIPTION
## Proposed changes
When receiving multiline SmartREST messages, splitting simply by `\n` is not a right approach because a SmartREST message can also contain `\n`, e.g. an argument of c8y_Command.

Also, in case of an operation failure, giving only the last line of stderr is not easy enough for users to understand why the operation failed. It should give also the whole context as much as possible.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#1687

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

