### PR TITLE
Support custom fragments in alarm creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "c8y-remote-access-plugin"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "async-compat",
  "async-tungstenite",
@@ -479,6 +479,7 @@ dependencies = [
  "csv",
  "download",
  "futures",
+ "maplit",
  "mockall",
  "mockito",
  "mqtt_channel",
@@ -3283,6 +3284,7 @@ dependencies = [
  "csv",
  "download",
  "json-writer",
+ "maplit",
  "mockall",
  "mqtt_channel",
  "nanoid",

--- a/crates/core/c8y_api/Cargo.toml
+++ b/crates/core/c8y_api/Cargo.toml
@@ -35,6 +35,7 @@ tracing = { version = "0.1", features = ["attributes", "log"] }
 anyhow = "1.0"
 assert-json-diff = "2.0"
 assert_matches = "1.5"
+maplit = "1.0.2"
 mockito = "0.31"
 regex = "1.7"
 tempfile = "3.3"

--- a/crates/core/tedge_api/Cargo.toml
+++ b/crates/core/tedge_api/Cargo.toml
@@ -31,6 +31,7 @@ anyhow = "1.0"
 assert_matches = "1.5"
 clock = { path = "../../common/clock" }
 criterion = "0.3"
+maplit = "1.0.2"
 mockall = "0.11"
 proptest = "1.0"
 regex = "1.5"

--- a/crates/core/tedge_mapper/src/c8y/converter.rs
+++ b/crates/core/tedge_mapper/src/c8y/converter.rs
@@ -76,7 +76,6 @@ const INTERNAL_ALARMS_TOPIC: &str = "c8y-internal/alarms/";
 const TEDGE_EVENTS_TOPIC: &str = "tedge/events/";
 const C8Y_JSON_MQTT_EVENTS_TOPIC: &str = "c8y/event/events/create";
 const TEDGE_AGENT_LOG_DIR: &str = "tedge/agent";
-
 const CREATE_EVENT_SMARTREST_CODE: u16 = 400;
 
 #[derive(Debug)]


### PR DESCRIPTION
Signed-off-by: Pradeep Kumar K J <pradeepkumar.kj@softwareag.com>

## Proposed changes

Create an alarm with custom fragments
Supports for both `thin-edge` devices as well as for the `child` devices.
For example, if an alarm message is published with a custom fragment as below a child device it must create an alarm with the custom message.
```
tedge mqtt pub tedge/alarms/critical/myCustomAlarmType/child_device_example '{ "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1682

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

