### PR TITLE
Implement a health-check actor for c8y-device-management plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
  "tedge_actors",
  "tedge_config",
  "tedge_file_system_ext",
+ "tedge_health_ext",
  "tedge_http_ext",
  "tedge_mqtt_ext",
  "tedge_signal_ext",
@@ -3600,6 +3601,22 @@ dependencies = [
  "tedge_utils",
  "tokio",
  "try-traits",
+]
+
+[[package]]
+name = "tedge_health_ext"
+version = "0.9.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "log",
+ "serde",
+ "serde_json",
+ "tedge_actors",
+ "tedge_api",
+ "tedge_mqtt_ext",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/bin/c8y-device-management/Cargo.toml
+++ b/crates/bin/c8y-device-management/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4"
 tedge_actors = { path = "../../core/tedge_actors" }
 tedge_config = { path = "../../common/tedge_config" }
 tedge_file_system_ext = { path = "../../extensions/tedge_file_system_ext" }
+tedge_health_ext = { path = "../../extensions/tedge_health_ext" }
 tedge_http_ext = { path = "../../extensions/tedge_http_ext" }
 tedge_mqtt_ext = { path = "../../extensions/tedge_mqtt_ext" }
 tedge_signal_ext = { path = "../../extensions/tedge_signal_ext" }

--- a/crates/extensions/tedge_health_ext/Cargo.toml
+++ b/crates/extensions/tedge_health_ext/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tedge_health_ext"
+description = "thin-edge Cumulocity extension adding support for health monitoring"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+
+[dependencies]
+async-trait = "0.1"
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.93"
+tedge_actors = { path = "../../core/tedge_actors" }
+tedge_api = { path = "../../core/tedge_api" }
+tedge_mqtt_ext = { path = "../../extensions/tedge_mqtt_ext" }
+thiserror = "1.0"
+tokio = { version = "1.23", features = ["macros"] }
+
+[dev-dependencies]
+anyhow = "1.0.69"

--- a/crates/extensions/tedge_health_ext/src/actor.rs
+++ b/crates/extensions/tedge_health_ext/src/actor.rs
@@ -1,0 +1,46 @@
+use async_trait::async_trait;
+use tedge_actors::Actor;
+use tedge_actors::ReceiveMessages;
+use tedge_actors::RuntimeError;
+use tedge_actors::SimpleMessageBox;
+use tedge_mqtt_ext::MqttMessage;
+
+use tedge_api::health::health_status_down_message;
+use tedge_api::health::health_status_up_message;
+
+pub struct HealthMonitorActor {
+    daemon_name: String,
+}
+
+impl HealthMonitorActor {
+    pub fn new(daemon_name: String) -> Self {
+        Self { daemon_name }
+    }
+
+    pub fn up_health_status(&self) -> MqttMessage {
+        health_status_up_message(&self.daemon_name)
+    }
+
+    pub fn down_health_status(&self) -> MqttMessage {
+        health_status_down_message(&self.daemon_name)
+    }
+}
+
+#[async_trait]
+impl Actor for HealthMonitorActor {
+    type MessageBox = SimpleMessageBox<MqttMessage, MqttMessage>;
+
+    fn name(&self) -> &str {
+        "HealthMonitorActor"
+    }
+
+    async fn run(mut self, mut messages: Self::MessageBox) -> Result<(), RuntimeError> {
+        messages.send(self.up_health_status()).await?;
+        while let Some(_message) = messages.recv().await {
+            {
+                messages.send(self.up_health_status()).await?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/extensions/tedge_health_ext/src/lib.rs
+++ b/crates/extensions/tedge_health_ext/src/lib.rs
@@ -1,0 +1,83 @@
+mod actor;
+
+#[cfg(test)]
+mod tests;
+
+use actor::HealthMonitorActor;
+use tedge_actors::Builder;
+use tedge_actors::DynSender;
+use tedge_actors::LinkError;
+use tedge_actors::MessageSink;
+use tedge_actors::RuntimeRequest;
+use tedge_actors::RuntimeRequestSink;
+use tedge_actors::ServiceConsumer;
+use tedge_actors::SimpleMessageBox;
+use tedge_actors::SimpleMessageBoxBuilder;
+use tedge_api::health::health_status_down_message;
+use tedge_api::health::health_status_up_message;
+use tedge_mqtt_ext::MqttConfig;
+use tedge_mqtt_ext::MqttMessage;
+use tedge_mqtt_ext::TopicFilter;
+
+type HealthMonitorMessageBox = SimpleMessageBox<MqttMessage, MqttMessage>;
+
+pub struct HealthMonitorBuilder {
+    service_name: String,
+    subscriptions: TopicFilter,
+    box_builder: SimpleMessageBoxBuilder<MqttMessage, MqttMessage>,
+}
+
+impl HealthMonitorBuilder {
+    pub fn new(service_name: &str) -> Self {
+        let subscriptions = vec![
+            "tedge/health-check",
+            &format!("tedge/health-check/{service_name}"),
+        ]
+        .try_into()
+        .expect("Failed to create the HealthMonitorActor topicfilter");
+        HealthMonitorBuilder {
+            service_name: service_name.to_owned(),
+            subscriptions,
+            box_builder: SimpleMessageBoxBuilder::new(service_name, 16),
+        }
+    }
+
+    pub fn set_init_and_last_will(&self, config: MqttConfig) -> MqttConfig {
+        let name = self.service_name.to_owned();
+        config
+            .with_initial_message(move || health_status_up_message(&name))
+            .with_last_will_message(health_status_down_message(&self.service_name))
+    }
+}
+
+impl RuntimeRequestSink for HealthMonitorBuilder {
+    fn get_signal_sender(&self) -> DynSender<RuntimeRequest> {
+        Box::new(self.box_builder.get_signal_sender())
+    }
+}
+
+impl Builder<(HealthMonitorActor, HealthMonitorMessageBox)> for HealthMonitorBuilder {
+    type Error = LinkError;
+
+    fn try_build(self) -> Result<(HealthMonitorActor, HealthMonitorMessageBox), Self::Error> {
+        let message_box = self.box_builder.build();
+
+        let actor = HealthMonitorActor::new(self.service_name);
+
+        Ok((actor, message_box))
+    }
+}
+
+impl ServiceConsumer<MqttMessage, MqttMessage, TopicFilter> for HealthMonitorBuilder {
+    fn get_config(&self) -> TopicFilter {
+        self.subscriptions.clone()
+    }
+
+    fn set_request_sender(&mut self, request_sender: DynSender<MqttMessage>) {
+        self.box_builder.set_request_sender(request_sender);
+    }
+
+    fn get_response_sender(&self) -> DynSender<MqttMessage> {
+        self.box_builder.get_sender()
+    }
+}

--- a/crates/extensions/tedge_health_ext/src/tests.rs
+++ b/crates/extensions/tedge_health_ext/src/tests.rs
@@ -1,0 +1,55 @@
+use std::time::Duration;
+
+use crate::HealthMonitorBuilder;
+use crate::HealthMonitorMessageBox;
+use tedge_actors::Actor;
+use tedge_actors::Builder;
+use tedge_actors::ReceiveMessages;
+use tedge_actors::ServiceConsumer;
+use tedge_actors::SimpleMessageBoxBuilder;
+use tedge_mqtt_ext::MqttMessage;
+use tedge_mqtt_ext::Topic;
+use tokio::time::timeout;
+const TEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[tokio::test]
+async fn send_health_check_message_to_generic_topic() -> Result<(), anyhow::Error> {
+    let mut mqtt_message_box = spawn_a_health_check_actor("health-check-service-1").await?;
+    let health_check_request = MqttMessage::new(&Topic::new_unchecked("tedge/health-check"), "");
+    mqtt_message_box.send(health_check_request).await.unwrap();
+
+    if let Some(message) = timeout(TEST_TIMEOUT, mqtt_message_box.recv()).await? {
+        assert!(message.payload_str()?.contains("up"))
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn send_health_check_message_to_service_specific_topic() -> Result<(), anyhow::Error> {
+    let mut mqtt_message_box = spawn_a_health_check_actor("health-check-service-2").await?;
+    let health_check_request =
+        MqttMessage::new(&Topic::new_unchecked("tedge/health-check/health-test"), "");
+    mqtt_message_box.send(health_check_request).await.unwrap();
+
+    if let Some(message) = timeout(TEST_TIMEOUT, mqtt_message_box.recv()).await? {
+        assert!(message.payload_str()?.contains("up"))
+    }
+
+    Ok(())
+}
+
+async fn spawn_a_health_check_actor(
+    service_to_be_monitored: &str,
+) -> Result<HealthMonitorMessageBox, anyhow::Error> {
+    let mut health_mqtt_builder: SimpleMessageBoxBuilder<MqttMessage, MqttMessage> =
+        SimpleMessageBoxBuilder::new("MQTT", 5);
+
+    let health_actor = HealthMonitorBuilder::new(service_to_be_monitored);
+
+    let health_actor = health_actor.with_connection(&mut health_mqtt_builder);
+    let (actor, message_box) = health_actor.build();
+    tokio::spawn(actor.run(message_box));
+
+    Ok(health_mqtt_builder.build())
+}


### PR DESCRIPTION
## Proposed changes

Code changes for adding a `health-check` actor.
This actor responds to the mqtt requests on `tedge/health-check/#` topics about the status of the service on `tedge/health/<service-name>` topic.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1768

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

