### PR TITLE
Add a Config type parameter to MessageSink 

### DIFF
--- a/crates/core/tedge_actors/src/builders.rs
+++ b/crates/core/tedge_actors/src/builders.rs
@@ -68,31 +68,33 @@ pub trait Builder<T>: Sized {
 pub struct NoConfig;
 
 /// The builder of a MessageBox must implement this trait for every message type that can be sent to it
-pub trait MessageSink<M: Message> {
+pub trait MessageSink<M: Message, Config> {
+    /// Return the config used by this actor to connect the message source
+    fn get_config(&self) -> Config;
+
     /// Return the sender that can be used by peers to send messages to this actor
     fn get_sender(&self) -> DynSender<M>;
 
     /// Add a source of messages to the actor under construction
-    fn add_input<N, Config>(&mut self, source: &mut impl MessageSource<N, Config>, config: Config)
+    fn add_input<N>(&mut self, source: &mut impl MessageSource<N, Config>)
     where
         N: Message,
         M: From<N>,
     {
-        source.register_peer(config, crate::adapt(&self.get_sender()))
+        source.register_peer(self.get_config(), crate::adapt(&self.get_sender()))
     }
 
     /// Add a source of messages to the actor under construction,
     /// the messages being translated on the fly
-    fn add_mapped_input<N, Config, DynMessageMapper>(
+    fn add_mapped_input<N, DynMessageMapper>(
         &mut self,
         source: &mut impl MessageSource<N, Config>,
-        config: Config,
         cast: DynMessageMapper,
     ) where
         N: Message,
         DynMessageMapper: Fn(DynSender<M>) -> DynSender<N>,
     {
-        source.register_peer(config, cast(self.get_sender()))
+        source.register_peer(self.get_config(), cast(self.get_sender()))
     }
 }
 
@@ -100,6 +102,11 @@ pub trait MessageSink<M: Message> {
 pub trait MessageSource<M: Message, Config> {
     /// The message will be sent to the peer using the provided `sender`
     fn register_peer(&mut self, config: Config, sender: DynSender<M>);
+
+    /// Connect a peer actor that will consume the message produced by this actor
+    fn add_sink(&mut self, peer: &mut impl MessageSink<M, Config>) {
+        self.register_peer(peer.get_config(), peer.get_sender());
+    }
 }
 
 /// The builder of a MessageBox must implement this trait to receive requests from the runtime
@@ -211,7 +218,11 @@ impl<I: Message, O: Message, C> MessageSource<O, C> for SimpleMessageBoxBuilder<
     }
 }
 
-impl<I: Message, O: Message> MessageSink<I> for SimpleMessageBoxBuilder<I, O> {
+impl<I: Message, O: Message> MessageSink<I, NoConfig> for SimpleMessageBoxBuilder<I, O> {
+    fn get_config(&self) -> NoConfig {
+        NoConfig
+    }
+
     fn get_sender(&self) -> DynSender<I> {
         self.input_sender.sender_clone()
     }

--- a/crates/core/tedge_actors/src/builders.rs
+++ b/crates/core/tedge_actors/src/builders.rs
@@ -37,6 +37,7 @@ use crate::DynSender;
 use crate::KeyedSender;
 use crate::LoggingReceiver;
 use crate::LoggingSender;
+use crate::MappingSender;
 use crate::Message;
 use crate::NullSender;
 use crate::RuntimeError;
@@ -84,17 +85,60 @@ pub trait MessageSink<M: Message, Config> {
         source.register_peer(self.get_config(), crate::adapt(&self.get_sender()))
     }
 
-    /// Add a source of messages to the actor under construction,
-    /// the messages being translated on the fly
-    fn add_mapped_input<N, DynMessageMapper>(
+    /// Add a source of messages to the actor under construction, the messages being translated on the fly.
+    ///
+    /// The transformation function will be applied to the messages sent by the source,
+    /// to convert them in a sequence, possibly empty, of messages forwarded to this sink.
+    ///
+    /// ```
+    /// # use std::time::Duration;
+    /// # use tedge_actors::Builder;
+    /// # use tedge_actors::ChannelError;
+    /// # use tedge_actors::MessageReceiver;
+    /// # use tedge_actors::MessageSink;
+    /// # use tedge_actors::NoMessage;
+    /// # use tedge_actors::Sender;
+    /// # use tedge_actors::SimpleMessageBox;
+    /// # use tedge_actors::SimpleMessageBoxBuilder;
+    /// # use tedge_actors::test_helpers::MessageReceiverExt;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(),ChannelError> {
+    /// let mut receiver_builder = SimpleMessageBoxBuilder::new("Recv", 16);
+    /// let mut sender_builder = SimpleMessageBoxBuilder::new("Send", 16);
+    ///
+    /// // Convert the `&str` sent by the source into an iterator of `char` as expected by the receiver.
+    /// receiver_builder.add_mapped_input(&mut sender_builder, |str: &'static str| str.chars() );
+    ///
+    /// let mut sender: SimpleMessageBox<NoMessage, &'static str>= sender_builder.build();
+    /// let receiver: SimpleMessageBox<char, NoMessage> = receiver_builder.build();
+    ///
+    /// sender.send("Hello!").await?;
+    ///
+    /// let mut receiver = receiver.with_timeout(Duration::from_millis(100));
+    /// assert_eq!(receiver.recv().await, Some('H'));
+    /// assert_eq!(receiver.recv().await, Some('e'));
+    /// assert_eq!(receiver.recv().await, Some('l'));
+    /// assert_eq!(receiver.recv().await, Some('l'));
+    /// assert_eq!(receiver.recv().await, Some('o'));
+    /// assert_eq!(receiver.recv().await, Some('!'));
+    /// assert_eq!(receiver.recv().await, None);
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn add_mapped_input<N, MS, MessageMapper>(
         &mut self,
         source: &mut impl MessageSource<N, Config>,
-        cast: DynMessageMapper,
+        cast: MessageMapper,
     ) where
         N: Message,
-        DynMessageMapper: Fn(DynSender<M>) -> DynSender<N>,
+        MS: Iterator<Item = M> + Send,
+        MessageMapper: Fn(N) -> MS,
+        MessageMapper: 'static + Send + Sync,
     {
-        source.register_peer(self.get_config(), cast(self.get_sender()))
+        let sender = MappingSender::new(self.get_sender(), cast);
+        source.register_peer(self.get_config(), sender.into())
     }
 }
 

--- a/crates/core/tedge_actors/src/messages.rs
+++ b/crates/core/tedge_actors/src/messages.rs
@@ -1,15 +1,11 @@
 use std::fmt::Debug;
 
-use crate::fan_in_message_type;
-use crate::RuntimeRequest;
-
 /// A message exchanged between two actors
 pub trait Message: Debug + Send + Sync + 'static {}
 
 /// There is no need to tag messages as such
 impl<T: Debug + Send + Sync + 'static> Message for T {}
 
-// TODO: maybe don't need this, if you don't any other message types just accept RuntimeRequests?
-// FIXME: fix the rustdoc on macro
-// Message type used by actor with no inputs or no outputs
-fan_in_message_type!(NoMessage[RuntimeRequest]: Debug);
+/// A type to tell no message is received or sent
+#[derive(Debug)]
+pub enum NoMessage {}

--- a/crates/core/tedge_actors/src/runtime.rs
+++ b/crates/core/tedge_actors/src/runtime.rs
@@ -5,6 +5,7 @@ use crate::Builder;
 use crate::ChannelError;
 use crate::DynSender;
 use crate::MessageSink;
+use crate::NoConfig;
 use crate::RuntimeError;
 use crate::RuntimeRequestSink;
 use futures::channel::mpsc;
@@ -130,7 +131,11 @@ impl RuntimeHandle {
     }
 }
 
-impl MessageSink<RuntimeAction> for RuntimeHandle {
+impl MessageSink<RuntimeAction, NoConfig> for RuntimeHandle {
+    fn get_config(&self) -> NoConfig {
+        NoConfig
+    }
+
     fn get_sender(&self) -> DynSender<RuntimeAction> {
         self.actions_sender.clone().into()
     }

--- a/crates/core/tedge_actors/src/test_helpers.rs
+++ b/crates/core/tedge_actors/src/test_helpers.rs
@@ -630,7 +630,11 @@ impl<I: MessagePlus, O: MessagePlus> MessageSource<O, NoConfig> for Probe<I, O> 
     }
 }
 
-impl<I: MessagePlus, O: MessagePlus> MessageSink<I> for Probe<I, O> {
+impl<I: MessagePlus, O: MessagePlus> MessageSink<I, NoConfig> for Probe<I, O> {
+    fn get_config(&self) -> NoConfig {
+        NoConfig
+    }
+
     fn get_sender(&self) -> DynSender<I> {
         self.input_interceptor.clone().into()
     }

--- a/crates/extensions/c8y_config_manager/src/lib.rs
+++ b/crates/extensions/c8y_config_manager/src/lib.rs
@@ -148,13 +148,7 @@ impl ConfigManagerBuilder {
     where
         T: MessageSource<FsWatchEvent, PathBuf>,
     {
-        let watch_dir = self
-            .config
-            .config_dir
-            .clone()
-            .join(DEFAULT_OPERATION_DIR_NAME);
-        fs_builder.register_peer(watch_dir, self.events_sender.clone().into());
-
+        fs_builder.add_sink(self);
         Ok(())
     }
 
@@ -167,7 +161,14 @@ impl ConfigManagerBuilder {
     }
 }
 
-impl MessageSink<FsWatchEvent> for ConfigManagerBuilder {
+impl MessageSink<FsWatchEvent, PathBuf> for ConfigManagerBuilder {
+    fn get_config(&self) -> PathBuf {
+        self.config
+            .config_dir
+            .clone()
+            .join(DEFAULT_OPERATION_DIR_NAME)
+    }
+
     fn get_sender(&self) -> DynSender<FsWatchEvent> {
         self.events_sender.clone().into()
     }

--- a/crates/extensions/c8y_log_manager/src/lib.rs
+++ b/crates/extensions/c8y_log_manager/src/lib.rs
@@ -69,12 +69,7 @@ impl LogManagerBuilder {
         &mut self,
         fs_builder: &mut impl MessageSource<FsWatchEvent, PathBuf>,
     ) -> Result<(), LinkError> {
-        let config_dir = self.config.config_dir.clone();
-        fs_builder.register_peer(
-            config_dir,
-            tedge_actors::adapt(&self.box_builder.get_sender()),
-        );
-
+        fs_builder.add_sink(self);
         Ok(())
     }
 
@@ -105,7 +100,11 @@ impl ServiceConsumer<MqttMessage, MqttMessage, TopicFilter> for LogManagerBuilde
     }
 }
 
-impl MessageSink<FsWatchEvent> for LogManagerBuilder {
+impl MessageSink<FsWatchEvent, PathBuf> for LogManagerBuilder {
+    fn get_config(&self) -> PathBuf {
+        self.config.config_dir.clone()
+    }
+
     fn get_sender(&self) -> DynSender<FsWatchEvent> {
         tedge_actors::adapt(&self.box_builder.get_sender())
     }

--- a/crates/extensions/tedge_mqtt_ext/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/lib.rs
@@ -15,6 +15,7 @@ use tedge_actors::LoggingSender;
 use tedge_actors::MessageReceiver;
 use tedge_actors::MessageSink;
 use tedge_actors::MessageSource;
+use tedge_actors::NoConfig;
 use tedge_actors::RuntimeError;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
@@ -80,7 +81,11 @@ impl MessageSource<MqttMessage, TopicFilter> for MqttActorBuilder {
     }
 }
 
-impl MessageSink<MqttMessage> for MqttActorBuilder {
+impl MessageSink<MqttMessage, NoConfig> for MqttActorBuilder {
+    fn get_config(&self) -> NoConfig {
+        NoConfig
+    }
+
     fn get_sender(&self) -> DynSender<MqttMessage> {
         self.publish_sender.clone().into()
     }


### PR DESCRIPTION
## Proposed changes

 Add a Config type parameter to MessageSink, so a message sink can provides its config to connect the source.

Now a source and sink can be connected with `source.add_sink()` without any knowledge of the config nor the internal sender used by the sink (as it was the case with `sink.register_peer(config,&mut sender).

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

