### PR TITLE
Fix typo in mqtt.client.auth.key set error message

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -520,14 +520,14 @@ impl ConfigSettingAccessor<MqttClientAuthKeySetting> for TEdgeConfig {
             .client_auth
             .as_ref()
             .ok_or(ConfigSettingError::ConfigNotSet {
-                key: "mqtt.client.auth.certkey",
+                key: "mqtt.client.auth.keyfile",
             })?
             .key_file
             .clone()
             // TODO (Marcel): remove unnecessary Options once tedge_config is
             // refactored
             .ok_or(ConfigSettingError::ConfigNotSet {
-                key: "mqtt.client.auth.certkey",
+                key: "mqtt.client.auth.keyfile",
             })
     }
 

--- a/docs/src/howto-guides/029_mqtt_local_broker_authentication.md
+++ b/docs/src/howto-guides/029_mqtt_local_broker_authentication.md
@@ -90,11 +90,11 @@ keyfile  PATH_TO_CLIENT_CA_CERTIFICATE
 ### Step 2: Configure thin-edge.io to use a client certificate and private key
 
 ```sh
-tedge config set mqtt.client.auth.cert_file PATH_TO_CLIENT_CERTIFICATE
-tedge config set mqtt.client.auth.key_file PATH_TO_CLIENT_PRIVATE_KEY
+tedge config set mqtt.client.auth.certfile PATH_TO_CLIENT_CERTIFICATE
+tedge config set mqtt.client.auth.keyfile PATH_TO_CLIENT_PRIVATE_KEY
 ```
 
-Both `cert_file` and `key_file` are required to enable client authentication.
+Both `certfile` and `keyfile` are required to enable client authentication.
 Setting only one of them will result in an error about the second one not being
 set.
 


### PR DESCRIPTION
## Proposed changes

There was a typo in `tedge config set mqtt.client.auth.key` which sneaked past the MQTT client authentication review.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This highlights one more place where `tedge_config` could use some deduplication. 