### PR TITLE
Wait for mapper health message before starting software list assertion

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/software.robot
+++ b/tests/RobotFramework/tests/cumulocity/software.robot
@@ -2,27 +2,33 @@
 Resource    ../../resources/common.resource
 Library    Cumulocity
 Library    ThinEdgeIO
+Library    DateTime
 
 Test Tags    theme:c8y    theme:software    theme:plugins
+Test Setup       Custom Setup
 Test Teardown    Get Logs
 
 *** Test Cases ***
 Software list should be populated during startup
-    ${DEVICE_SN}=                            Setup
-    Device Should Exist                      ${DEVICE_SN}
-    Device Should Have Installed Software    tedge
+    Device Should Have Installed Software    tedge    timeout=120
 
 Install software via Cumulocity
-    ${DEVICE_SN}=                            Setup
-    Device Should Exist                      ${DEVICE_SN}
-    Sleep    12s    reason=FIX: Wait for device to be ready for operations
     ${OPERATION}=    Install Software        c8y-remote-access-plugin    # TODO: Use different package
     Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
     Device Should Have Installed Software    c8y-remote-access-plugin
 
 Software list should only show currently installed software and not candidates
-    [Tags]    flakey
+    ${EXPECTED_VERSION}=    Execute Command    dpkg -s tedge | grep "^Version: " | cut -d' ' -f2    strip=True
+    Device Should Have Installed Software    tedge,^${EXPECTED_VERSION}::apt$        timeout=120
+
+*** Keywords ***
+
+Custom Setup
     ${DEVICE_SN}=                            Setup
     Device Should Exist                      ${DEVICE_SN}
-    ${EXPECTED_VERSION}=    Execute Command    dpkg -s tedge | grep "^Version: " | cut -d' ' -f2    strip=True
-    Device Should Have Installed Software    tedge,^${EXPECTED_VERSION}::apt$
+    Set Test Variable    $DEVICE_SN
+    Should Have MQTT Messages    tedge/health/tedge-mapper-c8y
+    [Documentation]    WORKAROUND: #1731 The tedge-mapper-c8y is restarted due to a supsected race condition between the mapper and tedge-agent which results in the software list message being lost
+    ${timestamp}=        Get Current Date
+    Restart Service    tedge-mapper-c8y
+    Should Have MQTT Messages    tedge/health/tedge-mapper-c8y    date_from=${timestamp}

--- a/tests/images/debian-systemd/files/mosquitto.conf
+++ b/tests/images/debian-systemd/files/mosquitto.conf
@@ -1,1 +1,2 @@
 log_dest syslog
+log_type debug


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Extend software tests to wait for the `tedge-mapper-c8y` health message to be published locally before checking if the software list is installed. The software list check already has a default timeout of 30 seconds, however since the device is created in Cumulocity IoT during the connection phase, the full initialization sequence can take longer, so the cloud side software list check timer should not start until the mapper is fully up and running.

A ticket has been created referring to ticket which the workarounds were created for: https://github.com/thin-edge/thin-edge.io/issues/1731

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

