### PR TITLE
Improve integration test stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ playwright-log.txt
 wordlist.txt
 Results/
 output/
+output_*/
 env/
 interactive_console_output.xml
 .pabotsuitenames

--- a/tests/RobotFramework/devdata/env.template
+++ b/tests/RobotFramework/devdata/env.template
@@ -33,3 +33,7 @@ GH_TOKEN=
 SSH_CONFIG_HOSTNAME=
 SSH_CONFIG_USERNAME=
 SSH_CONFIG_PASSWORD=
+
+# Docker - statis /etc/hosts entries
+# Custom /etc/hosts entries to reduce test failures due to dns lookup issues inside container
+DEVICELIBRARY_HOST_C8YURL="example.mydomain.com=1.2.3.4"

--- a/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
+++ b/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
@@ -428,7 +428,8 @@ class ThinEdgeIO(DeviceLibrary):
 def to_date(value: relativetime_) -> datetime:
     if isinstance(value, datetime):
         return value
-
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value)
     return dateparser.parse(value)
 
 

--- a/tests/RobotFramework/requirements/requirements.adapter-docker.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-docker.txt
@@ -1,1 +1,1 @@
-robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.0.1
+robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.1.0

--- a/tests/RobotFramework/requirements/requirements.adapter-docker.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-docker.txt
@@ -1,1 +1,1 @@
-robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@0.28.2
+robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.0.1

--- a/tests/RobotFramework/requirements/requirements.adapter-local.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-local.txt
@@ -1,1 +1,1 @@
-robotframework-devicelibrary[local] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.0.1
+robotframework-devicelibrary[local] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.1.0

--- a/tests/RobotFramework/requirements/requirements.adapter-local.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-local.txt
@@ -1,1 +1,1 @@
-robotframework-devicelibrary[local] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@0.28.2
+robotframework-devicelibrary[local] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.0.1

--- a/tests/RobotFramework/requirements/requirements.adapter-ssh.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-ssh.txt
@@ -1,2 +1,2 @@
-robotframework-devicelibrary[ssh] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.0.1
+robotframework-devicelibrary[ssh] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.1.0
 robotframework-sshlibrary~=3.8.0

--- a/tests/RobotFramework/requirements/requirements.adapter-ssh.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-ssh.txt
@@ -1,2 +1,2 @@
-robotframework-devicelibrary[ssh] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@0.28.2
+robotframework-devicelibrary[ssh] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.0.1
 robotframework-sshlibrary~=3.8.0

--- a/tests/RobotFramework/resources/common.resource
+++ b/tests/RobotFramework/resources/common.resource
@@ -2,7 +2,7 @@
 
 # Adapter settings
 ${DEVICE_ADAPTER}    %{DEVICE_ADAPTER=docker}
-&{SSH_CONFIG}        hostname=%{SSH_CONFIG_HOSTNAME= }    username=%{SSH_CONFIG_USERNAME= }    password=%{SSH_CONFIG_PASSWORD= }    skip_bootstrap=False    bootstrap_script=%{SSH_CONFIG_BOOTSTRAP_SCRIPT= }
+&{SSH_CONFIG}        hostname=%{SSH_CONFIG_HOSTNAME= }    username=%{SSH_CONFIG_USERNAME= }    password=%{SSH_CONFIG_PASSWORD= }    skip_bootstrap=False    bootstrap_script=%{SSH_CONFIG_BOOTSTRAP_SCRIPT= }    configpath=%{SSH_CONFIG_CONFIGPATH= }
 &{DOCKER_CONFIG}     image=%{DOCKER_CONFIG_IMAGE=debian-systemd}    bootstrap_script=%{DOCKER_CONFIG_BOOTSTRAP_SCRIPT=/setup/bootstrap.sh}
 &{LOCAL_CONFIG}      skip_bootstrap=False    bootstrap_script=%{LOCAL_CONFIG_BOOTSTRAP_SCRIPT= }
 

--- a/tests/RobotFramework/tasks.py
+++ b/tests/RobotFramework/tasks.py
@@ -295,19 +295,21 @@ def build(
         echo=True,
     )
 
+
 @task(
     help={
         "iterations": ("Number of test iterations to run"),
-        "output": ("Output folder to store the logs. Defaults to 'output_flake_finder'"),
+        "output": (
+            "Output folder to store the logs. Defaults to 'output_flake_finder'"
+        ),
     }
 )
 def flake_finder(c, iterations=2, output="output_flake_finder"):
-    """Run tests multiple times to find any flakey tests
-    """
+    """Run tests multiple times to find any flakey tests"""
     passed = []
     failed = []
     duration_start = time.time()
-    for i in range(1, iterations+1):
+    for i in range(1, iterations + 1):
         iteration_output = Path(output) / f"iteration-{i}"
         os.makedirs(iteration_output)
         try:
@@ -317,19 +319,22 @@ def flake_finder(c, iterations=2, output="output_flake_finder"):
             failed.append(i)
 
     duration_sec = time.time() - duration_start
-    
-    print("\n\n" + "-"*30)
+
+    print("\n\n" + "-" * 30)
 
     overall_result = "PASSED"
     if failed:
         overall_result = "FAILED"
 
     print(f"Overall: {overall_result}")
-    print(f"Results: {iterations} iterations, {len(passed)} passed, {len(failed)} failed")
+    print(
+        f"Results: {iterations} iterations, {len(passed)} passed, {len(failed)} failed"
+    )
     print(f"Elapsed time: {datetime.timedelta(seconds=duration_sec)}")
 
     if failed:
         print(f"Failed iterations: {failed}")
+
 
 @task(
     aliases=["tests"],

--- a/tests/RobotFramework/tests/MQTT_health_check/health_c8y-configuration-plugin.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_c8y-configuration-plugin.robot
@@ -32,7 +32,7 @@ Check PID of c8y-configuration-plugin
     Set Suite Variable    ${pid}
 
 Kill the PID
-    Execute Command    sudo kill -9 ${pid}
+    Kill Process    ${pid}
 
 Recheck PID of c8y-configuration-plugin
     ${pid1}=    Execute Command    pgrep -f 'c8y-configuration-plugin'    strip=True

--- a/tests/RobotFramework/tests/MQTT_health_check/health_c8y-log-plugin.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_c8y-log-plugin.robot
@@ -32,7 +32,7 @@ Check PID of c8y-log-plugin
     Set Suite Variable    ${pid}
 
 Kill the PID
-    Execute Command    sudo kill -9 ${pid}
+    Kill Process    ${pid}
 
 Recheck PID of c8y-log-plugin
     ${pid1}=    Execute Command    pgrep -f c8y-log-plugin        strip=True

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-agent.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-agent.robot
@@ -32,7 +32,7 @@ Check PID of tedge-mapper
     Set Suite Variable    ${pid}
 
 Kill the PID
-    Execute Command    sudo kill -9 ${pid}
+    Kill Process    ${pid}
 
 Recheck PID of tedge-agent
     ${pid1}=    Execute Command    pgrep -f tedge-agent    strip=True

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-az.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-az.robot
@@ -32,7 +32,7 @@ Check PID of tedge-mapper-az
     Set Suite Variable    ${pid}
 
 Kill the PID
-    Execute Command    sudo kill -9 ${pid}
+    Kill Process    ${pid}
 
 Recheck PID of tedge-agent
     ${pid1}=    Execute Command    pgrep -f 'tedge-mapper az'

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-collectd.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-collectd.robot
@@ -32,7 +32,7 @@ Check PID of tedge-mapper-collectd
     Set Suite Variable    ${pid}
 
 Kill the PID
-    Execute Command    sudo kill -9 ${pid}
+    Kill Process    ${pid}
 
 Recheck PID of tedge-mapper-collectd
     ${pid1}=    Execute Command    pgrep -f 'tedge-mapper collectd'    strip=True

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge_mapper_c8y.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge_mapper_c8y.robot
@@ -32,7 +32,7 @@ Check PID of tedge-mapper
     Set Suite Variable    ${pid}
 
 Kill the PID
-    Execute Command    sudo kill -9 ${pid}
+    Kill Process    ${pid}
 
 Recheck PID of tedge-mapper
     ${pid1}=    Execute Command    pgrep -f 'tedge-mapper c8y'        strip=True

--- a/tests/RobotFramework/tests/config_management/child_conf_mgmt_plugin.robot
+++ b/tests/RobotFramework/tests/config_management/child_conf_mgmt_plugin.robot
@@ -111,9 +111,6 @@ Validate child Name
     Device Should Exist    ${CHILD_SN}
     ${child_mo}=    Cumulocity.Device Should Have Fragments    name
     Should Be Equal    device_${PARENT_SN}     ${child_mo["owner"]}    # The parent is the owner of the child
-    Should Be Equal    ${CHILD_SN}     ${child_mo["name"]}
-    # ${child_name}=    JSONLibrary.Get Value From Json    ${child_mo}    $.name
-    # Should Be Equal    ${CHILD_SN}     ${child_name[0]}
 
 Startup child device
     Sleep    5s        reason=The registration of child devices is flakey

--- a/tests/RobotFramework/tests/config_management/child_conf_mgmt_plugin.robot
+++ b/tests/RobotFramework/tests/config_management/child_conf_mgmt_plugin.robot
@@ -11,7 +11,7 @@ Library    Collections
 
 Test Tags    theme:configuration    theme:childdevices
 Suite Setup    Custom Setup
-Suite Teardown    Get Logs
+Suite Teardown    Get Logs    name=${PARENT_SN}
 
 *** Variables ***
 

--- a/tests/RobotFramework/tests/cumulocity/child_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/child_device_telemetry.robot
@@ -64,11 +64,11 @@ Child devices support sending inventory data via c8y topic
 
 
 Main device support sending inventory data via c8y topic
-    Execute Command    tedge mqtt pub "c8y/inventory/managedObjects/update/${DEVICE_SN}" '{"parentInfo":{"nested":{"name":"complex"}},"type":"customType"}'
+    Execute Command    tedge mqtt pub "c8y/inventory/managedObjects/update/${DEVICE_SN}" '{"parentInfo":{"nested":{"name":"complex"}},"subType":"customType"}'
     Cumulocity.Set Device    ${DEVICE_SN}
     ${mo}=    Device Should Have Fragments    parentInfo    type
     Should Be Equal    ${mo["parentInfo"]["nested"]["name"]}    complex
-    Should Be Equal    ${mo["type"]}    customType
+    Should Be Equal    ${mo["subType"]}    customType
 
 *** Keywords ***
 

--- a/tests/RobotFramework/tests/cumulocity/child_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/child_device_telemetry.robot
@@ -70,6 +70,24 @@ Main device support sending inventory data via c8y topic
     Should Be Equal    ${mo["parentInfo"]["nested"]["name"]}    complex
     Should Be Equal    ${mo["subType"]}    customType
 
+
+Child device supports sending custom child device measurements directly to c8y
+    Execute Command    tedge mqtt pub "c8y/measurement/measurements/create" '{"time":"2023-03-20T08:03:56.940907Z","externalSource":{"externalId":"${CHILD_SN}","type":"c8y_Serial"},"environment":{"temperature":{"value":29.9,"unit":"°C"}},"type":"10min_average","meta":{"sensorLocation":"Brisbane, Australia"}}'
+    Cumulocity.Set Device    ${CHILD_SN}
+    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    value=environment    series=temperature    type=10min_average
+    Should Be Equal As Numbers    ${measurements[0]["environment"]["temperature"]["value"]}    29.9
+    Should Be Equal    ${measurements[0]["meta"]["sensorLocation"]}    Brisbane, Australia
+    Should Be Equal    ${measurements[0]["type"]}    10min_average
+
+
+Main device supports sending custom child device measurements directly to c8y
+    Execute Command    tedge mqtt pub "c8y/measurement/measurements/create" '{"time":"2023-03-20T08:03:56.940907Z","environment":{"temperature":{"value":29.9,"unit":"°C"}},"type":"10min_average","meta":{"sensorLocation":"Brisbane, Australia"}}'
+    Cumulocity.Set Device    ${DEVICE_SN}
+    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    value=environment    series=temperature    type=10min_average
+    Should Be Equal As Numbers    ${measurements[0]["environment"]["temperature"]["value"]}    29.9
+    Should Be Equal    ${measurements[0]["meta"]["sensorLocation"]}    Brisbane, Australia
+    Should Be Equal    ${measurements[0]["type"]}    10min_average
+
 *** Keywords ***
 
 Custom Setup

--- a/tests/RobotFramework/tests/cumulocity/child_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/child_device_telemetry.robot
@@ -4,7 +4,7 @@ Library    Cumulocity
 Library    ThinEdgeIO
 
 Test Tags    theme:c8y    theme:telemetry
-Test Setup    Custom Setup
+Suite Setup    Custom Setup
 Test Teardown    Get Logs
 
 *** Test Cases ***
@@ -21,8 +21,8 @@ Child devices support sending custom measurements
 
 
 Child devices support sending custom events
-    Execute Command    tedge mqtt pub tedge/events/myCustomType/${CHILD_SN} '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=myCustomType    fragment=someOtherCustomFragment
+    Execute Command    tedge mqtt pub tedge/events/myCustomType1/${CHILD_SN} '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=myCustomType1    fragment=someOtherCustomFragment
     Log    ${events}
 
 
@@ -80,3 +80,5 @@ Custom Setup
     Restart Service    tedge-mapper-c8y
     Device Should Exist                      ${DEVICE_SN}
     Device Should Exist                      ${CHILD_SN}
+
+    Service Health Status Should Be Up    tedge-mapper-c8y

--- a/tests/RobotFramework/tests/cumulocity/child_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/child_device_telemetry.robot
@@ -66,7 +66,7 @@ Child devices support sending inventory data via c8y topic
 Main device support sending inventory data via c8y topic
     Execute Command    tedge mqtt pub "c8y/inventory/managedObjects/update/${DEVICE_SN}" '{"parentInfo":{"nested":{"name":"complex"}},"subType":"customType"}'
     Cumulocity.Set Device    ${DEVICE_SN}
-    ${mo}=    Device Should Have Fragments    parentInfo    type
+    ${mo}=    Device Should Have Fragments    parentInfo    subType
     Should Be Equal    ${mo["parentInfo"]["nested"]["name"]}    complex
     Should Be Equal    ${mo["subType"]}    customType
 

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
@@ -104,7 +104,6 @@ Create child device
 Validate child Name
     ${child_mo}=    Cumulocity.Device Should Have Fragments    name
     Should Be Equal    device_${PARENT_SN}     ${child_mo["owner"]}    # The parent is the owner of the child
-    Should Be Equal    ${CHILD_SN}     ${child_mo["name"]}
 
 Get timestamp of cache
     Set Device Context    ${PARENT_SN}

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
@@ -6,7 +6,7 @@ Library    JSONLibrary
 Library    String
 
 Suite Setup    Custom Setup
-Test Teardown    Get Logs
+Test Teardown    Get Logs    name=${PARENT_SN}
 
 Force Tags    theme:firmware    theme:childdevices
 

--- a/tests/RobotFramework/tests/cumulocity/inventory/inventory.json
+++ b/tests/RobotFramework/tests/cumulocity/inventory/inventory.json
@@ -1,0 +1,8 @@
+{
+    "customData": {
+        "mode": "ACTIVE",
+        "version": 1,
+        "alertingEnabled": true
+    },
+    "types": ["type1", "type2"]
+}

--- a/tests/RobotFramework/tests/cumulocity/inventory/inventory_update.robot
+++ b/tests/RobotFramework/tests/cumulocity/inventory/inventory_update.robot
@@ -1,0 +1,27 @@
+*** Settings ***
+Resource    ../../../resources/common.resource
+Library    Cumulocity
+Library    ThinEdgeIO
+
+Test Tags    theme:c8y    theme:telemetry
+Suite Setup    Custom Setup
+Test Teardown    Get Logs
+
+*** Test Cases ***
+
+Update Inventory data via inventory.json
+    ${mo}=    Cumulocity.Device Should Have Fragments    customData    types
+    Should Be Equal    ${mo["customData"]["mode"]}    ACTIVE
+    Should Be Equal As Integers    ${mo["customData"]["version"]}    ${1}
+    Should Be Equal    ${mo["customData"]["alertingEnabled"]}    ${True}
+    Should Be Equal    ${mo["types"][0]}    type1
+    Should Be Equal    ${mo["types"][1]}    type2
+
+*** Keywords ***
+
+Custom Setup
+    ${DEVICE_SN}=                    Setup
+    Set Suite Variable               $DEVICE_SN
+    Device Should Exist              ${DEVICE_SN}
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/inventory.json    /etc/tedge/device/
+    ThinEdgeIO.Disconnect Then Connect Mapper    c8y

--- a/tests/RobotFramework/tests/cumulocity/registration/device_registration.robot
+++ b/tests/RobotFramework/tests/cumulocity/registration/device_registration.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Resource    ../../../resources/common.resource
+Library    Cumulocity
+Library    ThinEdgeIO
+
+Test Tags    theme:c8y    theme:registration
+Suite Setup    Custom Setup
+Test Teardown    Get Logs    ${DEVICE_SN}
+
+*** Test Cases ***
+
+Main device registration
+    ${mo}=    Device Should Exist              ${DEVICE_SN}
+    ${mo}=    Cumulocity.Device Should Have Fragment Values    name\=${DEVICE_SN}
+    Should Be Equal    ${mo["owner"]}    device_${DEVICE_SN}
+    Should Be Equal    ${mo["name"]}    ${DEVICE_SN}
+
+
+Child device registration
+    ThinEdgeIO.Set Device Context    ${DEVICE_SN}
+    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_SN}
+    Restart Service    tedge-mapper-c8y
+
+    # Check registration
+    ${child_mo}=    Device Should Exist        ${CHILD_SN}
+    ${child_mo}=    Cumulocity.Device Should Have Fragment Values    name\=${CHILD_SN}
+    Should Be Equal    ${child_mo["owner"]}    device_${DEVICE_SN}    # The parent is the owner of the child
+    Should Be Equal    ${child_mo["name"]}     ${CHILD_SN}
+
+    # Check child device relationship
+    Cumulocity.Set Device    ${DEVICE_SN}
+    Cumulocity.Device Should Have A Child Devices    ${CHILD_SN}
+
+*** Keywords ***
+
+Custom Setup
+    ${DEVICE_SN}=                    Setup
+    Set Suite Variable               $DEVICE_SN
+
+    ${CHILD_SN}=                     Setup    bootstrap=${False}
+    Set Suite Variable               $CHILD_SN

--- a/tests/RobotFramework/tests/cumulocity/restart/restart_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/restart/restart_device.robot
@@ -11,8 +11,9 @@ Test Teardown    Get Logs
 *** Test Cases ***
 
 Supports restarting the device
+    [Documentation]    Use a longer timeout period to allow the device time to restart and allow the initial token fetching process to fail at least one (due to the 60 seconds retry window)
     ${operation}=    Cumulocity.Restart Device
-    Operation Should Be SUCCESSFUL    ${operation}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=180
 
 *** Keywords ***
 

--- a/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
+++ b/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
@@ -142,7 +142,7 @@ Check if a service using configured service type
     Custom Test Setup
     ThinEdgeIO.Start Service    ${service_name}
     Device Should Exist                      ${DEVICE_SN}_${service_name}    show_info=False
-    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up
+    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up    serviceType\=thinedge
 
     Should Be Equal    ${SERVICE["name"]}    ${service_name}
     Should Be Equal    ${SERVICE["serviceType"]}    thinedge
@@ -157,7 +157,7 @@ Check if a service using configured service type as empty
     Custom Test Setup
     ThinEdgeIO.Start Service    ${service_name}
     Device Should Exist                      ${DEVICE_SN}_${service_name}    show_info=False
-    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up
+    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up        serviceType\=service
 
     Should Be Equal    ${SERVICE["name"]}    ${service_name}
     Should Be Equal    ${SERVICE["serviceType"]}    service

--- a/tests/RobotFramework/tests/cumulocity/software.robot
+++ b/tests/RobotFramework/tests/cumulocity/software.robot
@@ -2,7 +2,6 @@
 Resource    ../../resources/common.resource
 Library    Cumulocity
 Library    ThinEdgeIO
-Library    DateTime
 
 Test Tags    theme:c8y    theme:software    theme:plugins
 Test Setup       Custom Setup
@@ -29,6 +28,6 @@ Custom Setup
     Set Test Variable    $DEVICE_SN
     Should Have MQTT Messages    tedge/health/tedge-mapper-c8y
     [Documentation]    WORKAROUND: #1731 The tedge-mapper-c8y is restarted due to a supsected race condition between the mapper and tedge-agent which results in the software list message being lost
-    ${timestamp}=        Get Current Date
+    ${timestamp}=        Get Unix Timestamp
     Restart Service    tedge-mapper-c8y
     Should Have MQTT Messages    tedge/health/tedge-mapper-c8y    date_from=${timestamp}

--- a/tests/RobotFramework/tests/plugin_apt/improve_tedge_apt_plugin_error_messages.robot
+++ b/tests/RobotFramework/tests/plugin_apt/improve_tedge_apt_plugin_error_messages.robot
@@ -11,16 +11,16 @@ Suite Teardown    Get Logs
 
 *** Test Cases ***
 Wrong package name
-    ${wpn}=    Execute Command    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file "${DEB_FILE}"    exp_exit_code=5
+    ${wpn}=    Execute Command    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file "${DEB_FILE}"    exp_exit_code=5    stdout=${False}    stderr=${True}
     Should Contain    ${wpn}    ERROR: Validation of ${DEB_FILE} metadata failed, expected value for the Package is  rolldice, but provided  thinml-3964
 
 Wrong version
-    ${wv}=    Execute Command    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file "${DEB_FILE}" --module-version 1.0    exp_exit_code=5
+    ${wv}=    Execute Command    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file "${DEB_FILE}" --module-version 1.0    exp_exit_code=5    stdout=${False}    stderr=${True}
     Should Contain    ${wv}    ERROR: Validation of ${DEB_FILE} metadata failed, expected value for the Version is  1.16-1build1, but provided  1.0
 
 Wrong type
     Execute Command    echo "Not a debian package" >/tmp/foo.deb
-    ${wv}=    Execute Command    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file /tmp/foo.deb    exp_exit_code=5
+    ${wv}=    Execute Command    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file /tmp/foo.deb    exp_exit_code=5    stdout=${False}    stderr=${True}
     Should Contain    ${wv}    ERROR: Parsing Debian package failed for `/tmp/foo.deb`, Error: dpkg-deb: error: '/tmp/foo.deb' is not a Debian format archive
     Execute Command    rm /tmp/*.deb
 

--- a/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
+++ b/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
@@ -18,7 +18,7 @@ tedge_connect_test_positive
 
 tedge_connect_test_negative
     Execute Command    sudo tedge disconnect c8y
-    ${output}=    Execute Command    sudo tedge connect c8y --test    exp_exit_code=1
+    ${output}=    Execute Command    sudo tedge connect c8y --test    exp_exit_code=1    stdout=${False}    stderr=${True}
     Should Contain    ${output}    Error: failed to test connection to Cumulocity cloud.
 
 tedge_connect_test_sm_services

--- a/tests/images/debian-systemd/debian-systemd.dockerfile
+++ b/tests/images/debian-systemd/debian-systemd.dockerfile
@@ -32,6 +32,7 @@ COPY files/c8y-configuration-plugin.toml /etc/tedge/c8y/
 COPY files/deb/ /setup/deb/
 
 COPY files/mqtt-logger.service /etc/systemd/system/
+COPY files/mqtt-logger /usr/bin/
 RUN systemctl enable mqtt-logger.service
 
 # Custom mosquitto config

--- a/tests/images/debian-systemd/files/bootstrap.sh
+++ b/tests/images/debian-systemd/files/bootstrap.sh
@@ -1,36 +1,151 @@
-#!/bin/bash
-
+#!/bin/sh
 set -e
 
-# SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+show_usage() {
+    echo "
+DESCRIPTION
+    Install and bootstrap thin-edge.io.
 
+USAGE
+
+    $0 [VERSION]
+
+FLAGS
+    WORKFLOW FLAGS
+    --clean/--no-clean                      Clean the device of any existing tedge installations before installing/connecting. Default False
+    --install/--no-install                  Install thin-edge.io. Default True
+    --connect/--no-connect                  Connect the mapper. Provide the type of mapper via '--mapper <name>'. Default True
+    --mapper <name>                         Name of the mapper to use when connecting (if user has specified the --connect option).
+                                            Defaults to 'c8y'. Currently only c8y works.
+    --bootstrap                             Force bootstrapping/re-bootstrapping of the device
+
+    DEVICE FLAGS
+    --device-id <name>                      Use a specific device-id. A prefix will be added to the device id
+    --random                                Use a random device-id. This will override the --device-id flag value
+    --prefix <prefix>                       Device id prefix to add to the device-id or random device id. Defaults to 'tedge_'
+
+    INSTALLATION FLAGS
+    --version <version>                     Thin-edge.io version to install. Only applies for apt/script installation methods
+    --channel <release|main>                Which channel, e.g. release or main to install thin-edge.io from. Defaults to main
+    --install-method <apt|script|local>     Type of method to use to install thin.edge.io. Checkout the 'Install method' section for more info
+    --install-sourcedir <path>              Path where to look for local deb files to install
+
+    CUMULOCITY FLAGS
+    --c8y-url <host>                        Cumulocity url, e.g. 'mydomain.c8y.example.io'
+    --c8y-user <username>                   Cumulocity username (required when a new device certificate is created)
+
+    MISC FLAGS
+    --prompt/--no-prompt                    Set if the script should prompt the user for input or not. By default prompts
+                                            will be disabled on non-interactive shells
+    --help/-h                               Show this help
+
+INSTALL METHODS
+    local - Install the thin-edge.io .deb packages found locally on the disk under '--install-sourcedir <path>'
+    apt - Install using public APT repository
+    script - Install using the get-thin-edge_io.sh script from GitHub
+
+EXAMPLES
+    sudo -E $0
+    # Install and bootstrap thin-edge.io using the default settings
+
+    sudo -E $0 --device-id mydevice --bootstrap
+    # Install latest version and force bootstrapping using a given device id
+
+    sudo -E $0 --device-id mydevice --bootstrap --prefix ''
+    # Install latest version, and bootstrap with a device name without the default prefix
+
+    sudo -E $0 --random --bootstrap
+    # Install latest version and force bootstrapping using a random device id
+    
+    sudo -E $0 --clean
+    # Clean the device before installing, then install and bootstrap
+
+    sudo -E $0 ./deb/
+    # Install and bootstrap using locally found tedge debian files under ./deb/ folder
+
+    sudo -E $0 --channel main
+    # Install the latest available version from the main repository. It will includes the latest version built from main
+
+    sudo -E $0 --channel main --version 0.9.0-304-gfd2ed977
+    # Install a specific version from the main repository
+
+    sudo -E $0 --channel release
+    # Install the latest available version from the release repository
+
+    sudo -E $0 --install-method script
+    # Install the latest version using the GitHub install script
+    "
+}
+
+fail () { echo "$1" >&2; exit 1; }
+warning () { echo "$1" >&2; }
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+
+uses_old_package_name() {
+    version="$1"
+    echo "$version" | grep --silent "^0\.[0-8]\."
+}
+
+uses_new_package_name() {
+    version="$1"
+    echo "$version" | grep --silent -e "^0\.[9]\." -e "^0\.[1-9][0-9]" -e "^[1-9]"
+}
+
+parse_domain() {
+    echo "$1" | sed -E 's|^.*://||g' | sed -E 's|/$||g'
+}
+
+banner() {
+    echo
+    echo "----------------------------------------------------------"
+    echo "$1"
+    echo "----------------------------------------------------------"
+}
+
+# Defaults
+DEVICE_ID=${DEVICE_ID:-}
+BOOTSTRAP=${BOOTSTRAP:-}
 CONNECT=${CONNECT:-1}
 INSTALL=${INSTALL:-1}
-PRE_CLEAN=${PRE_CLEAN:-0}
+CLEAN=${CLEAN:-0}
+VERSION=${VERSION:-}
 INSTALL_METHOD="${INSTALL_METHOD:-}"
 INSTALL_SOURCEDIR=${INSTALL_SOURCEDIR:-.}
 MAX_CONNECT_ATTEMPTS=${MAX_CONNECT_ATTEMPTS:-2}
 TEDGE_MAPPER=${TEDGE_MAPPER:-c8y}
 ARCH=${ARCH:-}
 USE_RANDOM_ID=${USE_RANDOM_ID:-0}
+SHOULD_PROMPT=${SHOULD_PROMPT:-1}
+CAN_PROMPT=0
+UPLOAD_CERT_WAIT=${UPLOAD_CERT_WAIT:-1}
+CONFIGURE_TEST_SETUP=${CONFIGURE_TEST_SETUP:-1}
+TEST_USER=${TEST_USER:-petertest}
+PREFIX=${PREFIX:-tedge_}
+REPO_CHANNEL=${REPO_CHANNEL:-main}
+C8Y_BASEURL=${C8Y_BASEURL:-}
+
 
 get_debian_arch() {
-    local arch=
-    if command -v dpkg &> /dev/null; then
+    arch=
+    if command_exists dpkg; then
         arch=$(dpkg --print-architecture)
     else
         arch=$(uname -m)
         case "$arch" in
-            armv7l|armv6l)
+            armv7*|armv6*)
                 arch="armhf"
                 ;;
 
-            aarch64)
-                arch="armhf"
+            aarch64|arm64)
+                arch="arm64"
                 ;;
 
-            x86_64)
+            x86_64|amd64)
                 arch="amd64"
+                ;;
+
+            *)
+                fail "Unsupported architecture. arch=$arch. This script only supports: [armv6l, armv7l, aarch64, x86_64]"
                 ;;
         esac
     fi
@@ -38,210 +153,28 @@ get_debian_arch() {
     echo "$arch"
 }
 
-ARCH=$(get_debian_arch)
-
-while [ $# -gt 0 ]
-do
-    case "$1" in
-        --no-install)
-            INSTALL=0
-            ;;
-
-        --no-connect)
-            CONNECT=0
-            ;;
-
-        --use-random-id)
-            USE_RANDOM_ID=1
-            ;;
-
-        --mapper)
-            TEDGE_MAPPER="$2"
-            shift
-            ;;
-
-        --install-method)
-            # Either "apt", "script" or "local". Unknown options will use "script"
-            INSTALL_METHOD="$2"
-            shift
-            ;;
-
-        --install-sourcedir)
-            # Source install directory if install method "local" is used. Location of the .deb files
-            INSTALL_SOURCEDIR="$2"
-            shift
-            ;;
-    esac
-    shift
-done
-
-#
-# Auto detect the install method by checking the local install folder
-#
-if [ -z "$INSTALL_METHOD" ]; then
-    if [[ -n $(find "$INSTALL_SOURCEDIR" -type f -name "tedge_*.deb") ]]; then
-        echo "Found local .deb files in folder [$INSTALL_SOURCEDIR], so using local dpkg install method"
-        INSTALL_METHOD=local
-    else
-        echo "No local .deb files found in folder [$INSTALL_SOURCEDIR], so using apt install method"
-        INSTALL_METHOD=apt
-    fi
-fi
-
-# ---------------------------------------
-# Install helpers
-# ---------------------------------------
-configure_repos() {
-    LINUX_ARCH=$(uname -m)
-    REPOS=()
-
-    case "$LINUX_ARCH" in
-        armv6l)
-            # armv6 need their own repo as the debian arch (armhf) collides with that of armv7 (which is also armhf)
-            REPOS=(
-                # tedge-release-armv6
-                tedge-main-armv6
-            )
-            ;;
-        
-        *)
-            REPOS=(
-                # tedge-release
-                tedge-main
-            )
-            ;;
-    esac
-
-    for repo_name in "${REPOS[@]}"; do
-        # Use a fixed distribution string to avoid guess work, and it does not really matter anyway
-        curl -1sLf \
-            "https://dl.cloudsmith.io/public/thinedge/${repo_name}/setup.deb.sh" \
-            | distro=raspbian version=11 codename=bullseye sudo -E bash
-    done
-}
-
-install_via_apt() {
-    apt-get update
-
-    if ! command -v mosquitto &>/dev/null; then
-        apt-get install -y mosquitto
-    fi
-
-    apt-get install -y \
-        tedge \
-        tedge-mapper \
-        tedge-agent \
-        tedge-apt-plugin \
-        c8y-configuration-plugin \
-        c8y-log-plugin \
-        c8y-firmware-plugin \
-        tedge-watchdog
-}
-
-install_via_script() {
-    apt-get update
-    curl -fsSL https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/get-thin-edge_io.sh | sudo sh -s
-}
-
-find_then_install_deb() {
-    SOURCE_DIR="$1"
-    PATTERN="$2"
-
-    find "$SOURCE_DIR" -type f -name "$PATTERN" -print0 \
-    | sort -r -V \
-    | head -z -n 1 \
-    | xargs -r0 dpkg -i
-}
-
-install_via_local_files() {
-    if ! command -v mosquitto &>/dev/null; then
-        apt-get update
-        apt-get install -y mosquitto
-    fi
-
-    # Install tedge packages in same order as the get-thin-edge_io.sh script
-    find_then_install_deb "$INSTALL_SOURCEDIR" "tedge_[0-9]*_$ARCH.deb"
-    find_then_install_deb "$INSTALL_SOURCEDIR" "tedge[_-]mapper_*_$ARCH.deb"
-    find_then_install_deb "$INSTALL_SOURCEDIR" "tedge[_-]agent_*_$ARCH.deb"
-    find_then_install_deb "$INSTALL_SOURCEDIR" "tedge[_-]apt[_-]plugin_*_$ARCH.deb"
-    find_then_install_deb "$INSTALL_SOURCEDIR" "c8y[_-]configuration[_-]plugin_*_$ARCH.deb"
-    find_then_install_deb "$INSTALL_SOURCEDIR" "c8y[_-]log[_-]plugin_*_$ARCH.deb"
-    find_then_install_deb "$INSTALL_SOURCEDIR" "c8y-firmware-plugin_*_$ARCH.deb"
-    find_then_install_deb "$INSTALL_SOURCEDIR" "tedge[_-]watchdog_*_$ARCH.deb"
-}
-
-cleanup() {
-    echo "Cleaning up tedge files"
-    # Remove existing config files as it can cause issues 
-    sudo apt-get purge -y "tedge*" "c8y*"
-    sudo rm -f /etc/tedge/tedge.toml
-    sudo rm -f /etc/tedge/system.toml
-    sudo rm -f /var/log/tedge/agent/*.log
-}
-
-# Cleanup device as sometimes the existing state can affect tests
-if [ "$PRE_CLEAN" == 1 ]; then
-    cleanup
-fi
-
-# Try disconnect mapper before installing (in case if left over from last installation)
-if command -v tedge &>/dev/null; then
-    # disconnect mapper (don't both testing)
-    sudo tedge disconnect "$TEDGE_MAPPER" || true
-fi
-
-# ---------------------------------------
-# Install
-# ---------------------------------------
-if [ "$INSTALL" == 1 ]; then
-    echo ----------------------------------------------------------
-    echo Installing thin-edge.io
-    echo ----------------------------------------------------------
-    echo
-    configure_repos
-
-    INSTALL_METHOD=${INSTALL_METHOD:-script}
-
-    case "$INSTALL_METHOD" in
-        apt)
-            echo "Installing thin-edge.io using apt"
-            install_via_apt
-            ;;
-
-        local)
-            if [ $# -gt 1 ]; then
-                INSTALL_SOURCEDIR="$2"
-            fi
-            echo "Installing thin-edge.io using local files (from path=$INSTALL_SOURCEDIR)"
-            install_via_local_files
-            ;;
-
-        *)
-            echo "Installing thin-edge.io using the 'get-thin-edge_io.sh' script"
-            # Remove system.toml as the latest official release does not support custom reboot command
-            rm -f /etc/tedge/system.toml
-            install_via_script
-            ;;
-    esac
-fi
-
-echo ----------------------------------------------------------
-echo Bootstrapping device
-echo ----------------------------------------------------------
-echo
-
-PREFIX=${PREFIX:-tedge}
-
-if [ -n "$PREFIX" ]; then
-    PREFIX="${PREFIX}_"
-fi
-
-get_device_id() {
-    if [ "$USE_RANDOM_ID" == "1" ]; then
+generate_device_id() {
+    #
+    # Generate a device id
+    # Either use a raond device, or the device's hostname
+    #
+    if [ "$USE_RANDOM_ID" = "1" ]; then
         if [ -n "$DEVICE_ID" ]; then
             echo "Overriding the non-empty DEVICE_ID variable with a random name" >&2
         fi
-        DEVICE_ID="${PREFIX}$(echo "$RANDOM" | md5sum | head -c 10)"
+
+        RANDOM_ID=
+        if [ -e /dev/urandom ]; then
+            RANDOM_ID=$(head -c 128 /dev/urandom | md5sum | head -c 10)
+        elif [ -e /dev/random ]; then
+            RANDOM_ID=$(head -c 128 /dev/random | md5sum | head -c 10)
+        fi
+
+        if [ -n "$RANDOM_ID" ]; then
+            DEVICE_ID="${PREFIX}${RANDOM_ID}"
+        else
+            warning "Could not generate a random id. Check if /dev/random is available or not"
+        fi
     fi
 
     if [ -n "$DEVICE_ID" ]; then
@@ -260,60 +193,532 @@ get_device_id() {
     echo "${PREFIX}unknown-device"
 }
 
-if [ -n "$C8Y_BASEURL" ]; then
-    C8Y_HOST="$C8Y_BASEURL"
-fi
+check_sudo() {
+    if [ "$(id -u)" -ne 0 ]; then
+        echo "Please run as root or using sudo"
+        show_usage
+        exit 1
+    fi
+}
 
-if [ -z "$C8Y_HOST" ]; then
-    echo "Missing Cumulocity Host url: C8Y_HOST" >&2
-    exit 1
-fi
+# ---------------------------------------
+# Argument parsing
+# ---------------------------------------
+while [ $# -gt 0 ]
+do
+    case "$1" in
+        # ----------------------
+        # Clean
+        # ----------------------
+        # Should the device be cleaned prior to installation/bootstrapping
+        --clean)
+            CLEAN=1
+            BOOTSTRAP=1
+            ;;
+        --no-clean)
+            CLEAN=0
+            ;;
 
-# Strip any http/s prefixes
-C8Y_HOST=$(echo "$C8Y_HOST" | sed -E 's|^.*://||g' | sed -E 's|/$||g')
+        # ----------------------
+        # Install thin-edge.io
+        # ----------------------
+        --install)
+            INSTALL=1
+            ;;
+        --no-install)
+            INSTALL=0
+            ;;
 
-# Check if tedge is installed before trying to bootstrap
-if ! command -v tedge &>/dev/null; then
-    echo "Skipping bootstrapping as tedge is not installed"
-    exit 0
-fi
+        # Which channel, e.g. release or main to install thin-edge.io from
+        --channel)
+            REPO_CHANNEL="$2"
+            shift
+            ;;
+        
+        # Tedge install options
+        --install-method)
+            # Either "apt", "script" or "local". Unknown options will use "script"
+            INSTALL_METHOD="$2"
+            shift
+            ;;
 
-echo "Setting c8y.url to $C8Y_HOST"
-tedge config set c8y.url "$C8Y_HOST"
+        --install-sourcedir)
+            # Source install directory if install method "local" is used. Location of the .deb files
+            INSTALL_SOURCEDIR="$2"
+            shift
+            ;;
+        
+        # ----------------------
+        # Bootstrap
+        # ----------------------
+        # Device id options
+        --device-id)
+            DEVICE_ID="$2"
+            shift
+            ;;
 
-CURRENT_DEVICE_ID=$( tedge config get device.id 2>/dev/null | grep -v "tedge_config::" || true)
-EXPECTED_CERT_COMMON_NAME=$(get_device_id)
-DEVICE_ID="$EXPECTED_CERT_COMMON_NAME"
+        --prefix)
+            PREFIX="$2"
+            shift
+            ;;
+        --random)
+            USE_RANDOM_ID=1
+            ;;
 
-# Remove existing certificate if it does not match
-if tedge cert show >/dev/null 2>&1; then
-    if [ "$CURRENT_DEVICE_ID" != "$EXPECTED_CERT_COMMON_NAME" ]; then
-        echo "Device does not match expected. got=$CURRENT_DEVICE_ID, want=$EXPECTED_CERT_COMMON_NAME. Removing existing certificate"
-        sudo tedge cert remove
+        --bootstrap)
+            BOOTSTRAP=1
+            ;;
+
+        --no-bootstrap)
+            BOOTSTRAP=0
+            ;;
+
+        # ----------------------
+        # Connect mapper
+        # ----------------------
+        --connect)
+            CONNECT=1
+            ;;
+        --no-connect)
+            CONNECT=0
+            ;;
+
+        # Preferred mapper
+        --mapper)
+            TEDGE_MAPPER="$2"
+            shift
+            ;;
+        
+        # Cumulocity settings
+        --c8y-user)
+            C8Y_USER="$2"
+            shift
+            ;;
+        --c8y-url)
+            C8Y_BASEURL="$2"
+            shift
+            ;;
+
+        # ----------------------
+        # Misc
+        # ----------------------
+        # Should prompt for use if information is missing?
+        --prompt)
+            SHOULD_PROMPT=1
+            ;;
+        --no-prompt)
+            SHOULD_PROMPT=0
+            ;;
+
+        --help|-h)
+            show_usage
+            exit 0
+            ;;
+        
+        *)
+            POSITIONAL_ARGS="$1"
+            ;;
+    esac
+    shift
+done
+
+set -- "$POSITIONAL_ARGS"
+
+# ---------------------------------------
+# Initializing
+# ---------------------------------------
+banner "Initializing"
+
+# Try guessing the positional arguments
+# If it looks like a directory, then use the as the install directory
+# else use it has a version. But in both ca
+while [ $# -gt 0 ]; do
+    if [ -d "$1" ] && [ -z "$INSTALL_SOURCEDIR" ]; then
+        echo "Detected install-sourcedir from positional argument. install-sourcedir=$1"
+        INSTALL_SOURCEDIR="$1"
+    elif [ -z "$VERSION" ]; then
+        echo "Detected version from positional argument. version=$1"
+        VERSION="$1"
+    else
+        fail "Unexpected positional arguments. Check the usage by provide '--help' for examples"
+    fi
+    shift
+done
+
+if [ -z "$REPO_CHANNEL" ]; then
+    if [ -z "$VERSION" ]; then
+        REPO_CHANNEL="release"
+    else
+        # Check if the user is requestion an official version or not
+        if echo "$VERSION" | grep --silent "^[0-9]\+.[0-9]\+.[0-9]\+$"; then
+            REPO_CHANNEL="release"
+        else
+            REPO_CHANNEL="main"
+        fi
     fi
 fi
 
-if ! tedge cert show >/dev/null 2>&1; then
-    echo "Creating certificate: $EXPECTED_CERT_COMMON_NAME"
-    tedge cert create --device-id "$EXPECTED_CERT_COMMON_NAME"
+#
+# Detect settings
+if command_exists tedge; then
+    if [ -z "$C8Y_BASEURL" ]; then
+        C8Y_BASEURL=$( tedge config list | grep "^c8y.url=" | sed 's/^c8y.url=//' )    
+    fi
 
-    if [ -n "$C8Y_PASSWORD" ]; then
-        echo "Uploading certificate to Cumulocity using tedge"
-        C8YPASS="$C8Y_PASSWORD" tedge cert upload c8y --user "$C8Y_USER"
+    if [ -z "$DEVICE_ID" ]; then
+        DEVICE_ID=$( tedge config list | grep "^device.id=" | sed 's/^device.id=//' )
+    fi
 
-        # Grace period for the server to process the certificate
-        sleep 1
+    # Detect if bootstrapping is required or not?
+    if [ -z "$BOOTSTRAP" ]; then
+        # If connection already exists, then assume bootstrapping does not need to occur again
+        # If already connected, then stick with using the same certificate
+        if tedge connect "$TEDGE_MAPPER" --test >/dev/null 2>&1; then
+            echo "No need for bootstrapping as $TEDGE_MAPPER mapper is already connected. You can force bootstrapping using either --bootstrap or --clean flags"
+            BOOTSTRAP=0
+        fi
+    fi
+fi
+
+if [ -z "$DEVICE_ID" ] || [ "$CLEAN" = 1 ]; then
+    DEVICE_ID=$(generate_device_id)
+fi
+
+if [ -z "$BOOTSTRAP" ]; then
+    BOOTSTRAP=1
+fi
+
+#
+# Detect if the shell is running in interactive mode or not
+if [ -t 0 ]; then
+    CAN_PROMPT=1
+else
+    CAN_PROMPT=0
+fi
+
+#
+# Auto detect the install method by checking the local install folder
+#
+# Only the script install method supports installing from older versions
+if [ -z "$INSTALL_METHOD" ]; then
+    if [ -n "$(find "$INSTALL_SOURCEDIR" -type f -name "tedge_[0-9]*.deb")" ]; then
+        echo "Using local dpkg install method as local .deb files were found in folder: $INSTALL_SOURCEDIR"
+        INSTALL_METHOD=local
+    else
+        echo "Using apt install method as no local .deb files found in folder: $INSTALL_SOURCEDIR"
+        INSTALL_METHOD=apt
     fi
 else
-    echo "Certificate already exists"
+    if [ "$INSTALL_METHOD" != "apt" ] && [ "$INSTALL_METHOD" != "local" ] && [ "$INSTALL_METHOD" != "script" ]; then
+        fail "Invalid install method [$INSTALL_METHOD]. Only 'apt', 'local' or 'script' values are supported"
+    fi
 fi
 
-if [[ "$CONNECT" == 1 ]]; then
+
+# ---------------------------------------
+# Install helpers
+# ---------------------------------------
+configure_repos() {
+    LINUX_ARCH=$(uname -m)
+    REPO=""
+    REPO_SUFFIX=
+
+    case "$LINUX_ARCH" in
+        armv6l)
+            # armv6 need their own repo as the debian arch (armhf) collides with that of armv7 (which is also armhf)
+            REPO_SUFFIX="-armv6"
+            ;;
+    esac
+
+    case "$REPO_CHANNEL" in
+        main|release)
+            REPO="tedge-${REPO_CHANNEL}${REPO_SUFFIX}"
+            ;;
+
+        *)
+            fail "Invalid channel"
+            ;;
+    esac
+
+    # Remove any other repos
+    DELETED_REPOS=$(sudo find /etc/apt/sources.list.d/ -type f \( -name "thinedge-*.list" -a ! -name "thinedge-${REPO}.list" -a ! -name "thinedge-community.list" \) -delete -print0)
+    if [ -n "$DELETED_REPOS" ]; then
+        echo "Cleaning other repos. $DELETED_REPOS"
+        sudo apt-get clean -y
+
+        # When changing repository channel the package needs to be removed but keep files
+        remove_tedge
+    fi
+
+    if command_exists bash; then
+        if [ ! -f "/etc/apt/sources.list.d/thinedge-${REPO}.list" ]; then
+            # Use a fixed distribution string to avoid guess work, and it does not really matter anyway
+            curl -1sLf \
+            "https://dl.cloudsmith.io/public/thinedge/${REPO}/setup.deb.sh" \
+            | distro=raspbian version=11 codename=bullseye sudo -E bash
+        else
+            echo "Repo (channel=${REPO_CHANNEL}) is already configured"
+        fi
+    else
+        # TODO: Support non-bash environments (but the cloudsmith script only supports bash)
+        fail "Bash is missing. Currently this script requires bash to setup the apt repos"
+        # deb [signed-by=/usr/share/keyrings/thinedge-tedge-release-archive-keyring.gpg] https://dl.cloudsmith.io/public/thinedge/tedge-release/deb/raspbian bullseye main
+    fi
+}
+
+install_via_apt() {
+    sudo apt-get update
+
+    if ! command -v mosquitto >/dev/null 2>&1; then
+        sudo apt-get install -y mosquitto
+    fi
+
+    if [ -n "$VERSION" ]; then
+        echo "Installing specific version: $VERSION"
+        sudo apt-get install -y --allow-downgrades \
+            tedge="$VERSION" \
+            tedge-mapper="$VERSION" \
+            tedge-agent="$VERSION" \
+            tedge-apt-plugin="$VERSION" \
+            c8y-configuration-plugin="$VERSION" \
+            c8y-log-plugin="$VERSION" \
+            c8y-firmware-plugin="$VERSION" \
+            tedge-watchdog="$VERSION"
+    else
+        echo "Installing latest available version"
+        sudo apt-get install -y --allow-downgrades \
+            tedge \
+            tedge-mapper \
+            tedge-agent \
+            tedge-apt-plugin \
+            c8y-configuration-plugin \
+            c8y-log-plugin \
+            c8y-firmware-plugin \
+            tedge-watchdog
+    fi
+}
+
+install_via_script() {
+    sudo apt-get update
+    if [ -n "$VERSION" ]; then
+        echo "Installing specific version: $VERSION"
+        curl -fsSL https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/get-thin-edge_io.sh | sudo sh -s "$VERSION"
+    else
+        echo "Installing latest official version"
+        curl -fsSL https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/get-thin-edge_io.sh | sudo sh -s
+    fi
+}
+
+find_then_install_deb() {
+    SOURCE_DIR="$1"
+    PATTERN="$2"
+
+    find "$SOURCE_DIR" -type f -name "$PATTERN" -print0 \
+    | sort -r -V \
+    | head -z -n 1 \
+    | xargs -r0 sudo dpkg -i
+}
+
+install_via_local_files() {
+    if ! command_exists mosquitto; then
+        sudo apt-get update
+        sudo apt-get install -y mosquitto
+    fi
+
+    ARCH=$(get_debian_arch)
+
+    # Install tedge packages in same order as the get-thin-edge_io.sh script
+    find_then_install_deb "$INSTALL_SOURCEDIR" "tedge_[0-9]*_$ARCH.deb"
+    find_then_install_deb "$INSTALL_SOURCEDIR" "tedge[_-]mapper_*_$ARCH.deb"
+    find_then_install_deb "$INSTALL_SOURCEDIR" "tedge[_-]agent_*_$ARCH.deb"
+    find_then_install_deb "$INSTALL_SOURCEDIR" "tedge[_-]apt[_-]plugin_*_$ARCH.deb"
+    find_then_install_deb "$INSTALL_SOURCEDIR" "c8y[_-]configuration[_-]plugin_*_$ARCH.deb"
+    find_then_install_deb "$INSTALL_SOURCEDIR" "c8y[_-]log[_-]plugin_*_$ARCH.deb"
+    find_then_install_deb "$INSTALL_SOURCEDIR" "c8y-firmware-plugin_*_$ARCH.deb"
+    find_then_install_deb "$INSTALL_SOURCEDIR" "tedge[_-]watchdog_*_$ARCH.deb"
+}
+
+clean_files() {
+    echo "Cleaning up tedge files"
+    sudo rm -f /etc/tedge/tedge.toml
+    sudo rm -f /etc/tedge/system.toml
+    sudo rm -f /var/log/tedge/agent/*.log
+}
+
+stop_services() {
+    if command_exists systemctl; then
+        sudo systemctl stop tedge-agent >/dev/null 2>&1 || true
+        sudo systemctl stop tedge-mapper-c8y >/dev/null 2>&1 || true
+    fi
+}
+
+purge_tedge() {
+    echo "Purging tedge"
+
+    # try stopping agent (as downgrading can have problems)
+    stop_services
+
+    # Remove existing config files as it can cause issues
+    sudo apt-get purge -y "tedge*" "c8y*"
+
+    # Refresh path, to ensure old binaries are still not being detected
+    hash -r
+}
+
+remove_tedge() {
+    echo "Removing tedge"
+
+    # try stopping agent (as downgrading can have problems)
+    stop_services
+
+    # Remove packages but keep configuration files
+    sudo apt-get remove -y "tedge*" "c8y*"
+
+    # Refresh path, to ensure old binaries are still not being detected
+    hash -r
+}
+
+install_tedge() {
+    configure_repos
+
+    # Check if any packages are incompatible, if so remove the previous version first
+    # Use new and old packages names, and check each of them one by one
+    packages="tedge tedge-mapper tedge-agent c8y-log-plugin c8y-configuration-plugin c8y-remote-access-plugin"
+    packages="$packages tedge tedge_mapper tedge_agent c8y_log_plugin c8y_configuration_plugin"
+    REMOVE_BEFORE_INSTALL=0
+
+    for package in $packages; do
+        if command_exists "$package"; then
+            EXISTING_VERSION=$("$package" --version | tail -1 | cut -d' ' -f2 || true)
+
+            if [ -n "$EXISTING_VERSION" ]; then
+                if uses_old_package_name "$VERSION" && uses_new_package_name "$EXISTING_VERSION"; then
+                    REMOVE_BEFORE_INSTALL=1
+                    break
+                fi
+            fi
+        fi
+    done
+
+    if [ "$REMOVE_BEFORE_INSTALL" = 1 ]; then
+        echo "Uninstalling tedge before downgrading because the package names changed"
+        # TODO: This does not work as the script requires bash and not sh
+        curl -sSL https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/uninstall-thin-edge_io.sh | sudo bash -s remove
+
+        # Preserve c8y settings
+        if [ -n "$C8Y_BASEURL" ]; then
+            c8y_url=$(parse_domain "$C8Y_BASEURL")
+            sudo sh -c "
+            echo '[c8y]' > /etc/tedge/tedge.toml;
+            echo 'url = \"${c8y_url}\"' >> /etc/tedge/tedge.toml
+            "
+        else
+            sudo rm -f /etc/tedge/tedge.toml
+        fi
+        sudo rm -f /etc/tedge/system.toml
+        # Refresh path, to ensure old binaries are still not being detected
+        hash -r
+    fi
+
+    if [ "$INSTALL_METHOD" = "apt" ] && uses_old_package_name "$VERSION"; then
+        echo "Installing versions older than 0.9.0 is not supported via apt. Using the 'script' install method"
+        INSTALL_METHOD="script"
+    fi
+
+    case "$INSTALL_METHOD" in
+        apt)
+            echo "Installing thin-edge.io using apt"
+            if ! install_via_apt; then
+                echo "Installing via apt failed, installing via script"
+                install_via_script
+            fi
+            ;;
+
+        local)
+            echo "Installing thin-edge.io using local files (from path=$INSTALL_SOURCEDIR)"
+            install_via_local_files
+            ;;
+
+        *)
+            echo "Installing thin-edge.io using the 'get-thin-edge_io.sh' script"
+            # Remove system.toml as the latest official release does not support custom reboot command
+            rm -f /etc/tedge/system.toml
+            install_via_script
+            ;;
+    esac
+}
+
+prompt_value() {
+    user_text="$1"
+    value="$2"
+
+    if [ "$SHOULD_PROMPT" = 1 ] && [ "$CAN_PROMPT" = 1 ]; then
+        printf "\n%s (%s): " "$user_text" "${value:-not set}" >&2
+        read -r user_input
+        if [ -n "$user_input" ]; then
+            value="$user_input"
+        fi
+    fi
+    echo "$value"
+}
+
+bootstrap_c8y() {
+    # If bootstrapping is called, then it assumes the full bootstrapping
+    # needs to be done.
+
+    # Force disconnection of mapper before setting url
+    sudo tedge disconnect "$TEDGE_MAPPER" >/dev/null 2>&1 || true
+
+    DEVICE_ID=$(prompt_value "Enter the device.id" "$DEVICE_ID")
+
+    # Remove existing certificate if it does not match
+    if tedge cert show >/dev/null 2>&1; then
+        echo "Removing existing device certificate"
+        sudo tedge cert remove
+    fi
+
+    echo "Creating certificate: $DEVICE_ID"
+    sudo tedge cert create --device-id "$DEVICE_ID"
+
+    # Cumulocity URL
+    C8Y_BASEURL=$(prompt_value "Enter the Cumulocity IoT url" "$C8Y_BASEURL")
+
+    # Normalize url, by stripping url schema
+    if [ -n "$C8Y_BASEURL" ]; then
+        C8Y_BASEURL=$(parse_domain "$C8Y_BASEURL")
+    fi
+
+    echo "Setting c8y.url to $C8Y_BASEURL"
+    sudo tedge config set c8y.url "$C8Y_BASEURL"
+
+    C8Y_USER=$(prompt_value "Enter your Cumulocity user" "$C8Y_USER")
+
+    if [ -n "$C8Y_USER" ]; then
+        echo "Uploading certificate to Cumulocity using tedge"
+        if [ -n "$C8Y_PASSWORD" ]; then
+            C8YPASS="$C8Y_PASSWORD" tedge cert upload c8y --user "$C8Y_USER"
+        else
+            echo ""
+            tedge cert upload c8y --user "$C8Y_USER"
+        fi
+    else
+        fail "When manually bootstrapping you have to upload the certificate again as the device certificate is recreated"
+    fi
+
+    # Grace period for the server to process the certificate
+    # but it is not critical for the connection, as the connection
+    # supports automatic retries, but it can improve the first connection success rate
+    sleep "$UPLOAD_CERT_WAIT"
+}
+
+connect_mappers() {
     # retry connection attempts
+    sudo tedge disconnect "$TEDGE_MAPPER" || true
+
     CONNECT_ATTEMPT=0
     while true; do
         CONNECT_ATTEMPT=$((CONNECT_ATTEMPT + 1))
-        if tedge connect "$TEDGE_MAPPER"; then
+        if sudo tedge connect "$TEDGE_MAPPER"; then
             break
         else
             if [ "$CONNECT_ATTEMPT" -ge "$MAX_CONNECT_ATTEMPTS" ]; then
@@ -325,26 +730,92 @@ if [[ "$CONNECT" == 1 ]]; then
         echo "WARNING: Connection attempt failed ($CONNECT_ATTEMPT of $MAX_CONNECT_ATTEMPTS)! Retrying to connect in 2s"
         sleep 2
     done
-fi
+}
 
-# Add additional tools
-systemctl start ssh
+display_banner_c8y() {
+    echo
+    echo "----------------------------------------------------------"
+    echo "Device information"
+    echo "----------------------------------------------------------"
+    echo ""
+    echo "tedge.version:   $(tedge --version 2>/dev/null | tail -1 | cut -d' ' -f2)"
+    echo "device.id:       ${DEVICE_ID}"
+    DEVICE_SEARCH=$(echo "$DEVICE_ID" | sed 's/-/*/g')
+    echo "Cumulocity IoT:  https://${C8Y_BASEURL}/apps/devicemanagement/index.html#/assetsearch?filter=*${DEVICE_SEARCH}*"
+    echo ""
+    echo "----------------------------------------------------------"    
+}
 
-if ! id -u peter >/dev/null 2>&1; then
-    useradd -ms /bin/bash peter && echo "peter:peter" | chpasswd && adduser peter sudo
-fi
+configure_test_user() {
+    if [ -n "$TEST_USER" ]; then
+        if ! id -u "$TEST_USER" >/dev/null 2>&1; then
+            sudo useradd -ms /bin/sh "${TEST_USER}" && echo "${TEST_USER}:${TEST_USER}" | sudo chpasswd && sudo adduser "${TEST_USER}" sudo
+        fi
+    fi
+}
 
-echo "Setting sudoers.d config"
-echo '%sudo ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/all
-echo 'tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown' > /etc/sudoers.d/tedge
+post_configure() {
+    echo "Setting sudoers.d config"
+    sudo sh -c "echo '%sudo ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/all"
+    sudo sh -c "echo 'tedge  ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown' > /etc/sudoers.d/tedge"
+}
 
+main() {
+    # ---------------------------------------
+    # Preparation (clean and disconnect)
+    # ---------------------------------------
+    # Cleanup device as sometimes the existing state can affect tests
+    if [ "$CLEAN" = 1 ]; then
+        banner "Preparing device"
+        purge_tedge
+        clean_files
+    fi
 
-echo
-echo "----------------------------------------------------------"
-echo "Device information"
-echo "----------------------------------------------------------"
-echo ""
-echo "device.id:       ${DEVICE_ID}"
-echo "Cumulocity IoT:  https://${C8Y_HOST}/apps/devicemanagement/index.html#/assetsearch?filter=*${DEVICE_ID//-/*}*"
-echo ""
-echo "----------------------------------------------------------"
+    # ---------------------------------------
+    # Install
+    # ---------------------------------------
+    if [ "$INSTALL" = 1 ]; then
+        banner "Installing thin-edge.io"
+        install_tedge
+    fi
+
+    # ---------------------------------------
+    # Bootstrap
+    # ---------------------------------------
+    if [ "$BOOTSTRAP" = 1 ]; then
+        banner "Bootstraping device"
+        # Check if tedge is installed before trying to bootstrap
+        if ! command_exists tedge; then
+            fail "Can not bootstrap as tedge is not installed"
+        fi
+
+        bootstrap_c8y
+    fi
+
+    # ---------------------------------------
+    # Connect
+    # ---------------------------------------
+    if [ "$CONNECT" = 1 ]; then
+        banner "Connecting mapper"
+        connect_mappers
+    fi
+
+    # ---------------------------------------
+    # Post setup
+    # ---------------------------------------
+    if [ "$CONFIGURE_TEST_SETUP" = 1 ]; then
+        configure_test_user
+        post_configure
+
+        # Add additional tools
+        if command_exists systemctl; then
+            sudo systemctl start ssh
+        fi
+    fi
+
+    if [ "$BOOTSTRAP" = 1 ] || [ "$CONNECT" = 1 ]; then
+        display_banner_c8y
+    fi
+}
+
+main

--- a/tests/images/debian-systemd/files/mqtt-logger
+++ b/tests/images/debian-systemd/files/mqtt-logger
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -e
+
+MQTT_HOST=${MQTT_HOST:-localhost}
+MQTT_PORT=${MQTT_PORT:-1883}
+OUTPUT_LOG=${OUTPUT_LOG:-}
+WAIT=${WAIT:-1}
+
+usage() {
+    echo "
+        $0 [--host <host>] [--port <port>] [--log <path>] [--wait <seconds>]
+    
+    FLAGS
+        --host <host>       MQTT broker host
+        --port <port>       MQTT broker port
+        --log <path>        File path to write the mqtt messages to. The messages will be written to stdout and the given file
+        --wait <sec>        Seconds to wait before trying to reconnect if the mqtt client gets disconnected
+    
+    EXAMPLES
+        $0
+        # Subscribe to the default mqtt broker on localhost:1883
+
+        $0 --log /var/log/mqtt-messages.log
+        # Subscribe to all topics and write the messages to file
+    "
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --host)
+            MQTT_HOST="$2"
+            shift
+            ;;
+        --port)
+            MQTT_PORT="$2"
+            shift
+            ;;
+        --wait)
+            WAIT="$2"
+            shift
+            ;;
+        --log)
+            OUTPUT_LOG="$2"
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option" >&2
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+log() {
+    echo "$*" >&2
+}
+
+subscribe() {
+    mosquitto_sub --nodelay -h "$MQTT_HOST" -p "$MQTT_PORT" -t '#' -F '{"timestamp":%U,"message":%j,"payload_hex":"%x"}'
+}
+
+# Wait for mosquitto process to start up (to reduce spamming logs with uninteresting info)
+if command -v pgrep >/dev/null 2>&1; then
+    if [ "$MQTT_HOST" = "localhost" ] || [ "$MQTT_HOST" = "127.0.0.1" ]; then
+        while :; do
+            if pgrep -fa "mosquitto " >/dev/null 2>&1; then
+                break
+            fi
+            sleep 0.5
+        done
+    fi
+fi
+
+# Keep trying forever
+while true; do
+    log "Starting mqtt-logger to ${MQTT_HOST}:${MQTT_PORT}"
+    if [ -n "$OUTPUT_LOG" ]; then
+        subscribe | tee -a "$OUTPUT_LOG" || true
+    else
+        subscribe || true
+    fi
+    log "mqtt-logger stopped, waiting ${WAIT} second/s and trying again"
+    sleep "$WAIT"
+done

--- a/tests/images/debian-systemd/files/mqtt-logger.service
+++ b/tests/images/debian-systemd/files/mqtt-logger.service
@@ -1,13 +1,10 @@
 [Unit]
 Description=Dependent service
 After=mosquitto.service
-#Requires=mosquitto.service
 
 [Service]
-Environment=MQTT_HOST=localhost
-Environment=MQTT_PORT=1883
 EnvironmentFile=-/etc/mosquitto-logger/env
-ExecStart=mosquitto_sub -h "$MQTT_HOST" -p "$MQTT_PORT" -t '#' -F '{"timestamp":%%U,"message":%%j,"payload_hex":"%%x"}'
+ExecStart=/usr/bin/mqtt-logger
 Restart=always
 RestartSec=3
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

The integration tests were ran repeatedly to try to locate sources of flakiness. Flakey tests were spotted by running the integration tests 100 times, and repeating the same 100 iterations after each set of changes to validate them. Whilst the flakiness may not be 100% removed, it is considerable improved at around 98% passing rate.

**Stability improvements**

* Use `Kill Process` keyword which will wait for a process to be killed
* Remove assertions for main device and child devices for configuration and firmware related tests. Instead this is covered by new Registration tests.
* child device configuration management: Get logs of parent device by default
* Use device time rather than test runner time for `Get Unix Timestamp` keyword
* Support for setting manual dns entries in the container when using the `docker` adapter. Settings can be added in the `.env` file. This is only needed if users suffer from sporadic DNS failures (e.g. when using `colima` on MacOS)

In addition to the stability improvements, some general improvements were made to the testing setup (discovered during the flake finder phase):

* Add new `invoke flake-finder` task to help find flakey integration tests
* Update library dependencies (`robotframework-cumulocity` and `robotframework-devicelibrary`)
* Improve `bootstrap.sh` script to make more user friendly to support running it localy during manual testing 
* Add update inventory tests
* Add tests for publishing custom Cumulocity measurements
* Refactor `Execute Command` usage to use updated interface which allows controlling the return of stdout and stderr separately

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

