### PR TITLE
fix(test): increase operation assertion timeouts

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation.robot
@@ -11,12 +11,12 @@ Test Teardown    Get Logs
 
 Successful firmware operation
     ${operation}=    Cumulocity.Install Firmware    ubuntu    1.0.2    https://dummy.url/firmware.zip
-    ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=120
     Device Should Have Firmware    ubuntu    1.0.2    https://dummy.url/firmware.zip
 
 Install with empty firmware name
     ${operation}=    Cumulocity.Install Firmware    ${EMPTY}    1.0.2    https://dummy.url/firmware.zip
-    Operation Should Be FAILED    ${operation}    failure_reason=.*Invalid firmware name. Firmware name cannot be empty
+    Operation Should Be FAILED    ${operation}    failure_reason=.*Invalid firmware name. Firmware name cannot be empty    timeout=120
 
 
 *** Keywords ***


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Allow enough time to retry fetching the jwt token if it fails the first time.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

Found during a PR check failure on:
* https://github.com/thin-edge/thin-edge.io/actions/runs/4873733875/attempts/1
