### PR TITLE
Remove tedge_actors dependency on anyhow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -175,6 +175,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: reports
+        path: reports
     - name: Send report to commit
       uses: joonvena/robotframework-reporter-action@v2.1
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,6 @@ dependencies = [
 name = "c8y_config_manager"
 version = "0.9.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "c8y_api",
  "c8y_http_proxy",
@@ -3479,7 +3478,6 @@ dependencies = [
 name = "tedge_actors"
 version = "0.9.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "env_logger 0.10.0",
  "futures",

--- a/crates/core/tedge_actors/Cargo.toml
+++ b/crates/core/tedge_actors/Cargo.toml
@@ -10,7 +10,6 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
 async-trait = "0.1"
 futures = { version = "0.3" }
 log = "0.4"

--- a/crates/core/tedge_actors/src/examples/calculator.rs
+++ b/crates/core/tedge_actors/src/examples/calculator.rs
@@ -1,6 +1,6 @@
 // TODO: make examples respond to RuntimeRequests
 use crate::Actor;
-use crate::ChannelError;
+use crate::RuntimeError;
 use crate::Server;
 use crate::SimpleMessageBox;
 use async_trait::async_trait;
@@ -34,7 +34,7 @@ impl Actor for Calculator {
         "Calculator"
     }
 
-    async fn run(mut self, mut messages: Self::MessageBox) -> Result<(), ChannelError> {
+    async fn run(mut self, mut messages: Self::MessageBox) -> Result<(), RuntimeError> {
         while let Some(op) = messages.recv().await {
             // Process in turn each input message
             let from = self.state;
@@ -93,7 +93,7 @@ impl Actor for Player {
         &self.name
     }
 
-    async fn run(self, mut messages: Self::MessageBox) -> Result<(), ChannelError> {
+    async fn run(self, mut messages: Self::MessageBox) -> Result<(), RuntimeError> {
         // Send a first identity `Operation` to see where we are.
         messages.send(Operation::Add(0)).await?;
 

--- a/crates/core/tedge_actors/src/lib.rs
+++ b/crates/core/tedge_actors/src/lib.rs
@@ -12,7 +12,7 @@
 //! - output messages produced by the actor.
 //!
 //! ```
-//! # use crate::tedge_actors::{Actor, ChannelError, MessageBox, RuntimeRequest, SimpleMessageBox};
+//! # use crate::tedge_actors::{Actor, RuntimeError, MessageBox, RuntimeRequest, SimpleMessageBox};
 //! # use async_trait::async_trait;
 //! #
 //! /// State of the calculator actor
@@ -53,7 +53,7 @@
 //!         "Calculator"
 //!     }
 //!
-//!     async fn run(mut self, mut messages: Self::MessageBox) -> Result<(), ChannelError> {
+//!     async fn run(mut self, mut messages: Self::MessageBox)-> Result<(), RuntimeError>  {
 //!         while let Some(op) = messages.recv().await {
 //!             // Process in turn each input message
 //!             let from = self.state;
@@ -216,7 +216,7 @@
 //!
 //! ```
 //! # use async_trait::async_trait;
-//! # use tedge_actors::{Actor, ChannelError, MessageBox, ClientMessageBox, ServerActor, SimpleMessageBox};
+//! # use tedge_actors::{Actor, RuntimeError, MessageBox, ClientMessageBox, ServerActor, SimpleMessageBox};
 //! # use crate::tedge_actors::examples::calculator::*;
 //!
 //! /// An actor that send operations to a calculator service to reach a given target.
@@ -240,7 +240,7 @@
 //!         &self.name
 //!     }
 //!
-//!     async fn run(self, mut messages: Self::MessageBox) -> Result<(), ChannelError> {
+//!     async fn run(self, mut messages: Self::MessageBox)-> Result<(), RuntimeError>  {
 //!         // Send a first identity `Operation` to see where we are.
 //!         messages.send(Operation::Add(0)).await?;
 //!

--- a/crates/core/tedge_actors/src/runtime.rs
+++ b/crates/core/tedge_actors/src/runtime.rs
@@ -289,10 +289,7 @@ mod tests {
             "Echo"
         }
 
-        async fn run(
-            mut self,
-            mut messages: SimpleMessageBox<EchoMessage, EchoMessage>,
-        ) -> Result<(), ChannelError> {
+        async fn run(mut self, mut messages: Self::MessageBox) -> Result<(), RuntimeError> {
             // FIXME: If the channel we use to send messages is dropped then we will get an ChannelError::SendError
             // FIXME: but I don't think we shouldn't return this error if the message box has a shutdown message for us
             while let Some(message) = messages.recv().await {
@@ -318,10 +315,7 @@ mod tests {
             "Ending"
         }
 
-        async fn run(
-            mut self,
-            _: SimpleMessageBox<RuntimeRequest, ()>,
-        ) -> Result<(), ChannelError> {
+        async fn run(mut self, _: Self::MessageBox) -> Result<(), RuntimeError> {
             Ok(())
         }
     }

--- a/crates/extensions/c8y_config_manager/Cargo.toml
+++ b/crates/extensions/c8y_config_manager/Cargo.toml
@@ -10,7 +10,6 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
 async-trait = "0.1"
 c8y_api = { path = "../../core/c8y_api" }
 c8y_http_proxy = { path = "../../extensions/c8y_http_proxy" }

--- a/crates/extensions/c8y_config_manager/src/download.rs
+++ b/crates/extensions/c8y_config_manager/src/download.rs
@@ -57,7 +57,7 @@ impl ConfigDownloadManager {
         &mut self,
         smartrest_request: SmartRestConfigDownloadRequest,
         message_box: &mut ConfigManagerMessageBox,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), ConfigManagementError> {
         info!(
             "Received c8y_DownloadConfigFile request for config type: {} from device: {}",
             smartrest_request.config_type, smartrest_request.device
@@ -76,7 +76,7 @@ impl ConfigDownloadManager {
         &mut self,
         smartrest_request: SmartRestConfigDownloadRequest,
         message_box: &mut ConfigManagerMessageBox,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), ConfigManagementError> {
         let executing_message = DownloadConfigFileStatusMessage::executing()?;
         message_box.mqtt_publisher.send(executing_message).await?;
 
@@ -96,7 +96,7 @@ impl ConfigDownloadManager {
                     )
                     .await
                 }
-                Err(err) => Err(err.into()),
+                Err(err) => Err(err),
             }
         };
 
@@ -133,7 +133,7 @@ impl ConfigDownloadManager {
         file_path: PathBuf,
         file_permissions: PermissionEntry,
         message_box: &mut ConfigManagerMessageBox,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), ConfigManagementError> {
         message_box
             .c8y_http_proxy
             .download_file(download_url, file_path, file_permissions)
@@ -152,7 +152,7 @@ impl ConfigDownloadManager {
         &mut self,
         smartrest_request: SmartRestConfigDownloadRequest,
         message_box: &mut ConfigManagerMessageBox,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), ConfigManagementError> {
         let child_id = smartrest_request.device;
         let config_type = smartrest_request.config_type;
 
@@ -307,7 +307,7 @@ impl ConfigDownloadManager {
         &mut self,
         timeout: OperationTimeout,
         message_box: &mut ConfigManagerMessageBox,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), ConfigManagementError> {
         let child_id = timeout.event.child_id;
         let config_type = timeout.event.config_type;
         let operation_key = ChildConfigOperationKey {

--- a/crates/extensions/c8y_config_manager/src/error.rs
+++ b/crates/extensions/c8y_config_manager/src/error.rs
@@ -1,6 +1,8 @@
 use std::io;
+use tedge_actors::RuntimeError;
 use tedge_mqtt_ext::Topic;
 use tedge_utils::file::FileError;
+use tedge_utils::paths::PathsError;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(thiserror::Error, Debug)]
@@ -39,4 +41,16 @@ pub enum ConfigManagementError {
 
     #[error(transparent)]
     FromChannelError(#[from] tedge_actors::ChannelError),
+
+    #[error(transparent)]
+    FromC8YRestError(#[from] c8y_http_proxy::messages::C8YRestError),
+
+    #[error(transparent)]
+    FromPathsError(#[from] PathsError),
+}
+
+impl From<ConfigManagementError> for RuntimeError {
+    fn from(error: ConfigManagementError) -> Self {
+        RuntimeError::ActorError(Box::new(error))
+    }
 }

--- a/crates/extensions/c8y_config_manager/src/tests.rs
+++ b/crates/extensions/c8y_config_manager/src/tests.rs
@@ -11,6 +11,7 @@ use c8y_http_proxy::messages::UploadConfigFile;
 use std::time::Duration;
 use tedge_actors::Actor;
 use tedge_actors::Builder;
+use tedge_actors::DynError;
 use tedge_actors::SimpleMessageBox;
 use tedge_actors::SimpleMessageBoxBuilder;
 use tedge_mqtt_ext::MqttMessage;
@@ -22,7 +23,7 @@ use tokio::time::timeout;
 const TEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[tokio::test]
-async fn test_config_plugin_init() -> anyhow::Result<()> {
+async fn test_config_plugin_init() -> Result<(), DynError> {
     let device_id = "tedge-device".to_string();
     let test_config_type = "test-config";
     let test_config_path = "/some/test/config";
@@ -56,7 +57,7 @@ async fn test_config_plugin_init() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_config_upload_tedge_device() -> anyhow::Result<()> {
+async fn test_config_upload_tedge_device() -> Result<(), DynError> {
     let device_id = "tedge-device".to_string();
     let test_config_type = "test-config";
     let test_config_path = "/some/test/config";
@@ -116,7 +117,7 @@ async fn test_config_upload_tedge_device() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn test_config_download_tedge_device() -> anyhow::Result<()> {
+async fn test_config_download_tedge_device() -> Result<(), DynError> {
     let device_id = "tedge-device".to_string();
     let test_config_type = "test-config";
     let test_config_path = "/some/test/config";
@@ -185,11 +186,14 @@ async fn test_config_download_tedge_device() -> anyhow::Result<()> {
 async fn spawn_config_manager(
     device_id: &str,
     tedge_temp_dir: &TempTedgeDir,
-) -> anyhow::Result<(
-    SimpleMessageBox<MqttMessage, MqttMessage>,
-    SimpleMessageBox<C8YRestRequest, C8YRestResult>,
-    SimpleMessageBox<OperationTimer, OperationTimeout>,
-)> {
+) -> Result<
+    (
+        SimpleMessageBox<MqttMessage, MqttMessage>,
+        SimpleMessageBox<C8YRestRequest, C8YRestResult>,
+        SimpleMessageBox<OperationTimer, OperationTimeout>,
+    ),
+    DynError,
+> {
     let tedge_host = "127.0.0.1";
     let c8y_host = "test.c8y.io";
     let mqtt_port = 1234;

--- a/crates/extensions/c8y_http_proxy/src/actor.rs
+++ b/crates/extensions/c8y_http_proxy/src/actor.rs
@@ -30,8 +30,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 use tedge_actors::fan_in_message_type;
 use tedge_actors::Actor;
-use tedge_actors::ChannelError;
 use tedge_actors::MessageBox;
+use tedge_actors::RuntimeError;
 use tedge_actors::ServerMessageBox;
 use tedge_http_ext::HttpHandle;
 use tedge_http_ext::HttpRequest;
@@ -57,7 +57,7 @@ impl Actor for C8YHttpConfig {
         "C8YHttpProxy"
     }
 
-    async fn run(self, messages: Self::MessageBox) -> Result<(), ChannelError> {
+    async fn run(self, messages: Self::MessageBox) -> Result<(), RuntimeError> {
         let actor = C8YHttpProxyActor::new(self, messages);
         actor.run().await
     }
@@ -114,7 +114,7 @@ impl C8YHttpProxyActor {
         }
     }
 
-    pub async fn run(mut self) -> Result<(), ChannelError> {
+    pub async fn run(mut self) -> Result<(), RuntimeError> {
         self.init().await;
 
         while let Some((client_id, request)) = self.peers.clients.recv().await {

--- a/crates/extensions/c8y_log_manager/src/actor.rs
+++ b/crates/extensions/c8y_log_manager/src/actor.rs
@@ -22,9 +22,9 @@ use tedge_actors::fan_in_message_type;
 use tedge_actors::futures::channel::mpsc;
 use tedge_actors::futures::StreamExt;
 use tedge_actors::Actor;
-use tedge_actors::ChannelError;
 use tedge_actors::DynSender;
 use tedge_actors::MessageBox;
+use tedge_actors::RuntimeError;
 use tedge_actors::RuntimeRequest;
 use tedge_api::health::get_health_status_message;
 use tedge_api::health::health_check_topics;
@@ -357,7 +357,7 @@ impl Actor for LogManagerActor {
         "LogManager"
     }
 
-    async fn run(mut self, mut messages: Self::MessageBox) -> Result<(), ChannelError> {
+    async fn run(mut self, mut messages: Self::MessageBox) -> Result<(), RuntimeError> {
         self.reload_supported_log_types().await.unwrap();
         self.get_pending_operations_from_cloud().await.unwrap();
 

--- a/crates/extensions/tedge_http_ext/src/lib.rs
+++ b/crates/extensions/tedge_http_ext/src/lib.rs
@@ -13,12 +13,12 @@ use std::convert::Infallible;
 use actor::*;
 use tedge_actors::Actor;
 use tedge_actors::Builder;
-use tedge_actors::ChannelError;
 use tedge_actors::ClientMessageBox;
 use tedge_actors::ConcurrentServerActor;
 use tedge_actors::ConcurrentServerMessageBox;
 use tedge_actors::DynSender;
 use tedge_actors::NoConfig;
+use tedge_actors::RuntimeError;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
 use tedge_actors::ServerMessageBoxBuilder;
@@ -43,7 +43,7 @@ impl HttpActorBuilder {
         Ok(HttpActorBuilder { actor, box_builder })
     }
 
-    pub async fn run(self) -> Result<(), ChannelError> {
+    pub async fn run(self) -> Result<(), RuntimeError> {
         let actor = self.actor;
         let messages = self.box_builder.build();
 

--- a/crates/extensions/tedge_script_ext/src/lib.rs
+++ b/crates/extensions/tedge_script_ext/src/lib.rs
@@ -3,10 +3,10 @@ use std::process::Output;
 
 use tedge_actors::Actor;
 use tedge_actors::Builder;
-use tedge_actors::ChannelError;
 use tedge_actors::ConcurrentServerActor;
 use tedge_actors::ConcurrentServerMessageBox;
 use tedge_actors::DynSender;
+use tedge_actors::RuntimeError;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
 use tedge_actors::Server;
@@ -39,7 +39,7 @@ impl Server for ScriptActor {
 }
 
 impl ScriptActorBuilder {
-    pub async fn run(self) -> Result<(), ChannelError> {
+    pub async fn run(self) -> Result<(), RuntimeError> {
         self.actor.run(self.box_builder.build()).await
     }
 }

--- a/crates/extensions/tedge_signal_ext/src/lib.rs
+++ b/crates/extensions/tedge_signal_ext/src/lib.rs
@@ -5,12 +5,12 @@ use std::convert::Infallible;
 use tedge_actors::futures::StreamExt;
 use tedge_actors::Actor;
 use tedge_actors::Builder;
-use tedge_actors::ChannelError;
 use tedge_actors::DynSender;
 use tedge_actors::MessageSource;
 use tedge_actors::NoConfig;
 use tedge_actors::NoMessage;
 use tedge_actors::RuntimeAction;
+use tedge_actors::RuntimeError;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
 use tedge_actors::SimpleMessageBox;
@@ -63,7 +63,7 @@ impl Actor for SignalActor {
         "Signal-Handler"
     }
 
-    async fn run(self, mut messages: Self::MessageBox) -> Result<(), ChannelError> {
+    async fn run(self, mut messages: Self::MessageBox) -> Result<(), RuntimeError> {
         let mut signals = Signals::new([SIGTERM, SIGINT, SIGQUIT]).unwrap(); // FIXME
         loop {
             tokio::select! {

--- a/crates/extensions/tedge_timer_ext/src/actor.rs
+++ b/crates/extensions/tedge_timer_ext/src/actor.rs
@@ -8,8 +8,8 @@ use std::collections::BinaryHeap;
 use std::fmt::Debug;
 use std::pin::Pin;
 use tedge_actors::Actor;
-use tedge_actors::ChannelError;
 use tedge_actors::ClientId;
+use tedge_actors::RuntimeError;
 use tedge_actors::ServerMessageBox;
 use tokio::time::sleep_until;
 use tokio::time::Instant;
@@ -165,7 +165,7 @@ impl Actor for TimerActor {
         "Timer"
     }
 
-    async fn run(mut self, mut messages: Self::MessageBox) -> Result<(), ChannelError> {
+    async fn run(mut self, mut messages: Self::MessageBox) -> Result<(), RuntimeError> {
         loop {
             if let Some(current) = self.current_timer.take() {
                 let time_elapsed = current.sleep;


### PR DESCRIPTION
A library crate should not depend on anyhow

## Proposed changes

- Remove tedge_actors dependency on anyhow
- Remove c8y_config_manager dependency on anyhow
- Extends RuntimeError with a case for any std::error::Error
- Change the signature of Actor::run to raise RuntimeError

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/1724


## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

