### PR TITLE
Fix setting names to match the new tedge-config

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,6 +3,7 @@ mosquitto = "mosquitto"
 hda = "hda"
 tegde = "tedge"
 OT = "OT"
+Robocorp = "Robocorp"
 
 [files]
 extend-exclude = [

--- a/crates/common/tedge_config/src/tedge_config_cli/new.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/new.rs
@@ -390,7 +390,7 @@ define_tedge_config! {
                 #[tedge_config(deprecated_name = "cadir")]
                 ca_dir: Utf8PathBuf,
 
-                /// Path to the client certficate
+                /// Path to the client certificate
                 #[doku(as = "PathBuf")]
                 #[tedge_config(example = "/etc/mosquitto/auth_certificates/cert.pem")]
                 #[tedge_config(deprecated_name = "certfile")]

--- a/crates/common/tedge_config/src/tedge_config_cli/new.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/new.rs
@@ -445,7 +445,7 @@ define_tedge_config! {
     http: {
         bind: {
             /// Http server port used by the File Transfer Service
-            #[tedge_config(example = "8000", deprecated_key = "http.port")]
+            #[tedge_config(example = "8000", default(value = 8000u16), deprecated_key = "http.port")]
             port: u16,
 
             /// Http server address used by the File Transfer Service

--- a/crates/common/tedge_config_macros/examples/macro.rs
+++ b/crates/common/tedge_config_macros/examples/macro.rs
@@ -118,7 +118,7 @@ define_tedge_config! {
                 #[tedge_config(deprecated_name = "capath")]
                 ca_path: Utf8PathBuf,
 
-                /// Path to the client certficate
+                /// Path to the client certificate
                 #[doku(as = "PathBuf")]
                 #[tedge_config(deprecated_name = "certfile")]
                 cert_file: Utf8PathBuf,

--- a/crates/common/tedge_config_macros/impl/src/input/parse.rs
+++ b/crates/common/tedge_config_macros/impl/src/input/parse.rs
@@ -1,4 +1,4 @@
-//! The inital parsing logic
+//! The initial parsing logic
 //!
 //! This is designed to take a [proc_macro2::TokenStream] and turn it into
 //! something useful with the aid of [syn].

--- a/crates/common/tedge_config_macros/impl/src/lib.rs
+++ b/crates/common/tedge_config_macros/impl/src/lib.rs
@@ -179,7 +179,7 @@ mod tests {
     }
 
     #[test]
-    fn serde_rename_is_not_allowd() {
+    fn serde_rename_is_not_allowed() {
         assert!(generate_configuration(quote! {
             device: {
                 #[serde(rename = "type")]

--- a/crates/common/tedge_config_macros/src/define_tedge_config_docs.md
+++ b/crates/common/tedge_config_macros/src/define_tedge_config_docs.md
@@ -279,7 +279,7 @@ define_tedge_config! {
 ```
 
 Additional notes about fields can be added using `#[tedge_config(note =
-"content")]`. This will be added to `tedge config list --doc` on a seperate
+"content")]`. This will be added to `tedge config list --doc` on a separate
 line, with a coloured heading to make it more distinctive.
 
 ## Reader: `#[tedge_config(reader(...))]`

--- a/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
+++ b/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
@@ -109,14 +109,14 @@ set/unset aws.url
     ${unset}     Execute Command    tedge config list
     Should not Contain    ${unset}    aws.url=
 
-set/unset aws.root.cert.path
-    Execute Command    sudo tedge config set aws.root.cert.path /etc/ssl/certs1   #Changing aws.root.cert.path
+set/unset aws.root_cert_path
+    Execute Command    sudo tedge config set aws.root_cert_path /etc/ssl/certs1   #Changing aws.aws.root_cert_path
     ${set}     Execute Command    tedge config list
-    Should Contain    ${set}    aws.root.cert.path=/etc/ssl/certs1
+    Should Contain    ${set}    aws.root_cert_path=/etc/ssl/certs1
 
-    Execute Command    sudo tedge config unset aws.root.cert.path    #Undo the change by using the 'unset' command, value returns to default one
+    Execute Command    sudo tedge config unset aws.root_cert_path    #Undo the change by using the 'unset' command, value returns to default one
     ${unset}     Execute Command    tedge config list
-    Should Contain    ${unset}    aws.root.cert.path=/etc/ssl/certs
+    Should Contain    ${unset}    aws.root_cert_path=/etc/ssl/certs
 
 set/unset aws.mapper.timestamp
     Execute Command    sudo tedge config set aws.mapper.timestamp false  #Changing aws.mapper.timestamp
@@ -160,14 +160,14 @@ set/unset mqtt.bind.port
     ${unset}    Execute Command    tedge config list
     Should Contain    ${unset}    mqtt.bind.port=1883
 
-set/unset http.port
-    Execute Command    sudo tedge config set http.port 7777  #Changing http.port
+set/unset http.bind.port
+    Execute Command    sudo tedge config set http.bind.port 7777  #Changing http.bind.port
     ${set}     Execute Command    tedge config list
-    Should Contain    ${set}    http.port=7777
+    Should Contain    ${set}    http.bind.port=7777
 
-    Execute Command    sudo tedge config unset http.port    #Undo the change by using the 'unset' command, value returns to default one
+    Execute Command    sudo tedge config unset http.bind.port    #Undo the change by using the 'unset' command, value returns to default one
     ${unset}     Execute Command    tedge config list
-    Should Contain    ${unset}    http.port=8000
+    Should Contain    ${unset}    http.bind.port=8000
 
 set/unset tmp.path
     Execute Command    sudo tedge config set tmp.path /tmp1    #Changing tmp.path
@@ -229,59 +229,59 @@ set/unset az.url
     ${unset}     Execute Command    tedge config list
     Should not Contain    ${unset}    az.url=
 
-set/unset mqtt.external.port 
-    Execute Command    sudo tedge config set mqtt.external.port 8888  #Changing mqtt.external.port
+set/unset mqtt.external.bind.port
+    Execute Command    sudo tedge config set mqtt.external.bind.port 8888  #Changing mqtt.external.bind.port
     ${set}     Execute Command    tedge config list
-    Should Contain    ${set}    mqtt.external.port=8888
+    Should Contain    ${set}    mqtt.external.bind.port=8888
 
-    Execute Command    sudo tedge config unset mqtt.external.port     #Undo the change by using the 'unset' command, value returns to default one
+    Execute Command    sudo tedge config unset mqtt.external.bind.port     #Undo the change by using the 'unset' command, value returns to default one
     ${unset}     Execute Command    tedge config list
-    Should Not Contain    ${unset}    mqtt.external.port=
+    Should Not Contain    ${unset}    mqtt.external.bind.port=
 
-mqtt.external.bind_address
-    Execute Command    sudo tedge config set mqtt.external.bind_address 0.0.0.0  #Changing mqtt.external.bind_address
+mqtt.external.bind.address
+    Execute Command    sudo tedge config set mqtt.external.bind.address 0.0.0.0  #Changing mqtt.external.bind.address
     ${set}     Execute Command    tedge config list
-    Should Contain    ${set}    mqtt.external.bind_address=0.0.0.0
+    Should Contain    ${set}    mqtt.external.bind.address=0.0.0.0
 
-    Execute Command    sudo tedge config unset mqtt.external.bind_address    #Undo the change by using the 'unset' command, value returns to default one
+    Execute Command    sudo tedge config unset mqtt.external.bind.address    #Undo the change by using the 'unset' command, value returns to default one
     ${unset}     Execute Command    tedge config list
-    Should Not Contain    ${unset}    mqtt.external.bind_address=
+    Should Not Contain    ${unset}    mqtt.external.bind.address=
 
-mqtt.external.bind_interface
-    Execute Command    sudo tedge config set mqtt.external.bind_interface wlan0  #Changing mqtt.external.bind_interface
+mqtt.external.bind.interface
+    Execute Command    sudo tedge config set mqtt.external.bind.interface wlan0  #Changing mqtt.external.bind.interface
     ${set}     Execute Command    tedge config list
-    Should Contain    ${set}    mqtt.external.bind_interface=wlan0
+    Should Contain    ${set}    mqtt.external.bind.interface=wlan0
 
-    Execute Command    sudo tedge config unset mqtt.external.bind_interface    #Undo the change by using the 'unset' command, value returns to default one
+    Execute Command    sudo tedge config unset mqtt.external.bind.interface    #Undo the change by using the 'unset' command, value returns to default one
     ${unset}     Execute Command    tedge config list
-    Should Not Contain    ${unset}    mqtt.external.bind_interface=
+    Should Not Contain    ${unset}    mqtt.external.bind.interface=
 
-set/unset mqtt.external.capath
-    Execute Command    sudo tedge config set mqtt.external.capath /etc/ssl/certsNote   #Changing mqtt.external.capath
+set/unset mqtt.external.ca_path
+    Execute Command    sudo tedge config set mqtt.external.ca_path /etc/ssl/certsNote   #Changing mqtt.external.ca_path
     ${set}     Execute Command    tedge config list
-    Should Contain    ${set}    mqtt.external.capath=/etc/ssl/certsNote
+    Should Contain    ${set}    mqtt.external.ca_path=/etc/ssl/certsNote
 
-    Execute Command    sudo tedge config unset mqtt.external.capath    #Undo the change by using the 'unset' command, value returns to default one
+    Execute Command    sudo tedge config unset mqtt.external.ca_path   #Undo the change by using the 'unset' command, value returns to default one
     ${unset}     Execute Command    tedge config list
-    Should Not Contain    ${unset}    mqtt.external.capath=
+    Should Not Contain    ${unset}    mqtt.external.ca_path=
 
-set/unset mqtt.external.certfile
-    Execute Command    sudo tedge config set mqtt.external.certfile /etc/tedge/device-certs/tedge-certificate.pemNote   #Changing mqtt.external.certfile
+set/unset mqtt.external.cert_file
+    Execute Command    sudo tedge config set mqtt.external.cert_file /etc/tedge/device-certs/tedge-certificate.pemNote   #Changing mqtt.external.cert_file
     ${set}     Execute Command    tedge config list
-    Should Contain    ${set}    mqtt.external.certfile=/etc/tedge/device-certs/tedge-certificate.pemNote
+    Should Contain    ${set}    mqtt.external.cert_file=/etc/tedge/device-certs/tedge-certificate.pemNote
 
-    Execute Command    sudo tedge config unset mqtt.external.certfile    #Undo the change by using the 'unset' command, value returns to default one
+    Execute Command    sudo tedge config unset mqtt.external.cert_file    #Undo the change by using the 'unset' command, value returns to default one
     ${unset}     Execute Command    tedge config list
-    Should Not Contain    ${unset}    mqtt.external.certfile=
+    Should Not Contain    ${unset}    mqtt.external.cert_file=
 
-set/unset mqtt.external.keyfile
-    Execute Command    sudo tedge config set mqtt.external.keyfile /etc/tedge/device-certs/tedge-private-key.pemNote   #Changing mqtt.external.keyfile
+set/unset mqtt.external.key_file
+    Execute Command    sudo tedge config set mqtt.external.key_file /etc/tedge/device-certs/tedge-private-key.pemNote   #Changing mqtt.external.key_file
     ${set}     Execute Command    tedge config list
-    Should Contain    ${set}    mqtt.external.keyfile=/etc/tedge/device-certs/tedge-private-key.pemNote
+    Should Contain    ${set}    mqtt.external.key_file=/etc/tedge/device-certs/tedge-private-key.pemNote
 
-    Execute Command    sudo tedge config unset mqtt.external.keyfile    #Undo the change by using the 'unset' command, value returns to default one
+    Execute Command    sudo tedge config unset mqtt.external.key_file    #Undo the change by using the 'unset' command, value returns to default one
     ${unset}     Execute Command    tedge config list
-    Should Not Contain    ${unset}    mqtt.external.keyfile=
+    Should Not Contain    ${unset}    mqtt.external.key_file=
 
 set/unset software.plugin.default
     Execute Command    sudo tedge config set software.plugin.default apt   #Changing software.plugin.default


### PR DESCRIPTION
## Proposed changes

The tests were broken because of two conflicting merges:
- Adding tests for misc settings: https://github.com/thin-edge/thin-edge.io/pull/1976
- Changing setting names: https://github.com/thin-edge/thin-edge.io/pull/1936

This clash is a call for https://github.com/thin-edge/thin-edge.io/issues/1393

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

