### PR TITLE
docs: use inline code blocks to avoid warnings

### DIFF
--- a/docs/src/tutorials/write-my-software-management-plugin.md
+++ b/docs/src/tutorials/write-my-software-management-plugin.md
@@ -67,12 +67,12 @@ Here is the table of the commands that you can use in a plugin.
 |list| - | lines with tab separated values |Returns the list of software modules that have been installed with this plugin.|
 |prepare| - | - |Executes the provided actions before a sequence of install and remove commands.|
 |finalize| - | - |Executes the provided actions after a sequence of install and remove commands.|
-|install| NAME [--module-version VERSION] [--file FILE] | - |Executes the action of installation.|
-|remove| NAME [--module-version VERSION] | - |Executes the action of uninstallation.|
-|update-list| COMMAND NAME [--module-version VERSION] [--file FILE] | - |Executes the list of `install` and `remove` commands.|
+|install| `NAME [--module-version VERSION] [--file FILE]` | - |Executes the action of installation.|
+|remove| `NAME [--module-version VERSION]` | - |Executes the action of uninstallation.|
+|update-list| `COMMAND NAME [--module-version VERSION] [--file FILE]` | - |Executes the list of `install` and `remove` commands.|
 
 The order of the commands invoked by the Software Management Agent is:
-`prepare` -> `update-list` or [`install`, `remove`] ->`finalize`
+`prepare` -> `update-list` or (`install`, `remove`) ->`finalize`
 
 > **info**: There is no guarantee of the order between `install` and `remove`.
 > If you need a specific order, use `update-list` command instead.


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->
Documentation styling improvements to avoid the false positive "potential incomplete link" warnings.

For example, previously the docs were generating the following warnings (which are now removed):

```sh
warning: Potential incomplete link
   ┌─ tutorials/write-my-software-management-plugin.md:72:28
   │
72 │ |update-list| COMMAND NAME [--module-version VERSION] [--file FILE] | - |Executes the list of `install` and `remove` commands.|
   │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ Did you forget to define a URL for `--module-version VERSION`?
   │
   = hint: declare the link's URL. For example: `[--module-version VERSION]: http://example.com/`
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

