### PR TITLE
Simplify Actor Builders

### DIFF
--- a/crates/bin/c8y-device-management/src/main.rs
+++ b/crates/bin/c8y-device-management/src/main.rs
@@ -17,7 +17,7 @@ use tedge_config::TEdgeConfig;
 use tedge_config::TEdgeConfigError;
 use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 use tedge_file_system_ext::FsWatchActorBuilder;
-use tedge_http_ext::HttpActorBuilder;
+use tedge_http_ext::HttpActor;
 use tedge_mqtt_ext::MqttActorBuilder;
 use tedge_mqtt_ext::MqttConfig;
 use tedge_signal_ext::SignalActor;
@@ -38,7 +38,7 @@ async fn main() -> anyhow::Result<()> {
     let mut mqtt_actor = MqttActorBuilder::new(mqtt_config.clone().with_session_name(PLUGIN_NAME));
 
     let mut jwt_actor = C8YJwtRetriever::builder(mqtt_config);
-    let mut http_actor = HttpActorBuilder::new()?;
+    let mut http_actor = HttpActor::new().builder();
     let c8y_http_config = (&tedge_config).try_into()?;
     let mut c8y_http_proxy_actor =
         C8YHttpProxyBuilder::new(c8y_http_config, &mut http_actor, &mut jwt_actor);

--- a/crates/bin/c8y-device-management/src/main.rs
+++ b/crates/bin/c8y-device-management/src/main.rs
@@ -55,8 +55,8 @@ async fn main() -> anyhow::Result<()> {
     // Connect other actor instances to config manager actor
     config_actor.with_fs_connection(&mut fs_watch_actor)?;
     config_actor.with_c8y_http_proxy(&mut c8y_http_proxy_actor)?;
-    config_actor.connect_to(&mut mqtt_actor);
-    config_actor.connect_to(&mut timer_actor);
+    config_actor.set_connection(&mut mqtt_actor);
+    config_actor.set_connection(&mut timer_actor);
 
     //Instantiate log manager actor
     let log_manager_config =

--- a/crates/bin/c8y-device-management/src/main.rs
+++ b/crates/bin/c8y-device-management/src/main.rs
@@ -8,6 +8,7 @@ use tedge_actors::MessageSink;
 use tedge_actors::MessageSource;
 use tedge_actors::NoConfig;
 use tedge_actors::Runtime;
+use tedge_actors::ServiceConsumer;
 use tedge_config::get_tedge_config;
 use tedge_config::ConfigSettingAccessor;
 use tedge_config::MqttBindAddressSetting;
@@ -54,8 +55,8 @@ async fn main() -> anyhow::Result<()> {
     // Connect other actor instances to config manager actor
     config_actor.with_fs_connection(&mut fs_watch_actor)?;
     config_actor.with_c8y_http_proxy(&mut c8y_http_proxy_actor)?;
-    config_actor.with_mqtt_connection(&mut mqtt_actor)?;
-    config_actor.with_timer(&mut timer_actor)?;
+    config_actor.connect_to(&mut mqtt_actor);
+    config_actor.connect_to(&mut timer_actor);
 
     //Instantiate log manager actor
     let log_manager_config =

--- a/crates/core/tedge_actors/src/actors.rs
+++ b/crates/core/tedge_actors/src/actors.rs
@@ -112,6 +112,7 @@ impl<S: Server + Clone> Actor for ConcurrentServerActor<S> {
 
 #[cfg(test)]
 pub mod tests {
+    use crate::test_helpers::ServiceProviderExt;
     use crate::*;
     use async_trait::async_trait;
     use futures::channel::mpsc;
@@ -140,7 +141,9 @@ pub mod tests {
     #[tokio::test]
     async fn running_an_actor_without_a_runtime() {
         let actor = Echo;
-        let (mut client_message_box, actor_message_box) = SimpleMessageBox::channel("test", 16);
+        let mut box_builder = SimpleMessageBoxBuilder::new("test", 16);
+        let mut client_message_box = box_builder.new_client_box(NoConfig);
+        let actor_message_box = box_builder.build();
         let actor_task = spawn(actor.run(actor_message_box));
 
         // Messages sent to the actor

--- a/crates/core/tedge_actors/src/examples/calculator.rs
+++ b/crates/core/tedge_actors/src/examples/calculator.rs
@@ -121,7 +121,6 @@ mod tests {
     use crate::Actor;
     use crate::Builder;
     use crate::ChannelError;
-    use crate::NoConfig;
     use crate::ServerActor;
     use crate::ServerMessageBoxBuilder;
     use crate::ServiceConsumer;
@@ -137,7 +136,7 @@ mod tests {
         let mut probe = Probe::new();
         player_box_builder
             .with_probe(&mut probe)
-            .connect_to(&mut service_box_builder, NoConfig);
+            .connect_to(&mut service_box_builder);
 
         // Spawn the actors
         tokio::spawn(ServerActor::new(Calculator::default()).run(service_box_builder.build()));

--- a/crates/core/tedge_actors/src/examples/calculator.rs
+++ b/crates/core/tedge_actors/src/examples/calculator.rs
@@ -136,7 +136,7 @@ mod tests {
         let mut probe = Probe::new();
         player_box_builder
             .with_probe(&mut probe)
-            .connect_to(&mut service_box_builder);
+            .set_connection(&mut service_box_builder);
 
         // Spawn the actors
         tokio::spawn(ServerActor::new(Calculator::default()).run(service_box_builder.build()));

--- a/crates/core/tedge_actors/src/lib.rs
+++ b/crates/core/tedge_actors/src/lib.rs
@@ -75,11 +75,8 @@
 //!
 //! ## Testing an actor
 //!
-//! To run and test an actor one needs to establish a bidirectional channel to its message box.
-//! The simpler is to use the `Actor::MessageBox::channel()` function that creates two message boxes.
-//! Along a message box ready to be used by the actor,
-//! this function returns a second box connected to the former.
-//! This message box can then be used to:
+//! To run and test an actor one needs to create a test message box connected to the actor message box.
+//! This test box can then be used to:
 //! - send input messages to the actor
 //! - receive output messages sent by the actor.
 //!
@@ -90,8 +87,12 @@
 //! # #[tokio::main]
 //! # async fn main() {
 //! #
-//! // Create a message box for the actor, along a test box ready to communicate with actor.
-//! let (mut test_box, actor_box) = SimpleMessageBox::channel("Test", 10);
+//! // Create a message box for the actor, along a test box ready to communicate with the actor.
+//! use tedge_actors::{Builder, NoConfig, SimpleMessageBoxBuilder};
+//! use tedge_actors::test_helpers::ServiceProviderExt;
+//! let mut actor_box_builder = SimpleMessageBoxBuilder::new("Actor", 10);
+//! let mut test_box = actor_box_builder.new_client_box(NoConfig);
+//! let actor_box = actor_box_builder.build();
 //!
 //! // The actor is then spawn in the background with its message box.
 //! let actor = Calculator::default();
@@ -171,14 +172,17 @@
 //! This actor can then be tested using a test box connected to the actor box.
 //!
 //! ```
-//! # use tedge_actors::{Actor, MessageBox, ReceiveMessages, ServerActor, SimpleMessageBox};
+//! # use tedge_actors::{Actor, Builder, MessageBox, NoConfig, ReceiveMessages, ServerActor, SimpleMessageBox, SimpleMessageBoxBuilder};
+//! # use tedge_actors::test_helpers::ServiceProviderExt;
 //! # use crate::tedge_actors::examples::calculator::*;
 //! #
 //! # #[tokio::main]
 //! # async fn main_test() {
 //! #
 //! // As for any actor, one needs a bidirectional channel to the message box of the service.
-//! let (mut test_box, actor_box) = SimpleMessageBox::channel("Test", 10);
+//! let mut actor_box_builder = SimpleMessageBoxBuilder::new("Actor", 10);
+//! let mut test_box = actor_box_builder.new_client_box(NoConfig);
+//! let actor_box = actor_box_builder.build();
 //!
 //! // The actor is then spawn in the background with its message box.
 //! let service = Calculator::default();

--- a/crates/core/tedge_actors/src/lib.rs
+++ b/crates/core/tedge_actors/src/lib.rs
@@ -280,12 +280,12 @@
 //! // Connecting the two boxes, so the box built by the `player_box_builder`:
 //! // - receives as input the messages sent by the box built by the `service_box_builder`
 //! // - sends its output to the service input box.
-//! player_1_box_builder.connect_to(&mut service_box_builder);
+//! player_1_box_builder.set_connection(&mut service_box_builder);
 //!
 //! // Its matters that the builder of the service box is a `ServerMessageBoxBuilder`:
 //! // this builder accept other actors to connect to the same service.
 //! let mut player_2_box_builder = SimpleMessageBoxBuilder::new("Player 2", 1);
-//! player_2_box_builder.connect_to(&mut service_box_builder);
+//! player_2_box_builder.set_connection(&mut service_box_builder);
 //!
 //! // One can then build the message boxes
 //! let service_box: ServerMessageBox<Operation,Update> = service_box_builder.build();
@@ -339,7 +339,7 @@
 //!
 //! // Connect the two actor message boxes interposing a probe.
 //! let mut probe = Probe::new();
-//! player_box_builder.with_probe(&mut probe).connect_to(&mut service_box_builder);
+//! player_box_builder.with_probe(&mut probe).set_connection(&mut service_box_builder);
 //!
 //! // Spawn the actors
 //! tokio::spawn(ServerActor::new(Calculator::default()).run(service_box_builder.build()));

--- a/crates/core/tedge_actors/src/lib.rs
+++ b/crates/core/tedge_actors/src/lib.rs
@@ -259,7 +259,7 @@
 //! to establish appropriate connections between the actor message boxes.
 //!
 //! ```
-//! # use tedge_actors::{Actor, Builder, ChannelError, MessageBox, ServiceConsumer, NoConfig, ReceiveMessages, ServerActor, ServerMessageBox, ServerMessageBoxBuilder, SimpleMessageBox, SimpleMessageBoxBuilder};
+//! # use tedge_actors::{Actor, Builder, ChannelError, MessageBox, ReceiveMessages, ServiceConsumer, ServerActor, ServerMessageBox, ServerMessageBoxBuilder, SimpleMessageBox, SimpleMessageBoxBuilder};
 //! # use crate::tedge_actors::examples::calculator::*;
 //! # #[tokio::main]
 //! # async fn main_test() -> Result<(),ChannelError> {
@@ -276,12 +276,12 @@
 //! // Connecting the two boxes, so the box built by the `player_box_builder`:
 //! // - receives as input the messages sent by the box built by the `service_box_builder`
 //! // - sends its output to the service input box.
-//! player_1_box_builder.connect_to(&mut service_box_builder, NoConfig);
+//! player_1_box_builder.connect_to(&mut service_box_builder);
 //!
 //! // Its matters that the builder of the service box is a `ServerMessageBoxBuilder`:
 //! // this builder accept other actors to connect to the same service.
 //! let mut player_2_box_builder = SimpleMessageBoxBuilder::new("Player 2", 1);
-//! player_2_box_builder.connect_to(&mut service_box_builder, NoConfig);
+//! player_2_box_builder.connect_to(&mut service_box_builder);
 //!
 //! // One can then build the message boxes
 //! let service_box: ServerMessageBox<Operation,Update> = service_box_builder.build();
@@ -322,7 +322,7 @@
 //! Here, we interpose a `Probe` between two actors to observe their interactions.
 //!
 //! ```
-//! # use tedge_actors::{Actor, Builder, ChannelError, ServiceConsumer, NoConfig, ServerActor, ServerMessageBoxBuilder, SimpleMessageBoxBuilder};
+//! # use tedge_actors::{Actor, Builder, ChannelError, ServiceConsumer, ServerActor, ServerMessageBoxBuilder, SimpleMessageBoxBuilder};
 //! # use tedge_actors::test_helpers::{ServiceConsumerExt, Probe, ProbeEvent};
 //! # use tedge_actors::test_helpers::ProbeEvent::{Recv, Send};
 //! # use crate::tedge_actors::examples::calculator::*;
@@ -335,7 +335,7 @@
 //!
 //! // Connect the two actor message boxes interposing a probe.
 //! let mut probe = Probe::new();
-//! player_box_builder.with_probe(&mut probe).connect_to(&mut service_box_builder, NoConfig);
+//! player_box_builder.with_probe(&mut probe).connect_to(&mut service_box_builder);
 //!
 //! // Spawn the actors
 //! tokio::spawn(ServerActor::new(Calculator::default()).run(service_box_builder.build()));

--- a/crates/core/tedge_actors/src/message_boxes.rs
+++ b/crates/core/tedge_actors/src/message_boxes.rs
@@ -202,7 +202,7 @@ impl<Input: Message, Output: Message> SimpleMessageBox<Input, Output> {
     pub fn channel(name: &str, capacity: usize) -> (SimpleMessageBox<Output, Input>, Self) {
         let mut client_box = SimpleMessageBoxBuilder::new(&format!("{}-Client", name), capacity);
         let mut service_box = SimpleMessageBoxBuilder::new(&format!("{}-Service", name), capacity);
-        service_box.connect_with(&mut client_box, NoConfig);
+        service_box.connect_with(&mut client_box);
         (client_box.build(), service_box.build())
     }
 
@@ -418,15 +418,14 @@ pub struct ClientMessageBox<Request, Response> {
 }
 
 impl<Request: Message, Response: Message> ClientMessageBox<Request, Response> {
-    /// Create a new `ClientMessageBox` connected to the service with the given config.
-    pub fn new<Config>(
+    /// Create a new `ClientMessageBox` connected to the service.
+    pub fn new(
         client_name: &str,
-        service: &mut impl ServiceProvider<Request, Response, Config>,
-        config: Config,
+        service: &mut impl ServiceProvider<Request, Response, NoConfig>,
     ) -> Self {
         let capacity = 1; // At most one response is ever expected
         let messages = SimpleMessageBoxBuilder::new(client_name, capacity)
-            .connected_to(service, config)
+            .connected_to(service)
             .build();
         ClientMessageBox { messages }
     }

--- a/crates/core/tedge_actors/src/message_boxes.rs
+++ b/crates/core/tedge_actors/src/message_boxes.rs
@@ -398,7 +398,7 @@ impl<Request: Message, Response: Message> ClientMessageBox<Request, Response> {
     ) -> Self {
         let capacity = 1; // At most one response is ever expected
         let messages = SimpleMessageBoxBuilder::new(client_name, capacity)
-            .connected_to(service)
+            .with_connection(service)
             .build();
         ClientMessageBox { messages }
     }

--- a/crates/core/tedge_actors/src/test_helpers.rs
+++ b/crates/core/tedge_actors/src/test_helpers.rs
@@ -132,7 +132,7 @@ pub trait ServiceConsumerExt<Request: MessagePlus, Response: MessagePlus> {
 
 impl<T, Request: MessagePlus, Response: MessagePlus> ServiceConsumerExt<Request, Response> for T
 where
-    T: ServiceConsumer<Request, Response>,
+    T: ServiceConsumer<Request, Response, NoConfig>,
 {
     fn with_probe<'a>(
         &'a mut self,

--- a/crates/core/tedge_actors/src/test_helpers.rs
+++ b/crates/core/tedge_actors/src/test_helpers.rs
@@ -190,7 +190,7 @@ where
         let name = "client-box";
         let capacity = 16;
         let mut client_box = ConsumerBoxBuilder::new(name, capacity, config);
-        self.connect_with(&mut client_box);
+        self.add_peer(&mut client_box);
         client_box.build()
     }
 }

--- a/crates/core/tedge_actors/src/tests.rs
+++ b/crates/core/tedge_actors/src/tests.rs
@@ -46,7 +46,7 @@ async fn spawn_concurrent_sleep_service(
     let actor = ConcurrentServerActor::new(service);
     let mut box_builder = SimpleMessageBoxBuilder::new(actor.name(), 16);
     let mut handle_builder = SimpleMessageBoxBuilder::new("handle", 16);
-    box_builder.connect_with(&mut handle_builder);
+    box_builder.add_peer(&mut handle_builder);
 
     let handle = handle_builder.build();
     let messages = ConcurrentServerMessageBox::new(max_concurrency, box_builder.build());

--- a/crates/extensions/c8y_config_manager/src/lib.rs
+++ b/crates/extensions/c8y_config_manager/src/lib.rs
@@ -101,24 +101,25 @@ impl ConfigManagerBuilder {
     }
 }
 
-impl MessageSource<SetTimeout<ChildConfigOperationKey>, NoConfig> for ConfigManagerBuilder {
-    fn register_peer(
-        &mut self,
-        _config: NoConfig,
-        sender: DynSender<SetTimeout<ChildConfigOperationKey>>,
-    ) {
-        self.timer_sender = Some(sender);
-    }
-}
-
 impl MessageSink<FsWatchEvent> for ConfigManagerBuilder {
     fn get_sender(&self) -> DynSender<FsWatchEvent> {
         self.events_sender.clone().into()
     }
 }
 
-impl MessageSink<Timeout<ChildConfigOperationKey>> for ConfigManagerBuilder {
-    fn get_sender(&self) -> DynSender<Timeout<ChildConfigOperationKey>> {
+impl
+    ServiceConsumer<SetTimeout<ChildConfigOperationKey>, Timeout<ChildConfigOperationKey>, NoConfig>
+    for ConfigManagerBuilder
+{
+    fn get_config(&self) -> NoConfig {
+        NoConfig
+    }
+
+    fn set_request_sender(&mut self, sender: DynSender<SetTimeout<ChildConfigOperationKey>>) {
+        self.timer_sender = Some(sender);
+    }
+
+    fn get_response_sender(&self) -> DynSender<Timeout<ChildConfigOperationKey>> {
         self.events_sender.clone().into()
     }
 }

--- a/crates/extensions/c8y_config_manager/src/lib.rs
+++ b/crates/extensions/c8y_config_manager/src/lib.rs
@@ -78,7 +78,7 @@ impl ConfigManagerBuilder {
     where
         T: ServiceProvider<MqttMessage, MqttMessage, TopicFilter>,
     {
-        mqtt.connect_with(self);
+        mqtt.add_peer(self);
         Ok(())
     }
 
@@ -96,7 +96,7 @@ impl ConfigManagerBuilder {
         &mut self,
         timer_builder: &mut impl ServiceProvider<OperationTimer, OperationTimeout, NoConfig>,
     ) -> Result<(), LinkError> {
-        timer_builder.connect_with(self);
+        timer_builder.add_peer(self);
         Ok(())
     }
 }

--- a/crates/extensions/c8y_http_proxy/src/credentials.rs
+++ b/crates/extensions/c8y_http_proxy/src/credentials.rs
@@ -128,12 +128,8 @@ impl<S: Server<Request = JwtRequest, Response = JwtResult>>
 impl<S: Server<Request = JwtRequest, Response = JwtResult>>
     ServiceProvider<JwtRequest, JwtResult, NoConfig> for JwtRetrieverBuilder<S>
 {
-    fn connect_with(
-        &mut self,
-        peer: &mut impl ServiceConsumer<JwtRequest, JwtResult>,
-        config: NoConfig,
-    ) {
-        self.message_box.connect_with(peer, config)
+    fn connect_with(&mut self, peer: &mut impl ServiceConsumer<JwtRequest, JwtResult, NoConfig>) {
+        self.message_box.connect_with(peer)
     }
 }
 

--- a/crates/extensions/c8y_http_proxy/src/credentials.rs
+++ b/crates/extensions/c8y_http_proxy/src/credentials.rs
@@ -5,22 +5,12 @@ use mqtt_channel::Connection;
 use mqtt_channel::PubChannel;
 use mqtt_channel::StreamExt;
 use mqtt_channel::Topic;
-use mqtt_channel::TopicFilter;
-use std::convert::Infallible;
 use std::time::Duration;
-use tedge_actors::Actor;
-use tedge_actors::Builder;
 use tedge_actors::ClientMessageBox;
-use tedge_actors::DynSender;
-use tedge_actors::NoConfig;
-use tedge_actors::RuntimeRequest;
-use tedge_actors::RuntimeRequestSink;
+use tedge_actors::Sequential;
 use tedge_actors::Server;
-use tedge_actors::ServerActor;
-use tedge_actors::ServerMessageBox;
-use tedge_actors::ServerMessageBoxBuilder;
-use tedge_actors::ServiceConsumer;
-use tedge_actors::ServiceProvider;
+use tedge_actors::ServerActorBuilder;
+use tedge_actors::ServerConfig;
 
 pub type JwtRequest = ();
 pub type JwtResult = Result<String, SmartRestDeserializerError>;
@@ -34,10 +24,11 @@ pub struct C8YJwtRetriever {
 }
 
 impl C8YJwtRetriever {
-    pub fn builder(mqtt_config: mqtt_channel::Config) -> JwtRetrieverBuilder<C8YJwtRetriever> {
-        JwtRetrieverBuilder::new(C8YJwtRetriever {
-            mqtt_config: mqtt_config.with_subscriptions(TopicFilter::new_unchecked("c8y/s/dat")),
-        })
+    pub fn builder(
+        mqtt_config: mqtt_channel::Config,
+    ) -> ServerActorBuilder<C8YJwtRetriever, Sequential> {
+        let server = C8YJwtRetriever { mqtt_config };
+        ServerActorBuilder::new(server, &ServerConfig::default(), Sequential)
     }
 }
 
@@ -94,49 +85,5 @@ impl Server for ConstJwtRetriever {
 
     async fn handle(&mut self, _request: Self::Request) -> Self::Response {
         Ok(self.token.clone())
-    }
-}
-
-/// Build an actor from a JwtRetriever service
-pub struct JwtRetrieverBuilder<S: Server<Request = JwtRequest, Response = JwtResult>> {
-    actor: ServerActor<S>,
-    message_box: ServerMessageBoxBuilder<(), JwtResult>,
-}
-
-impl<S: Server<Request = JwtRequest, Response = JwtResult>> JwtRetrieverBuilder<S> {
-    pub fn new(service: S) -> Self {
-        let actor = ServerActor::new(service);
-        let message_box = ServerMessageBoxBuilder::new(actor.name(), 10);
-        JwtRetrieverBuilder { actor, message_box }
-    }
-}
-
-impl<S: Server<Request = JwtRequest, Response = JwtResult>>
-    Builder<(ServerActor<S>, ServerMessageBox<(), JwtResult>)> for JwtRetrieverBuilder<S>
-{
-    type Error = Infallible;
-
-    fn try_build(self) -> Result<(ServerActor<S>, ServerMessageBox<(), JwtResult>), Self::Error> {
-        Ok(self.build())
-    }
-
-    fn build(self) -> (ServerActor<S>, ServerMessageBox<(), JwtResult>) {
-        (self.actor, self.message_box.build())
-    }
-}
-
-impl<S: Server<Request = JwtRequest, Response = JwtResult>>
-    ServiceProvider<JwtRequest, JwtResult, NoConfig> for JwtRetrieverBuilder<S>
-{
-    fn connect_with(&mut self, peer: &mut impl ServiceConsumer<JwtRequest, JwtResult, NoConfig>) {
-        self.message_box.connect_with(peer)
-    }
-}
-
-impl<S: Server<Request = JwtRequest, Response = JwtResult>> RuntimeRequestSink
-    for JwtRetrieverBuilder<S>
-{
-    fn get_signal_sender(&self) -> DynSender<RuntimeRequest> {
-        self.message_box.get_signal_sender()
     }
 }

--- a/crates/extensions/c8y_http_proxy/src/handle.rs
+++ b/crates/extensions/c8y_http_proxy/src/handle.rs
@@ -23,7 +23,7 @@ impl C8YHttpProxy {
         client_name: &str,
         proxy_builder: &mut impl ServiceProvider<C8YRestRequest, C8YRestResult, NoConfig>,
     ) -> Self {
-        let c8y = ClientMessageBox::new(client_name, proxy_builder, NoConfig);
+        let c8y = ClientMessageBox::new(client_name, proxy_builder);
         C8YHttpProxy { c8y }
     }
 

--- a/crates/extensions/c8y_http_proxy/src/lib.rs
+++ b/crates/extensions/c8y_http_proxy/src/lib.rs
@@ -109,11 +109,11 @@ impl Builder<(C8YHttpConfig, C8YHttpProxyMessageBox)> for C8YHttpProxyBuilder {
 }
 
 impl ServiceProvider<C8YRestRequest, C8YRestResult, NoConfig> for C8YHttpProxyBuilder {
-    fn connect_with(
+    fn add_peer(
         &mut self,
         peer: &mut impl ServiceConsumer<C8YRestRequest, C8YRestResult, NoConfig>,
     ) {
-        self.clients.connect_with(peer)
+        self.clients.add_peer(peer)
     }
 }
 

--- a/crates/extensions/c8y_http_proxy/src/lib.rs
+++ b/crates/extensions/c8y_http_proxy/src/lib.rs
@@ -79,8 +79,8 @@ impl C8YHttpProxyBuilder {
         jwt: &mut impl ServiceProvider<(), JwtResult, NoConfig>,
     ) -> Self {
         let clients = ServerMessageBoxBuilder::new("C8Y-REST", 10);
-        let http = ClientMessageBox::new("C8Y-REST => HTTP", http, NoConfig);
-        let jwt = JwtRetriever::new("C8Y-REST => JWT", jwt, NoConfig);
+        let http = ClientMessageBox::new("C8Y-REST => HTTP", http);
+        let jwt = JwtRetriever::new("C8Y-REST => JWT", jwt);
         C8YHttpProxyBuilder {
             config,
             clients,
@@ -111,10 +111,9 @@ impl Builder<(C8YHttpConfig, C8YHttpProxyMessageBox)> for C8YHttpProxyBuilder {
 impl ServiceProvider<C8YRestRequest, C8YRestResult, NoConfig> for C8YHttpProxyBuilder {
     fn connect_with(
         &mut self,
-        peer: &mut impl ServiceConsumer<C8YRestRequest, C8YRestResult>,
-        config: NoConfig,
+        peer: &mut impl ServiceConsumer<C8YRestRequest, C8YRestResult, NoConfig>,
     ) {
-        self.clients.connect_with(peer, config)
+        self.clients.connect_with(peer)
     }
 }
 

--- a/crates/extensions/tedge_http_ext/src/actor.rs
+++ b/crates/extensions/tedge_http_ext/src/actor.rs
@@ -1,4 +1,3 @@
-use crate::HttpError;
 use crate::HttpRequest;
 use crate::HttpResult;
 use async_trait::async_trait;
@@ -14,7 +13,7 @@ pub struct HttpService {
 }
 
 impl HttpService {
-    pub(crate) fn new() -> Result<Self, HttpError> {
+    pub(crate) fn new() -> Self {
         let https = HttpsConnectorBuilder::new()
             .with_native_roots()
             .https_or_http()
@@ -22,7 +21,7 @@ impl HttpService {
             .enable_http2()
             .build();
         let client = Client::builder().build(https);
-        Ok(HttpService { client })
+        HttpService { client }
     }
 }
 

--- a/crates/extensions/tedge_http_ext/src/lib.rs
+++ b/crates/extensions/tedge_http_ext/src/lib.rs
@@ -8,84 +8,35 @@ mod tests;
 pub mod test_helpers;
 
 pub use messages::*;
-use std::convert::Infallible;
 
 use actor::*;
-use tedge_actors::Actor;
-use tedge_actors::Builder;
-use tedge_actors::ConcurrentServerActor;
-use tedge_actors::ConcurrentServerMessageBox;
-use tedge_actors::DynSender;
-use tedge_actors::NoConfig;
-use tedge_actors::RuntimeError;
-use tedge_actors::RuntimeRequest;
-use tedge_actors::RuntimeRequestSink;
-use tedge_actors::ServerMessageBoxBuilder;
-use tedge_actors::ServiceConsumer;
-use tedge_actors::ServiceProvider;
+use tedge_actors::Concurrent;
+use tedge_actors::ServerActorBuilder;
+use tedge_actors::ServerConfig;
 
-pub struct HttpActorBuilder {
-    actor: ConcurrentServerActor<HttpService>,
-    pub box_builder: ServerMessageBoxBuilder<HttpRequest, HttpResult>,
+#[derive(Debug, Default)]
+pub struct HttpActor {
+    config: ServerConfig,
 }
 
-impl HttpActorBuilder {
-    pub fn new() -> Result<Self, HttpError> {
-        let service = HttpService::new()?;
-        let actor = ConcurrentServerActor::new(service);
-        let box_builder = ServerMessageBoxBuilder::new("HTTP", 16).with_max_concurrency(4);
-
-        Ok(HttpActorBuilder { actor, box_builder })
+impl HttpActor {
+    pub fn new() -> Self {
+        HttpActor::default()
     }
 
-    pub async fn run(self) -> Result<(), RuntimeError> {
-        let actor = self.actor;
-        let messages = self.box_builder.build();
-
-        actor.run(messages).await
-    }
-}
-
-impl
-    Builder<(
-        ConcurrentServerActor<HttpService>,
-        ConcurrentServerMessageBox<HttpRequest, HttpResult>,
-    )> for HttpActorBuilder
-{
-    type Error = Infallible;
-
-    fn try_build(
-        self,
-    ) -> Result<
-        (
-            ConcurrentServerActor<HttpService>,
-            ConcurrentServerMessageBox<HttpRequest, HttpResult>,
-        ),
-        Self::Error,
-    > {
-        Ok(self.build())
+    pub fn builder(&self) -> ServerActorBuilder<HttpService, Concurrent> {
+        ServerActorBuilder::new(HttpService::new(), &self.config, Concurrent)
     }
 
-    fn build(
-        self,
-    ) -> (
-        ConcurrentServerActor<HttpService>,
-        ConcurrentServerMessageBox<HttpRequest, HttpResult>,
-    ) {
-        let actor = self.actor;
-        let actor_box = self.box_builder.build();
-        (actor, actor_box)
+    pub fn with_capacity(self, capacity: usize) -> Self {
+        Self {
+            config: self.config.with_capacity(capacity),
+        }
     }
-}
 
-impl ServiceProvider<HttpRequest, HttpResult, NoConfig> for HttpActorBuilder {
-    fn connect_with(&mut self, peer: &mut impl ServiceConsumer<HttpRequest, HttpResult, NoConfig>) {
-        self.box_builder.connect_with(peer)
-    }
-}
-
-impl RuntimeRequestSink for HttpActorBuilder {
-    fn get_signal_sender(&self) -> DynSender<RuntimeRequest> {
-        self.box_builder.get_signal_sender()
+    pub fn with_max_concurrency(self, max_concurrency: usize) -> Self {
+        Self {
+            config: self.config.with_max_concurrency(max_concurrency),
+        }
     }
 }

--- a/crates/extensions/tedge_http_ext/src/lib.rs
+++ b/crates/extensions/tedge_http_ext/src/lib.rs
@@ -79,12 +79,8 @@ impl
 }
 
 impl ServiceProvider<HttpRequest, HttpResult, NoConfig> for HttpActorBuilder {
-    fn connect_with(
-        &mut self,
-        peer: &mut impl ServiceConsumer<HttpRequest, HttpResult>,
-        config: NoConfig,
-    ) {
-        self.box_builder.connect_with(peer, config)
+    fn connect_with(&mut self, peer: &mut impl ServiceConsumer<HttpRequest, HttpResult, NoConfig>) {
+        self.box_builder.connect_with(peer)
     }
 }
 

--- a/crates/extensions/tedge_http_ext/src/tests.rs
+++ b/crates/extensions/tedge_http_ext/src/tests.rs
@@ -15,8 +15,8 @@ async fn get_over_https() {
 }
 
 async fn spawn_http_actor() -> ClientMessageBox<HttpRequest, HttpResult> {
-    let mut builder = HttpActorBuilder::new().unwrap();
-    let handle = ClientMessageBox::new("Tester", &mut builder.box_builder);
+    let mut builder = HttpActor::new().builder();
+    let handle = ClientMessageBox::new("Tester", &mut builder);
 
     tokio::spawn(builder.run());
 

--- a/crates/extensions/tedge_http_ext/src/tests.rs
+++ b/crates/extensions/tedge_http_ext/src/tests.rs
@@ -16,7 +16,7 @@ async fn get_over_https() {
 
 async fn spawn_http_actor() -> ClientMessageBox<HttpRequest, HttpResult> {
     let mut builder = HttpActorBuilder::new().unwrap();
-    let handle = ClientMessageBox::new("Tester", &mut builder.box_builder, NoConfig);
+    let handle = ClientMessageBox::new("Tester", &mut builder.box_builder);
 
     tokio::spawn(builder.run());
 

--- a/crates/extensions/tedge_mqtt_ext/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/lib.rs
@@ -70,9 +70,9 @@ impl MqttActorBuilder {
 impl ServiceProvider<MqttMessage, MqttMessage, TopicFilter> for MqttActorBuilder {
     fn connect_with(
         &mut self,
-        peer: &mut impl ServiceConsumer<MqttMessage, MqttMessage>,
-        subscriptions: TopicFilter,
+        peer: &mut impl ServiceConsumer<MqttMessage, MqttMessage, TopicFilter>,
     ) {
+        let subscriptions = peer.get_config();
         self.subscriber_addresses
             .push((subscriptions, peer.get_response_sender()));
         peer.set_request_sender(self.publish_sender.clone().into())

--- a/crates/extensions/tedge_mqtt_ext/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/lib.rs
@@ -68,10 +68,7 @@ impl MqttActorBuilder {
 }
 
 impl ServiceProvider<MqttMessage, MqttMessage, TopicFilter> for MqttActorBuilder {
-    fn connect_with(
-        &mut self,
-        peer: &mut impl ServiceConsumer<MqttMessage, MqttMessage, TopicFilter>,
-    ) {
+    fn add_peer(&mut self, peer: &mut impl ServiceConsumer<MqttMessage, MqttMessage, TopicFilter>) {
         let subscriptions = peer.get_config();
         self.subscriber_addresses
             .push((subscriptions, peer.get_response_sender()));

--- a/crates/extensions/tedge_mqtt_ext/src/tests.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/tests.rs
@@ -6,6 +6,46 @@ use tedge_actors::SimpleMessageBoxBuilder;
 
 type MqttClient = SimpleMessageBox<MqttMessage, MqttMessage>;
 
+struct MqttClientBuilder {
+    subscriptions: TopicFilter,
+    box_builder: SimpleMessageBoxBuilder<MqttMessage, MqttMessage>,
+}
+
+impl MqttClientBuilder {
+    fn new(name: &str, subscriptions: &(impl Clone + Into<TopicFilter>)) -> Self {
+        MqttClientBuilder {
+            subscriptions: subscriptions.clone().into(),
+            box_builder: SimpleMessageBoxBuilder::new(name, 16),
+        }
+    }
+}
+
+impl ServiceConsumer<MqttMessage, MqttMessage, TopicFilter> for MqttClientBuilder {
+    fn get_config(&self) -> TopicFilter {
+        self.subscriptions.clone()
+    }
+
+    fn set_request_sender(&mut self, request_sender: DynSender<MqttMessage>) {
+        self.box_builder.set_request_sender(request_sender)
+    }
+
+    fn get_response_sender(&self) -> DynSender<MqttMessage> {
+        self.box_builder.get_response_sender()
+    }
+}
+
+impl Builder<MqttClient> for MqttClientBuilder {
+    type Error = Infallible;
+
+    fn try_build(self) -> Result<MqttClient, Self::Error> {
+        Ok(self.build())
+    }
+
+    fn build(self) -> MqttClient {
+        self.box_builder.build()
+    }
+}
+
 #[tokio::test]
 async fn communicate_over_mqtt() {
     let broker = mqtt_tests::test_mqtt_broker();
@@ -13,20 +53,20 @@ async fn communicate_over_mqtt() {
     let mut mqtt = MqttActorBuilder::new(mqtt_config);
 
     let alice_topic = Topic::new_unchecked("messages/for/alice");
-    let mut alice: MqttClient = SimpleMessageBoxBuilder::new("Alice", 16)
-        .connected_to(&mut mqtt, alice_topic.clone().into())
+    let mut alice: MqttClient = MqttClientBuilder::new("Alice", &alice_topic)
+        .connected_to(&mut mqtt)
         .build();
 
     let bob_topic = Topic::new_unchecked("messages/for/bob");
-    let mut bob: MqttClient = SimpleMessageBoxBuilder::new("Bob", 16)
-        .connected_to(&mut mqtt, bob_topic.clone().into())
+    let mut bob: MqttClient = MqttClientBuilder::new("Bob", &bob_topic)
+        .connected_to(&mut mqtt)
         .build();
 
     let mut all_topics = TopicFilter::empty();
     all_topics.add_all(alice_topic.clone().into());
     all_topics.add_all(bob_topic.clone().into());
-    let mut spy: MqttClient = SimpleMessageBoxBuilder::new("Spy", 16)
-        .connected_to(&mut mqtt, all_topics.clone())
+    let mut spy: MqttClient = MqttClientBuilder::new("Spy", &all_topics)
+        .connected_to(&mut mqtt)
         .build();
 
     tokio::spawn(mqtt_actor(mqtt));

--- a/crates/extensions/tedge_mqtt_ext/src/tests.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/tests.rs
@@ -54,19 +54,19 @@ async fn communicate_over_mqtt() {
 
     let alice_topic = Topic::new_unchecked("messages/for/alice");
     let mut alice: MqttClient = MqttClientBuilder::new("Alice", &alice_topic)
-        .connected_to(&mut mqtt)
+        .with_connection(&mut mqtt)
         .build();
 
     let bob_topic = Topic::new_unchecked("messages/for/bob");
     let mut bob: MqttClient = MqttClientBuilder::new("Bob", &bob_topic)
-        .connected_to(&mut mqtt)
+        .with_connection(&mut mqtt)
         .build();
 
     let mut all_topics = TopicFilter::empty();
     all_topics.add_all(alice_topic.clone().into());
     all_topics.add_all(bob_topic.clone().into());
     let mut spy: MqttClient = MqttClientBuilder::new("Spy", &all_topics)
-        .connected_to(&mut mqtt)
+        .with_connection(&mut mqtt)
         .build();
 
     tokio::spawn(mqtt_actor(mqtt));

--- a/crates/extensions/tedge_script_ext/src/lib.rs
+++ b/crates/extensions/tedge_script_ext/src/lib.rs
@@ -1,16 +1,8 @@
-use std::convert::Infallible;
 use std::process::Output;
-
-use tedge_actors::Actor;
-use tedge_actors::Builder;
-use tedge_actors::ConcurrentServerActor;
-use tedge_actors::ConcurrentServerMessageBox;
-use tedge_actors::DynSender;
-use tedge_actors::RuntimeError;
-use tedge_actors::RuntimeRequest;
-use tedge_actors::RuntimeRequestSink;
+use tedge_actors::Concurrent;
 use tedge_actors::Server;
-use tedge_actors::ServerMessageBoxBuilder;
+use tedge_actors::ServerActorBuilder;
+use tedge_actors::ServerConfig;
 
 #[derive(Clone)]
 pub struct ScriptActor;
@@ -38,52 +30,9 @@ impl Server for ScriptActor {
     }
 }
 
-impl ScriptActorBuilder {
-    pub async fn run(self) -> Result<(), RuntimeError> {
-        self.actor.run(self.box_builder.build()).await
-    }
-}
-
-pub struct ScriptActorBuilder {
-    actor: ConcurrentServerActor<ScriptActor>,
-    box_builder: ServerMessageBoxBuilder<Execute, std::io::Result<Output>>,
-}
-
-impl
-    Builder<(
-        ConcurrentServerActor<ScriptActor>,
-        ConcurrentServerMessageBox<Execute, std::io::Result<Output>>,
-    )> for ScriptActorBuilder
-{
-    type Error = Infallible;
-
-    fn try_build(
-        self,
-    ) -> Result<
-        (
-            ConcurrentServerActor<ScriptActor>,
-            ConcurrentServerMessageBox<Execute, std::io::Result<Output>>,
-        ),
-        Self::Error,
-    > {
-        Ok(self.build())
-    }
-
-    fn build(
-        self,
-    ) -> (
-        ConcurrentServerActor<ScriptActor>,
-        ConcurrentServerMessageBox<Execute, std::io::Result<Output>>,
-    ) {
-        let actor = self.actor;
-        let messages = self.box_builder.build();
-        (actor, messages)
-    }
-}
-
-impl RuntimeRequestSink for ScriptActorBuilder {
-    fn get_signal_sender(&self) -> DynSender<RuntimeRequest> {
-        self.box_builder.get_signal_sender()
+impl ScriptActor {
+    pub fn builder() -> ServerActorBuilder<ScriptActor, Concurrent> {
+        ServerActorBuilder::new(ScriptActor, &ServerConfig::default(), Concurrent)
     }
 }
 
@@ -95,14 +44,10 @@ mod tests {
 
     #[tokio::test]
     async fn script() {
-        let csa = ConcurrentServerActor::new(ScriptActor);
-        let mut builder = ScriptActorBuilder {
-            actor: csa,
-            box_builder: ServerMessageBoxBuilder::new("Script", 100),
-        };
-        let mut handle = ClientMessageBox::new("Tester", &mut builder.box_builder);
+        let mut actor = ScriptActor::builder();
+        let mut handle = ClientMessageBox::new("Tester", &mut actor);
 
-        tokio::spawn(builder.run());
+        tokio::spawn(actor.run());
 
         let output = handle
             .await_response(Execute {

--- a/crates/extensions/tedge_script_ext/src/lib.rs
+++ b/crates/extensions/tedge_script_ext/src/lib.rs
@@ -90,7 +90,6 @@ impl RuntimeRequestSink for ScriptActorBuilder {
 #[cfg(test)]
 mod tests {
     use tedge_actors::ClientMessageBox;
-    use tedge_actors::NoConfig;
 
     use super::*;
 
@@ -101,7 +100,7 @@ mod tests {
             actor: csa,
             box_builder: ServerMessageBoxBuilder::new("Script", 100),
         };
-        let mut handle = ClientMessageBox::new("Tester", &mut builder.box_builder, NoConfig);
+        let mut handle = ClientMessageBox::new("Tester", &mut builder.box_builder);
 
         tokio::spawn(builder.run());
 

--- a/crates/extensions/tedge_timer_ext/src/builder.rs
+++ b/crates/extensions/tedge_timer_ext/src/builder.rs
@@ -51,12 +51,9 @@ impl RuntimeRequestSink for TimerActorBuilder {
 }
 
 impl<T: Message> ServiceProvider<SetTimeout<T>, Timeout<T>, NoConfig> for TimerActorBuilder {
-    fn connect_with(
-        &mut self,
-        peer: &mut impl ServiceConsumer<SetTimeout<T>, Timeout<T>, NoConfig>,
-    ) {
+    fn add_peer(&mut self, peer: &mut impl ServiceConsumer<SetTimeout<T>, Timeout<T>, NoConfig>) {
         let mut adapter = AnyTimerAdapter::new(peer);
-        self.box_builder.connect_with(&mut adapter);
+        self.box_builder.add_peer(&mut adapter);
     }
 }
 

--- a/crates/extensions/tedge_timer_ext/src/tests.rs
+++ b/crates/extensions/tedge_timer_ext/src/tests.rs
@@ -61,9 +61,11 @@ async fn timeout_requests_lead_to_chronological_timeout_responses() {
     );
 }
 
-async fn spawn_timer_actor<T: Message>(peer: &mut impl ServiceConsumer<SetTimeout<T>, Timeout<T>>) {
+async fn spawn_timer_actor<T: Message>(
+    peer: &mut impl ServiceConsumer<SetTimeout<T>, Timeout<T>, NoConfig>,
+) {
     let mut builder = TimerActor::builder();
-    builder.connect_with(peer, NoConfig);
+    builder.connect_with(peer);
 
     tokio::spawn(async move {
         let (actor, actor_box) = builder.build();

--- a/crates/extensions/tedge_timer_ext/src/tests.rs
+++ b/crates/extensions/tedge_timer_ext/src/tests.rs
@@ -65,7 +65,7 @@ async fn spawn_timer_actor<T: Message>(
     peer: &mut impl ServiceConsumer<SetTimeout<T>, Timeout<T>, NoConfig>,
 ) {
     let mut builder = TimerActor::builder();
-    builder.connect_with(peer);
+    builder.add_peer(peer);
 
     tokio::spawn(async move {
         let (actor, actor_box) = builder.build();


### PR DESCRIPTION
## Proposed changes

WIP

- [x] Add a Config to each ServiceConsumer.
        So a ServiceConsumer can be connected to a ServiceProvider
        without any knowledge of the config used by the former to connect the latter.
- [x] Deprecate SimpleMessageBox::channel function
- [ ] Replace the specific connect methods (e.g. `with_c8y_http_proxy`) with generic invocations of `connect_to`. 


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/1724

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

