### PR TITLE
Add a RobotFramework test for c8y-firmware-plugin

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware1.txt
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware1.txt
@@ -1,0 +1,1 @@
+dummy firmware file

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
@@ -1,0 +1,168 @@
+*** Settings ***
+Resource    ../../../resources/common.resource
+Library    Cumulocity
+Library    ThinEdgeIO
+Library    JSONLibrary
+Library    DebugLibrary
+Library    ../../../.venv/lib/python3.9/site-packages/robot/libraries/String.py
+Library    ../../../.venv/lib/python3.9/site-packages/robot/libraries/OperatingSystem.py
+Library    ../../../.venv/lib/python3.9/site-packages/robot/libraries/DateTime.py
+
+Suite Setup    Custom Setup
+Test Teardown    Get Logs
+
+Force Tags    theme:firmware    theme:childdevices
+
+*** Variables ***
+
+${PARENT_IP}
+${HTTP_PORT}    8000
+
+${PARENT_SN}
+${CHILD_SN}
+
+${op_id}
+${cache_key}
+${file_url}
+${file_transfer_url}
+${file_creation_time}
+
+*** Test Cases ***
+Prerequisite Parent
+    Set Device Context    ${PARENT_SN}    #Creates ssh connection to the parent device
+    Execute Command    sudo tedge disconnect c8y
+
+    Delete child related content    #Delete any previous created child related configuration files/folders on the parent device
+    Check for child related content    #Checks if folders that will trigger child device creation are existing
+    Set external MQTT bind address    #Setting external MQTT bind address which child will use for communication
+    Set external MQTT port    #Setting external MQTT port which child will use for communication Default:1883
+
+    Sleep    3s
+    Execute Command    sudo tedge connect c8y
+    Restart Firmware plugin    #Stop and Start c8y-firmware-plugin
+    Cumulocity.Log Device Info
+
+Prerequisite Child
+    Child device delete firmware file    #Delete previous downloaded firmware file
+    Create child device    #Let mapper to create a child device
+    Validate child Name    #This is to check the existence of the bug: https://github.com/thin-edge/thin-edge.io/issues/1569
+
+Child device firmware update
+    Upload binary to Cumulocity
+    Create c8y_Firmware operation
+    Validate firmware update request
+    Child device response on update request    #Child device is sending 'executing' and 'successful' MQTT responses
+    Validate Cumulocity operation status and MO
+
+Child device firmware update with cache
+    Get timestamp of cache
+    Create c8y_Firmware operation
+    Validate firmware update request
+    Child device response on update request    #Child device is sending 'executing' and 'successful' MQTT responses
+    Validate Cumulocity operation status and MO
+    Validate if file is not newly downloaded
+
+*** Keywords ***
+Delete child related content
+    Execute Command    sudo rm -rf /etc/tedge/operations/c8y/TST*         #if folder exists, child device will be created
+    Execute Command    sudo rm -rf /etc/tedge/c8y/TST*                    #if folder exists, child device will be created
+    Execute Command    sudo rm -rf /var/tedge/file-transfer/*
+    Execute Command    sudo rm -rf /var/tedge/cache/*
+    Execute Command    sudo rm -rf /var/tedge/firmware/*
+
+Check for child related content
+    Set Device Context    ${PARENT_SN}
+    Directory Should Not Have Sub Directories    /etc/tedge/operations/c8y
+    Directory Should Not Have Sub Directories    /etc/tedge/c8y
+    Directory Should Not Have Sub Directories    /var/tedge/file-transfer
+    Directory Should Be Empty    /var/tedge/cache
+    Directory Should Be Empty    /var/tedge/firmware
+
+Set external MQTT bind address
+    Set Device Context    ${PARENT_SN}
+    Execute Command    sudo tedge config set mqtt.external.bind_address ${PARENT_IP}
+
+Set external MQTT port
+    Set Device Context    ${PARENT_SN}
+    Execute Command    sudo tedge config set mqtt.external.port 1883
+
+Restart Firmware plugin
+    ThinEdgeIO.Restart Service    c8y-firmware-plugin.service
+
+Child device delete firmware file
+    Set Device Context    ${CHILD_SN}
+    Execute Command    sudo rm -f firmware1
+
+Create child device
+    [Documentation]    FIXME: Due to the initialization bug, child device not being registered, we need to restart mapper. See the bug report XXX
+    Set Device Context    ${PARENT_SN}
+    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_SN}
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Firmware    /etc/tedge/operations/c8y/${CHILD_SN}/
+    ThinEdgeIO.Restart Service    tedge-mapper-c8y
+    Cumulocity.Device Should Exist    ${CHILD_SN}
+
+Validate child Name
+    ${child_mo}=    Cumulocity.Device Should Have Fragments    name
+    Should Be Equal    device_${PARENT_SN}     ${child_mo["owner"]}    # The parent is the owner of the child
+    Should Be Equal    ${CHILD_SN}     ${child_mo["name"]}
+
+Get timestamp of cache
+    Set Device Context    ${PARENT_SN}
+    ${file_creation_time}=    Execute Command    date -r /var/tedge/cache/${cache_key}
+    Set Suite Variable    $file_creation_time
+
+Upload binary to Cumulocity
+    ${file_url}=     Cumulocity.Create Inventory Binary    firmware1.txt    firmware1    file=${CURDIR}/firmware1.txt
+    Set Suite Variable    $file_url
+
+Create c8y_Firmware operation
+    ${operation}=    Cumulocity.Install Firmware    firmware1    1.0    ${file_url}
+    Set Suite Variable    $operation
+    Cumulocity.Operation Should Be DELIVERED    ${operation}
+
+Validate if file is not newly downloaded
+    Set Device Context    ${PARENT_SN}
+    ${file_creation_time_new}=    Execute Command    date -r /var/tedge/cache/${cache_key}
+    Should Be Equal    ${file_creation_time}    ${file_creation_time_new}
+
+Validate firmware update request
+    Set Device Context    ${PARENT_SN}
+    ${listen}=    ThinEdgeIO.Should Have MQTT Messages    topic=tedge/${CHILD_SN}/commands/req/firmware_update    date_from=-5s
+    ${message}=    JSONLibrary.Convert String To Json    ${listen[0]}
+
+    Should Not Be Empty    ${message["id"]}
+    Should Be Equal    ${message["attempt"]}    ${1}
+    Should Be Equal    ${message["name"]}    firmware1
+    Should Be Equal    ${message["version"]}    1.0
+    Should Be Equal    ${message["sha256"]}    4b0126519dfc1a3023851bfcc5b312b20fc80452256f7f40a5d8722765500ba9
+    Should Match Regexp    ${message["url"]}    ^http://${PARENT_IP}:${HTTP_PORT}/tedge/file-transfer/${CHILD_SN}/firmware_update/[0-9A-Za-z]+$
+
+    ${cache_key}=    Get Regexp Matches    ${message["url"]}    ^http://${PARENT_IP}:${HTTP_PORT}/tedge/file-transfer/${CHILD_SN}/firmware_update/([0-9A-Za-z]+)$    1
+
+    Set Suite Variable    $op_id    ${message["id"]}
+    Set Suite Variable    $file_transfer_url    ${message["url"]}
+    Set Suite Variable    $cache_key    ${cache_key[0]}
+
+Child device response on update request
+    Set Device Context    ${CHILD_SN}
+    Set Test Variable    $topic_res    tedge/${CHILD_SN}/commands/res/firmware_update
+
+    Execute Command    mosquitto_pub -h ${PARENT_IP} -t ${topic_res} -m '{"id":"${op_id}", "status":"executing"}'
+    Execute Command    curl ${file_transfer_url} --output firmware1
+    Execute Command    mosquitto_pub -h ${PARENT_IP} -t ${topic_res} -m '{"id":"${op_id}", "status":"successful"}'
+
+Validate Cumulocity operation status and MO
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Device Should Have Firmware    firmware1    version=1.0    url=${file_url}
+
+Custom Setup
+    # Parent
+    ${parent_sn}=    Setup    skip_bootstrap=False
+    Set Suite Variable    $PARENT_SN    ${parent_sn}
+
+    ${parent_ip}=    Get IP Address
+    Set Suite Variable    $PARENT_IP    ${parent_ip}
+
+    # Child
+    ${child_sn}=    Setup    skip_bootstrap=True
+    Set Suite Variable    $CHILD_SN         ${child_sn}

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
@@ -3,10 +3,7 @@ Resource    ../../../resources/common.resource
 Library    Cumulocity
 Library    ThinEdgeIO
 Library    JSONLibrary
-Library    DebugLibrary
-Library    ../../../.venv/lib/python3.9/site-packages/robot/libraries/String.py
-Library    ../../../.venv/lib/python3.9/site-packages/robot/libraries/OperatingSystem.py
-Library    ../../../.venv/lib/python3.9/site-packages/robot/libraries/DateTime.py
+Library    String
 
 Suite Setup    Custom Setup
 Test Teardown    Get Logs
@@ -94,11 +91,14 @@ Child device delete firmware file
     Execute Command    sudo rm -f firmware1
 
 Create child device
-    [Documentation]    FIXME: Due to the initialization bug, child device not being registered, we need to restart mapper. See the bug report XXX
+    [Documentation]    FIXME: Without the first sleep after "Set Device Context", the device didn't get created.
+    ...    The second sleep ensures that first 101 (creating child device object) is sent, then next 114 (declaring supported operation).
+    ...    If the order is opposite, the child device name will start with "MQTT Device".
     Set Device Context    ${PARENT_SN}
+    Sleep    3s
     Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_SN}
+    Sleep    3s
     ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Firmware    /etc/tedge/operations/c8y/${CHILD_SN}/
-    ThinEdgeIO.Restart Service    tedge-mapper-c8y
     Cumulocity.Device Should Exist    ${CHILD_SN}
 
 Validate child Name

--- a/tests/images/debian-systemd/files/bootstrap.sh
+++ b/tests/images/debian-systemd/files/bootstrap.sh
@@ -135,6 +135,7 @@ install_via_apt() {
         c8y-configuration-plugin \
         c8y-log-plugin \
         tedge-watchdog
+    apt-get install -y c8y-firmware-plugin
 }
 
 install_via_script() {
@@ -165,6 +166,7 @@ install_via_local_files() {
     find_then_install_deb "$INSTALL_SOURCEDIR" "tedge[_-]apt[_-]plugin_*_$ARCH.deb"
     find_then_install_deb "$INSTALL_SOURCEDIR" "c8y[_-]configuration[_-]plugin_*_$ARCH.deb"
     find_then_install_deb "$INSTALL_SOURCEDIR" "c8y[_-]log[_-]plugin_*_$ARCH.deb"
+    find_then_install_deb "$INSTALL_SOURCEDIR" "c8y-firmware-plugin_*_$ARCH.deb"
     find_then_install_deb "$INSTALL_SOURCEDIR" "tedge[_-]watchdog_*_$ARCH.deb"
 }
 


### PR DESCRIPTION
## Proposed changes
Create a new test file for c8y-firmware-plugin. Prepared two scenarios:
1. Happy path with file download.
2. Happy path without file download (hitting the file cache).

Note:
* `c8y-firmware-plugin` must be installed after `tedge-agent`, otherwise the installation of `c8y-firmware-plugin` will fail due to the failure to create directories under `/var/tedge` by `c8y-firmware-plugin --init`. That's why the change on the bootstrap script looks a bit strange.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#1696 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

