### PR TITLE
c8y-configuration-plugin panics when required folder/s are missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,6 +3829,7 @@ name = "tedge_file_system_ext"
 version = "0.10.0"
 dependencies = [
  "async-trait",
+ "log",
  "tedge_actors",
  "tedge_test_utils",
  "tedge_utils",

--- a/crates/common/tedge_config/src/tedge_config_cli/error.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/error.rs
@@ -26,6 +26,9 @@ pub enum TEdgeConfigError {
 
     #[error(transparent)]
     Multi(#[from] Multi),
+
+    #[error(transparent)]
+    DirNotFound(#[from] tedge_utils::paths::PathsError),
 }
 
 impl TEdgeConfigError {

--- a/crates/extensions/c8y_config_manager/src/config.rs
+++ b/crates/extensions/c8y_config_manager/src/config.rs
@@ -1,4 +1,5 @@
 use c8y_api::smartrest::topic::C8yTopic;
+use tedge_utils::paths::validate_parent_dir_exists;
 
 use std::path::Path;
 use std::path::PathBuf;
@@ -86,7 +87,7 @@ impl ConfigManagerConfig {
         let tedge_http_address = tedge_config.query(HttpBindAddressSetting)?;
         let tedge_http_port: u16 = tedge_config.query(HttpPortSetting)?.into();
 
-        Ok(ConfigManagerConfig::new(
+        let config = ConfigManagerConfig::new(
             config_dir,
             tmp_dir,
             data_dir,
@@ -95,6 +96,8 @@ impl ConfigManagerConfig {
             mqtt_port,
             tedge_http_address,
             tedge_http_port,
-        ))
+        );
+        validate_parent_dir_exists(config.plugin_config_path.as_path())?;
+        Ok(config)
     }
 }

--- a/crates/extensions/c8y_log_manager/src/config.rs
+++ b/crates/extensions/c8y_log_manager/src/config.rs
@@ -18,6 +18,7 @@ use tedge_config::TEdgeConfig;
 use tedge_config::TEdgeConfigError;
 use tedge_config::TmpPathSetting;
 use tedge_mqtt_ext::MqttMessage;
+use tedge_utils::paths::validate_parent_dir_exists;
 
 pub const DEFAULT_PLUGIN_CONFIG_FILE_NAME: &str = "c8y-log-plugin.toml";
 pub const DEFAULT_OPERATION_DIR_NAME: &str = "c8y/";
@@ -54,6 +55,7 @@ impl LogManagerConfig {
         let plugin_config_path = config_dir
             .join(DEFAULT_OPERATION_DIR_NAME)
             .join(DEFAULT_PLUGIN_CONFIG_FILE_NAME);
+        validate_parent_dir_exists(&plugin_config_path)?;
 
         let plugin_config = LogPluginConfig::new(&plugin_config_path);
 

--- a/crates/extensions/tedge_file_system_ext/Cargo.toml
+++ b/crates/extensions/tedge_file_system_ext/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 
 [dependencies]
 async-trait = "0.1"
+log = "0.4"
 tedge_actors = { path = "../../core/tedge_actors" }
 tedge_utils = { path = "../../common/tedge_utils", features = ["fs-notify"] }
 tokio = { version = "1.23", features = ["macros"] }


### PR DESCRIPTION
## Proposed changes

The issue here is in `tedge_file_system_ext` in the `FsWatchActor` `run` function, the errors are not handled, and using `unwrap`, Because of this when there are no directories to add `fs watch` it panics.

The proposed solution is to handle these panics gracefully by removing unwrap.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1955

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

