### PR TITLE
Await for a shutdown request when a restart is triggered

### DIFF
--- a/crates/core/tedge_agent/Cargo.toml
+++ b/crates/core/tedge_agent/Cargo.toml
@@ -60,6 +60,7 @@ tracing = { version = "0.1", features = ["attributes", "log"] }
 
 [dev-dependencies]
 serial_test = "0.8"
+tedge_actors = { path = "../../core/tedge_actors", features = ["test-helpers"] }
 tedge_test_utils = { path = "../../tests/tedge_test_utils" }
 test-case = "2.2"
 tokio-test = "0.4"

--- a/crates/core/tedge_agent/src/restart_manager/actor.rs
+++ b/crates/core/tedge_agent/src/restart_manager/actor.rs
@@ -10,6 +10,7 @@ use crate::state_repository::state::StateStatus;
 use async_trait::async_trait;
 use std::time::Duration;
 use tedge_actors::Actor;
+use tedge_actors::ChannelError;
 use tedge_actors::MessageReceiver;
 use tedge_actors::RuntimeError;
 use tedge_actors::RuntimeRequest;
@@ -44,10 +45,15 @@ impl Actor for RestartManagerActor {
     }
 
     async fn run(&mut self) -> Result<(), RuntimeError> {
-        self.process_pending_restart_operation().await?;
+        if let Some(response) = self.process_pending_restart_operation().await {
+            self.message_box.send(response).await?;
+        }
 
         while let Some(request) = self.message_box.recv().await {
-            let maybe_error = self.handle_restart_operation(&request).await;
+            let executing_response = self.update_state_repository(&request).await;
+            self.message_box.send(executing_response).await?;
+
+            let maybe_error = self.handle_restart_operation().await;
 
             match timeout(Duration::from_secs(5), self.message_box.recv_signal()).await {
                 Ok(Some(RuntimeRequest::Shutdown)) => {
@@ -84,10 +90,8 @@ impl RestartManagerActor {
         }
     }
 
-    async fn process_pending_restart_operation(&mut self) -> Result<(), RestartManagerError> {
+    async fn process_pending_restart_operation(&mut self) -> Option<RestartOperationResponse> {
         let state: Result<State, _> = self.state_repository.load().await;
-
-        let mut status = OperationStatus::Failed;
 
         if let State {
             operation_id: Some(id),
@@ -99,45 +103,62 @@ impl RestartManagerActor {
                 operation: None,
             },
         } {
+            self.clear_state_repository().await;
+
             match operation {
                 StateStatus::Restart(RestartOperationStatus::Restarting) => {
-                    let _state = self.state_repository.clear().await?;
+                    let status = match has_rebooted(&self.config.tmp_dir) {
+                        Ok(true) => {
+                            info!("Device restart successful.");
+                            OperationStatus::Successful
+                        }
+                        Ok(false) => {
+                            info!("Device failed to restart.");
+                            OperationStatus::Failed
+                        }
+                        Err(err) => {
+                            error!("Fail to detect a restart: {err}");
+                            OperationStatus::Failed
+                        }
+                    };
 
-                    if has_rebooted(&self.config.tmp_dir)? {
-                        info!("Device restart successful.");
-                        status = OperationStatus::Successful;
-                    }
+                    return Some(RestartOperationResponse { id, status });
                 }
-                StateStatus::Restart(RestartOperationStatus::Pending) => {}
-                StateStatus::Software(_) => {
-                    error!("SoftwareOperation in store.");
+                StateStatus::Restart(RestartOperationStatus::Pending) => {
+                    error!("The agent has been restarted but not the device");
+                    let status = OperationStatus::Failed;
+                    return Some(RestartOperationResponse { id, status });
                 }
-                StateStatus::UnknownOperation => {
+                StateStatus::Software(_) | StateStatus::UnknownOperation => {
                     error!("UnknownOperation in store.");
                 }
             };
-            self.message_box
-                .send(RestartOperationResponse { id, status })
-                .await?;
         }
-        Ok(())
+        None
     }
 
-    async fn handle_restart_operation(
+    async fn update_state_repository(
         &mut self,
         request: &RestartOperationRequest,
-    ) -> Result<(), RestartManagerError> {
-        self.state_repository
-            .store(&State {
-                operation_id: Some(request.id.clone()),
-                operation: Some(StateStatus::Restart(RestartOperationStatus::Restarting)),
-            })
-            .await?;
+    ) -> RestartOperationResponse {
+        let response = RestartOperationResponse::new(request);
+        let state = State {
+            operation_id: Some(request.id.clone()),
+            operation: Some(StateStatus::Restart(RestartOperationStatus::Restarting)),
+        };
 
-        // Send 'executing'
-        let executing_response = RestartOperationResponse::new(&RestartOperationRequest::default());
-        self.message_box.send(executing_response).await?;
+        if let Err(err) = self.state_repository.store(&state).await {
+            error!(
+                "Fail to update the restart state in {} due to: {}",
+                self.state_repository.state_repo_path, err
+            );
+            return response.with_status(OperationStatus::Failed);
+        }
 
+        response
+    }
+
+    async fn handle_restart_operation(&mut self) -> Result<(), RestartManagerError> {
         create_tmp_restart_file(&self.config.tmp_dir)?;
 
         let commands = self.get_restart_operation_commands().await?;
@@ -160,12 +181,21 @@ impl RestartManagerActor {
     async fn handle_error(
         &mut self,
         request: &RestartOperationRequest,
-    ) -> Result<(), RestartManagerError> {
-        self.state_repository.clear().await?;
+    ) -> Result<(), ChannelError> {
+        self.clear_state_repository().await;
         let status = OperationStatus::Failed;
         let response = RestartOperationResponse::new(request).with_status(status);
         self.message_box.send(response).await?;
         Ok(())
+    }
+
+    async fn clear_state_repository(&mut self) {
+        if let Err(err) = self.state_repository.clear().await {
+            error!(
+                "Fail to clear the restart state in {} due to: {}",
+                self.state_repository.state_repo_path, err
+            );
+        }
     }
 
     async fn get_restart_operation_commands(&self) -> Result<Vec<Command>, RestartManagerError> {

--- a/crates/core/tedge_agent/src/restart_manager/error.rs
+++ b/crates/core/tedge_agent/src/restart_manager/error.rs
@@ -17,17 +17,8 @@ pub enum RestartManagerError {
     FromSystemServices(#[from] tedge_config::system_services::SystemServiceError),
 
     #[error(transparent)]
-    FromChannelError(#[from] tedge_actors::ChannelError),
-
-    #[error(transparent)]
     FromState(#[from] crate::state_repository::error::StateError),
 
     #[error("Could not convert {timestamp:?} to unix timestamp. Error message: {error_msg}")]
     TimestampConversionError { timestamp: i64, error_msg: String },
-}
-
-impl From<RestartManagerError> for tedge_actors::RuntimeError {
-    fn from(error: RestartManagerError) -> Self {
-        tedge_actors::RuntimeError::ActorError(Box::new(error))
-    }
 }

--- a/crates/core/tedge_agent/src/state_repository/state.rs
+++ b/crates/core/tedge_agent/src/state_repository/state.rs
@@ -9,7 +9,7 @@ use tokio::fs;
 
 #[derive(Debug)]
 pub struct AgentStateRepository {
-    state_repo_path: Utf8PathBuf,
+    pub state_repo_path: Utf8PathBuf,
     state_repo_root: Utf8PathBuf,
 }
 


### PR DESCRIPTION
The restart actor must specifically await a shutdown request to check that the restart has been successfully triggered without consuming subsequent requests.

## Proposed changes

Use the `recv_signal()` method instead of the `recv_message` method. The former consumes only runtime requests while the latter primary purpose is to consume regular messages (while being alerted of any high-priority signal sent by the runtime).

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/1964

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

