### PR TITLE
build linux/musl target by default for host arch

### DIFF
--- a/ci/build_scripts/build.sh
+++ b/ci/build_scripts/build.sh
@@ -20,7 +20,7 @@ Usage:
 Args:
     ARCH     RUST target architecture which can be a value listed from the command 'rustc --print target-list'
              If left blank then the TARGET will be set to the linux musl variant appropriate for your machine.
-             For example, if building on MacOS M1, you 'aarch64-unknown-linux-musl' will be selected, for linux x86_64,
+             For example, if building on MacOS M1, 'aarch64-unknown-linux-musl' will be selected, for linux x86_64,
              'x86_64-unknown-linux-musl' will be selected.
 
     Example ARCH (target) values:

--- a/ci/build_scripts/build.sh
+++ b/ci/build_scripts/build.sh
@@ -19,7 +19,9 @@ Usage:
 
 Args:
     ARCH     RUST target architecture which can be a value listed from the command 'rustc --print target-list'
-             If left blank then the TARGET will be set to that of the machine building the packages.
+             If left blank then the TARGET will be set to the linux musl variant appropriate for your machine.
+             For example, if building on MacOS M1, you 'aarch64-unknown-linux-musl' will be selected, for linux x86_64,
+             'x86_64-unknown-linux-musl' will be selected.
 
     Example ARCH (target) values:
 
@@ -44,13 +46,10 @@ Env:
 
 Examples:
     $0
-    # Build for the current CPU architecture
+    # Build for the linux/musl target appropriate for the current CPU architecture
 
     $0 aarch64-unknown-linux-musl
     # Build for arm64 linux (musl)
-
-    $0 aarch64-unknown-linux-gnu
-    # Build for arm64 linux (gnu lib)
 
     $0 x86_64-unknown-linux-musl
     # Build for x86_64 linux (musl)
@@ -60,6 +59,9 @@ Examples:
 
     $0 arm-unknown-linux-musleabihf
     # Build for armv6 (armhf) linux (musl)
+
+    $0 aarch64-unknown-linux-gnu
+    # Build for arm64 linux (gnu lib)
 
     export GIT_SEMVER=0.9.0-experiment-0.1
     $0
@@ -141,9 +143,37 @@ if ! python3 -c 'import ziglang' &>/dev/null; then
     pip3 install ziglang
 fi
 
+if [ -z "$ARCH" ]; then
+    # If no target has been given, choose the target triple based on the
+    # host's architecture, however use the musl builds by default!
+    HOST_ARCH="$(uname -m || true)"
+    case "$HOST_ARCH" in
+        x86_64*|amd64*)
+            ARCH=x86_64-unknown-linux-musl
+            ;;
+
+        aarch64|arm64)
+            ARCH=aarch64-unknown-linux-musl
+            ;;
+
+        armv7*)
+            ARCH=armv7-unknown-linux-musleabihf
+            ;;
+
+        armv6*)
+            ARCH=arm-unknown-linux-musleabihf
+            ;;
+    esac
+fi
+
 if [ -n "$ARCH" ]; then
+    echo "Using target: $ARCH"
     TARGET+=("--target=$ARCH")
     rustup target add "$ARCH"
+else
+    # Note: This will build the artifacts under target/release and not target/<triple>/release !
+    HOST_TARGET=$(rustc --version --verbose | grep host: | cut -d' ' -f2)
+    echo "Using host target: $HOST_TARGET"
 fi
 
 # Custom options for different targets


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->
When building the binaries/packages via the `ci/build_scripts/build.sh` script, it now detects the appropriate target (linux/musl variant) based on your current host architecture if the user does not provide a target triple.

For example executing the `ci/build_scripts/build.sh` script with no arguments will choose the following targets:

* `aarch64-unknown-linux-musl` on MacOS M1 natively (aarch64)
* `aarch64-unknown-linux-musl` on MacOS M1 running inside a linux vm (aarch64)
* `x86_64-unknown-linux-musl` on amd64/x86_64
* `armv7-unknown-linux-musleabihf` on amv7
* `arm-unknown-linux-musleabihf` on amv6

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

This change was brought on from several discussions with core team members about how the integration tests was not detecting the correct binaries for their host machine. Since the integration tests relies on an explicit target mapping (and not the default target), the build script was changed to better support auto detection of the correct build target based on CPU architecture (regardless of host operating system type as tedge only supports linux targets). The user can still explicitly set their target triple if they need a specific build, however it is more convenient for develops to not have to specify their host target all the time.