### PR TITLE
mosquitto.conf: put `per_listener_settings` first

### DIFF
--- a/configuration/debian/tedge/postinst
+++ b/configuration/debian/tedge/postinst
@@ -3,7 +3,18 @@ set -e
 
 ### Add include to mosquitto.conf so tedge specific conf will be loaded
 if ! grep -q "/etc/tedge/mosquitto-conf" "/etc/mosquitto/mosquitto.conf"; then
-    echo "include_dir /etc/tedge/mosquitto-conf" >>/etc/mosquitto/mosquitto.conf
+    # Append `include_dir /etc/tedge/mosquitto-conf` before `include_dir
+    # /etc/mosquitto/conf.d` so that conf files in conf.d inherit
+    # `per_listener_settings` defined in /etc/tedge/mosquitto-conf.
+    # `per_listener_settings` has to be defined once, before other listener
+    # settings or else it causes the following error:
+    #
+    # Error: per_listener_settings must be set before any other security
+    # settings.
+    mosquitto_conf=$(awk '/include_dir \/etc\/mosquitto\/conf.d/ \
+    { print "include_dir /etc/tedge/mosquitto-conf"; }1' \
+    /etc/mosquitto/mosquitto.conf)
+    echo "$mosquitto_conf" > /etc/mosquitto/mosquitto.conf
 fi
 
 # Initialize the tedge


### PR DESCRIPTION
## Proposed changes

Use awk to put `include_dir /etc/tedge/mosquitto-conf` before `include_dir /etc/mosquitto/conf.d` so that `per_listener_settings` that appears in `tedge-mosquitto.conf` appears first.

Fixes #1852.

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #1852

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This is a quick workaround, perhaps `per_listener_settings true` line should be included in the top level `mosquitto.conf` file?
