### PR TITLE
Correct spell check errors

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
+++ b/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
@@ -10,7 +10,7 @@ Test Teardown    Get Logs
 *** Test Cases ***
 
 Install c8y-remote-access-plugin
-    Skip    remote-access is not yet part of the offficial release. Enable when it is
+    Skip    remote-access is not yet part of the official release. Enable when it is
     Device Should Have Installed Software    c8y-remote-access-plugin
     File Should Exist    /etc/tedge/operations/c8y/c8y_RemoteAccessConnect
     Execute Command    dpkg -r c8y-remote-access-plugin

--- a/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
+++ b/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
@@ -12,7 +12,7 @@ Test Teardown    Get Logs
 
 *** Variables ***
 # Timeout in seconds used to wait for a service to be up. A longer timeout is sometimes needed in case
-# if the service encounters a 'c8y_api::http_proxy: An error occurred while retrieving internal Id, operation will retry in 60 seconds and mapper will reinitialise'
+# if the service encounters a 'c8y_api::http_proxy: An error occurred while retrieving internal Id, operation will retry in 60 seconds and mapper will reinitialize'
 # error on startup, and then waits 60 seconds before trying again. The timeout should be larger than this interval to give the service a chance to retry without
 # failing the test
 ${TIMEOUT}=    ${90}

--- a/tests/RobotFramework/tests/cumulocity/software.robot
+++ b/tests/RobotFramework/tests/cumulocity/software.robot
@@ -27,7 +27,7 @@ Custom Setup
     Device Should Exist                      ${DEVICE_SN}
     Set Test Variable    $DEVICE_SN
     Should Have MQTT Messages    tedge/health/tedge-mapper-c8y
-    [Documentation]    WORKAROUND: #1731 The tedge-mapper-c8y is restarted due to a supsected race condition between the mapper and tedge-agent which results in the software list message being lost
+    [Documentation]    WORKAROUND: #1731 The tedge-mapper-c8y is restarted due to a suspected race condition between the mapper and tedge-agent which results in the software list message being lost
     ${timestamp}=        Get Unix Timestamp
     Restart Service    tedge-mapper-c8y
     Should Have MQTT Messages    tedge/health/tedge-mapper-c8y    date_from=${timestamp}


### PR DESCRIPTION
Corrected spell check errors in the .robot files

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

