### PR TITLE
Replace hard-coded cli output with generated cmdrun output

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -p tedge
 
       - name: Update PATH
         run: echo "$PWD/target/debug" >> $GITHUB_PATH

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -140,7 +140,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -p tedge
 
       - name: Update PATH
         run: echo "$PWD/target/debug" >> $GITHUB_PATH

--- a/docs/src/references/c8y-log-management.md
+++ b/docs/src/references/c8y-log-management.md
@@ -78,23 +78,7 @@ This will enable the `c8y-log-plugin.toml` to be tracked and managed by the `c8y
 ## Usage
 
 ```shell
-c8y-log-plugin
-```
-
-```
-Plugin supporting log management from Cumulocity on thin-edge.
-USAGE:
-    c8y-log-plugin [OPTIONS]
-OPTIONS:
-        --config-dir <CONFIG_DIR>      Root directory of tedge config and plugin config files [default: `/etc/tedge`]
-        --config-file <CONFIG_FILE>    Path to the plugin config file [default: `$CONFIG_DIR/c8y/c8y-log-plugin.toml`]
-        --init                         Initializes this plugin by creating all the necessary config files that it needs
-    -h, --help                         Print help information
-    -V, --version                      Print version information
-
-    On start, `c8y-log-plugin` notifies the cloud tenant of the managed log types, defined in `c8y-log-plugin.toml`.
-    On receipt of log requests from the cloud, the log files are fetched using the glob path patterns listed in this config file.
-    The cloud tenant is also notified of the progress of the log request operation until success/failure.
+<!-- cmdrun c8y-log-plugin --help -->
 ```
 
 ## Logging


### PR DESCRIPTION
## Proposed changes

* Replace `c8y-log-plugin` hardcoded (and outdated) output with generated output using `cmdrun`.
* Fix workflow to build all the tedge commands and have them available when generating the doc.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

