### PR TITLE
Add test for checking the lock file creation set/unset

### DIFF
--- a/tests/RobotFramework/tests/configuration/lock_file.robot
+++ b/tests/RobotFramework/tests/configuration/lock_file.robot
@@ -8,14 +8,14 @@ Test Teardown   Get Logs
 
 *** Test Cases ***
 
-Check lock file existance in default folder
-    [Documentation]    Whe deploying thin-edge components in single-process containers, 
+Check lock file existence in default folder
+    [Documentation]    When deploying thin-edge components in single-process containers, 
     ...    the lock file mechanism used by some components (e.g. tedge-agent, tedge-mapper) 
     ...    do not makes sense as the container filesystem is isolated. 
     ...    Having the lock file system just adds unnecessary dependencies on the /run/lock folder.
-    File Should Exist    /var/lock/tedge-agent.lock
-    File Should Exist    /var/lock/tedge-mapper-c8y.lock
-    
+    File Should Exist    /run/lock/tedge-agent.lock
+    File Should Exist    /run/lock/tedge-mapper-c8y.lock
+
 Switch off lock file creation
     [Documentation]    Add a new configuration option under the '[run]'' section to turn off the lock file generation logic. 
     ...    '[run]' 
@@ -26,11 +26,11 @@ Switch off lock file creation
     Stop Service    tedge-mapper-c8y
     Stop Service    tedge-agent
     #Remove the existing lock files
-    Execute Command    sudo rm /var/lock/ted*
+    Execute Command    sudo rm /run/lock/ted*
     Execute Command    sudo tedge config set run.lock_files false
     #Restart the stopped sewrvices
     Start Service    tedge-mapper-c8y
     Start Service    tedge-agent
     #Check that no lock file is created
-    File Should Not Exist    /var/lock/tedge-agent.lock
-    File Should Not Exist    /var/lock/tedge-mapper-c8y.lock
+    File Should Not Exist    /run/lock/tedge-agent.lock
+    File Should Not Exist    /run/lock/tedge-mapper-c8y.lock

--- a/tests/RobotFramework/tests/configuration/lock_file.robot
+++ b/tests/RobotFramework/tests/configuration/lock_file.robot
@@ -16,6 +16,12 @@ Check lock file existence in default folder
     File Should Exist    /run/lock/tedge-agent.lock
     File Should Exist    /run/lock/tedge-mapper-c8y.lock
 
+Check starting same service twice
+    [Documentation]    This step is checking if same service can be started twice, 
+    ...    expected is that this should not be the case
+    Execute Command    sudo runuser -u tedge tedge-agent    exp_exit_code=!0
+    Execute Command    sudo runuser -u tedge tedge-mapper-c8y    exp_exit_code=!0
+
 Switch off lock file creation
     [Documentation]    Add a new configuration option under the '[run]'' section to turn off the lock file generation logic. 
     ...    '[run]' 

--- a/tests/RobotFramework/tests/configuration/lock_file.robot
+++ b/tests/RobotFramework/tests/configuration/lock_file.robot
@@ -2,7 +2,7 @@
 Resource    ../../resources/common.resource
 Library    ThinEdgeIO
 
-Test Tags    
+Test Tags    theme:configuration
 Suite Setup    Setup
 Test Teardown   Get Logs
 
@@ -28,7 +28,7 @@ Switch off lock file creation
     #Remove the existing lock files
     Execute Command    sudo rm /run/lock/ted*
     Execute Command    sudo tedge config set run.lock_files false
-    #Restart the stopped sewrvices
+    #Restart the stopped services
     Start Service    tedge-mapper-c8y
     Start Service    tedge-agent
     #Check that no lock file is created

--- a/tests/RobotFramework/tests/configuration/lock_file.robot
+++ b/tests/RobotFramework/tests/configuration/lock_file.robot
@@ -1,0 +1,35 @@
+*** Settings ***
+Resource    ../../resources/common.resource
+Library    ThinEdgeIO
+
+Test Tags    
+Suite Setup    Setup
+Test Teardown   Get Logs
+
+*** Test Cases ***
+
+Check lock file existance in default folder
+    [Documentation]    Whe deploying thin-edge components in single-process containers, 
+    ...    the lock file mechanism used by some components (e.g. tedge-agent, tedge-mapper) 
+    ...    do not makes sense as the container filesystem is isolated. 
+    ...    Having the lock file system just adds unnecessary dependencies on the /run/lock folder.
+    File Should Exist    /var/lock/tedge-agent.lock
+    File Should Exist    /var/lock/tedge-mapper-c8y.lock
+    #Stop the running services
+    Stop Service    tedge-mapper-c8y
+    Stop Service    tedge-agent
+    #Remove the existing lock files
+    Execute Command    sudo rm /var/lock/ted*
+Switch off lock file creation
+    [Documentation]    Add a new configuration option under the '[run]'' section to turn off the lock file generation logic. 
+    ...    '[run]' 
+    ...    'lock_files = false' 
+    ...    Having this configuration setting allows the user to set it using a common environment 
+    ...    setting when running the components in individual containers.
+    Execute Command    sudo tedge config set run.lock_files false
+    #Restart the stopped sewrvices
+    Start Service    tedge-mapper-c8y
+    Start Service    tedge-agent
+    #Check that no lock file is created
+    File Should Not Exist    /var/lock/tedge-agent.lock
+    File Should Not Exist    /var/lock/tedge-mapper-c8y.lock

--- a/tests/RobotFramework/tests/configuration/lock_file.robot
+++ b/tests/RobotFramework/tests/configuration/lock_file.robot
@@ -15,17 +15,18 @@ Check lock file existance in default folder
     ...    Having the lock file system just adds unnecessary dependencies on the /run/lock folder.
     File Should Exist    /var/lock/tedge-agent.lock
     File Should Exist    /var/lock/tedge-mapper-c8y.lock
-    #Stop the running services
-    Stop Service    tedge-mapper-c8y
-    Stop Service    tedge-agent
-    #Remove the existing lock files
-    Execute Command    sudo rm /var/lock/ted*
+    
 Switch off lock file creation
     [Documentation]    Add a new configuration option under the '[run]'' section to turn off the lock file generation logic. 
     ...    '[run]' 
     ...    'lock_files = false' 
     ...    Having this configuration setting allows the user to set it using a common environment 
     ...    setting when running the components in individual containers.
+    #Stop the running services
+    Stop Service    tedge-mapper-c8y
+    Stop Service    tedge-agent
+    #Remove the existing lock files
+    Execute Command    sudo rm /var/lock/ted*
     Execute Command    sudo tedge config set run.lock_files false
     #Restart the stopped sewrvices
     Start Service    tedge-mapper-c8y

--- a/tests/RobotFramework/tests/configuration/lock_file.robot
+++ b/tests/RobotFramework/tests/configuration/lock_file.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Library    ThinEdgeIO    adapter=ssh
 
 Test Tags    theme:configuration
 Suite Setup    Setup
@@ -19,8 +19,8 @@ Check lock file existence in default folder
 Check starting same service twice
     [Documentation]    This step is checking if same service can be started twice, 
     ...    expected is that this should not be the case
-    Execute Command    sudo runuser -u tedge tedge-agent    exp_exit_code=!0
-    Execute Command    sudo runuser -u tedge tedge-mapper-c8y    exp_exit_code=!0
+    Execute Command    sudo -u tedge tedge-agent    exp_exit_code=!0
+    Execute Command    sudo -u tedge tedge-mapper c8y    exp_exit_code=!0
 
 Switch off lock file creation
     [Documentation]    Add a new configuration option under the '[run]'' section to turn off the lock file generation logic. 

--- a/tests/RobotFramework/tests/configuration/lock_file.robot
+++ b/tests/RobotFramework/tests/configuration/lock_file.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Resource    ../../resources/common.resource
-Library    ThinEdgeIO    adapter=ssh
+Library    ThinEdgeIO
 
 Test Tags    theme:configuration
 Suite Setup    Setup


### PR DESCRIPTION
Added test that is checking the lock file creation set/unset

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

