### PR TITLE
Add separate HTTP and MQTT endpoints for Cumulocity

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/models/connect_url.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/connect_url.rs
@@ -4,8 +4,8 @@ use url::Host;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
 #[serde(try_from = "String", into = "String")]
 pub struct ConnectUrl {
-    input: String,
-    host: Host,
+    pub(crate) input: String,
+    pub(crate) host: Host,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/common/tedge_config/src/tedge_config_cli/models/host_port.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/host_port.rs
@@ -1,0 +1,117 @@
+use crate::ConnectUrl;
+use crate::Port;
+use serde::Deserialize;
+use serde::Serialize;
+use std::num::ParseIntError;
+use url::Host;
+
+/// A combination of a host and a port number.
+///
+/// This type is used for serializing and deserializing host strings with a port
+/// optionally present, like `my-tenant.cumulocity.com` or
+/// `mqtt.my-tenant.cumulocity.com:2137`. The port can be omitted in the parsed
+/// string, because user code can easily derive a reasonable default port number
+/// from the context this type is used in, e.g. 443 for HTTPS or 8883 for MQTT
+/// TLS. To easily specify this fallback port, a const type parameter is used.
+///
+/// # Examples
+///
+/// ```
+/// # use tedge_config::{HostPort, Port};
+/// // use a fallback port if not present in string
+/// let http = HostPort::<443>::try_from("my-tenant.cumulocity.com".to_string()).unwrap();
+/// assert_eq!(http.port(), Port(443));
+///
+/// // allow port to be overridden using standard `:PORT` notation
+/// let http = HostPort::<443>::try_from("my-tenant.cumulocity.com:8080".to_string()).unwrap();
+/// assert_eq!(http.port(), Port(8080));
+///
+/// // return error for malformed host strings
+/// assert!(HostPort::<443>::try_from("my-tenant.cumulocity.com:8080:443".to_string()).is_err());
+/// assert!(HostPort::<443>::try_from(":8080".to_string()).is_err());
+/// assert!(HostPort::<443>::try_from("[:::1]:8080".to_string()).is_err());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(into = "String", try_from = "String")]
+pub struct HostPort<const P: u16> {
+    input: String,
+    hostname: url::Host,
+    port: Port,
+}
+
+impl<const P: u16> HostPort<P> {
+    /// Returns the hostname.
+    ///
+    /// A hostname can be either a DNS domain name, an IPv4 address, or an IPv6
+    /// address.
+    pub fn host(&self) -> &url::Host {
+        &self.hostname
+    }
+
+    /// Returns the port number.
+    ///
+    /// If `:PORT` suffix was present when deserializing, this specified port is
+    /// used. If not, a fallback port from the const type parameter is used.
+    pub fn port(&self) -> Port {
+        self.port
+    }
+
+    /// Returns a string representation of the host.
+    ///
+    /// In practice, it just returns the input string used to construct the
+    /// struct.
+    pub fn as_str(&self) -> &str {
+        &self.input
+    }
+}
+
+impl<const P: u16> From<HostPort<P>> for String {
+    fn from(value: HostPort<P>) -> Self {
+        value.input
+    }
+}
+
+impl<const P: u16> TryFrom<String> for HostPort<P> {
+    type Error = ParseHostPortError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let (hostname, port) = if let Some((hostname, port)) = s.split_once(':') {
+            let port = Port(port.parse()?);
+            let hostname: Host<String> = Host::parse(hostname)?;
+            (hostname, port)
+        } else {
+            let hostname: Host<String> = Host::parse(&s)?;
+            (hostname, Port(P))
+        };
+
+        Ok(HostPort {
+            input: s,
+            hostname,
+            port,
+        })
+    }
+}
+
+impl<const P: u16> From<ConnectUrl> for HostPort<P> {
+    fn from(value: ConnectUrl) -> Self {
+        HostPort {
+            input: value.input,
+            hostname: value.host,
+            port: Port(P),
+        }
+    }
+}
+
+/// An error which can be returned when parsing a [`HostPort`].
+///
+/// The parsing can fail when:
+/// - host can not be parsed as IPv4/IPv6 addresses or a DNS name
+/// - the `[:PORT]` suffix is present and `PORT` can't be parsed as valid `u16`
+#[derive(Debug, thiserror::Error)]
+pub enum ParseHostPortError {
+    #[error("Could not parse hostname")]
+    ParseHostname(#[from] url::ParseError),
+
+    #[error("Could not parse port")]
+    ParsePort(#[from] ParseIntError),
+}

--- a/crates/common/tedge_config/src/tedge_config_cli/models/host_port.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/host_port.rs
@@ -9,7 +9,7 @@ use url::Host;
 ///
 /// This type is used for serializing and deserializing host strings with a port
 /// optionally present, like `my-tenant.cumulocity.com` or
-/// `mqtt.my-tenant.cumulocity.com:2137`. The port can be omitted in the parsed
+/// `mqtt.my-tenant.cumulocity.com:1234`. The port can be omitted in the parsed
 /// string, because user code can easily derive a reasonable default port number
 /// from the context this type is used in, e.g. 443 for HTTPS or 8883 for MQTT
 /// TLS. To easily specify this fallback port, a const type parameter is used.
@@ -17,19 +17,20 @@ use url::Host;
 /// # Examples
 ///
 /// ```
-/// # use tedge_config::{HostPort, Port};
+/// # use tedge_config::{HostPort, Port, HTTPS_PORT};
+///
 /// // use a fallback port if not present in string
-/// let http = HostPort::<443>::try_from("my-tenant.cumulocity.com".to_string()).unwrap();
-/// assert_eq!(http.port(), Port(443));
+/// let http = HostPort::<HTTPS_PORT>::try_from("my-tenant.cumulocity.com".to_string()).unwrap();
+/// assert_eq!(http.port(), Port(HTTPS_PORT));
 ///
 /// // allow port to be overridden using standard `:PORT` notation
-/// let http = HostPort::<443>::try_from("my-tenant.cumulocity.com:8080".to_string()).unwrap();
+/// let http = HostPort::<HTTPS_PORT>::try_from("my-tenant.cumulocity.com:8080".to_string()).unwrap();
 /// assert_eq!(http.port(), Port(8080));
 ///
 /// // return error for malformed host strings
-/// assert!(HostPort::<443>::try_from("my-tenant.cumulocity.com:8080:443".to_string()).is_err());
-/// assert!(HostPort::<443>::try_from(":8080".to_string()).is_err());
-/// assert!(HostPort::<443>::try_from("[:::1]:8080".to_string()).is_err());
+/// assert!(HostPort::<HTTPS_PORT>::try_from("my-tenant.cumulocity.com:8080:443".to_string()).is_err());
+/// assert!(HostPort::<HTTPS_PORT>::try_from(":8080".to_string()).is_err());
+/// assert!(HostPort::<HTTPS_PORT>::try_from("[:::1]:8080".to_string()).is_err());
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(into = "String", try_from = "String")]

--- a/crates/common/tedge_config/src/tedge_config_cli/models/mod.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/mod.rs
@@ -1,14 +1,18 @@
 pub mod connect_url;
 pub mod flag;
-mod host_port;
+pub mod host_port;
 pub mod ipaddress;
 pub mod port;
 pub mod seconds;
 pub mod templates_set;
 
+pub const HTTPS_PORT: u16 = 443;
+pub const MQTT_TLS_PORT: u16 = 8883;
+
 pub use self::connect_url::*;
 pub use self::flag::*;
-pub use self::host_port::*;
+#[doc(inline)]
+pub use self::host_port::HostPort;
 pub use self::ipaddress::*;
 pub use self::port::*;
 pub use self::seconds::*;

--- a/crates/common/tedge_config/src/tedge_config_cli/models/mod.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod connect_url;
 pub mod flag;
+mod host_port;
 pub mod ipaddress;
 pub mod port;
 pub mod seconds;
@@ -7,6 +8,7 @@ pub mod templates_set;
 
 pub use self::connect_url::*;
 pub use self::flag::*;
+pub use self::host_port::*;
 pub use self::ipaddress::*;
 pub use self::port::*;
 pub use self::seconds::*;

--- a/crates/common/tedge_config/src/tedge_config_cli/settings.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/settings.rs
@@ -97,7 +97,7 @@ impl ConfigSetting for C8yHttpSetting {
 
     const DESCRIPTION: &'static str = "HTTP endpoint for the Cumulocity tenant. \
         Example: http.your-tenant.cumulocity.com:1234";
-    type Value = HostPort<443>;
+    type Value = HostPort<HTTPS_PORT>;
 }
 
 /// MQTT endpoint for the Cumulocity tenant.
@@ -111,7 +111,7 @@ impl ConfigSetting for C8yMqttSetting {
 
     const DESCRIPTION: &'static str = "MQTT endpoint for the Cumulocity tenant. \
         Example: mqtt.your-tenant.cumulocity.com:1234";
-    type Value = HostPort<8883>;
+    type Value = HostPort<MQTT_TLS_PORT>;
 }
 
 ///

--- a/crates/common/tedge_config/src/tedge_config_cli/settings.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/settings.rs
@@ -95,7 +95,7 @@ impl ConfigSetting for C8yHttpSetting {
 
     const DESCRIPTION: &'static str = "HTTP endpoint for the Cumulocity tenant. \
         Example: http.your-tenant.cumulocity.com:1234";
-    type Value = ConnectUrl;
+    type Value = HostPort<443>;
 }
 
 /// MQTT endpoint for the Cumulocity tenant.
@@ -109,7 +109,7 @@ impl ConfigSetting for C8yMqttSetting {
 
     const DESCRIPTION: &'static str = "MQTT endpoint for the Cumulocity tenant. \
         Example: mqtt.your-tenant.cumulocity.com:1234";
-    type Value = ConnectUrl;
+    type Value = HostPort<8883>;
 }
 
 ///

--- a/crates/common/tedge_config/src/tedge_config_cli/settings.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/settings.rs
@@ -74,8 +74,10 @@ impl ConfigSetting for DeviceCertPathSetting {
 /// Example: your-tenant.cumulocity.com
 ///
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[deprecated = "Use `C8yHttpSetting` or `C8yMqttSetting` instead"]
 pub struct C8yUrlSetting;
 
+#[allow(deprecated)]
 impl ConfigSetting for C8yUrlSetting {
     const KEY: &'static str = "c8y.url";
 

--- a/crates/common/tedge_config/src/tedge_config_cli/settings.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/settings.rs
@@ -84,6 +84,34 @@ impl ConfigSetting for C8yUrlSetting {
     type Value = ConnectUrl;
 }
 
+/// HTTP endpoint for the Cumulocity tenant.
+///
+/// Example: http.your-tenant.cumulocity.com:1234
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct C8yHttpSetting;
+
+impl ConfigSetting for C8yHttpSetting {
+    const KEY: &'static str = "c8y.http";
+
+    const DESCRIPTION: &'static str = "HTTP endpoint for the Cumulocity tenant. \
+        Example: http.your-tenant.cumulocity.com:1234";
+    type Value = ConnectUrl;
+}
+
+/// MQTT endpoint for the Cumulocity tenant.
+///
+/// Example: mqtt.your-tenant.cumulocity.com:1234
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct C8yMqttSetting;
+
+impl ConfigSetting for C8yMqttSetting {
+    const KEY: &'static str = "c8y.mqtt";
+
+    const DESCRIPTION: &'static str = "MQTT endpoint for the Cumulocity tenant. \
+        Example: mqtt.your-tenant.cumulocity.com:1234";
+    type Value = ConnectUrl;
+}
+
 ///
 /// Path where Cumulocity root certificate(s) are located.
 ///

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -177,7 +177,7 @@ impl ConfigSettingAccessor<C8yUrlSetting> for TEdgeConfig {
 
 impl ConfigSettingAccessor<C8yHttpSetting> for TEdgeConfig {
     #[allow(deprecated)]
-    fn query(&self, _setting: C8yHttpSetting) -> ConfigSettingResult<HostPort<443>> {
+    fn query(&self, _setting: C8yHttpSetting) -> ConfigSettingResult<HostPort<HTTPS_PORT>> {
         self.data
             .c8y
             .http
@@ -192,7 +192,7 @@ impl ConfigSettingAccessor<C8yHttpSetting> for TEdgeConfig {
     fn update(
         &mut self,
         _setting: C8yHttpSetting,
-        value: HostPort<443>,
+        value: HostPort<HTTPS_PORT>,
     ) -> ConfigSettingResult<()> {
         self.data.c8y.http = Some(value);
         Ok(())
@@ -206,7 +206,7 @@ impl ConfigSettingAccessor<C8yHttpSetting> for TEdgeConfig {
 
 impl ConfigSettingAccessor<C8yMqttSetting> for TEdgeConfig {
     #[allow(deprecated)]
-    fn query(&self, _setting: C8yMqttSetting) -> ConfigSettingResult<HostPort<8883>> {
+    fn query(&self, _setting: C8yMqttSetting) -> ConfigSettingResult<HostPort<MQTT_TLS_PORT>> {
         self.data
             .c8y
             .mqtt
@@ -221,7 +221,7 @@ impl ConfigSettingAccessor<C8yMqttSetting> for TEdgeConfig {
     fn update(
         &mut self,
         _setting: C8yMqttSetting,
-        value: HostPort<8883>,
+        value: HostPort<MQTT_TLS_PORT>,
     ) -> ConfigSettingResult<()> {
         self.data.c8y.mqtt = Some(value);
         Ok(())

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -160,7 +160,7 @@ impl ConfigSettingAccessor<C8yUrlSetting> for TEdgeConfig {
             .clone()
             .ok_or(ConfigSettingError::ConfigNotSet {
                 key: C8yUrlSetting::KEY,
-        })
+            })
     }
 
     fn update(&mut self, _setting: C8yUrlSetting, value: ConnectUrl) -> ConfigSettingResult<()> {
@@ -175,19 +175,23 @@ impl ConfigSettingAccessor<C8yUrlSetting> for TEdgeConfig {
 }
 
 impl ConfigSettingAccessor<C8yHttpSetting> for TEdgeConfig {
-    fn query(&self, _setting: C8yHttpSetting) -> ConfigSettingResult<ConnectUrl> {
+    fn query(&self, _setting: C8yHttpSetting) -> ConfigSettingResult<HostPort<443>> {
         self.data
             .c8y
             .http
             .as_ref()
-            .or(self.data.c8y.url.as_ref())
             .cloned()
+            .or(self.data.c8y.url.as_ref().cloned().map(ConnectUrl::into))
             .ok_or(ConfigSettingError::ConfigNotSet {
                 key: C8yUrlSetting::KEY,
             })
     }
 
-    fn update(&mut self, _setting: C8yHttpSetting, value: ConnectUrl) -> ConfigSettingResult<()> {
+    fn update(
+        &mut self,
+        _setting: C8yHttpSetting,
+        value: HostPort<443>,
+    ) -> ConfigSettingResult<()> {
         self.data.c8y.http = Some(value);
         Ok(())
     }
@@ -199,19 +203,23 @@ impl ConfigSettingAccessor<C8yHttpSetting> for TEdgeConfig {
 }
 
 impl ConfigSettingAccessor<C8yMqttSetting> for TEdgeConfig {
-    fn query(&self, _setting: C8yMqttSetting) -> ConfigSettingResult<ConnectUrl> {
+    fn query(&self, _setting: C8yMqttSetting) -> ConfigSettingResult<HostPort<8883>> {
         self.data
             .c8y
             .mqtt
             .as_ref()
-            .or(self.data.c8y.url.as_ref())
             .cloned()
+            .or(self.data.c8y.url.as_ref().cloned().map(ConnectUrl::into))
             .ok_or(ConfigSettingError::ConfigNotSet {
                 key: C8yUrlSetting::KEY,
             })
     }
 
-    fn update(&mut self, _setting: C8yMqttSetting, value: ConnectUrl) -> ConfigSettingResult<()> {
+    fn update(
+        &mut self,
+        _setting: C8yMqttSetting,
+        value: HostPort<8883>,
+    ) -> ConfigSettingResult<()> {
         self.data.c8y.mqtt = Some(value);
         Ok(())
     }

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -160,7 +160,7 @@ impl ConfigSettingAccessor<C8yUrlSetting> for TEdgeConfig {
             .clone()
             .ok_or(ConfigSettingError::ConfigNotSet {
                 key: C8yUrlSetting::KEY,
-            })
+        })
     }
 
     fn update(&mut self, _setting: C8yUrlSetting, value: ConnectUrl) -> ConfigSettingResult<()> {
@@ -170,6 +170,54 @@ impl ConfigSettingAccessor<C8yUrlSetting> for TEdgeConfig {
 
     fn unset(&mut self, _setting: C8yUrlSetting) -> ConfigSettingResult<()> {
         self.data.c8y.url = None;
+        Ok(())
+    }
+}
+
+impl ConfigSettingAccessor<C8yHttpSetting> for TEdgeConfig {
+    fn query(&self, _setting: C8yHttpSetting) -> ConfigSettingResult<ConnectUrl> {
+        self.data
+            .c8y
+            .http
+            .as_ref()
+            .or(self.data.c8y.url.as_ref())
+            .cloned()
+            .ok_or(ConfigSettingError::ConfigNotSet {
+                key: C8yUrlSetting::KEY,
+            })
+    }
+
+    fn update(&mut self, _setting: C8yHttpSetting, value: ConnectUrl) -> ConfigSettingResult<()> {
+        self.data.c8y.http = Some(value);
+        Ok(())
+    }
+
+    fn unset(&mut self, _setting: C8yHttpSetting) -> ConfigSettingResult<()> {
+        self.data.c8y.http = None;
+        Ok(())
+    }
+}
+
+impl ConfigSettingAccessor<C8yMqttSetting> for TEdgeConfig {
+    fn query(&self, _setting: C8yMqttSetting) -> ConfigSettingResult<ConnectUrl> {
+        self.data
+            .c8y
+            .mqtt
+            .as_ref()
+            .or(self.data.c8y.url.as_ref())
+            .cloned()
+            .ok_or(ConfigSettingError::ConfigNotSet {
+                key: C8yUrlSetting::KEY,
+            })
+    }
+
+    fn update(&mut self, _setting: C8yMqttSetting, value: ConnectUrl) -> ConfigSettingResult<()> {
+        self.data.c8y.mqtt = Some(value);
+        Ok(())
+    }
+
+    fn unset(&mut self, _setting: C8yMqttSetting) -> ConfigSettingResult<()> {
+        self.data.c8y.mqtt = None;
         Ok(())
     }
 }

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -152,6 +152,7 @@ impl ConfigSettingAccessor<AwsUrlSetting> for TEdgeConfig {
     }
 }
 
+#[allow(deprecated)]
 impl ConfigSettingAccessor<C8yUrlSetting> for TEdgeConfig {
     fn query(&self, _setting: C8yUrlSetting) -> ConfigSettingResult<ConnectUrl> {
         self.data
@@ -175,6 +176,7 @@ impl ConfigSettingAccessor<C8yUrlSetting> for TEdgeConfig {
 }
 
 impl ConfigSettingAccessor<C8yHttpSetting> for TEdgeConfig {
+    #[allow(deprecated)]
     fn query(&self, _setting: C8yHttpSetting) -> ConfigSettingResult<HostPort<443>> {
         self.data
             .c8y
@@ -203,6 +205,7 @@ impl ConfigSettingAccessor<C8yHttpSetting> for TEdgeConfig {
 }
 
 impl ConfigSettingAccessor<C8yMqttSetting> for TEdgeConfig {
+    #[allow(deprecated)]
     fn query(&self, _setting: C8yMqttSetting) -> ConfigSettingResult<HostPort<8883>> {
         self.data
             .c8y

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config_dto.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config_dto.rs
@@ -83,11 +83,11 @@ pub(crate) struct CumulocityConfigDto {
 
     /// HTTP Endpoint for the Cumulocity tenant, with optional port.
     #[doku(example = "http.your-tenant.cumulocity.com:1234", as = "String")]
-    pub(crate) http: Option<ConnectUrl>,
+    pub(crate) http: Option<HostPort<443>>,
 
     /// MQTT Endpoint for the Cumulocity tenant, with optional port.
     #[doku(example = "mqtt.your-tenant.cumulocity.com:1234", as = "String")]
-    pub(crate) mqtt: Option<ConnectUrl>,
+    pub(crate) mqtt: Option<HostPort<8883>>,
 
     /// The path where Cumulocity root certificate(s) are stored. The value can
     /// be a directory path as well as the path of the direct certificate file.

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config_dto.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config_dto.rs
@@ -83,11 +83,11 @@ pub(crate) struct CumulocityConfigDto {
 
     /// HTTP Endpoint for the Cumulocity tenant, with optional port.
     #[doku(example = "http.your-tenant.cumulocity.com:1234", as = "String")]
-    pub(crate) http: Option<HostPort<443>>,
+    pub(crate) http: Option<HostPort<HTTPS_PORT>>,
 
     /// MQTT Endpoint for the Cumulocity tenant, with optional port.
     #[doku(example = "mqtt.your-tenant.cumulocity.com:1234", as = "String")]
-    pub(crate) mqtt: Option<HostPort<8883>>,
+    pub(crate) mqtt: Option<HostPort<MQTT_TLS_PORT>>,
 
     /// The path where Cumulocity root certificate(s) are stored. The value can
     /// be a directory path as well as the path of the direct certificate file.

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config_dto.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config_dto.rs
@@ -81,6 +81,14 @@ pub(crate) struct CumulocityConfigDto {
     #[doku(example = "your-tenant.cumulocity.com", as = "String")]
     pub(crate) url: Option<ConnectUrl>,
 
+    /// HTTP Endpoint for the Cumulocity tenant, with optional port.
+    #[doku(example = "http.your-tenant.cumulocity.com:1234", as = "String")]
+    pub(crate) http: Option<ConnectUrl>,
+
+    /// MQTT Endpoint for the Cumulocity tenant, with optional port.
+    #[doku(example = "mqtt.your-tenant.cumulocity.com:1234", as = "String")]
+    pub(crate) mqtt: Option<ConnectUrl>,
+
     /// The path where Cumulocity root certificate(s) are stored. The value can
     /// be a directory path as well as the path of the direct certificate file.
     #[doku(example = "/etc/tedge/c8y-trusted-root-certificates.pem")]

--- a/crates/common/tedge_config/tests/test_tedge_config.rs
+++ b/crates/common/tedge_config/tests/test_tedge_config.rs
@@ -65,7 +65,11 @@ path = "/some/data/path"
     );
 
     assert_eq!(
-        config.query(C8yUrlSetting)?.as_str(),
+        config.query(C8yHttpSetting)?.as_str(),
+        "your-tenant.cumulocity.com"
+    );
+    assert_eq!(
+        config.query(C8yMqttSetting)?.as_str(),
         "your-tenant.cumulocity.com"
     );
     assert_eq!(
@@ -199,7 +203,11 @@ bind_address = "0.0.0.0"
         );
 
         assert_eq!(
-            config.query(C8yUrlSetting)?.as_str(),
+            config.query(C8yHttpSetting)?.as_str(),
+            "your-tenant.cumulocity.com"
+        );
+        assert_eq!(
+            config.query(C8yMqttSetting)?.as_str(),
             "your-tenant.cumulocity.com"
         );
         assert_eq!(
@@ -278,7 +286,8 @@ bind_address = "0.0.0.0"
             Utf8PathBuf::from("/path/to/cert")
         );
 
-        assert_eq!(config.query(C8yUrlSetting)?.as_str(), updated_c8y_url);
+        assert_eq!(config.query(C8yHttpSetting)?.as_str(), updated_c8y_url);
+        assert_eq!(config.query(C8yMqttSetting)?.as_str(), updated_c8y_url);
         assert_eq!(
             config.query(C8yRootCertPathSetting)?,
             Utf8PathBuf::from("default_c8y_root_cert_path")
@@ -358,7 +367,8 @@ fn test_parse_config_with_only_device_configuration() -> Result<(), TEdgeConfigE
         Utf8PathBuf::from("/etc/ssl/certs/tedge-private-key.pem")
     );
 
-    assert!(config.query_optional(C8yUrlSetting)?.is_none());
+    assert!(config.query_optional(C8yHttpSetting)?.is_none());
+    assert!(config.query_optional(C8yMqttSetting)?.is_none());
     assert_eq!(
         config.query(C8yRootCertPathSetting)?,
         Utf8PathBuf::from("/etc/ssl/certs")
@@ -408,7 +418,11 @@ url = "your-tenant.cumulocity.com"
     );
 
     assert_eq!(
-        config.query(C8yUrlSetting)?.as_str(),
+        config.query(C8yHttpSetting)?.as_str(),
+        "your-tenant.cumulocity.com"
+    );
+    assert_eq!(
+        config.query(C8yMqttSetting)?.as_str(),
         "your-tenant.cumulocity.com"
     );
     assert_eq!(
@@ -459,7 +473,8 @@ url = "MyAzure.azure-devices.net"
         Utf8PathBuf::from("/etc/ssl/certs/tedge-private-key.pem"),
     );
 
-    assert!(config.query_optional(C8yUrlSetting)?.is_none());
+    assert!(config.query_optional(C8yHttpSetting)?.is_none());
+    assert!(config.query_optional(C8yMqttSetting)?.is_none());
     assert_eq!(
         config.query(C8yRootCertPathSetting)?,
         Utf8PathBuf::from("/dev/null")
@@ -512,7 +527,8 @@ bind_address = "1.2.3.4"
         Utf8PathBuf::from("/etc/ssl/certs/tedge-private-key.pem"),
     );
 
-    assert!(config.query_optional(C8yUrlSetting)?.is_none());
+    assert!(config.query_optional(C8yHttpSetting)?.is_none());
+    assert!(config.query_optional(C8yMqttSetting)?.is_none());
     assert_eq!(
         config.query(C8yRootCertPathSetting)?,
         Utf8PathBuf::from("/dev/null")
@@ -635,7 +651,8 @@ fn test_parse_config_empty_file() -> Result<(), TEdgeConfigError> {
         Utf8PathBuf::from("/etc/ssl/certs/tedge-private-key.pem"),
     );
 
-    assert!(config.query_optional(C8yUrlSetting)?.is_none());
+    assert!(config.query_optional(C8yHttpSetting)?.is_none());
+    assert!(config.query_optional(C8yMqttSetting)?.is_none());
     assert_eq!(
         config.query(C8yRootCertPathSetting)?,
         Utf8PathBuf::from("/etc/ssl/certs")
@@ -684,7 +701,8 @@ fn test_parse_config_no_config_file() -> Result<(), TEdgeConfigError> {
         Utf8PathBuf::from("/non/existent/path/device-certs/tedge-private-key.pem"),
     );
 
-    assert!(config.query_optional(C8yUrlSetting)?.is_none());
+    assert!(config.query_optional(C8yHttpSetting)?.is_none());
+    assert!(config.query_optional(C8yMqttSetting)?.is_none());
     assert_eq!(
         config.query(C8yRootCertPathSetting)?,
         Utf8PathBuf::from("/etc/ssl/certs")
@@ -799,7 +817,8 @@ port = 1024
 
     let original_c8y_url = ConnectUrl::try_from("your-tenant.cumulocity.com")?;
     let original_c8y_root_cert_path = Utf8PathBuf::from("/path/to/c8y/root/cert");
-    assert_eq!(config.query(C8yUrlSetting)?, original_c8y_url);
+    assert_eq!(config.query(C8yHttpSetting)?, original_c8y_url);
+    assert_eq!(config.query(C8yMqttSetting)?, original_c8y_url);
     assert_eq!(
         config.query(C8yRootCertPathSetting)?,
         original_c8y_root_cert_path
@@ -837,7 +856,8 @@ port = 1024
         original_device_cert_path
     );
 
-    assert_eq!(config.query(C8yUrlSetting)?, updated_c8y_url);
+    assert_eq!(config.query(C8yHttpSetting)?, updated_c8y_url);
+    assert_eq!(config.query(C8yMqttSetting)?, updated_c8y_url);
     assert_eq!(
         config.query(C8yRootCertPathSetting)?,
         Utf8PathBuf::from("/etc/ssl/certs")

--- a/crates/common/tedge_config/tests/test_tedge_config.rs
+++ b/crates/common/tedge_config/tests/test_tedge_config.rs
@@ -815,10 +815,11 @@ port = 1024
         original_device_cert_path
     );
 
-    let original_c8y_url = ConnectUrl::try_from("your-tenant.cumulocity.com")?;
     let original_c8y_root_cert_path = Utf8PathBuf::from("/path/to/c8y/root/cert");
-    assert_eq!(config.query(C8yHttpSetting)?, original_c8y_url);
-    assert_eq!(config.query(C8yMqttSetting)?, original_c8y_url);
+    let c8y_http_host = config.query(C8yHttpSetting).unwrap();
+    let c8y_mqtt_host = config.query(C8yMqttSetting).unwrap();
+    assert_eq!(c8y_http_host.port(), Port(443));
+    assert_eq!(c8y_mqtt_host.port(), Port(8883));
     assert_eq!(
         config.query(C8yRootCertPathSetting)?,
         original_c8y_root_cert_path
@@ -836,7 +837,25 @@ port = 1024
     assert_eq!(config.query(MqttPortSetting)?, Port(1024));
 
     let updated_c8y_url = ConnectUrl::try_from("other-tenant.cumulocity.com")?;
-    config.update(C8yUrlSetting, updated_c8y_url.clone())?;
+    config.update(C8yUrlSetting, updated_c8y_url)?;
+
+    config
+        .update(
+            C8yHttpSetting,
+            HostPort::<443>::try_from("http.other-tenant.cumulocity.com:1234".to_string()).unwrap(),
+        )
+        .unwrap();
+    assert_eq!(config.query(C8yHttpSetting).unwrap().port(), Port(1234));
+
+    config
+        .update(
+            C8yMqttSetting,
+            HostPort::<8883>::try_from("http.other-tenant.cumulocity.com:2137".to_string())
+                .unwrap(),
+        )
+        .unwrap();
+    assert_eq!(config.query(C8yMqttSetting).unwrap().port(), Port(2137));
+
     config.unset(C8yRootCertPathSetting)?;
 
     let updated_azure_url = ConnectUrl::try_from("OtherAzure.azure-devices.net")?;
@@ -856,8 +875,6 @@ port = 1024
         original_device_cert_path
     );
 
-    assert_eq!(config.query(C8yHttpSetting)?, updated_c8y_url);
-    assert_eq!(config.query(C8yMqttSetting)?, updated_c8y_url);
     assert_eq!(
         config.query(C8yRootCertPathSetting)?,
         Utf8PathBuf::from("/etc/ssl/certs")
@@ -954,6 +971,52 @@ cert_path = "/path/to/cert"
     assert_eq!(config.query(DeviceIdSetting)?, device_id);
 
     Ok(())
+}
+
+#[test]
+fn http_and_mqtt_hosts_serialize_and_deserialize_correctly() {
+    let no_ports = r#"
+[c8y]
+url = "tenant.cumulocity.com"
+http = "http.tenant.cumulocity.com"
+mqtt = "mqtt.tenant.cumulocity.com"
+"#;
+
+    let (_tempdir, config_location) = create_temp_tedge_config(no_ports).unwrap();
+    let repository =
+        TEdgeConfigRepository::new_with_defaults(config_location, dummy_tedge_config_defaults());
+    let config = repository.load().unwrap();
+
+    assert_eq!(config.query(C8yHttpSetting).unwrap().port().0, 443);
+    assert_eq!(config.query(C8yMqttSetting).unwrap().port().0, 8883);
+
+    // test updating C8yHttpSetting
+    repository
+        .update_toml(&|config| {
+            let new_c8y_http =
+                HostPort::<443>::try_from("custom.domain.com:8080".to_string()).unwrap();
+            config.update(C8yHttpSetting, new_c8y_http)
+        })
+        .unwrap();
+
+    let toml_content =
+        std::fs::read_to_string(&repository.get_config_location().tedge_config_file_path).unwrap();
+    assert!(toml_content.contains("http = \"custom.domain.com:8080\""));
+    assert!(toml_content.contains("mqtt = \"mqtt.tenant.cumulocity.com\""));
+
+    // test updating C8yMqttSetting
+    repository
+        .update_toml(&|config| {
+            let new_c8y_mqtt =
+                HostPort::<8883>::try_from("custom.domain.com:1883".to_string()).unwrap();
+            config.update(C8yMqttSetting, new_c8y_mqtt)
+        })
+        .unwrap();
+
+    let toml_content =
+        std::fs::read_to_string(&repository.get_config_location().tedge_config_file_path).unwrap();
+    assert!(toml_content.contains("http = \"custom.domain.com:8080\""));
+    assert!(toml_content.contains("mqtt = \"custom.domain.com:1883\""));
 }
 
 fn create_temp_tedge_config(content: &str) -> std::io::Result<(TempTedgeDir, TEdgeConfigLocation)> {

--- a/crates/common/tedge_config/tests/test_tedge_config.rs
+++ b/crates/common/tedge_config/tests/test_tedge_config.rs
@@ -229,6 +229,7 @@ bind_address = "0.0.0.0"
 
         assert_eq!(config.query(ServiceTypeSetting)?, "service");
 
+        #[allow(deprecated)]
         config.update(
             C8yUrlSetting,
             ConnectUrl::try_from(updated_c8y_url).unwrap(),
@@ -837,6 +838,7 @@ port = 1024
     assert_eq!(config.query(MqttPortSetting)?, Port(1024));
 
     let updated_c8y_url = ConnectUrl::try_from("other-tenant.cumulocity.com")?;
+    #[allow(deprecated)]
     config.update(C8yUrlSetting, updated_c8y_url)?;
 
     config

--- a/crates/common/tedge_config/tests/test_tedge_config.rs
+++ b/crates/common/tedge_config/tests/test_tedge_config.rs
@@ -844,7 +844,8 @@ port = 1024
     config
         .update(
             C8yHttpSetting,
-            HostPort::<443>::try_from("http.other-tenant.cumulocity.com:1234".to_string()).unwrap(),
+            HostPort::<HTTPS_PORT>::try_from("http.other-tenant.cumulocity.com:1234".to_string())
+                .unwrap(),
         )
         .unwrap();
     assert_eq!(config.query(C8yHttpSetting).unwrap().port(), Port(1234));
@@ -852,8 +853,10 @@ port = 1024
     config
         .update(
             C8yMqttSetting,
-            HostPort::<8883>::try_from("http.other-tenant.cumulocity.com:2137".to_string())
-                .unwrap(),
+            HostPort::<MQTT_TLS_PORT>::try_from(
+                "http.other-tenant.cumulocity.com:2137".to_string(),
+            )
+            .unwrap(),
         )
         .unwrap();
     assert_eq!(config.query(C8yMqttSetting).unwrap().port(), Port(2137));
@@ -996,7 +999,7 @@ mqtt = "mqtt.tenant.cumulocity.com"
     repository
         .update_toml(&|config| {
             let new_c8y_http =
-                HostPort::<443>::try_from("custom.domain.com:8080".to_string()).unwrap();
+                HostPort::<HTTPS_PORT>::try_from("custom.domain.com:8080".to_string()).unwrap();
             config.update(C8yHttpSetting, new_c8y_http)
         })
         .unwrap();
@@ -1010,7 +1013,7 @@ mqtt = "mqtt.tenant.cumulocity.com"
     repository
         .update_toml(&|config| {
             let new_c8y_mqtt =
-                HostPort::<8883>::try_from("custom.domain.com:1883".to_string()).unwrap();
+                HostPort::<MQTT_TLS_PORT>::try_from("custom.domain.com:1883".to_string()).unwrap();
             config.update(C8yMqttSetting, new_c8y_mqtt)
         })
         .unwrap();

--- a/crates/core/tedge/src/cli/certificate/cli.rs
+++ b/crates/core/tedge/src/cli/certificate/cli.rs
@@ -64,7 +64,7 @@ impl BuildCommand for TEdgeCertCli {
                     UploadCertCli::C8y { username } => UploadCertCmd {
                         device_id: config.query(DeviceIdSetting)?,
                         path: config.query(DeviceCertPathSetting)?,
-                        host: config.query(C8yUrlSetting)?,
+                        host: config.query(C8yHttpSetting)?,
                         username,
                     },
                 };

--- a/crates/core/tedge/src/cli/certificate/upload.rs
+++ b/crates/core/tedge/src/cli/certificate/upload.rs
@@ -25,7 +25,7 @@ struct UploadCertBody {
 pub struct UploadCertCmd {
     pub device_id: String,
     pub path: Utf8PathBuf,
-    pub host: HostPort<443>,
+    pub host: HostPort<HTTPS_PORT>,
     pub username: String,
 }
 

--- a/crates/core/tedge/src/cli/certificate/upload.rs
+++ b/crates/core/tedge/src/cli/certificate/upload.rs
@@ -25,7 +25,7 @@ struct UploadCertBody {
 pub struct UploadCertCmd {
     pub device_id: String,
     pub path: Utf8PathBuf,
-    pub host: ConnectUrl,
+    pub host: HostPort<443>,
     pub username: String,
 }
 
@@ -61,8 +61,8 @@ impl UploadCertCmd {
         };
 
         // To post certificate c8y requires one of the following endpoints:
-        // https://<tenant_id>.cumulocity.url.io/tenant/tenants/<tenant_id>/trusted-certificates
-        // https://<tenant_domain>.cumulocity.url.io/tenant/tenants/<tenant_id>/trusted-certificates
+        // https://<tenant_id>.cumulocity.url.io[:port]/tenant/tenants/<tenant_id>/trusted-certificates
+        // https://<tenant_domain>.cumulocity.url.io[:port]/tenant/tenants/<tenant_id>/trusted-certificates
         // and therefore we need to get tenant_id.
         let tenant_id = get_tenant_id_blocking(
             &client,

--- a/crates/core/tedge/src/cli/config/config_key.rs
+++ b/crates/core/tedge/src/cli/config/config_key.rs
@@ -44,6 +44,8 @@ impl ConfigKey {
             config_key!(DeviceKeyPathSetting),
             config_key!(DeviceCertPathSetting),
             config_key!(C8yUrlSetting),
+            config_key!(C8yHttpSetting),
+            config_key!(C8yMqttSetting),
             config_key!(C8yRootCertPathSetting),
             config_key!(C8ySmartRestTemplates),
             config_key!(AzureUrlSetting),

--- a/crates/core/tedge/src/cli/config/config_key.rs
+++ b/crates/core/tedge/src/cli/config/config_key.rs
@@ -37,6 +37,7 @@ macro_rules! config_key {
 }
 
 impl ConfigKey {
+    #[allow(deprecated)]
     pub fn list_all() -> Vec<ConfigKey> {
         vec![
             config_key!(DeviceIdSetting),

--- a/crates/core/tedge/src/cli/connect/bridge_config_c8y.rs
+++ b/crates/core/tedge/src/cli/connect/bridge_config_c8y.rs
@@ -2,10 +2,11 @@ use crate::cli::connect::BridgeConfig;
 use camino::Utf8PathBuf;
 use tedge_config::HostPort;
 use tedge_config::TemplatesSet;
+use tedge_config::MQTT_TLS_PORT;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct BridgeConfigC8yParams {
-    pub mqtt_host: HostPort<8883>,
+    pub mqtt_host: HostPort<MQTT_TLS_PORT>,
     pub config_file: String,
     pub remote_clientid: String,
     pub bridge_root_cert_path: Utf8PathBuf,
@@ -107,7 +108,7 @@ impl From<BridgeConfigC8yParams> for BridgeConfig {
 fn test_bridge_config_from_c8y_params() -> anyhow::Result<()> {
     use std::convert::TryFrom;
     let params = BridgeConfigC8yParams {
-        mqtt_host: HostPort::<8883>::try_from("test.test.io".to_string())?,
+        mqtt_host: HostPort::<MQTT_TLS_PORT>::try_from("test.test.io".to_string())?,
         config_file: "c8y-bridge.conf".into(),
         remote_clientid: "alpha".into(),
         bridge_root_cert_path: Utf8PathBuf::from("./test_root.pem"),

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -134,7 +134,10 @@ impl Command for ConnectCommand {
         }
 
         if let Cloud::C8y = self.cloud {
-            check_connected_c8y_tenant_as_configured(&config, &config.query_string(C8yUrlSetting)?);
+            check_connected_c8y_tenant_as_configured(
+                &config,
+                &config.query_string(C8yMqttSetting)?,
+            );
             enable_software_management(&bridge_config, self.service_manager.as_ref());
         }
 
@@ -173,7 +176,7 @@ impl ConnectCommand {
             }
             Cloud::C8y => {
                 let params = BridgeConfigC8yParams {
-                    connect_url: config.query(C8yUrlSetting)?,
+                    connect_url: config.query(C8yMqttSetting)?,
                     mqtt_tls_port: MQTT_TLS_PORT,
                     config_file: C8Y_CONFIG_FILENAME.into(),
                     bridge_root_cert_path: config.query(C8yRootCertPathSetting)?,

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -176,8 +176,7 @@ impl ConnectCommand {
             }
             Cloud::C8y => {
                 let params = BridgeConfigC8yParams {
-                    connect_url: config.query(C8yMqttSetting)?,
-                    mqtt_tls_port: MQTT_TLS_PORT,
+                    mqtt_host: config.query(C8yMqttSetting)?,
                     config_file: C8Y_CONFIG_FILENAME.into(),
                     bridge_root_cert_path: config.query(C8yRootCertPathSetting)?,
                     remote_clientid: config.query(DeviceIdSetting)?,

--- a/crates/extensions/c8y_config_manager/src/config.rs
+++ b/crates/extensions/c8y_config_manager/src/config.rs
@@ -21,7 +21,6 @@ pub struct ConfigManagerConfig {
     pub device_id: String,
     pub mqtt_host: String,
     pub mqtt_port: u16,
-    pub c8y_url: ConnectUrl,
     pub tedge_http_host: String,
     pub plugin_config_path: PathBuf,
     pub plugin_config: PluginConfig,
@@ -39,7 +38,6 @@ impl ConfigManagerConfig {
         device_id: String,
         mqtt_host: String,
         mqtt_port: u16,
-        c8y_url: ConnectUrl,
         tedge_http_address: IpAddress,
         tedge_http_port: u16,
     ) -> Self {
@@ -66,7 +64,6 @@ impl ConfigManagerConfig {
             device_id,
             mqtt_host,
             mqtt_port,
-            c8y_url,
             tedge_http_host,
             plugin_config_path,
             plugin_config,
@@ -86,7 +83,6 @@ impl ConfigManagerConfig {
         let data_dir: PathBuf = tedge_config.query(DataPathSetting)?.into();
         let mqtt_host = tedge_config.query(MqttClientHostSetting)?;
         let mqtt_port = tedge_config.query(MqttClientPortSetting)?.into();
-        let c8y_url = tedge_config.query(C8yUrlSetting)?;
         let tedge_http_address = tedge_config.query(HttpBindAddressSetting)?;
         let tedge_http_port: u16 = tedge_config.query(HttpPortSetting)?.into();
 
@@ -97,7 +93,6 @@ impl ConfigManagerConfig {
             device_id,
             mqtt_host,
             mqtt_port,
-            c8y_url,
             tedge_http_address,
             tedge_http_port,
         ))

--- a/crates/extensions/c8y_config_manager/src/tests.rs
+++ b/crates/extensions/c8y_config_manager/src/tests.rs
@@ -987,7 +987,6 @@ async fn spawn_config_manager(
         device_id.to_string(),
         tedge_host.to_string(),
         mqtt_port,
-        c8y_host.to_string().try_into().unwrap(),
         tedge_host.to_string().try_into().unwrap(),
         tedge_http_port,
     );

--- a/crates/extensions/c8y_config_manager/src/tests.rs
+++ b/crates/extensions/c8y_config_manager/src/tests.rs
@@ -977,7 +977,6 @@ async fn spawn_config_manager(
     DynError,
 > {
     let tedge_host = "127.0.0.1";
-    let c8y_host = "test.c8y.io";
     let mqtt_port = 1234;
     let tedge_http_port = 9876;
 

--- a/crates/extensions/c8y_firmware_manager/src/config.rs
+++ b/crates/extensions/c8y_firmware_manager/src/config.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
 use tedge_api::health::health_check_topics;
-use tedge_config::C8yUrlSetting;
+use tedge_config::C8yHttpSetting;
 use tedge_config::ConfigSettingAccessor;
 use tedge_config::DataPathSetting;
 use tedge_config::DeviceIdSetting;
@@ -90,7 +90,7 @@ impl FirmwareManagerConfig {
                 .query(FirmwareChildUpdateTimeoutSetting)?
                 .into(),
         );
-        let c8y_url = tedge_config.query(C8yUrlSetting)?.into();
+        let c8y_url = tedge_config.query(C8yHttpSetting)?.into();
 
         Ok(Self::new(
             tedge_device_id,

--- a/crates/extensions/c8y_http_proxy/src/lib.rs
+++ b/crates/extensions/c8y_http_proxy/src/lib.rs
@@ -14,7 +14,7 @@ use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
 use tedge_actors::ServerMessageBoxBuilder;
 use tedge_actors::ServiceProvider;
-use tedge_config::C8yUrlSetting;
+use tedge_config::C8yHttpSetting;
 use tedge_config::ConfigSettingAccessor;
 use tedge_config::DeviceIdSetting;
 use tedge_config::TEdgeConfig;
@@ -43,7 +43,7 @@ impl TryFrom<&TEdgeConfig> for C8YHttpConfig {
     type Error = TEdgeConfigError;
 
     fn try_from(tedge_config: &TEdgeConfig) -> Result<Self, Self::Error> {
-        let c8y_host = tedge_config.query(C8yUrlSetting)?;
+        let c8y_host = tedge_config.query(C8yHttpSetting)?;
         let device_id = tedge_config.query(DeviceIdSetting)?;
         let tmp_dir = tedge_config.query(TmpPathSetting)?.into();
         Ok(Self {

--- a/crates/extensions/c8y_log_manager/src/actor.rs
+++ b/crates/extensions/c8y_log_manager/src/actor.rs
@@ -521,7 +521,6 @@ mod tests {
             device_id: "SUT".to_string(),
             mqtt_host: "127.0.0.1".to_string(),
             mqtt_port: 1883,
-            c8y_url: "mytenant.c8y.com".try_into().unwrap(),
             tedge_http_host: "127.0.0.1".try_into().unwrap(),
             tedge_http_port: 80,
             plugin_config_path: temp_dir.join("c8y-log-plugin.toml"),

--- a/crates/extensions/c8y_log_manager/src/config.rs
+++ b/crates/extensions/c8y_log_manager/src/config.rs
@@ -7,9 +7,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use tedge_config::C8yUrlSetting;
 use tedge_config::ConfigSettingAccessor;
-use tedge_config::ConnectUrl;
 use tedge_config::DeviceIdSetting;
 use tedge_config::HttpBindAddressSetting;
 use tedge_config::HttpPortSetting;
@@ -32,7 +30,6 @@ pub struct LogManagerConfig {
     pub device_id: String,
     pub mqtt_host: String,
     pub mqtt_port: u16,
-    pub c8y_url: ConnectUrl,
     pub tedge_http_host: IpAddress,
     pub tedge_http_port: u16,
     pub plugin_config_path: PathBuf,
@@ -51,8 +48,6 @@ impl LogManagerConfig {
         let mqtt_host = tedge_config.query(MqttClientHostSetting)?;
         let mqtt_port = tedge_config.query(MqttClientPortSetting)?.into();
 
-        let c8y_url = tedge_config.query(C8yUrlSetting)?;
-
         let tedge_http_host = tedge_config.query(HttpBindAddressSetting)?;
         let tedge_http_port: u16 = tedge_config.query(HttpPortSetting)?.into();
 
@@ -68,7 +63,6 @@ impl LogManagerConfig {
             device_id,
             mqtt_host,
             mqtt_port,
-            c8y_url,
             tedge_http_host,
             tedge_http_port,
             plugin_config_path,

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -5,7 +5,7 @@ use camino::Utf8PathBuf;
 use std::path::Path;
 use std::path::PathBuf;
 use tedge_api::topic::ResponseTopic;
-use tedge_config::C8yUrlSetting;
+use tedge_config::C8yHttpSetting;
 use tedge_config::ConfigSettingAccessor;
 use tedge_config::DeviceIdSetting;
 use tedge_config::DeviceTypeSetting;
@@ -59,7 +59,7 @@ impl C8yMapperConfig {
         let device_id = tedge_config.query(DeviceIdSetting)?;
         let device_type = tedge_config.query(DeviceTypeSetting)?;
         let service_type = tedge_config.query(ServiceTypeSetting)?;
-        let c8y_host = tedge_config.query(C8yUrlSetting)?.into();
+        let c8y_host = tedge_config.query(C8yHttpSetting)?.into();
 
         Ok(C8yMapperConfig::new(
             config_dir,

--- a/plugins/c8y_remote_access_plugin/src/main.rs
+++ b/plugins/c8y_remote_access_plugin/src/main.rs
@@ -6,7 +6,7 @@ use futures::future::try_select;
 use futures::future::Either;
 use miette::Context;
 use miette::IntoDiagnostic;
-use tedge_config::C8yUrlSetting;
+use tedge_config::C8yHttpSetting;
 use tedge_config::ConfigRepository;
 use tedge_config::ConfigSettingAccessor;
 use tedge_config::TEdgeConfig;
@@ -143,7 +143,7 @@ async fn spawn_child(command: String) -> miette::Result<()> {
 }
 
 async fn proxy(command: RemoteAccessConnect, config: TEdgeConfig) -> miette::Result<()> {
-    let host = config.query(C8yUrlSetting).into_diagnostic()?;
+    let host = config.query(C8yHttpSetting).into_diagnostic()?;
     let url = build_proxy_url(host.as_str(), command.key())?;
     let jwt = Jwt::retrieve(&config)
         .await


### PR DESCRIPTION
## Proposed changes

This PR adds `c8y.http` and `c8y.mqtt` config options intended to override `c8y.url` option in HTTP and MQTT contexts respectively. This is necessary for when HTTP and MQTT servers are present under different domain names. These settings are optional and are derived from `c8y.url` if not present.

In code, settings `C8yHttpSetting` and `C8yMqttSetting` were added. Their `query()` methods were made to look whether `c8y.http/mqtt` option was defined first, and if not, they use the value of `c8y.url`. The old `C8yUrlSetting` accessor was left as it is because changing its behaviour would break setting/listing config options, in the future it should be made deprecated and phased out.

Previously used for deserializing `ConnectUrl` type does not allow specifying ports in host strings. To allow for deserializing with ports optionally specified, as well as to know upfront what default port we use in case it is not specified, and still handle possible parsing errors, `HostPort` type was created, which uses a const type parameter to specify which default port we expect:

[from doctest]:
```rust
// use a fallback port if not present in string
let http = HostPort::<443>::try_from("my-tenant.cumulocity.com".to_string()).unwrap();
assert_eq!(http.port(), Port(443));

// allow port to be overridden using standard `:PORT` notation
let http = HostPort::<443>::try_from("my-tenant.cumulocity.com:8080".to_string()).unwrap();
assert_eq!(http.port(), Port(8080));

// return error for malformed host strings
assert!(HostPort::<443>::try_from("my-tenant.cumulocity.com:8080:443".to_string()).is_err());
assert!(HostPort::<443>::try_from(":8080".to_string()).is_err());
assert!(HostPort::<443>::try_from("[:::1]:8080".to_string()).is_err());
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- https://github.com/thin-edge/thin-edge.io/issues/1931

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

I'd like to hear some feedback regarding:

- **naming**: while better than e.g. `c8y.url`/`C8yUrlSetting`, which are not really URLs, because they can't contain scheme, port, query, fragments, etc. so the name is I think a bit misleading, `HostPort`, while accurate, is maybe a bit awkward. I thought of naming it `ServiceHost`, because really we use it to connect to a known service (HTTP or MQTT) on a certain host and port.
- **structure** while using const generics we can easily create `HostPort` with any expected port, just specifying the port inline kind of smells like magic numbers. We could do an alternative with a trait + marker structs with associated const:

  ```rust
  trait Service {
      const FALLBACK_PORT: u16;
  }
  
  struct Http;
  impl Service for Http {
      const FALLBACK_PORT: u16 = 443;
  }
  
  struct Mqtt;
  impl Service for Mqtt {
      const FALLBACK_PORT: u16 = 8883;
  }
  
  struct HostPort2<S: Service> {
      input: String,
      host: url::Host,
      port: Port,
      _phantomdata: PhantomData<S>,
  }
  
  impl<S: Service> HostPort2<S> {
      /// Returns the port number.
      ///
      /// If `:PORT` suffix was present when deserializing, this specified port is
      /// used. If not, a fallback port from the const type parameter is used.
      pub fn port(&self) -> Port {
          self.port
      }
  }
  
  impl<S: Service> TryFrom<String> for HostPort2<S> {
      type Error = ParseHostnamePortError;
  
      fn try_from(s: String) -> Result<Self, Self::Error> {
          let (host, port) = if let Some((hostname, port)) = s.split_once(':') {
              let port = Port(port.parse()?);
              let hostname: Host<String> = Host::parse(hostname)?;
              (hostname, port)
          } else {
              let hostname: Host<String> = Host::parse(&s)?;
              (hostname, Port(S::FALLBACK_PORT))
          };
  
          Ok(HostPort2 {
              input: s,
              host,
              port,
              _phantomdata: PhantomData,
          })
      }
  }
  ```

  And then we use it the following way:
  ```rust
   let http: HostPort2<Http> =
              HostPort2::try_from("my-tenant.cumulocity.com".to_string()).unwrap();
  ```

- **tests** are they sufficient?