### PR TITLE
Fixed most clippy lints and enabled clippy for all targets

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -241,7 +241,7 @@ jobs:
         with:
           toolchain: stable
           command: clippy
-          args: --all-features -- -Aclippy::result-large-err
+          args: --all-targets --all-features
 
   cargo-audit:
     name: Run cargo audit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af91f40b7355f82b0a891f50e70399475945bb0b0da4f1700ce60761c9d3e359"
+checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
 dependencies = [
  "csv-core",
  "itoa",

--- a/crates/common/tedge_utils/src/file.rs
+++ b/crates/common/tedge_utils/src/file.rs
@@ -510,8 +510,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("file");
         let user = whoami::username();
-        create_file_with_user_group(&file_path.display().to_string(), &user, &user, 0o775, None)
-            .unwrap();
+        create_file_with_user_group(&file_path, &user, &user, 0o775, None).unwrap();
 
         let new_content = "abc";
         overwrite_file(file_path.as_path(), new_content).unwrap();

--- a/crates/core/c8y_api/Cargo.toml
+++ b/crates/core/c8y_api/Cargo.toml
@@ -11,7 +11,7 @@ repository = { workspace = true }
 [dependencies]
 async-trait = "0.1"
 clock = { path = "../../common/clock" }
-csv = "1.1"
+csv = "1.2.1"
 download = { path = "../../common/download" }
 futures = "0.3"
 mockall = "0.11"

--- a/crates/core/c8y_api/src/json_c8y.rs
+++ b/crates/core/c8y_api/src/json_c8y.rs
@@ -160,7 +160,7 @@ impl TryFrom<ThinEdgeEvent> for C8yCreateEvent {
             }
         }
         if let Some(source) = event.source {
-            update_the_external_source_event(&mut extras, &source)?;
+            update_the_external_source_event(&mut extras, &source);
         }
 
         Ok(Self {
@@ -205,16 +205,12 @@ fn combine_version_and_type(
         },
     }
 }
-fn update_the_external_source_event(
-    extras: &mut HashMap<String, Value>,
-    source: &str,
-) -> Result<(), SMCumulocityMapperError> {
+
+fn update_the_external_source_event(extras: &mut HashMap<String, Value>, source: &str) {
     let mut value = serde_json::Map::new();
     value.insert("externalId".to_string(), source.into());
     value.insert("type".to_string(), "c8y_Serial".into());
     extras.insert("externalSource".into(), value.into());
-
-    Ok(())
 }
 
 fn make_c8y_source_fragment(source_name: &str) -> Option<SourceInfo> {

--- a/crates/core/c8y_api/src/smartrest/alarm.rs
+++ b/crates/core/c8y_api/src/smartrest/alarm.rs
@@ -1,11 +1,10 @@
-use crate::smartrest::error::SmartRestSerializerError;
 use tedge_api::alarm::AlarmSeverity;
 use tedge_api::alarm::ThinEdgeAlarm;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 /// Converts from thin-edge alarm to C8Y alarm SmartREST message
-pub fn serialize_alarm(alarm: ThinEdgeAlarm) -> Result<String, SmartRestSerializerError> {
+pub fn serialize_alarm(alarm: ThinEdgeAlarm) -> Result<String, time::error::Format> {
     match alarm.data {
         None => Ok(format!("306,{}", alarm.name)),
         Some(alarm_data) => {

--- a/crates/core/c8y_api/src/smartrest/error.rs
+++ b/crates/core/c8y_api/src/smartrest/error.rs
@@ -5,7 +5,6 @@ use tedge_api::SoftwareUpdateResponse;
 // allowing large size difference between variants warning,
 // because the enum `SmartRestSerializerError` is already Boxed
 // in `SMCumulocityMapperError`
-#[allow(clippy::large_enum_variant)]
 #[derive(thiserror::Error, Debug)]
 pub enum SmartRestSerializerError {
     #[error("The operation status is not supported. {response:?}")]
@@ -49,7 +48,6 @@ pub enum SmartRestDeserializerError {
     NoResponse,
 }
 
-#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum OperationsError {
     #[error("Failed to read directory: {dir}")]

--- a/crates/core/c8y_api/src/smartrest/error.rs
+++ b/crates/core/c8y_api/src/smartrest/error.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::path::PathBuf;
 use tedge_api::SoftwareUpdateResponse;
 
@@ -13,8 +14,8 @@ pub enum SmartRestSerializerError {
     #[error("Failed to serialize SmartREST.")]
     InvalidCsv(#[from] csv::Error),
 
-    #[error(transparent)]
-    FromCsvWriter(#[from] csv::IntoInnerError<csv::Writer<Vec<u8>>>),
+    #[error("IO error")]
+    IoError(#[from] io::Error),
 
     #[error(transparent)]
     FromUtf8Error(#[from] std::string::FromUtf8Error),
@@ -62,9 +63,6 @@ pub enum OperationsError {
 
     #[error("Error while parsing operation file: '{0}': {1}.")]
     TomlError(PathBuf, #[source] toml::de::Error),
-
-    #[error(transparent)]
-    FromSmartRestSerializerError(#[from] SmartRestSerializerError),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/core/c8y_api/src/smartrest/operations.rs
+++ b/crates/core/c8y_api/src/smartrest/operations.rs
@@ -9,6 +9,8 @@ use crate::smartrest::smartrest_serializer::SmartRestSerializer;
 use crate::smartrest::smartrest_serializer::SmartRestSetSupportedOperations;
 use serde::Deserialize;
 
+use super::error::SmartRestSerializerError;
+
 /// Operations are derived by reading files subdirectories per cloud /etc/tedge/operations directory
 /// Each operation is a file name in one of the subdirectories
 /// The file name is the operation name
@@ -126,11 +128,11 @@ impl Operations {
             .collect::<HashSet<String>>()
     }
 
-    pub fn create_smartrest_ops_message(&self) -> Result<String, OperationsError> {
+    pub fn create_smartrest_ops_message(&self) -> Result<String, SmartRestSerializerError> {
         let mut ops = self.get_operations_list();
         ops.sort();
         let ops = ops.iter().map(|op| op as &str).collect::<Vec<&str>>();
-        Ok(SmartRestSetSupportedOperations::new(&ops).to_smartrest()?)
+        SmartRestSetSupportedOperations::new(&ops).to_smartrest()
     }
 }
 

--- a/crates/core/plugin_sm/src/plugin.rs
+++ b/crates/core/plugin_sm/src/plugin.rs
@@ -334,7 +334,7 @@ impl Plugin for ExternalPluginCommand {
             Ok(())
         } else {
             Err(SoftwareError::Install {
-                module: module.clone(),
+                module: Box::new(module.clone()),
                 reason: self.content(output.stderr)?,
             })
         }
@@ -352,7 +352,7 @@ impl Plugin for ExternalPluginCommand {
             Ok(())
         } else {
             Err(SoftwareError::Remove {
-                module: module.clone(),
+                module: Box::new(module.clone()),
                 reason: self.content(output.stderr)?,
             })
         }

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -874,7 +874,7 @@ mod tests {
 
             let plugins = Arc::new(Mutex::new(
                 ExternalPlugins::open(
-                    &dir.utf8_path().join("sm-plugins"),
+                    dir.utf8_path().join("sm-plugins"),
                     get_default_plugin(&agent.config.config_location).unwrap(),
                     Some(SUDO.into()),
                 )
@@ -918,7 +918,7 @@ mod tests {
 
             let plugins = Arc::new(Mutex::new(
                 ExternalPlugins::open(
-                    &dir.utf8_path().join("sm-plugins"),
+                    dir.utf8_path().join("sm-plugins"),
                     get_default_plugin(&agent.config.config_location).unwrap(),
                     Some(SUDO.into()),
                 )

--- a/crates/core/tedge_api/src/error.rs
+++ b/crates/core/tedge_api/src/error.rs
@@ -26,7 +26,7 @@ pub enum SoftwareError {
 
     #[error("Failed to install {module:?}")]
     Install {
-        module: SoftwareModule,
+        module: Box<SoftwareModule>,
         reason: String,
     },
 
@@ -53,7 +53,7 @@ pub enum SoftwareError {
 
     #[error("Failed to uninstall {module:?}")]
     Remove {
-        module: SoftwareModule,
+        module: Box<SoftwareModule>,
         reason: String,
     },
 

--- a/crates/core/tedge_api/src/lib.rs
+++ b/crates/core/tedge_api/src/lib.rs
@@ -707,13 +707,13 @@ mod tests {
         response.add_errors(
             "debian",
             vec![SoftwareError::Install {
-                module: SoftwareModule {
+                module: Box::new(SoftwareModule {
                     module_type: Some("debian".to_string()),
                     name: "collectd".to_string(),
                     version: Some("5.7".to_string()),
                     url: None,
                     file_path: None,
-                },
+                }),
                 reason: "Network timeout".to_string(),
             }],
         );
@@ -721,13 +721,13 @@ mod tests {
         response.add_errors(
             "docker",
             vec![SoftwareError::Remove {
-                module: SoftwareModule {
+                module: Box::new(SoftwareModule {
                     module_type: Some("docker".to_string()),
                     name: "mongodb".to_string(),
                     version: Some("4.4.6".to_string()),
                     url: None,
                     file_path: None,
-                },
+                }),
                 reason: "Other components dependent on it".to_string(),
             }],
         );

--- a/crates/core/tedge_api/src/messages.rs
+++ b/crates/core/tedge_api/src/messages.rs
@@ -10,20 +10,20 @@ pub trait Jsonify<'a>
 where
     Self: Deserialize<'a> + Serialize + Sized,
 {
-    fn from_json(json_str: &'a str) -> Result<Self, SoftwareError> {
-        Ok(serde_json::from_str(json_str)?)
+    fn from_json(json_str: &'a str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json_str)
     }
 
-    fn from_slice(bytes: &'a [u8]) -> Result<Self, SoftwareError> {
-        Ok(serde_json::from_slice(bytes)?)
+    fn from_slice(bytes: &'a [u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(bytes)
     }
 
-    fn to_json(&self) -> Result<String, SoftwareError> {
-        Ok(serde_json::to_string(self)?)
+    fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
     }
 
-    fn to_bytes(&self) -> Result<Vec<u8>, SoftwareError> {
-        Ok(serde_json::to_vec(self)?)
+    fn to_bytes(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
     }
 }
 

--- a/crates/core/tedge_mapper/src/aws/converter.rs
+++ b/crates/core/tedge_mapper/src/aws/converter.rs
@@ -105,6 +105,7 @@ mod tests {
     use crate::core::converter::*;
     use crate::core::error::ConversionError;
     use crate::core::size_threshold::SizeThreshold;
+    use crate::core::size_threshold::SizeThresholdExceededError;
 
     use assert_json_diff::*;
     use assert_matches::*;
@@ -247,11 +248,12 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(ConversionError::SizeThresholdExceeded {
-                topic: _topic,
-                actual_size: _input_size,
-                threshold: 1
-            })
+            Err(ConversionError::SizeThresholdExceeded(
+                SizeThresholdExceededError {
+                    size: _input_size,
+                    threshold: 1
+                }
+            ))
         );
     }
 }

--- a/crates/core/tedge_mapper/src/az/converter.rs
+++ b/crates/core/tedge_mapper/src/az/converter.rs
@@ -71,6 +71,7 @@ mod tests {
     use crate::core::converter::*;
     use crate::core::error::ConversionError;
     use crate::core::size_threshold::SizeThreshold;
+    use crate::core::size_threshold::SizeThresholdExceededError;
 
     use assert_json_diff::*;
     use assert_matches::*;
@@ -214,11 +215,12 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(ConversionError::SizeThresholdExceeded {
-                topic: _topic,
-                actual_size: 3,
-                threshold: 1
-            })
+            Err(ConversionError::SizeThresholdExceeded(
+                SizeThresholdExceededError {
+                    size: 3,
+                    threshold: 1
+                }
+            ))
         );
     }
 }

--- a/crates/core/tedge_mapper/src/c8y/converter.rs
+++ b/crates/core/tedge_mapper/src/c8y/converter.rs
@@ -157,6 +157,7 @@ where
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[cfg(test)]
     pub fn from_logs_path(
         size_threshold: SizeThreshold,

--- a/crates/core/tedge_mapper/src/c8y/converter.rs
+++ b/crates/core/tedge_mapper/src/c8y/converter.rs
@@ -27,8 +27,11 @@ use logged_command::LoggedCommand;
 use mqtt_channel::Message;
 use mqtt_channel::Topic;
 use plugin_sm::operation_logs::OperationLogs;
+use plugin_sm::operation_logs::OperationLogsError;
 use service_monitor::convert_health_status_message;
 use std::collections::HashMap;
+use tedge_config::TEdgeConfigError;
+use thiserror::Error;
 
 use std::fs;
 use std::fs::File;
@@ -121,11 +124,13 @@ where
         children: HashMap<String, Operations>,
         mapper_config: MapperConfig,
         mqtt_publisher: mpsc::UnboundedSender<Message>,
-    ) -> Result<Self, CumulocityMapperError> {
+    ) -> Result<Self, CumulocityConverterBuildError> {
         let alarm_converter = AlarmConverter::new();
 
         let tedge_config = get_tedge_config()?;
-        let logs_path = tedge_config.query(LogPathSetting)?;
+
+        // this can't fail because in absence of value this query returns a default
+        let logs_path = tedge_config.query(LogPathSetting).unwrap();
 
         let log_dir = PathBuf::from(&format!("{}/{TEDGE_AGENT_LOG_DIR}", logs_path));
 
@@ -358,6 +363,15 @@ where
     fn can_send_over_mqtt(&self, message: &Message) -> bool {
         message.payload_bytes().len() < self.size_threshold.0
     }
+}
+
+#[derive(Error, Debug)]
+pub enum CumulocityConverterBuildError {
+    #[error(transparent)]
+    InvalidConfig(#[from] TEdgeConfigError),
+
+    #[error(transparent)]
+    OperationLogsError(#[from] OperationLogsError),
 }
 
 #[async_trait]

--- a/crates/core/tedge_mapper/src/c8y/dynamic_discovery.rs
+++ b/crates/core/tedge_mapper/src/c8y/dynamic_discovery.rs
@@ -20,7 +20,6 @@ pub struct DiscoverOp {
 }
 
 #[derive(thiserror::Error, Debug)]
-#[allow(clippy::enum_variant_names)]
 pub enum DynamicDiscoverOpsError {
     #[error("A non-UTF8 path cannot be parsed as an operation: {0:?}")]
     NotAnOperation(PathBuf),

--- a/crates/core/tedge_mapper/src/c8y/error.rs
+++ b/crates/core/tedge_mapper/src/c8y/error.rs
@@ -44,6 +44,9 @@ pub enum CumulocityMapperError {
     #[error(transparent)]
     FromIo(#[from] std::io::Error),
 
+    #[error(transparent)]
+    FromSerde(#[from] serde_json::Error),
+
     #[error("Operation execution failed: {error_message}. Command: {command}. Operation name: {operation_name}")]
     ExecuteFailed {
         error_message: String,

--- a/crates/core/tedge_mapper/src/c8y/error.rs
+++ b/crates/core/tedge_mapper/src/c8y/error.rs
@@ -5,7 +5,6 @@ use c8y_api::smartrest::error::SmartRestSerializerError;
 use plugin_sm::operation_logs::OperationLogsError;
 
 #[derive(thiserror::Error, Debug)]
-#[allow(clippy::large_enum_variant)]
 #[allow(clippy::enum_variant_names)]
 pub enum CumulocityMapperError {
     #[error(transparent)]

--- a/crates/core/tedge_mapper/src/c8y/service_monitor.rs
+++ b/crates/core/tedge_mapper/src/c8y/service_monitor.rs
@@ -206,10 +206,10 @@ mod tests {
         c8y_monitor_topic: &str,
         c8y_monitor_payload: &str,
     ) {
-        let topic = Topic::new_unchecked(&health_topic);
+        let topic = Topic::new_unchecked(health_topic);
         let health_message = Message::new(&topic, health_payload.as_bytes().to_owned());
         let expected_message = Message::new(
-            &Topic::new_unchecked(&c8y_monitor_topic),
+            &Topic::new_unchecked(c8y_monitor_topic),
             c8y_monitor_payload.as_bytes(),
         );
 

--- a/crates/core/tedge_mapper/src/c8y/tests.rs
+++ b/crates/core/tedge_mapper/src/c8y/tests.rs
@@ -2,6 +2,7 @@ use crate::core::converter::Converter;
 use crate::core::error::ConversionError;
 use crate::core::mapper::create_mapper;
 use crate::core::size_threshold::SizeThreshold;
+use crate::core::size_threshold::SizeThresholdExceededError;
 use anyhow::Result;
 use assert_json_diff::assert_json_include;
 use assert_matches::assert_matches;
@@ -1238,11 +1239,12 @@ async fn check_c8y_threshold_packet_size() -> Result<(), anyhow::Error> {
 
     assert_matches!(
         converter.try_convert(&alarm_message).await,
-        Err(ConversionError::SizeThresholdExceeded {
-            topic: _,
-            actual_size: _,
-            threshold: _
-        })
+        Err(ConversionError::SizeThresholdExceeded(
+            SizeThresholdExceededError {
+                size: _,
+                threshold: _
+            }
+        ))
     );
     Ok(())
 }

--- a/crates/core/tedge_mapper/src/core/error.rs
+++ b/crates/core/tedge_mapper/src/core/error.rs
@@ -63,12 +63,8 @@ pub enum ConversionError {
     #[error(transparent)]
     FromThinEdgeJsonParser(#[from] tedge_api::parser::ThinEdgeJsonParserError),
 
-    #[error("The size of the message received on {topic} is {actual_size} which is greater than the threshold size of {threshold}.")]
-    SizeThresholdExceeded {
-        topic: String,
-        actual_size: usize,
-        threshold: usize,
-    },
+    #[error(transparent)]
+    SizeThresholdExceeded(#[from] super::size_threshold::SizeThresholdExceededError),
 
     #[error(transparent)]
     FromMqttClient(#[from] MqttError),

--- a/crates/core/tedge_mapper/src/core/size_threshold.rs
+++ b/crates/core/tedge_mapper/src/core/size_threshold.rs
@@ -1,22 +1,24 @@
 use mqtt_channel::Message;
-
-use super::error::ConversionError;
+use thiserror::Error;
 
 #[derive(Debug)]
 pub struct SizeThreshold(pub usize);
 
 impl SizeThreshold {
-    pub fn validate(&self, input: &Message) -> Result<(), ConversionError> {
-        let actual_size = input.payload_bytes().len();
+    pub fn validate(&self, input: &Message) -> Result<(), SizeThresholdExceededError> {
+        let size = input.payload_bytes().len();
         let threshold = self.0;
-        if actual_size > threshold {
-            Err(ConversionError::SizeThresholdExceeded {
-                topic: input.topic.name.clone(),
-                actual_size,
-                threshold,
-            })
+        if size > threshold {
+            Err(SizeThresholdExceededError { size, threshold })
         } else {
             Ok(())
         }
     }
+}
+
+#[derive(Error, Debug)]
+#[error("The payload size of the message is {size}, which is greater than the threshold size of {threshold}.")]
+pub struct SizeThresholdExceededError {
+    pub size: usize,
+    pub threshold: usize,
 }

--- a/crates/extensions/c8y_config_manager/src/actor.rs
+++ b/crates/extensions/c8y_config_manager/src/actor.rs
@@ -10,6 +10,7 @@ use super::upload::ConfigUploadManager;
 use super::upload::UploadConfigFileStatusMessage;
 use super::ConfigManagerConfig;
 use super::DEFAULT_PLUGIN_CONFIG_FILE_NAME;
+use crate::child_device::InvalidChildDeviceTopicError;
 use async_trait::async_trait;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestConfigDownloadRequest;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestConfigUploadRequest;
@@ -422,7 +423,7 @@ pub enum ConfigOperation {
 }
 
 impl TryFrom<&MqttMessage> for ConfigOperation {
-    type Error = ConfigManagementError;
+    type Error = InvalidChildDeviceTopicError;
 
     fn try_from(message: &MqttMessage) -> Result<Self, Self::Error> {
         let operation_name = get_operation_name_from_child_topic(&message.topic.name)?;
@@ -432,7 +433,7 @@ impl TryFrom<&MqttMessage> for ConfigOperation {
         } else if operation_name == "config_update" {
             Ok(Self::Update)
         } else {
-            Err(ConfigManagementError::InvalidChildDeviceTopic {
+            Err(InvalidChildDeviceTopicError {
                 topic: message.topic.name.clone(),
             })
         }

--- a/crates/extensions/c8y_config_manager/src/error.rs
+++ b/crates/extensions/c8y_config_manager/src/error.rs
@@ -4,7 +4,6 @@ use tedge_mqtt_ext::Topic;
 use tedge_utils::file::FileError;
 use tedge_utils::paths::PathsError;
 
-#[allow(clippy::large_enum_variant)]
 #[derive(thiserror::Error, Debug)]
 pub enum ConfigManagementError {
     #[error(transparent)]

--- a/crates/extensions/c8y_config_manager/src/error.rs
+++ b/crates/extensions/c8y_config_manager/src/error.rs
@@ -7,13 +7,11 @@ use tedge_utils::paths::PathsError;
 #[allow(clippy::large_enum_variant)]
 #[derive(thiserror::Error, Debug)]
 pub enum ConfigManagementError {
-    #[error(
-        "The requested config_type {config_type} is not defined in the plugin configuration file."
-    )]
-    InvalidRequestedConfigType { config_type: String },
+    #[error(transparent)]
+    InvalidRequestedConfigType(#[from] super::plugin_config::InvalidConfigTypeError),
 
-    #[error("Message received on invalid topic from child device: {topic}")]
-    InvalidChildDeviceTopic { topic: String },
+    #[error(transparent)]
+    InvalidChildDeviceTopic(#[from] super::child_device::InvalidChildDeviceTopicError),
 
     #[error("Invalid operation response with empty status received on topic: {0:?}")]
     EmptyOperationStatus(Topic),

--- a/crates/extensions/c8y_config_manager/src/plugin_config.rs
+++ b/crates/extensions/c8y_config_manager/src/plugin_config.rs
@@ -1,4 +1,3 @@
-use super::error::ConfigManagementError;
 use super::DEFAULT_PLUGIN_CONFIG_TYPE;
 use c8y_api::smartrest::topic::C8yTopic;
 use log::error;
@@ -172,11 +171,11 @@ impl PluginConfig {
     pub fn get_file_entry_from_type(
         &self,
         config_type: &str,
-    ) -> Result<FileEntry, ConfigManagementError> {
+    ) -> Result<FileEntry, InvalidConfigTypeError> {
         let file_entry = self
             .files
             .get(&config_type.to_string())
-            .ok_or(ConfigManagementError::InvalidRequestedConfigType {
+            .ok_or(InvalidConfigTypeError {
                 config_type: config_type.to_owned(),
             })?
             .to_owned();
@@ -191,4 +190,10 @@ impl PluginConfig {
         let supported_config_types = config_types.join(",");
         format!("119,{supported_config_types}")
     }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("The requested config_type {config_type} is not defined in the plugin configuration file.")]
+pub struct InvalidConfigTypeError {
+    pub config_type: String,
 }

--- a/crates/extensions/c8y_log_manager/src/actor.rs
+++ b/crates/extensions/c8y_log_manager/src/actor.rs
@@ -504,6 +504,7 @@ mod tests {
 
     /// Create a log manager actor builder
     /// along two boxes to exchange MQTT and HTTP messages with the log actor
+    #[allow(clippy::type_complexity)]
     fn new_log_manager_builder(
         temp_dir: &Path,
         log_config: LogPluginConfig,

--- a/plugins/c8y_firmware_plugin/src/error.rs
+++ b/plugins/c8y_firmware_plugin/src/error.rs
@@ -1,4 +1,3 @@
-#[allow(clippy::large_enum_variant)]
 #[derive(thiserror::Error, Debug)]
 pub enum FirmwareManagementError {
     #[error("Invalid topic received from child device: {topic}")]

--- a/plugins/c8y_firmware_plugin/src/message.rs
+++ b/plugins/c8y_firmware_plugin/src/message.rs
@@ -154,7 +154,7 @@ mod tests {
             "attempt": 1
         });
         assert_json_eq!(
-            serde_json::from_str::<serde_json::Value>(&message.payload_str().unwrap()).unwrap(),
+            serde_json::from_str::<serde_json::Value>(message.payload_str().unwrap()).unwrap(),
             expected_json
         );
     }


### PR DESCRIPTION
## Proposed changes

This PR removes all `#[allow()]`s and fixes all occurences of `clippy::result_large_err` and `clippy::large_enum_variant` warnings and fixes some other remaining lints. Details in commit messages.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- https://github.com/thin-edge/thin-edge.io/issues/1767

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This PR fixes error-related lints and sets up clippy in a way that lints should not gather up unaddressed, but there is still room for improvement relating to the structure of the errors, where the large number of variants, wrapping all possible error sources, and naming the variants in terms of which dependency thrown the error instead of what actually went wrong, make it harder to understand the actual error conditions (more about it [here](https://mmapped.blog/posts/12-rust-error-handling.html)), but as it would be too much work to refactor all the error types and too much disruption of possibly breaking a lot of perfectly working code, these improvements will possibly be made in the future on a module-by-module basis.

In essence, old code can remain as it is, but from now on I'd advise we need to look out for and ensure quality error handling in new code and perhaps slowly improving old code that new code frequently needs to interface with.