### PR TITLE
tedge-mapper-c8y service restart is required after a change of supported operation file contents

### DIFF
--- a/crates/core/c8y_api/src/smartrest/operations.rs
+++ b/crates/core/c8y_api/src/smartrest/operations.rs
@@ -64,7 +64,12 @@ pub fn is_valid_operation_name(operation: &str) -> bool {
 
 impl Operations {
     pub fn add_operation(&mut self, operation: Operation) {
-        if self.operations.iter().any(|o| o.name.eq(&operation.name)) {
+        if let Some(index) = self
+            .operations
+            .iter()
+            .position(|o| o.name.eq(&operation.name))
+        {
+            self.operations[index] = operation;
         } else {
             if let Some(detail) = operation.exec() {
                 if let Some(on_message) = &detail.on_message {

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -515,7 +515,7 @@ impl Converter for CumulocityConverter {
     ) -> Result<Option<Message>, ConversionError> {
         match message.ops_dir.parent() {
             Some(parent_dir) => {
-                if parent_dir.eq(&self.cfg_dir.join("operations").join("c8y")) {
+                if parent_dir.eq(&self.cfg_dir.join("operations")) {
                     // operation for parent
                     add_or_remove_operation(message, &mut self.operations)?;
                     Ok(Some(create_supported_operations(&message.ops_dir)?))
@@ -548,6 +548,7 @@ fn get_child_id(dir_path: &PathBuf) -> Result<String, ConversionError> {
         }),
     }
 }
+
 fn add_or_remove_operation(
     message: &DiscoverOp,
     ops: &mut Operations,


### PR DESCRIPTION
## Proposed changes

Dynamically update/populate the custom operations when there is a change in the custom operation file.

There are two issues here

- On the `fsnotify event, the child device` operations are getting updated.
- The operation that is present in the list was not updated with the changed operation data

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/1705

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

