### PR TITLE
Added examples to keywords

### DIFF
--- a/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
+++ b/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
@@ -117,6 +117,9 @@ class ThinEdgeIO(DeviceLibrary):
 
         Args:
             name (str, optional): Device name to get logs for. Defaults to None.
+
+        *Example:*
+        | `Test Teardown` | | | | | Get Logs | | | | | name=${PARENT_SN} |
         """
         if not self.current:
             log.info("Device has not been setup, so no logs to collect")
@@ -263,6 +266,14 @@ class ThinEdgeIO(DeviceLibrary):
             name (str): Setting name to update
             value (str): Value to be updated with
 
+        *Example:*
+
+        Update known setting
+        | ${DEVICE_SN} | | | | | Setup |
+        | `Set Tedge Configuration Using CLI` | | | | | device.type | | | | | mycustomtype |
+        | ${OUTPUT}= | | | | | `Execute Command` | | | | | tedge config get device.type |
+        | `Should Match` | | | | | ${OUTPUT} | | | | | mycustomtype\\n |
+
         Returns:
             str: Command output
         """
@@ -305,6 +316,9 @@ class ThinEdgeIO(DeviceLibrary):
         Args:
             mapper (str, optional): Mapper name, e.g. c8y, az, etc. Defaults to "c8y".
             sleep (float, optional): Time to wait in seconds before connecting. Defaults to 0.0.
+
+        *Examples:*
+        | `Disconnect Then Connect Mapper` | | | | | c8y |
         """
         self.tedge_disconnect(mapper)
         if sleep > 0:
@@ -372,6 +386,11 @@ class ThinEdgeIO(DeviceLibrary):
     #
     @keyword("Service Health Status Should Be Up")
     def assert_service_health_status_up(self, service: str) -> Dict[str, Any]:
+        """ Checks if the Service Health Status is up
+
+        *Example:*
+        | `Service Health Status Should Be Up` | | | | | tedge-mapper-c8y |
+        """
         return self._assert_health_status(service, status="up")
 
     @keyword("Service Health Status Should Be Down")
@@ -468,9 +487,10 @@ class ThinEdgeIO(DeviceLibrary):
         """
         Check for the presence of a topic
 
-        Examples
+        *Examples:*
 
-        | ${messages}= | Should Have MQTT Message | c8y/s/# | -30s | 0s |
+        | ${listen}= | | | | | `Should Have MQTT Message` | | | | |  topic=tedge/${CHILD_SN}/commands/req/config_snapshot | | | | | date_from=-5s |
+        | ${messages}= | | | | | `Should Have MQTT Message` | | | | |  tedge/health/c8y-log-plugin | | | | | minimum=1 | | | | |minimum=2 |
         """
         result = self._assert_mqtt_topic_messages(
             topic,


### PR DESCRIPTION
Added examples to keywords which was used in tests so far

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

