### PR TITLE
Downloader to download directly to target location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,6 +1102,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tedge_utils",
  "tempfile",
  "test-case",
  "thiserror",

--- a/crates/common/download/Cargo.toml
+++ b/crates/common/download/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.11", default-features = false, features = [
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tedge_utils = { path = "../tedge_utils" }
 thiserror = "1.0"
 tokio = { version = "1.23", features = ["fs"] }
 url = "2.2"

--- a/crates/common/download/src/error.rs
+++ b/crates/common/download/src/error.rs
@@ -20,6 +20,9 @@ pub enum DownloadError {
     #[error(transparent)]
     FromNix(#[from] nix::Error),
 
+    #[error(transparent)]
+    FromFileError(#[from] tedge_utils::file::FileError),
+
     #[error("Not enough disk space")]
     InsufficientSpace,
 

--- a/crates/common/tedge_utils/src/file.rs
+++ b/crates/common/tedge_utils/src/file.rs
@@ -39,8 +39,14 @@ pub enum FileError {
     #[error("Could not save the file {file:?} to disk. Received error: {from:?}.")]
     FailedToSync { file: PathBuf, from: std::io::Error },
 
-    #[error("No parent dir for {:?}", path)]
-    NoParentDir { path: PathBuf },
+    #[error("The path {0} does not have a parent directory")]
+    NoParentDir(PathBuf),
+
+    #[error("The path {0} does not have a file name")]
+    NoFileName(PathBuf),
+
+    #[error("The path {0} contains non UTF-8 characters in the file name")]
+    InvalidFileName(PathBuf),
 
     #[error(transparent)]
     FromIoError(#[from] std::io::Error),
@@ -96,9 +102,7 @@ pub async fn move_file(
             tokio::fs::create_dir_all(dir_to).await?;
             debug!("Created parent directories for {:?}", dest_path);
         } else {
-            return Err(FileError::NoParentDir {
-                path: dest_path.to_path_buf(),
-            });
+            return Err(FileError::NoParentDir(dest_path.to_path_buf()));
         }
     }
 

--- a/crates/core/c8y_api/src/http_proxy.rs
+++ b/crates/core/c8y_api/src/http_proxy.rs
@@ -29,6 +29,7 @@ use tedge_config::DeviceIdSetting;
 use tedge_config::MqttClientHostSetting;
 use tedge_config::MqttClientPortSetting;
 use tedge_config::TEdgeConfig;
+use tedge_utils::file::PermissionEntry;
 use time::OffsetDateTime;
 
 use download::Auth;
@@ -516,7 +517,7 @@ impl C8YHttpProxy for JwtAuthHttpProxy {
 
         // Download a file to tmp dir
         let target_path = tmp_dir.join(file_name);
-        let downloader = Downloader::new(target_path.as_path());
+        let downloader = Downloader::new(target_path.as_path(), PermissionEntry::default());
         downloader.download(&download_info).await?;
 
         Ok(downloader.filename().to_path_buf())

--- a/crates/extensions/c8y_http_proxy/src/messages.rs
+++ b/crates/extensions/c8y_http_proxy/src/messages.rs
@@ -30,15 +30,6 @@ pub enum C8YRestError {
     #[error("Failed with {0}")]
     CustomError(String),
 
-    #[error("The provided path {0} does not have a file name")]
-    NoFileNameError(PathBuf),
-
-    #[error("The provided path {0} contains non UTF-8 characters in the file name")]
-    InvalidFileNameError(PathBuf),
-
-    #[error("The provided path {0} does not have a parent directory")]
-    NoParentDirError(PathBuf),
-
     #[error(transparent)]
     FromDownloadError(#[from] download::DownloadError),
 


### PR DESCRIPTION
## Proposed changes

Downloader to download directly to target location instead of first downloading to temp location and then moving it. This eliminated the need to move the downloaded file between file systems.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

