### PR TITLE
extend error message for chown function

### DIFF
--- a/crates/common/tedge_utils/src/file.rs
+++ b/crates/common/tedge_utils/src/file.rs
@@ -291,7 +291,12 @@ pub fn change_user_and_group(file: &Path, user: &str, group: &str) -> Result<(),
 
     // if user and group are same as existing, then do not change
     if (ud != uid) && (gd != gid) {
-        chown(file, Some(Uid::from_raw(ud)), Some(Gid::from_raw(gd)))?;
+        chown(file, Some(Uid::from_raw(ud)), Some(Gid::from_raw(gd))).map_err(|e| {
+            FileError::MetaDataError {
+                name: file.display().to_string(),
+                from: e.into(),
+            }
+        })?;
     }
 
     Ok(())
@@ -306,7 +311,10 @@ fn change_user(file: &Path, user: &str) -> Result<(), FileError> {
 
     // if user is same as existing, then do not change
     if ud != uid {
-        chown(file, Some(Uid::from_raw(ud)), None)?;
+        chown(file, Some(Uid::from_raw(ud)), None).map_err(|e| FileError::MetaDataError {
+            name: file.display().to_string(),
+            from: e.into(),
+        })?;
     }
 
     Ok(())
@@ -323,7 +331,10 @@ fn change_group(file: &Path, group: &str) -> Result<(), FileError> {
 
     // if group is same as existing, then do not change
     if gd != gid {
-        chown(file, None, Some(Gid::from_raw(gd)))?;
+        chown(file, None, Some(Gid::from_raw(gd))).map_err(|e| FileError::MetaDataError {
+            name: file.display().to_string(),
+            from: e.into(),
+        })?;
     }
 
     Ok(())

--- a/crates/core/tedge/src/main.rs
+++ b/crates/core/tedge/src/main.rs
@@ -25,7 +25,8 @@ fn main() -> anyhow::Result<()> {
     set_log_level(tracing::Level::WARN);
 
     if opt.init {
-        initialize_tedge(&opt.config_dir)?;
+        initialize_tedge(&opt.config_dir)
+            .with_context(|| "Failed to initialize tedge. You have to run tedge with sudo.")?;
         return Ok(());
     }
 

--- a/plugins/c8y_configuration_plugin/src/main.rs
+++ b/plugins/c8y_configuration_plugin/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use c8y_config_manager::ConfigManagerBuilder;
 use c8y_config_manager::ConfigManagerConfig;
 use c8y_http_proxy::credentials::C8YJwtRetriever;
@@ -73,7 +74,12 @@ async fn main() -> Result<(), anyhow::Error> {
     let tedge_config = config_repository.load()?;
 
     if config_plugin_opt.init {
-        init(config_plugin_opt.config_dir)
+        init(config_plugin_opt.config_dir).with_context(|| {
+            format!(
+                "Failed to initialize {}. You have to run the command with sudo.",
+                PLUGIN_NAME
+            )
+        })
     } else {
         run(tedge_config).await
     }

--- a/plugins/c8y_firmware_plugin/src/main.rs
+++ b/plugins/c8y_firmware_plugin/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use c8y_firmware_manager::create_directories;
 use c8y_firmware_manager::FirmwareManagerBuilder;
 use c8y_firmware_manager::FirmwareManagerConfig;
@@ -72,7 +73,12 @@ async fn main() -> Result<(), anyhow::Error> {
     let tedge_config = config_repository.load()?;
 
     if firmware_plugin_opt.init {
-        init(&tedge_config)
+        init(&tedge_config).with_context(|| {
+            format!(
+                "Failed to initialize {}. You have to run the command with sudo.",
+                PLUGIN_NAME
+            )
+        })
     } else {
         run(tedge_config).await
     }

--- a/plugins/c8y_log_plugin/src/main.rs
+++ b/plugins/c8y_log_plugin/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use anyhow::Result;
 use c8y_http_proxy::credentials::C8YJwtRetriever;
 use c8y_http_proxy::C8YHttpProxyBuilder;
@@ -85,7 +86,12 @@ async fn main() -> Result<(), anyhow::Error> {
 
     if config_plugin_opt.init {
         let logs_dir = tedge_config.query(LogPathSetting)?;
-        init(&config_plugin_opt.config_dir, logs_dir.as_std_path())
+        init(&config_plugin_opt.config_dir, logs_dir.as_std_path()).with_context(|| {
+            format!(
+                "Failed to initialize {}. You have to run the command with sudo.",
+                C8Y_LOG_PLUGIN
+            )
+        })
     } else {
         run(tedge_config).await
     }

--- a/plugins/c8y_remote_access_plugin/src/main.rs
+++ b/plugins/c8y_remote_access_plugin/src/main.rs
@@ -38,7 +38,10 @@ async fn main() -> miette::Result<()> {
     let command = input::parse_arguments()?;
 
     match command {
-        Command::Init => declare_supported_operation(config_dir.tedge_config_root_path()),
+        Command::Init => declare_supported_operation(config_dir.tedge_config_root_path())
+            .with_context(|| {
+                "Failed to initialize c8y-remote-access-plugin. You have to run the command with sudo."
+            }),
         Command::Cleanup => {
             remove_supported_operation(config_dir.tedge_config_root_path());
             Ok(())


### PR DESCRIPTION
## Proposed changes
Small improvement to the error messages created by tedge init commands that was mentioned in #1795. Issue only happened when we wanted to change the owner/group of the file. The problem was with chown that handled errors by itself but did not provide any information about directory, file etc. 
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#1795
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

