### PR TITLE
http_ext: Replace request to httpbin with mock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "log",
- "mockito",
+ "mockito 0.31.1",
  "nix",
  "regex",
  "reqwest",
@@ -2181,6 +2181,26 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "similar",
+]
+
+[[package]]
+name = "mockito"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea57936ab3bf56156f135f20ee24b840e5a8ad97a8e1710eace33ac078f8f537"
+dependencies = [
+ "assert-json-diff",
+ "colored",
+ "futures",
+ "hyper",
+ "lazy_static",
+ "log",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -3610,7 +3630,7 @@ dependencies = [
  "certificate",
  "clap 3.2.25",
  "hyper",
- "mockito",
+ "mockito 0.31.1",
  "mqtt_tests",
  "pem",
  "predicates 2.1.5",
@@ -3810,7 +3830,7 @@ dependencies = [
  "async-trait",
  "download",
  "log",
- "mockito",
+ "mockito 0.31.1",
  "tedge_actors",
  "tedge_test_utils",
  "tedge_utils",
@@ -3855,6 +3875,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-rustls",
+ "mockito 1.0.2",
  "serde",
  "serde_json",
  "tedge_actors",

--- a/crates/extensions/tedge_http_ext/Cargo.toml
+++ b/crates/extensions/tedge_http_ext/Cargo.toml
@@ -25,3 +25,6 @@ serde_json = "1.0"
 tedge_actors = { path = "../../core/tedge_actors" }
 thiserror = "1.0"
 tokio = { version = "1.23", default_features = false, features = ["macros", "rt"] }
+
+[dev-dependencies]
+mockito = "1.0.2"

--- a/crates/extensions/tedge_http_ext/src/tests.rs
+++ b/crates/extensions/tedge_http_ext/src/tests.rs
@@ -3,9 +3,12 @@ use tedge_actors::ClientMessageBox;
 
 #[tokio::test]
 async fn get_over_https() {
+    let mut server = mockito::Server::new();
+    let _mock = server.mock("GET", "/").create();
+
     let mut http = spawn_http_actor().await;
 
-    let request = HttpRequestBuilder::get("https://httpbin.org/get")
+    let request = HttpRequestBuilder::get(server.url())
         .build()
         .expect("A simple HTTPS GET request");
 


### PR DESCRIPTION
## Proposed changes

The request to httpbin service was failing with a 504 for me, so I replaced it with a mock.

The mock is unfortunately HTTP only, so if the intent was to test HTTPS as well, then this PR removes it.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

