### PR TITLE
Add steps to check PID in lock file

### DIFF
--- a/tests/RobotFramework/tests/configuration/lock_file.robot
+++ b/tests/RobotFramework/tests/configuration/lock_file.robot
@@ -16,6 +16,27 @@ Check lock file existence in default folder
     File Should Exist    /run/lock/tedge-agent.lock
     File Should Exist    /run/lock/tedge-mapper-c8y.lock
 
+Check PID number in lock file
+    [Documentation]    Include the pid inside the existing lock files under /run/lock/
+    ${pid_agent1}=    Execute Command    pgrep -f 'tedge-agent'    strip=True
+    ${pid_mapper1}=    Execute Command    pgrep -f 'tedge-mapper c8y'    strip=True
+    ${pid_agent_lock1}=    Execute Command    cat /run/lock/tedge-agent.lock
+    ${pid_mapper_lock1}=    Execute Command    cat /run/lock/tedge-mapper-c8y.lock
+    Should Be Equal    ${pid_agent1}    ${pid_agent_lock1}
+    Should Be Equal    ${pid_mapper1}    ${pid_mapper_lock1}
+
+Check PID number in lock file after restarting the services
+    [Documentation]    Include the new pid generated after service restart 
+    ...  inside the existing lock files under /run/lock/
+    Restart Service    tedge-agent
+    Restart Service    tedge-mapper-c8y
+    ${pid_agent2}=    Execute Command    pgrep -f 'tedge-agent'    strip=True
+    ${pid_mapper2}=    Execute Command    pgrep -f 'tedge-mapper c8y'    strip=True
+    ${pid_agent_lock2}=    Execute Command    cat /run/lock/tedge-agent.lock
+    ${pid_mapper_lock2}=    Execute Command    cat /run/lock/tedge-mapper-c8y.lock
+    Should Be Equal    ${pid_agent2}    ${pid_agent_lock2}
+    Should Be Equal    ${pid_mapper2}    ${pid_mapper_lock2}
+
 Check starting same service twice
     [Documentation]    This step is checking if same service can be started twice, 
     ...    expected is that this should not be the case


### PR DESCRIPTION
1. Adding Step to check the PID number stored in the lock file is the actual PID number of the running service
2. Checking if after restarting the services the new PID number is stored in the lock files

# Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

