### PR TITLE
Adapt monitoring of daemons to new Service Monitoring Feature in 10.14

### DIFF
--- a/crates/core/tedge_api/src/health.rs
+++ b/crates/core/tedge_api/src/health.rs
@@ -27,7 +27,7 @@ pub async fn send_health_status(responses: &mut impl PubChannel, daemon_name: &s
     })
     .to_string();
 
-    let health_message = Message::new(&response_topic_health, health_status);
+    let health_message = Message::new(&response_topic_health, health_status).with_retain();
     let _ = responses.send(health_message).await;
 }
 

--- a/crates/core/tedge_mapper/src/c8y/converter.rs
+++ b/crates/core/tedge_mapper/src/c8y/converter.rs
@@ -27,7 +27,9 @@ use logged_command::LoggedCommand;
 use mqtt_channel::Message;
 use mqtt_channel::Topic;
 use plugin_sm::operation_logs::OperationLogs;
+use service_monitor::convert_health_status_message;
 use std::collections::HashMap;
+
 use std::fs;
 use std::fs::File;
 use std::io::Read;
@@ -58,6 +60,7 @@ use super::alarm_converter::AlarmConverter;
 use super::error::CumulocityMapperError;
 use super::fragments::C8yAgentFragment;
 use super::fragments::C8yDeviceDataFragment;
+use super::service_monitor;
 use c8y_api::smartrest::message::collect_smartrest_messages;
 use c8y_api::smartrest::message::get_failure_reason_for_smartrest;
 use c8y_api::smartrest::message::get_smartrest_device_id;
@@ -308,6 +311,29 @@ where
         }
     }
 
+    pub async fn process_health_status_message(
+        &mut self,
+        message: &Message,
+    ) -> Result<Vec<Message>, ConversionError> {
+        let mut mqtt_messages: Vec<Message> = Vec::new();
+
+        // When there is some messages to be sent on behalf of a child device,
+        // this child device must be declared first, if not done yet
+        let topic_split: Vec<&str> = message.topic.name.split('/').collect();
+        if topic_split.len() == 4 {
+            let child_id = topic_split[2];
+            add_external_device_registration_message(
+                child_id.to_string(),
+                &mut self.children,
+                &mut mqtt_messages,
+            );
+        }
+
+        let mut message = convert_health_status_message(message, self.device_name.clone());
+        mqtt_messages.append(&mut message);
+        Ok(mqtt_messages)
+    }
+
     fn serialize_to_smartrest(c8y_event: &C8yCreateEvent) -> Result<String, ConversionError> {
         Ok(format!(
             "{},{},\"{}\",{}",
@@ -347,6 +373,9 @@ where
             }
             topic if topic.name.starts_with(TEDGE_EVENTS_TOPIC) => {
                 self.try_convert_event(message).await
+            }
+            topic if topic.name.starts_with("tedge/health") => {
+                self.process_health_status_message(message).await
             }
             topic => match topic.clone().try_into() {
                 Ok(MapperSubscribeTopic::ResponseTopic(ResponseTopic::SoftwareListResponse)) => {

--- a/crates/core/tedge_mapper/src/c8y/mod.rs
+++ b/crates/core/tedge_mapper/src/c8y/mod.rs
@@ -6,6 +6,7 @@ mod fragments;
 pub mod json;
 pub mod mapper;
 mod serializer;
+pub mod service_monitor;
 
 #[cfg(test)]
 mod tests;

--- a/crates/core/tedge_mapper/src/c8y/service_monitor.rs
+++ b/crates/core/tedge_mapper/src/c8y/service_monitor.rs
@@ -1,0 +1,193 @@
+use c8y_api::smartrest::topic::SMARTREST_PUBLISH_TOPIC;
+use mqtt_channel::Message;
+use mqtt_channel::Topic;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct HealthStatus {
+    #[serde(rename = "type", default = "default_type")]
+    pub service_type: String,
+
+    #[serde(default = "default_status")]
+    pub status: String,
+}
+
+fn default_type() -> String {
+    "service".to_string()
+}
+
+fn default_status() -> String {
+    "unknown".to_string()
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+pub struct TopicInfo {
+    pub service_name: String,
+    pub child_id: Option<String>,
+}
+
+impl TopicInfo {
+    fn parse_topic_info(topic: &str) -> Self {
+        let topic_split: Vec<&str> = topic.split('/').collect();
+        let service_name = if topic_split.len() == 4 {
+            topic_split[3]
+        } else {
+            topic_split[2]
+        }
+        .to_string();
+
+        let child_id = if topic_split.len() == 4 {
+            Some(topic_split[2].to_owned())
+        } else {
+            None
+        };
+
+        Self {
+            service_name,
+            child_id,
+        }
+    }
+}
+
+pub fn convert_health_status_message(message: &Message, device_name: String) -> Vec<Message> {
+    let mut mqtt_messages: Vec<Message> = Vec::new();
+    let topic = message.topic.name.to_owned();
+    let topic_info = TopicInfo::parse_topic_info(&topic);
+
+    // If not Bridge health status
+    if !topic_info.service_name.contains("bridge") {
+        let payload_str = message
+            .payload_str()
+            .unwrap_or(r#""type":"service","status":"unknown""#);
+
+        let mut health_status =
+            serde_json::from_str(payload_str).unwrap_or_else(|_| HealthStatus {
+                service_type: "service".to_string(),
+                status: "unknown".to_string(),
+            });
+
+        if health_status.status.is_empty() {
+            health_status.status = "unknown".into();
+        }
+
+        if health_status.service_type.is_empty() {
+            health_status.service_type = "service".into();
+        }
+
+        let status_message = service_monitor_status_message(
+            &device_name,
+            &topic_info.service_name,
+            &health_status.status,
+            &health_status.service_type,
+            topic_info.child_id,
+        );
+
+        mqtt_messages.push(status_message);
+    }
+
+    mqtt_messages
+}
+
+pub fn service_monitor_status_message(
+    device_name: &str,
+    daemon_name: &str,
+    status: &str,
+    service_type: &str,
+    child_id: Option<String>,
+) -> Message {
+    match child_id {
+        Some(cid) => Message {
+            topic: Topic::new_unchecked(&format!("{SMARTREST_PUBLISH_TOPIC}/{cid}")),
+            payload: format!(
+                "102,{device_name}_{cid}_{daemon_name},{service_type},{daemon_name},{status}"
+            )
+            .into_bytes(),
+            qos: mqtt_channel::QoS::AtLeastOnce,
+            retain: false,
+        },
+        None => Message {
+            topic: Topic::new_unchecked(SMARTREST_PUBLISH_TOPIC),
+            payload: format!(
+                "102,{device_name}_{daemon_name},{service_type},{daemon_name},{status}"
+            )
+            .into_bytes(),
+            qos: mqtt_channel::QoS::AtLeastOnce,
+            retain: false,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+    #[test_case(
+        "test_device",
+        "tedge/health/tedge-mapper-c8y",
+        r#"{"pid":"1234","type":"systemd","status":"up"}"#,
+        "c8y/s/us",
+        r#"102,test_device_tedge-mapper-c8y,systemd,tedge-mapper-c8y,up"#;        
+        "service-monitoring-thin-edge-device"
+    )]
+    #[test_case(
+        "test_device",
+        "tedge/health/child/tedge-mapper-c8y",
+        r#"{"pid":"1234","type":"systemd","status":"up"}"#,
+        "c8y/s/us/child",
+        r#"102,test_device_child_tedge-mapper-c8y,systemd,tedge-mapper-c8y,up"#;
+        "service-monitoring-thin-edge-child-device"
+    )]
+    #[test_case(
+        "test_device",
+        "tedge/health/tedge-mapper-c8y",
+        r#"{"pid":"123456","type":"systemd"}"#,
+        "c8y/s/us",
+        r#"102,test_device_tedge-mapper-c8y,systemd,tedge-mapper-c8y,unknown"#;
+        "service-monitoring-thin-edge-no-status"
+    )]
+    #[test_case(
+        "test_device",
+        "tedge/health/tedge-mapper-c8y",
+        r#"{"type":"systemd"}"#,
+        "c8y/s/us",
+        r#"102,test_device_tedge-mapper-c8y,systemd,tedge-mapper-c8y,unknown"#;
+        "service-monitoring-thin-edge-no-status-no-pid"
+    )]
+    #[test_case(
+        "test_device",
+        "tedge/health/tedge-mapper-c8y",
+        r#"{"type":"", "status":""}"#,
+        "c8y/s/us",
+        r#"102,test_device_tedge-mapper-c8y,service,tedge-mapper-c8y,unknown"#;
+        "service-monitoring-empty-status-and-type"
+    )]
+    #[test_case(
+        "test_device",
+        "tedge/health/tedge-mapper-c8y",
+        "{}",
+        "c8y/s/us",
+        r#"102,test_device_tedge-mapper-c8y,service,tedge-mapper-c8y,unknown"#;
+        "service-monitoring-empty-health-message"
+    )]
+    fn translate_health_status_to_c8y_service_monitoring_message(
+        device_name: &str,
+        health_topic: &str,
+        health_payload: &str,
+        c8y_monitor_topic: &str,
+        c8y_monitor_payload: &str,
+    ) {
+        let topic = Topic::new_unchecked(&health_topic);
+        let health_message = Message::new(&topic, health_payload.as_bytes().to_owned());
+        let expected_message = Message::new(
+            &Topic::new_unchecked(&c8y_monitor_topic),
+            c8y_monitor_payload.as_bytes(),
+        );
+
+        let msg = convert_health_status_message(&health_message, device_name.into());
+        dbg!(msg[0].payload_str().unwrap());
+        dbg!(expected_message.payload_str().unwrap());
+
+        assert_eq!(msg[0], expected_message);
+    }
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -48,6 +48,7 @@
   - [How to install thin-edge manually with OpenRC](./howto-guides/026_how_to_install_thin_edge_manually.md)
   - [How to enable configuration management on child devices](./howto-guides/child_device_config_management_agent.md)
   - [How to connect to your thin-edge.io device with Cumulocity remote access](./howto-guides/027_remote_access_with_cumulocity.md)
+  - [How to monitor a service from Cumulocity](./howto-guides/028_c8y_service_monitoring.md)
 
 - [Developer Documentation](dev_doc.md)
 

--- a/docs/src/howto-guides/028_c8y_service_monitoring.md
+++ b/docs/src/howto-guides/028_c8y_service_monitoring.md
@@ -1,0 +1,59 @@
+# How to monitor health of service from Cumulocity IoT
+
+The health of a `thin-edge.io` service or any other `service` that is running on the `thin-edge.io` device
+or on the `child` device can be monitored from the **Cumulocity IoT** by sending the `health-status` message to **Cumulocity IoT**.
+
+## Send the health status of a service to `tedge/health` topic.
+
+The table below lists the MQTT topics to which the health status message should be sent, and the
+health status message format for both the `thin-edge` and for the `child` device.
+
+|Device-type|Thin-edge-Health-status-mqtt-topic|Health-status-message|
+|------|------------------------|---------------------|
+|Thin-edge-device|`tedge/health/<service-name>`|`{"status":"status of the service","type":"type of service"}`|
+|Child-device|`tedge/health/<child-device-id>/<service-name>`|`{"status":"status of the service","type":"type of service"}`|
+
+> Note: The `status` here can be `up or down` or any other string. For example, `unknown`.
+
+For example, to monitor the health status of a `tedge-mapper-c8y service` that is running on a `thin-edge.io` device
+one has to send the below message.
+
+```
+tedge mqtt pub tedge/health/tedge-mapper-c8y `{"status":"up","type":"thin-edge.io"}` -q 2 -r
+```
+
+The above message says that the `tedge-mapper-c8y` is `up` and the `type` of the service is `thin-edge.io`.
+
+
+To monitor the health of a `docker` service that is running on an `external-sensor` child device,
+
+```
+tedge mqtt pub tedge/health/external-sensor/docker `{"status":"up","type":"systemd"}` -q 2 -r
+```
+
+> Note: The health status message has to be sent as a `retain` message.
+
+When an `empty health status,i.e('{}' or '')` message sent, the `status` will be replaced with `unknown` and the `type` will be replaced with default value `service`.
+
+## Conversion of the `health status` message to `Cumulocity IoT service monitor` message.
+
+The `tedge-mapper-c8y` will translate the `health status` message that is received on `tedge/health/#`
+topic to `Cumulocity` specific `service monitor` message and sends it to `Cumulocity` cloud.
+
+The table below gives more information about the **Cumulocity IoT** topic and the translated service monitor message for both `thin-edge` as well as for `child` device.
+
+|Device-type|Cumulocity topic|Cumulocity smartrest message|
+|------|------------------------|---------------------|
+|Thin-edge-device|`c8y/s/us`|`102,<unique-service-id>,type,service-name,status`|
+|Child-device|`c8y/s/us/<child-id>`|`102,<unique-service-id>,type,service-name,status`|
+
+> Note: The `unique-service-id` for thin-edge device will be  `<device-name>_<service-name>`.
+In case of child device `<device-name>_<child-id>_<service-name>`.
+
+> Note: `102` is the `smartrest` template number for the service monitoring message.
+
+# References
+
+More info about the service monitoring can be found in the below link
+
+[Service monitoring Cumulocity IoT](https://cumulocity.com/guides/reference/smartrest-two/#service-creation-102)

--- a/docs/src/howto-guides/howto-guides.md
+++ b/docs/src/howto-guides/howto-guides.md
@@ -27,3 +27,4 @@
 25. [How to install thin-edge manually with openrc](./026_how_to_install_thin_edge_manually.md)
 26. [How to enable configuration management on child devices](./child_device_config_management_agent.md)
 27. [How to remotely connect to your thin-edge.io device via SSH/VNC/Telnet with Cumulocity remote access](./027_remote_access_with_cumulocity.md)
+28. [How to monitor a service from Cumulocity](./028_c8y_service_monitoring.md)


### PR DESCRIPTION
## Proposed changes

These code changes support monitoring of the `thin-edge` device service as well as the `child` devices service on c8y.

The `tedge-mapper-c8y` receives the health status from the thin-edge c8y services (tedge-agent, c8y-log-plugin, etc) or any child device service and translates into a smart rest (102) message, and sends it to c8y.

- The thin-edge device services must publish health status on `tedge/health/<service-name>` topic 
- The child device services must publish the health status on `tedge/health/<child-id>/<service-name>` topic

The health status will be published to c8y only on state change.i.e on start (up) or stop(down).





## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1353

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

