### PR TITLE
tedge alarm does not transform message fragment to text in the tedge-mapper-c8y

### DIFF
--- a/crates/core/c8y_api/src/smartrest/alarm.rs
+++ b/crates/core/c8y_api/src/smartrest/alarm.rs
@@ -141,7 +141,6 @@ mod tests {
     struct SmartRestAlarm {
         pub code: i32,
         pub name: String,
-        pub message: Option<String>,
         pub time: Option<OffsetDateTime>,
     }
 
@@ -164,7 +163,6 @@ mod tests {
             let smartrest_alarm: SmartRestAlarm = result.unwrap();
             assert_eq!(smartrest_alarm.code, 301);
             assert_eq!(smartrest_alarm.name, "empty_alarm".to_string());
-            assert_eq!(smartrest_alarm.message, None);
             assert_matches!(smartrest_alarm.time, Some(_))
         }
     }

--- a/crates/core/tedge_api/src/alarm.rs
+++ b/crates/core/tedge_api/src/alarm.rs
@@ -222,7 +222,7 @@ mod tests {
             }),
             source: None,
         };
-        "warning alarm parsing without text or timestamp"
+        "warning alarm parsing with empty json payload"
     )]
     #[test_case(
         "tedge/alarms/critical/temperature_alarm/extern_sensor",
@@ -241,6 +241,43 @@ mod tests {
             source: Some("extern_sensor".to_string()),
         };
         "critical alarm parsing with childId"
+    )]
+    #[test_case(
+        "tedge/alarms/critical/temperature_alarm/extern_sensor",
+        json!({
+            "text": "I raised it",
+            "message": "Raised alarm with a message",
+            "time": "2021-04-23T19:00:00+05:00",
+        }),
+        ThinEdgeAlarm {
+            name: "temperature_alarm".into(),
+            severity: AlarmSeverity::Critical,
+            data: Some(ThinEdgeAlarmData {
+                text: Some("I raised it".into()),
+                time: Some(datetime!(2021-04-23 19:00:00 +05:00)),
+                alarm_data:hashmap!{"message".to_string() => json!("Raised alarm with a message".to_string())},
+            }),
+            source: Some("extern_sensor".to_string()),
+        };
+        "critical alarm parsing with text and custom message with childid"
+    )]
+    #[test_case(
+        "tedge/alarms/critical/temperature_alarm/extern_sensor",
+        json!({
+            "message": "Raised alarm with a message",
+            "time": "2021-04-23T19:00:00+05:00",
+        }),
+        ThinEdgeAlarm {
+            name: "temperature_alarm".into(),
+            severity: AlarmSeverity::Critical,
+            data: Some(ThinEdgeAlarmData {
+                text: None,
+                time: Some(datetime!(2021-04-23 19:00:00 +05:00)),
+                alarm_data: hashmap!{"message".to_string() => json!("Raised alarm with a message".to_string())},
+            }),
+            source: Some("extern_sensor".to_string()),
+        };
+        "critical alarm parsing for child no text and with custom message"
     )]
     fn parse_thin_edge_alarm_json(
         alarm_topic: &str,


### PR DESCRIPTION
Signed-off-by: Pradeep Kumar K J <pradeepkumar.kj@softwareag.com>

## Proposed changes

This PR addresses

- Adding tests for custom fragments
- Updating the documents related to the `custom` fragments.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1710

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

