### PR TITLE
rework the variable containers

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/monitoring/monitor_device_collectd.robot
+++ b/tests/RobotFramework/tests/cumulocity/monitoring/monitor_device_collectd.robot
@@ -40,10 +40,10 @@ Check thin-edge monitoring
     Execute Command    sudo systemctl start tedge-mapper-collectd
     # Check thin-edge monitoring
     ${tedge_messages}=    Should Have MQTT Messages    topic=tedge/measurements    minimum=1    maximum=None
-    Should Contain    @{tedge_messages}   "time"
+    Should Contain    ${tedge_messages[0]}   "time"
     Should Contain Any    @{tedge_messages}    "memory"    "cpu"    "df-root"
     ${c8y_messages}=    Should Have MQTT Messages    topic=c8y/measurement/measurements/create    minimum=1    maximum=None
-    Should Contain    @{c8y_messages}    "type":"ThinEdgeMeasurement"
+    Should Contain    ${c8y_messages[0]}    "type":"ThinEdgeMeasurement"
 
 Check grouping of measurements 
     # This test step is only partially checking the grouping of the messages, because of the timeouts and the current design


### PR DESCRIPTION
Changed the usage of the variable containers which are filled with the MQTT messages

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

