### PR TITLE
fix: tedge-agent init on non-systemd installs

### DIFF
--- a/configuration/debian/tedge-agent/postinst
+++ b/configuration/debian/tedge-agent/postinst
@@ -7,23 +7,35 @@ if [ ! -e /usr/bin/tedge_agent ]; then
     ln -s /usr/bin/tedge-agent /usr/bin/tedge_agent
 fi
 
+# Use service manager agnostic tools (e.g. ps or pgrep) to determine if a process is running or not
+process_running() {
+    name="$1"
+    if command -v ps >/dev/null 2>&1; then
+        if ps -C "$name" >/dev/null; then
+            return 0
+        fi
+    elif command -v pgrep >/dev/null 2>&1; then
+        if pgrep -x "$name" >/dev/null; then
+            return 0
+        fi
+    fi
+    # Assume process is not running
+    return 1
+}
+
 # Initialize the agent __only__ if not when agent is running.
 # Indeed, during an OTA self-update, the previous version of the  `agent` is kept running
 # to monitor the installation of the new version up to completion.
-if command -v systemctl >/dev/null; then
-    if ! systemctl is-active --quiet tedge-agent ; then
-         # Flock file should be removed as `tedge-agent --init` must run as root
-         # although the flockfile is owned by `tedge`.
-         if [ -f "/run/lock/tedge_agent.lock" ]; then
-                rm /run/lock/tedge_agent.lock
-         fi
+# Note: Check for both tedge-agent and tedge_agent for backwards compatibility
+if ! (process_running tedge-agent || process_running tedge_agent); then
+    # Flock file should be removed as `tedge-agent --init` must run as root
+    # although the flockfile is owned by `tedge`. rm will ignore the files if they don't exist
+    rm -f /run/lock/tedge_agent.lock
+    rm -f /run/lock/tedge-agent.lock
 
-         if [ -f "/run/lock/tedge-agent.lock" ]; then
-                rm /run/lock/tedge-agent.lock
-         fi
-         # It must be run as root to create the directory `/var/tedge`.
-         tedge-agent --init
-    fi
+    # It must be run as root to create the directory `/var/tedge`.
+    # Ignore any errors during init so the installatino does not fail
+    tedge-agent --init ||:
 fi
 
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

The tedge-agent init. logic should still run when being installed on other linux OSs without systemd.

Previously the installation of c8y-firmware-plugin was failing because the tedge-agent was not running `tedge-agent --init` (and therefore not creating the /var/tedge folder) if systemd was not installed. This is common in container environments.

Summary of changes:

* Check if process is running rather than a service (to be service manager agnostic)
* Ignore any --init errors so install does not fail
* Simplify lock file logic by using `rm -f` which ignores files if they don't exist

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

