### PR TITLE
Improve naming for message box builder traits

### DIFF
--- a/crates/core/tedge_actors/src/actors.rs
+++ b/crates/core/tedge_actors/src/actors.rs
@@ -1,8 +1,8 @@
 use crate::ChannelError;
-use crate::ConcurrentServiceMessageBox;
+use crate::ConcurrentServerMessageBox;
 use crate::Message;
 use crate::MessageBox;
-use crate::ServiceMessageBox;
+use crate::ServerMessageBox;
 use async_trait::async_trait;
 
 /// Enable a struct to be used as an actor.
@@ -53,7 +53,7 @@ pub trait Service: 'static + Sized + Send + Sync {
 
 #[async_trait]
 impl<S: Service> Actor for ServiceActor<S> {
-    type MessageBox = ServiceMessageBox<S::Request, S::Response>;
+    type MessageBox = ServerMessageBox<S::Request, S::Response>;
 
     fn name(&self) -> &str {
         self.service.name()
@@ -86,7 +86,7 @@ impl<S: Service + Clone> ConcurrentServiceActor<S> {
 
 #[async_trait]
 impl<S: Service + Clone> Actor for ConcurrentServiceActor<S> {
-    type MessageBox = ConcurrentServiceMessageBox<S::Request, S::Response>;
+    type MessageBox = ConcurrentServerMessageBox<S::Request, S::Response>;
 
     fn name(&self) -> &str {
         self.service.name()

--- a/crates/core/tedge_actors/src/examples/calculator.rs
+++ b/crates/core/tedge_actors/src/examples/calculator.rs
@@ -121,15 +121,15 @@ mod tests {
     use crate::Builder;
     use crate::ChannelError;
     use crate::NoConfig;
+    use crate::ServerMessageBoxBuilder;
     use crate::ServiceActor;
     use crate::ServiceConsumer;
-    use crate::ServiceMessageBoxBuilder;
     use crate::SimpleMessageBoxBuilder;
 
     #[tokio::test]
     async fn observing_an_actor() -> Result<(), ChannelError> {
         // Build the actor message boxes
-        let mut service_box_builder = ServiceMessageBoxBuilder::new("Calculator", 16);
+        let mut service_box_builder = ServerMessageBoxBuilder::new("Calculator", 16);
         let mut player_box_builder = SimpleMessageBoxBuilder::new("Player 1", 1);
 
         // Connect the two actor message boxes interposing a probe.

--- a/crates/core/tedge_actors/src/examples/calculator.rs
+++ b/crates/core/tedge_actors/src/examples/calculator.rs
@@ -113,16 +113,16 @@ mod tests {
     use crate::examples::calculator::Operation;
     use crate::examples::calculator::Player;
     use crate::examples::calculator::Update;
-    use crate::test_helpers::MessageBoxPlugExt;
     use crate::test_helpers::Probe;
     use crate::test_helpers::ProbeEvent::Recv;
     use crate::test_helpers::ProbeEvent::Send;
+    use crate::test_helpers::ServiceConsumerExt;
     use crate::Actor;
     use crate::Builder;
     use crate::ChannelError;
-    use crate::MessageBoxPlug;
     use crate::NoConfig;
     use crate::ServiceActor;
+    use crate::ServiceConsumer;
     use crate::ServiceMessageBoxBuilder;
     use crate::SimpleMessageBoxBuilder;
 

--- a/crates/core/tedge_actors/src/examples/calculator.rs
+++ b/crates/core/tedge_actors/src/examples/calculator.rs
@@ -1,7 +1,7 @@
 // TODO: make examples respond to RuntimeRequests
 use crate::Actor;
 use crate::ChannelError;
-use crate::Service;
+use crate::Server;
 use crate::SimpleMessageBox;
 use async_trait::async_trait;
 
@@ -55,7 +55,7 @@ impl Actor for Calculator {
 
 /// Implementation of the calculator behavior as a service
 #[async_trait]
-impl Service for Calculator {
+impl Server for Calculator {
     type Request = Operation;
     type Response = Update;
 
@@ -121,8 +121,8 @@ mod tests {
     use crate::Builder;
     use crate::ChannelError;
     use crate::NoConfig;
+    use crate::ServerActor;
     use crate::ServerMessageBoxBuilder;
-    use crate::ServiceActor;
     use crate::ServiceConsumer;
     use crate::SimpleMessageBoxBuilder;
 
@@ -139,7 +139,7 @@ mod tests {
             .connect_to(&mut service_box_builder, NoConfig);
 
         // Spawn the actors
-        tokio::spawn(ServiceActor::new(Calculator::default()).run(service_box_builder.build()));
+        tokio::spawn(ServerActor::new(Calculator::default()).run(service_box_builder.build()));
         tokio::spawn(
             Player {
                 name: "Player".to_string(),

--- a/crates/core/tedge_actors/src/lib.rs
+++ b/crates/core/tedge_actors/src/lib.rs
@@ -216,7 +216,7 @@
 //!
 //! ```
 //! # use async_trait::async_trait;
-//! # use tedge_actors::{Actor, ChannelError, MessageBox, RequestResponseHandler, ServiceActor, SimpleMessageBox};
+//! # use tedge_actors::{Actor, ChannelError, MessageBox, ClientMessageBox, ServiceActor, SimpleMessageBox};
 //! # use crate::tedge_actors::examples::calculator::*;
 //!
 //! /// An actor that send operations to a calculator service to reach a given target.
@@ -259,7 +259,7 @@
 //! to establish appropriate connections between the actor message boxes.
 //!
 //! ```
-//! # use tedge_actors::{Actor, Builder, ChannelError, MessageBox, ServiceConsumer, NoConfig, ServiceActor, ServiceMessageBox, ServiceMessageBoxBuilder, SimpleMessageBox, SimpleMessageBoxBuilder};
+//! # use tedge_actors::{Actor, Builder, ChannelError, MessageBox, ServiceConsumer, NoConfig, ServiceActor, ServerMessageBox, ServerMessageBoxBuilder, SimpleMessageBox, SimpleMessageBoxBuilder};
 //! # use crate::tedge_actors::examples::calculator::*;
 //! # #[tokio::main]
 //! # async fn main_test() -> Result<(),ChannelError> {
@@ -267,7 +267,7 @@
 //!
 //! // Building a box to hold 16 pending requests for the calculator service
 //! // Note that a service actor requires a specific type of message box.
-//! let mut service_box_builder = ServiceMessageBoxBuilder::new("Calculator", 16);
+//! let mut service_box_builder = ServerMessageBoxBuilder::new("Calculator", 16);
 //!
 //! // Building a box to hold one pending message for the player
 //! // This actor never expect more then one message.
@@ -278,13 +278,13 @@
 //! // - sends its output to the service input box.
 //! player_1_box_builder.connect_to(&mut service_box_builder, NoConfig);
 //!
-//! // Its matters that the builder of the service box is a `ServiceMessageBoxBuilder`:
+//! // Its matters that the builder of the service box is a `ServerMessageBoxBuilder`:
 //! // this builder accept other actors to connect to the same service.
 //! let mut player_2_box_builder = SimpleMessageBoxBuilder::new("Player 2", 1);
 //! player_2_box_builder.connect_to(&mut service_box_builder, NoConfig);
 //!
 //! // One can then build the message boxes
-//! let service_box: ServiceMessageBox<Operation,Update> = service_box_builder.build();
+//! let service_box: ServerMessageBox<Operation,Update> = service_box_builder.build();
 //! let mut player_1_box = player_1_box_builder.build();
 //! let mut player_2_box = player_2_box_builder.build();
 //!
@@ -322,7 +322,7 @@
 //! Here, we interpose a `Probe` between two actors to observe their interactions.
 //!
 //! ```
-//! # use tedge_actors::{Actor, Builder, ChannelError, ServiceConsumer, NoConfig, ServiceActor, ServiceMessageBoxBuilder, SimpleMessageBoxBuilder};
+//! # use tedge_actors::{Actor, Builder, ChannelError, ServiceConsumer, NoConfig, ServiceActor, ServerMessageBoxBuilder, SimpleMessageBoxBuilder};
 //! # use tedge_actors::test_helpers::{ServiceConsumerExt, Probe, ProbeEvent};
 //! # use tedge_actors::test_helpers::ProbeEvent::{Recv, Send};
 //! # use crate::tedge_actors::examples::calculator::*;
@@ -330,7 +330,7 @@
 //! # async fn main_test() -> Result<(),ChannelError> {
 //! #
 //! // Build the actor message boxes
-//! let mut service_box_builder = ServiceMessageBoxBuilder::new("Calculator", 16);
+//! let mut service_box_builder = ServerMessageBoxBuilder::new("Calculator", 16);
 //! let mut player_box_builder = SimpleMessageBoxBuilder::new("Player 1", 1);
 //!
 //! // Connect the two actor message boxes interposing a probe.

--- a/crates/core/tedge_actors/src/lib.rs
+++ b/crates/core/tedge_actors/src/lib.rs
@@ -259,7 +259,7 @@
 //! to establish appropriate connections between the actor message boxes.
 //!
 //! ```
-//! # use tedge_actors::{Actor, Builder, ChannelError, MessageBox, MessageBoxPlug, NoConfig, ServiceActor, ServiceMessageBox, ServiceMessageBoxBuilder, SimpleMessageBox, SimpleMessageBoxBuilder};
+//! # use tedge_actors::{Actor, Builder, ChannelError, MessageBox, ServiceConsumer, NoConfig, ServiceActor, ServiceMessageBox, ServiceMessageBoxBuilder, SimpleMessageBox, SimpleMessageBoxBuilder};
 //! # use crate::tedge_actors::examples::calculator::*;
 //! # #[tokio::main]
 //! # async fn main_test() -> Result<(),ChannelError> {
@@ -322,8 +322,8 @@
 //! Here, we interpose a `Probe` between two actors to observe their interactions.
 //!
 //! ```
-//! # use tedge_actors::{Actor, Builder, ChannelError, MessageBoxPlug, NoConfig, ServiceActor, ServiceMessageBoxBuilder, SimpleMessageBoxBuilder};
-//! # use tedge_actors::test_helpers::{MessageBoxPlugExt, Probe, ProbeEvent};
+//! # use tedge_actors::{Actor, Builder, ChannelError, ServiceConsumer, NoConfig, ServiceActor, ServiceMessageBoxBuilder, SimpleMessageBoxBuilder};
+//! # use tedge_actors::test_helpers::{ServiceConsumerExt, Probe, ProbeEvent};
 //! # use tedge_actors::test_helpers::ProbeEvent::{Recv, Send};
 //! # use crate::tedge_actors::examples::calculator::*;
 //! # #[tokio::main]

--- a/crates/core/tedge_actors/src/lib.rs
+++ b/crates/core/tedge_actors/src/lib.rs
@@ -124,7 +124,7 @@
 //! that can work with several clients (sending the responses to the appropriate requesters).
 //!
 //! ```
-//! # use crate::tedge_actors::{Service, MessageBox, SimpleMessageBox};
+//! # use crate::tedge_actors::{Server, MessageBox, SimpleMessageBox};
 //! # use async_trait::async_trait;
 //!
 //! # use crate::tedge_actors::examples;
@@ -139,7 +139,7 @@
 //!
 //! /// Implementation of the calculator behavior
 //! #[async_trait]
-//! impl Service for Calculator {
+//! impl Server for Calculator {
 //!
 //!     type Request = Operation;
 //!     type Response = Update;
@@ -166,12 +166,12 @@
 //! ```
 //!
 //! A service can be tested directly through its `handle` method.
-//! One can also build an actor, here a `ServiceActor<Calculator>`,
+//! One can also build an actor, here a `ServerActor<Calculator>`,
 //! that uses the service implementation to serve requests.
 //! This actor can then be tested using a test box connected to the actor box.
 //!
 //! ```
-//! # use tedge_actors::{Actor, MessageBox, ServiceActor, SimpleMessageBox};
+//! # use tedge_actors::{Actor, MessageBox, ServerActor, SimpleMessageBox};
 //! # use crate::tedge_actors::examples::calculator::*;
 //! #
 //! # #[tokio::main]
@@ -182,7 +182,7 @@
 //!
 //! // The actor is then spawn in the background with its message box.
 //! let service = Calculator::default();
-//! let actor = ServiceActor::new(service);
+//! let actor = ServerActor::new(service);
 //! tokio::spawn(actor.run(actor_box));
 //!
 //! // One can then interact with the actor
@@ -216,7 +216,7 @@
 //!
 //! ```
 //! # use async_trait::async_trait;
-//! # use tedge_actors::{Actor, ChannelError, MessageBox, ClientMessageBox, ServiceActor, SimpleMessageBox};
+//! # use tedge_actors::{Actor, ChannelError, MessageBox, ClientMessageBox, ServerActor, SimpleMessageBox};
 //! # use crate::tedge_actors::examples::calculator::*;
 //!
 //! /// An actor that send operations to a calculator service to reach a given target.
@@ -259,7 +259,7 @@
 //! to establish appropriate connections between the actor message boxes.
 //!
 //! ```
-//! # use tedge_actors::{Actor, Builder, ChannelError, MessageBox, ServiceConsumer, NoConfig, ServiceActor, ServerMessageBox, ServerMessageBoxBuilder, SimpleMessageBox, SimpleMessageBoxBuilder};
+//! # use tedge_actors::{Actor, Builder, ChannelError, MessageBox, ServiceConsumer, NoConfig, ServerActor, ServerMessageBox, ServerMessageBoxBuilder, SimpleMessageBox, SimpleMessageBoxBuilder};
 //! # use crate::tedge_actors::examples::calculator::*;
 //! # #[tokio::main]
 //! # async fn main_test() -> Result<(),ChannelError> {
@@ -290,7 +290,7 @@
 //!
 //! // Then spawn the service
 //! let service = Calculator::default();
-//! tokio::spawn(ServiceActor::new(service).run(service_box));
+//! tokio::spawn(ServerActor::new(service).run(service_box));
 //!
 //! // And use the players' boxes to interact with the service.
 //! // Note that, compared to the test above of the calculator service,
@@ -322,7 +322,7 @@
 //! Here, we interpose a `Probe` between two actors to observe their interactions.
 //!
 //! ```
-//! # use tedge_actors::{Actor, Builder, ChannelError, ServiceConsumer, NoConfig, ServiceActor, ServerMessageBoxBuilder, SimpleMessageBoxBuilder};
+//! # use tedge_actors::{Actor, Builder, ChannelError, ServiceConsumer, NoConfig, ServerActor, ServerMessageBoxBuilder, SimpleMessageBoxBuilder};
 //! # use tedge_actors::test_helpers::{ServiceConsumerExt, Probe, ProbeEvent};
 //! # use tedge_actors::test_helpers::ProbeEvent::{Recv, Send};
 //! # use crate::tedge_actors::examples::calculator::*;
@@ -338,7 +338,7 @@
 //! player_box_builder.with_probe(&mut probe).connect_to(&mut service_box_builder, NoConfig);
 //!
 //! // Spawn the actors
-//! tokio::spawn(ServiceActor::new(Calculator::default()).run(service_box_builder.build()));
+//! tokio::spawn(ServerActor::new(Calculator::default()).run(service_box_builder.build()));
 //! tokio::spawn(Player { name: "Player".to_string(), target: 42}.run(player_box_builder.build()));
 //!
 //! // Observe the messages sent and received by the player.

--- a/crates/core/tedge_actors/src/message_boxes.rs
+++ b/crates/core/tedge_actors/src/message_boxes.rs
@@ -93,10 +93,10 @@ use crate::Builder;
 use crate::ChannelError;
 use crate::DynSender;
 use crate::Message;
-use crate::MessageBoxPlug;
-use crate::MessageBoxSocket;
 use crate::NoConfig;
 use crate::RuntimeRequest;
+use crate::ServiceConsumer;
+use crate::ServiceProvider;
 use crate::SimpleMessageBoxBuilder;
 use futures::channel::mpsc;
 use futures::StreamExt;
@@ -349,7 +349,7 @@ impl<Request: Message, Response: Message> RequestResponseHandler<Request, Respon
     /// Create a new `RequestResponseHandler` connected to the service with the given config.
     pub fn new<Config>(
         client_name: &str,
-        service: &mut impl MessageBoxSocket<Request, Response, Config>,
+        service: &mut impl ServiceProvider<Request, Response, Config>,
         config: Config,
     ) -> Self {
         let capacity = 1; // At most one response is ever expected

--- a/crates/core/tedge_actors/src/test_helpers.rs
+++ b/crates/core/tedge_actors/src/test_helpers.rs
@@ -1,12 +1,12 @@
 use crate::mpsc;
 use crate::DynSender;
 use crate::Message;
-use crate::MessageBoxPlug;
 use crate::MessageSink;
 use crate::MessageSource;
 use crate::NoConfig;
 use crate::NullSender;
 use crate::Sender;
+use crate::ServiceConsumer;
 use futures::stream::FusedStream;
 use futures::SinkExt;
 use futures::StreamExt;
@@ -123,16 +123,16 @@ impl<I: MessagePlus, O: MessagePlus> Probe<I, O> {
     }
 }
 
-pub trait MessageBoxPlugExt<Request: MessagePlus, Response: MessagePlus> {
+pub trait ServiceConsumerExt<Request: MessagePlus, Response: MessagePlus> {
     fn with_probe<'a>(
         &'a mut self,
         probe: &'a mut Probe<Response, Request>,
     ) -> &'a mut Probe<Response, Request>;
 }
 
-impl<T, Request: MessagePlus, Response: MessagePlus> MessageBoxPlugExt<Request, Response> for T
+impl<T, Request: MessagePlus, Response: MessagePlus> ServiceConsumerExt<Request, Response> for T
 where
-    T: MessageBoxPlug<Request, Response>,
+    T: ServiceConsumer<Request, Response>,
 {
     fn with_probe<'a>(
         &'a mut self,

--- a/crates/core/tedge_actors/src/tests.rs
+++ b/crates/core/tedge_actors/src/tests.rs
@@ -41,8 +41,7 @@ async fn spawn_concurrent_sleep_service(
 ) -> SimpleMessageBox<(ClientId, u64), (ClientId, u64)> {
     let service = SleepService;
     let actor = ConcurrentServiceActor::new(service);
-    let (handle, messages) =
-        ConcurrentServiceMessageBox::channel(actor.name(), 16, max_concurrency);
+    let (handle, messages) = ConcurrentServerMessageBox::channel(actor.name(), 16, max_concurrency);
 
     tokio::spawn(actor.run(messages));
 

--- a/crates/core/tedge_actors/src/tests.rs
+++ b/crates/core/tedge_actors/src/tests.rs
@@ -11,7 +11,7 @@ use tokio::time::sleep;
 struct SleepService;
 
 #[async_trait]
-impl Service for SleepService {
+impl Server for SleepService {
     type Request = u64;
     // A number a milli seconds to wait before returning a response
     type Response = u64; // An echo of the request
@@ -28,7 +28,7 @@ impl Service for SleepService {
 
 async fn spawn_sleep_service() -> SimpleMessageBox<(ClientId, u64), (ClientId, u64)> {
     let service = SleepService;
-    let actor = ServiceActor::new(service);
+    let actor = ServerActor::new(service);
     let (handle, messages) = SimpleMessageBox::channel(actor.name(), 16);
 
     tokio::spawn(actor.run(messages));
@@ -40,7 +40,7 @@ async fn spawn_concurrent_sleep_service(
     max_concurrency: usize,
 ) -> SimpleMessageBox<(ClientId, u64), (ClientId, u64)> {
     let service = SleepService;
-    let actor = ConcurrentServiceActor::new(service);
+    let actor = ConcurrentServerActor::new(service);
     let (handle, messages) = ConcurrentServerMessageBox::channel(actor.name(), 16, max_concurrency);
 
     tokio::spawn(actor.run(messages));

--- a/crates/extensions/c8y_config_manager/src/lib.rs
+++ b/crates/extensions/c8y_config_manager/src/lib.rs
@@ -19,12 +19,12 @@ use tedge_actors::futures::channel::mpsc;
 use tedge_actors::Builder;
 use tedge_actors::DynSender;
 use tedge_actors::LinkError;
-use tedge_actors::MessageBoxSocket;
 use tedge_actors::MessageSink;
 use tedge_actors::MessageSource;
 use tedge_actors::NoConfig;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
+use tedge_actors::ServiceProvider;
 use tedge_file_system_ext::FsWatchEvent;
 use tedge_mqtt_ext::*;
 use tedge_timer_ext::SetTimeout;
@@ -66,7 +66,7 @@ impl ConfigManagerBuilder {
     /// Connect this config manager instance to some http connection provider
     pub fn with_c8y_http_proxy(
         &mut self,
-        http: &mut impl MessageBoxSocket<C8YRestRequest, C8YRestResult, NoConfig>,
+        http: &mut impl ServiceProvider<C8YRestRequest, C8YRestResult, NoConfig>,
     ) -> Result<(), LinkError> {
         // self.connect_to(http, ());
         self.c8y_http_proxy = Some(C8YHttpProxy::new("ConfigManager => C8Y", http));
@@ -76,7 +76,7 @@ impl ConfigManagerBuilder {
     /// Connect this config manager instance to some mqtt connection provider
     pub fn with_mqtt_connection<T>(&mut self, mqtt: &mut T) -> Result<(), LinkError>
     where
-        T: MessageBoxSocket<MqttMessage, MqttMessage, TopicFilter>,
+        T: ServiceProvider<MqttMessage, MqttMessage, TopicFilter>,
     {
         let subscriptions = vec![
             "c8y/s/ds",
@@ -102,7 +102,7 @@ impl ConfigManagerBuilder {
 
     pub fn with_timer(
         &mut self,
-        timer_builder: &mut impl MessageBoxSocket<OperationTimer, OperationTimeout, NoConfig>,
+        timer_builder: &mut impl ServiceProvider<OperationTimer, OperationTimeout, NoConfig>,
     ) -> Result<(), LinkError> {
         timer_builder.connect_with(self, NoConfig);
         Ok(())

--- a/crates/extensions/c8y_http_proxy/src/actor.rs
+++ b/crates/extensions/c8y_http_proxy/src/actor.rs
@@ -32,7 +32,7 @@ use tedge_actors::fan_in_message_type;
 use tedge_actors::Actor;
 use tedge_actors::ChannelError;
 use tedge_actors::MessageBox;
-use tedge_actors::ServiceMessageBox;
+use tedge_actors::ServerMessageBox;
 use tedge_http_ext::HttpHandle;
 use tedge_http_ext::HttpRequest;
 use tedge_http_ext::HttpRequestBuilder;
@@ -65,7 +65,7 @@ impl Actor for C8YHttpConfig {
 
 pub struct C8YHttpProxyMessageBox {
     /// Connection to the clients
-    pub(crate) clients: ServiceMessageBox<C8YRestRequest, C8YRestResult>,
+    pub(crate) clients: ServerMessageBox<C8YRestRequest, C8YRestResult>,
 
     /// Connection to an HTTP actor
     pub(crate) http: HttpHandle,

--- a/crates/extensions/c8y_http_proxy/src/credentials.rs
+++ b/crates/extensions/c8y_http_proxy/src/credentials.rs
@@ -11,16 +11,16 @@ use std::time::Duration;
 use tedge_actors::Actor;
 use tedge_actors::Builder;
 use tedge_actors::DynSender;
-use tedge_actors::MessageBoxPlug;
-use tedge_actors::MessageBoxSocket;
 use tedge_actors::NoConfig;
 use tedge_actors::RequestResponseHandler;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
 use tedge_actors::Service;
 use tedge_actors::ServiceActor;
+use tedge_actors::ServiceConsumer;
 use tedge_actors::ServiceMessageBox;
 use tedge_actors::ServiceMessageBoxBuilder;
+use tedge_actors::ServiceProvider;
 
 pub type JwtRequest = ();
 pub type JwtResult = Result<String, SmartRestDeserializerError>;
@@ -126,11 +126,11 @@ impl<S: Service<Request = JwtRequest, Response = JwtResult>>
 }
 
 impl<S: Service<Request = JwtRequest, Response = JwtResult>>
-    MessageBoxSocket<JwtRequest, JwtResult, NoConfig> for JwtRetrieverBuilder<S>
+    ServiceProvider<JwtRequest, JwtResult, NoConfig> for JwtRetrieverBuilder<S>
 {
     fn connect_with(
         &mut self,
-        peer: &mut impl MessageBoxPlug<JwtRequest, JwtResult>,
+        peer: &mut impl ServiceConsumer<JwtRequest, JwtResult>,
         config: NoConfig,
     ) {
         self.message_box.connect_with(peer, config)

--- a/crates/extensions/c8y_http_proxy/src/handle.rs
+++ b/crates/extensions/c8y_http_proxy/src/handle.rs
@@ -6,8 +6,8 @@ use crate::messages::UploadConfigFile;
 use crate::messages::UploadLogBinary;
 use std::path::Path;
 use std::path::PathBuf;
+use tedge_actors::ClientMessageBox;
 use tedge_actors::NoConfig;
-use tedge_actors::RequestResponseHandler;
 use tedge_actors::ServiceProvider;
 use tedge_utils::file::PermissionEntry;
 
@@ -15,7 +15,7 @@ use super::messages::DownloadFile;
 
 /// Handle to the C8YHttpProxy
 pub struct C8YHttpProxy {
-    c8y: RequestResponseHandler<C8YRestRequest, C8YRestResult>,
+    c8y: ClientMessageBox<C8YRestRequest, C8YRestResult>,
 }
 
 impl C8YHttpProxy {
@@ -23,7 +23,7 @@ impl C8YHttpProxy {
         client_name: &str,
         proxy_builder: &mut impl ServiceProvider<C8YRestRequest, C8YRestResult, NoConfig>,
     ) -> Self {
-        let c8y = RequestResponseHandler::new(client_name, proxy_builder, NoConfig);
+        let c8y = ClientMessageBox::new(client_name, proxy_builder, NoConfig);
         C8YHttpProxy { c8y }
     }
 

--- a/crates/extensions/c8y_http_proxy/src/handle.rs
+++ b/crates/extensions/c8y_http_proxy/src/handle.rs
@@ -6,9 +6,9 @@ use crate::messages::UploadConfigFile;
 use crate::messages::UploadLogBinary;
 use std::path::Path;
 use std::path::PathBuf;
-use tedge_actors::MessageBoxSocket;
 use tedge_actors::NoConfig;
 use tedge_actors::RequestResponseHandler;
+use tedge_actors::ServiceProvider;
 use tedge_utils::file::PermissionEntry;
 
 use super::messages::DownloadFile;
@@ -21,7 +21,7 @@ pub struct C8YHttpProxy {
 impl C8YHttpProxy {
     pub fn new(
         client_name: &str,
-        proxy_builder: &mut impl MessageBoxSocket<C8YRestRequest, C8YRestResult, NoConfig>,
+        proxy_builder: &mut impl ServiceProvider<C8YRestRequest, C8YRestResult, NoConfig>,
     ) -> Self {
         let c8y = RequestResponseHandler::new(client_name, proxy_builder, NoConfig);
         C8YHttpProxy { c8y }

--- a/crates/extensions/c8y_http_proxy/src/lib.rs
+++ b/crates/extensions/c8y_http_proxy/src/lib.rs
@@ -10,8 +10,8 @@ use tedge_actors::DynSender;
 use tedge_actors::NoConfig;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
+use tedge_actors::ServerMessageBoxBuilder;
 use tedge_actors::ServiceConsumer;
-use tedge_actors::ServiceMessageBoxBuilder;
 use tedge_actors::ServiceProvider;
 use tedge_config::C8yUrlSetting;
 use tedge_config::ConfigSettingAccessor;
@@ -65,7 +65,7 @@ pub struct C8YHttpProxyBuilder {
     config: C8YHttpConfig,
 
     /// Message box for client requests and responses
-    clients: ServiceMessageBoxBuilder<C8YRestRequest, C8YRestResult>,
+    clients: ServerMessageBoxBuilder<C8YRestRequest, C8YRestResult>,
 
     /// Connection to an HTTP actor
     http: HttpHandle,
@@ -80,7 +80,7 @@ impl C8YHttpProxyBuilder {
         http: &mut impl HttpConnectionBuilder,
         jwt: &mut impl ServiceProvider<(), JwtResult, NoConfig>,
     ) -> Self {
-        let clients = ServiceMessageBoxBuilder::new("C8Y-REST", 10);
+        let clients = ServerMessageBoxBuilder::new("C8Y-REST", 10);
         let http = HttpHandle::new("C8Y-REST => HTTP", http, NoConfig);
         let jwt = JwtRetriever::new("C8Y-REST => JWT", jwt, NoConfig);
         C8YHttpProxyBuilder {

--- a/crates/extensions/c8y_http_proxy/src/lib.rs
+++ b/crates/extensions/c8y_http_proxy/src/lib.rs
@@ -7,12 +7,12 @@ use std::convert::Infallible;
 use std::path::PathBuf;
 use tedge_actors::Builder;
 use tedge_actors::DynSender;
-use tedge_actors::MessageBoxPlug;
-use tedge_actors::MessageBoxSocket;
 use tedge_actors::NoConfig;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
+use tedge_actors::ServiceConsumer;
 use tedge_actors::ServiceMessageBoxBuilder;
+use tedge_actors::ServiceProvider;
 use tedge_config::C8yUrlSetting;
 use tedge_config::ConfigSettingAccessor;
 use tedge_config::DeviceIdSetting;
@@ -53,7 +53,7 @@ impl TryFrom<&TEdgeConfig> for C8YHttpConfig {
     }
 }
 
-pub trait C8YConnectionBuilder: MessageBoxSocket<C8YRestRequest, C8YRestResult, NoConfig> {}
+pub trait C8YConnectionBuilder: ServiceProvider<C8YRestRequest, C8YRestResult, NoConfig> {}
 
 impl C8YConnectionBuilder for C8YHttpProxyBuilder {}
 
@@ -78,7 +78,7 @@ impl C8YHttpProxyBuilder {
     pub fn new(
         config: C8YHttpConfig,
         http: &mut impl HttpConnectionBuilder,
-        jwt: &mut impl MessageBoxSocket<(), JwtResult, NoConfig>,
+        jwt: &mut impl ServiceProvider<(), JwtResult, NoConfig>,
     ) -> Self {
         let clients = ServiceMessageBoxBuilder::new("C8Y-REST", 10);
         let http = HttpHandle::new("C8Y-REST => HTTP", http, NoConfig);
@@ -110,10 +110,10 @@ impl Builder<(C8YHttpConfig, C8YHttpProxyMessageBox)> for C8YHttpProxyBuilder {
     }
 }
 
-impl MessageBoxSocket<C8YRestRequest, C8YRestResult, NoConfig> for C8YHttpProxyBuilder {
+impl ServiceProvider<C8YRestRequest, C8YRestResult, NoConfig> for C8YHttpProxyBuilder {
     fn connect_with(
         &mut self,
-        peer: &mut impl MessageBoxPlug<C8YRestRequest, C8YRestResult>,
+        peer: &mut impl ServiceConsumer<C8YRestRequest, C8YRestResult>,
         config: NoConfig,
     ) {
         self.clients.connect_with(peer, config)

--- a/crates/extensions/c8y_http_proxy/src/tests.rs
+++ b/crates/extensions/c8y_http_proxy/src/tests.rs
@@ -5,8 +5,8 @@ use crate::C8YHttpProxyBuilder;
 use c8y_api::json_c8y::InternalIdResponse;
 use tedge_actors::Actor;
 use tedge_actors::Builder;
+use tedge_actors::ServerMessageBoxBuilder;
 use tedge_actors::ServiceActor;
-use tedge_actors::ServiceMessageBoxBuilder;
 use tedge_http_ext::test_helpers::FakeHttpServerBox;
 use tedge_http_ext::test_helpers::HttpResponseBuilder;
 use tedge_http_ext::HttpRequestBuilder;
@@ -69,7 +69,7 @@ async fn c8y_http_proxy_requests_the_device_internal_id_on_start() {
 /// Spawn an `C8YHttpProxyActor` instance
 /// Return two handles:
 /// - one `C8YHttpProxy` to send requests to the actor
-/// - one `ServiceMessageBoxBuilder<HttpRequest,HttpResponse> to fake the behavior of C8Y REST.
+/// - one `ServerMessageBoxBuilder<HttpRequest,HttpResponse> to fake the behavior of C8Y REST.
 ///
 /// This also spawns an actor to generate fake JWT tokens.
 /// The tests will only check that the http requests include this token.
@@ -80,7 +80,7 @@ async fn spawn_c8y_http_proxy(
     let jwt_actor = ServiceActor::new(ConstJwtRetriever {
         token: token.to_string(),
     });
-    let mut jwt = ServiceMessageBoxBuilder::new("JWT Actor", 16);
+    let mut jwt = ServerMessageBoxBuilder::new("JWT Actor", 16);
 
     let mut http = FakeHttpServerBox::builder();
 

--- a/crates/extensions/c8y_http_proxy/src/tests.rs
+++ b/crates/extensions/c8y_http_proxy/src/tests.rs
@@ -5,8 +5,8 @@ use crate::C8YHttpProxyBuilder;
 use c8y_api::json_c8y::InternalIdResponse;
 use tedge_actors::Actor;
 use tedge_actors::Builder;
+use tedge_actors::ServerActor;
 use tedge_actors::ServerMessageBoxBuilder;
-use tedge_actors::ServiceActor;
 use tedge_http_ext::test_helpers::FakeHttpServerBox;
 use tedge_http_ext::test_helpers::HttpResponseBuilder;
 use tedge_http_ext::HttpRequestBuilder;
@@ -77,7 +77,7 @@ async fn spawn_c8y_http_proxy(
     config: C8YHttpConfig,
     token: &str,
 ) -> (C8YHttpProxy, FakeHttpServerBox) {
-    let jwt_actor = ServiceActor::new(ConstJwtRetriever {
+    let jwt_actor = ServerActor::new(ConstJwtRetriever {
         token: token.to_string(),
     });
     let mut jwt = ServerMessageBoxBuilder::new("JWT Actor", 16);

--- a/crates/extensions/tedge_http_ext/src/actor.rs
+++ b/crates/extensions/tedge_http_ext/src/actor.rs
@@ -6,7 +6,7 @@ use hyper::client::Client;
 use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;
 use hyper_rustls::HttpsConnectorBuilder;
-use tedge_actors::Service;
+use tedge_actors::Server;
 
 #[derive(Clone)]
 pub struct HttpService {
@@ -27,7 +27,7 @@ impl HttpService {
 }
 
 #[async_trait]
-impl Service for HttpService {
+impl Server for HttpService {
     type Request = HttpRequest;
     type Response = HttpResult;
 

--- a/crates/extensions/tedge_http_ext/src/lib.rs
+++ b/crates/extensions/tedge_http_ext/src/lib.rs
@@ -15,8 +15,8 @@ use tedge_actors::Actor;
 use tedge_actors::Builder;
 use tedge_actors::ChannelError;
 use tedge_actors::ClientMessageBox;
+use tedge_actors::ConcurrentServerActor;
 use tedge_actors::ConcurrentServerMessageBox;
-use tedge_actors::ConcurrentServiceActor;
 use tedge_actors::DynSender;
 use tedge_actors::NoConfig;
 use tedge_actors::RuntimeRequest;
@@ -30,14 +30,14 @@ pub trait HttpConnectionBuilder: ServiceProvider<HttpRequest, HttpResult, NoConf
 impl<T> HttpConnectionBuilder for T where T: ServiceProvider<HttpRequest, HttpResult, NoConfig> {}
 
 pub struct HttpActorBuilder {
-    actor: ConcurrentServiceActor<HttpService>,
+    actor: ConcurrentServerActor<HttpService>,
     pub box_builder: ServerMessageBoxBuilder<HttpRequest, HttpResult>,
 }
 
 impl HttpActorBuilder {
     pub fn new() -> Result<Self, HttpError> {
         let service = HttpService::new()?;
-        let actor = ConcurrentServiceActor::new(service);
+        let actor = ConcurrentServerActor::new(service);
         let box_builder = ServerMessageBoxBuilder::new("HTTP", 16).with_max_concurrency(4);
 
         Ok(HttpActorBuilder { actor, box_builder })
@@ -53,7 +53,7 @@ impl HttpActorBuilder {
 
 impl
     Builder<(
-        ConcurrentServiceActor<HttpService>,
+        ConcurrentServerActor<HttpService>,
         ConcurrentServerMessageBox<HttpRequest, HttpResult>,
     )> for HttpActorBuilder
 {
@@ -63,7 +63,7 @@ impl
         self,
     ) -> Result<
         (
-            ConcurrentServiceActor<HttpService>,
+            ConcurrentServerActor<HttpService>,
             ConcurrentServerMessageBox<HttpRequest, HttpResult>,
         ),
         Self::Error,
@@ -74,7 +74,7 @@ impl
     fn build(
         self,
     ) -> (
-        ConcurrentServiceActor<HttpService>,
+        ConcurrentServerActor<HttpService>,
         ConcurrentServerMessageBox<HttpRequest, HttpResult>,
     ) {
         let actor = self.actor;

--- a/crates/extensions/tedge_http_ext/src/lib.rs
+++ b/crates/extensions/tedge_http_ext/src/lib.rs
@@ -17,17 +17,17 @@ use tedge_actors::ChannelError;
 use tedge_actors::ConcurrentServiceActor;
 use tedge_actors::ConcurrentServiceMessageBox;
 use tedge_actors::DynSender;
-use tedge_actors::MessageBoxPlug;
-use tedge_actors::MessageBoxSocket;
 use tedge_actors::NoConfig;
 use tedge_actors::RequestResponseHandler;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
+use tedge_actors::ServiceConsumer;
 use tedge_actors::ServiceMessageBoxBuilder;
+use tedge_actors::ServiceProvider;
 
 pub type HttpHandle = RequestResponseHandler<HttpRequest, HttpResult>;
-pub trait HttpConnectionBuilder: MessageBoxSocket<HttpRequest, HttpResult, NoConfig> {}
-impl<T> HttpConnectionBuilder for T where T: MessageBoxSocket<HttpRequest, HttpResult, NoConfig> {}
+pub trait HttpConnectionBuilder: ServiceProvider<HttpRequest, HttpResult, NoConfig> {}
+impl<T> HttpConnectionBuilder for T where T: ServiceProvider<HttpRequest, HttpResult, NoConfig> {}
 
 pub struct HttpActorBuilder {
     actor: ConcurrentServiceActor<HttpService>,
@@ -83,10 +83,10 @@ impl
     }
 }
 
-impl MessageBoxSocket<HttpRequest, HttpResult, NoConfig> for HttpActorBuilder {
+impl ServiceProvider<HttpRequest, HttpResult, NoConfig> for HttpActorBuilder {
     fn connect_with(
         &mut self,
-        peer: &mut impl MessageBoxPlug<HttpRequest, HttpResult>,
+        peer: &mut impl ServiceConsumer<HttpRequest, HttpResult>,
         config: NoConfig,
     ) {
         self.box_builder.connect_with(peer, config)

--- a/crates/extensions/tedge_http_ext/src/lib.rs
+++ b/crates/extensions/tedge_http_ext/src/lib.rs
@@ -14,31 +14,31 @@ use actor::*;
 use tedge_actors::Actor;
 use tedge_actors::Builder;
 use tedge_actors::ChannelError;
+use tedge_actors::ClientMessageBox;
+use tedge_actors::ConcurrentServerMessageBox;
 use tedge_actors::ConcurrentServiceActor;
-use tedge_actors::ConcurrentServiceMessageBox;
 use tedge_actors::DynSender;
 use tedge_actors::NoConfig;
-use tedge_actors::RequestResponseHandler;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
+use tedge_actors::ServerMessageBoxBuilder;
 use tedge_actors::ServiceConsumer;
-use tedge_actors::ServiceMessageBoxBuilder;
 use tedge_actors::ServiceProvider;
 
-pub type HttpHandle = RequestResponseHandler<HttpRequest, HttpResult>;
+pub type HttpHandle = ClientMessageBox<HttpRequest, HttpResult>;
 pub trait HttpConnectionBuilder: ServiceProvider<HttpRequest, HttpResult, NoConfig> {}
 impl<T> HttpConnectionBuilder for T where T: ServiceProvider<HttpRequest, HttpResult, NoConfig> {}
 
 pub struct HttpActorBuilder {
     actor: ConcurrentServiceActor<HttpService>,
-    pub box_builder: ServiceMessageBoxBuilder<HttpRequest, HttpResult>,
+    pub box_builder: ServerMessageBoxBuilder<HttpRequest, HttpResult>,
 }
 
 impl HttpActorBuilder {
     pub fn new() -> Result<Self, HttpError> {
         let service = HttpService::new()?;
         let actor = ConcurrentServiceActor::new(service);
-        let box_builder = ServiceMessageBoxBuilder::new("HTTP", 16).with_max_concurrency(4);
+        let box_builder = ServerMessageBoxBuilder::new("HTTP", 16).with_max_concurrency(4);
 
         Ok(HttpActorBuilder { actor, box_builder })
     }
@@ -54,7 +54,7 @@ impl HttpActorBuilder {
 impl
     Builder<(
         ConcurrentServiceActor<HttpService>,
-        ConcurrentServiceMessageBox<HttpRequest, HttpResult>,
+        ConcurrentServerMessageBox<HttpRequest, HttpResult>,
     )> for HttpActorBuilder
 {
     type Error = Infallible;
@@ -64,7 +64,7 @@ impl
     ) -> Result<
         (
             ConcurrentServiceActor<HttpService>,
-            ConcurrentServiceMessageBox<HttpRequest, HttpResult>,
+            ConcurrentServerMessageBox<HttpRequest, HttpResult>,
         ),
         Self::Error,
     > {
@@ -75,7 +75,7 @@ impl
         self,
     ) -> (
         ConcurrentServiceActor<HttpService>,
-        ConcurrentServiceMessageBox<HttpRequest, HttpResult>,
+        ConcurrentServerMessageBox<HttpRequest, HttpResult>,
     ) {
         let actor = self.actor;
         let actor_box = self.box_builder.build();

--- a/crates/extensions/tedge_http_ext/src/tests.rs
+++ b/crates/extensions/tedge_http_ext/src/tests.rs
@@ -13,9 +13,9 @@ async fn get_over_https() {
     assert_eq!(response.unwrap().status(), 200);
 }
 
-async fn spawn_http_actor() -> RequestResponseHandler<HttpRequest, HttpResult> {
+async fn spawn_http_actor() -> ClientMessageBox<HttpRequest, HttpResult> {
     let mut builder = HttpActorBuilder::new().unwrap();
-    let handle = RequestResponseHandler::new("Tester", &mut builder.box_builder, NoConfig);
+    let handle = ClientMessageBox::new("Tester", &mut builder.box_builder, NoConfig);
 
     tokio::spawn(builder.run());
 

--- a/crates/extensions/tedge_mqtt_ext/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/lib.rs
@@ -14,12 +14,12 @@ use tedge_actors::Builder;
 use tedge_actors::ChannelError;
 use tedge_actors::DynSender;
 use tedge_actors::MessageBox;
-use tedge_actors::MessageBoxPlug;
-use tedge_actors::MessageBoxSocket;
 use tedge_actors::MessageSink;
 use tedge_actors::MessageSource;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
+use tedge_actors::ServiceConsumer;
+use tedge_actors::ServiceProvider;
 
 pub type MqttConfig = mqtt_channel::Config;
 pub type MqttMessage = mqtt_channel::Message;
@@ -65,10 +65,10 @@ impl MqttActorBuilder {
     }
 }
 
-impl MessageBoxSocket<MqttMessage, MqttMessage, TopicFilter> for MqttActorBuilder {
+impl ServiceProvider<MqttMessage, MqttMessage, TopicFilter> for MqttActorBuilder {
     fn connect_with(
         &mut self,
-        peer: &mut impl MessageBoxPlug<MqttMessage, MqttMessage>,
+        peer: &mut impl ServiceConsumer<MqttMessage, MqttMessage>,
         subscriptions: TopicFilter,
     ) {
         self.subscriber_addresses

--- a/crates/extensions/tedge_script_ext/src/lib.rs
+++ b/crates/extensions/tedge_script_ext/src/lib.rs
@@ -4,13 +4,13 @@ use std::process::Output;
 use tedge_actors::Actor;
 use tedge_actors::Builder;
 use tedge_actors::ChannelError;
+use tedge_actors::ConcurrentServerActor;
 use tedge_actors::ConcurrentServerMessageBox;
-use tedge_actors::ConcurrentServiceActor;
 use tedge_actors::DynSender;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
+use tedge_actors::Server;
 use tedge_actors::ServerMessageBoxBuilder;
-use tedge_actors::Service;
 
 #[derive(Clone)]
 pub struct ScriptActor;
@@ -22,7 +22,7 @@ pub struct Execute {
 }
 
 #[async_trait::async_trait]
-impl Service for ScriptActor {
+impl Server for ScriptActor {
     type Request = Execute;
     type Response = std::io::Result<Output>;
 
@@ -45,13 +45,13 @@ impl ScriptActorBuilder {
 }
 
 pub struct ScriptActorBuilder {
-    actor: ConcurrentServiceActor<ScriptActor>,
+    actor: ConcurrentServerActor<ScriptActor>,
     box_builder: ServerMessageBoxBuilder<Execute, std::io::Result<Output>>,
 }
 
 impl
     Builder<(
-        ConcurrentServiceActor<ScriptActor>,
+        ConcurrentServerActor<ScriptActor>,
         ConcurrentServerMessageBox<Execute, std::io::Result<Output>>,
     )> for ScriptActorBuilder
 {
@@ -61,7 +61,7 @@ impl
         self,
     ) -> Result<
         (
-            ConcurrentServiceActor<ScriptActor>,
+            ConcurrentServerActor<ScriptActor>,
             ConcurrentServerMessageBox<Execute, std::io::Result<Output>>,
         ),
         Self::Error,
@@ -72,7 +72,7 @@ impl
     fn build(
         self,
     ) -> (
-        ConcurrentServiceActor<ScriptActor>,
+        ConcurrentServerActor<ScriptActor>,
         ConcurrentServerMessageBox<Execute, std::io::Result<Output>>,
     ) {
         let actor = self.actor;
@@ -96,7 +96,7 @@ mod tests {
 
     #[tokio::test]
     async fn script() {
-        let csa = ConcurrentServiceActor::new(ScriptActor);
+        let csa = ConcurrentServerActor::new(ScriptActor);
         let mut builder = ScriptActorBuilder {
             actor: csa,
             box_builder: ServerMessageBoxBuilder::new("Script", 100),

--- a/crates/extensions/tedge_timer_ext/src/actor.rs
+++ b/crates/extensions/tedge_timer_ext/src/actor.rs
@@ -10,7 +10,7 @@ use std::pin::Pin;
 use tedge_actors::Actor;
 use tedge_actors::ChannelError;
 use tedge_actors::ClientId;
-use tedge_actors::ServiceMessageBox;
+use tedge_actors::ServerMessageBox;
 use tokio::time::sleep_until;
 use tokio::time::Instant;
 
@@ -159,7 +159,7 @@ struct SleepHandle {
 
 #[async_trait]
 impl Actor for TimerActor {
-    type MessageBox = ServiceMessageBox<SetTimeout<AnyPayload>, Timeout<AnyPayload>>;
+    type MessageBox = ServerMessageBox<SetTimeout<AnyPayload>, Timeout<AnyPayload>>;
 
     fn name(&self) -> &str {
         "Timer"

--- a/crates/extensions/tedge_timer_ext/src/builder.rs
+++ b/crates/extensions/tedge_timer_ext/src/builder.rs
@@ -14,18 +14,18 @@ use tedge_actors::NoConfig;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
 use tedge_actors::Sender;
+use tedge_actors::ServerMessageBoxBuilder;
 use tedge_actors::ServiceConsumer;
-use tedge_actors::ServiceMessageBoxBuilder;
 use tedge_actors::ServiceProvider;
 
 pub struct TimerActorBuilder {
-    box_builder: ServiceMessageBoxBuilder<SetTimeout<AnyPayload>, Timeout<AnyPayload>>,
+    box_builder: ServerMessageBoxBuilder<SetTimeout<AnyPayload>, Timeout<AnyPayload>>,
 }
 
 impl Default for TimerActorBuilder {
     fn default() -> Self {
         TimerActorBuilder {
-            box_builder: ServiceMessageBoxBuilder::new("Timer", 16),
+            box_builder: ServerMessageBoxBuilder::new("Timer", 16),
         }
     }
 }

--- a/crates/extensions/tedge_timer_ext/src/tests.rs
+++ b/crates/extensions/tedge_timer_ext/src/tests.rs
@@ -5,9 +5,9 @@ use std::time::Duration;
 use tedge_actors::Actor;
 use tedge_actors::Builder;
 use tedge_actors::Message;
-use tedge_actors::MessageBoxPlug;
-use tedge_actors::MessageBoxSocket;
 use tedge_actors::NoConfig;
+use tedge_actors::ServiceConsumer;
+use tedge_actors::ServiceProvider;
 use tedge_actors::SimpleMessageBoxBuilder;
 
 #[tokio::test]
@@ -60,7 +60,7 @@ async fn timeout_requests_lead_to_chronological_timeout_responses() {
     );
 }
 
-async fn spawn_timer_actor<T: Message>(peer: &mut impl MessageBoxPlug<SetTimeout<T>, Timeout<T>>) {
+async fn spawn_timer_actor<T: Message>(peer: &mut impl ServiceConsumer<SetTimeout<T>, Timeout<T>>) {
     let mut builder = TimerActor::builder();
     builder.connect_with(peer, NoConfig);
 


### PR DESCRIPTION
## Proposed changes

- Rename ServiceProvider and ServiceConsumer the former Socket/Plug traits
- Rename Server the former Service trait
- Rename ServerMessageBox the former ServiceMessageBox trait
- Rename ServerClientMessageBox the former RequestResponseHandler struct


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1724

## Checklist


- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


