### PR TITLE
feat(tedge-mapper): retrieve agent version from cargo package version instead of calling the tedge cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,6 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
- "assert_cmd",
  "assert_matches",
  "async-trait",
  "c8y_api",

--- a/crates/extensions/c8y_mapper_ext/Cargo.toml
+++ b/crates/extensions/c8y_mapper_ext/Cargo.toml
@@ -10,7 +10,6 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-assert_cmd = "2.0"
 async-trait = "0.1"
 c8y_api = { path = "../../core/c8y_api" }
 c8y_http_proxy = { path = "../c8y_http_proxy" }

--- a/crates/extensions/c8y_mapper_ext/build.rs
+++ b/crates/extensions/c8y_mapper_ext/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    // export GIT_SEMVER=$(git describe --always --tags --abbrev=8 --dirty)
+    // https://github.com/rust-lang/cargo/issues/6583#issuecomment-1259871885
+    if let Ok(val) = std::env::var("GIT_SEMVER") {
+        println!("Using version defined by 'GIT_SEMVER={}'", val);
+        println!("cargo:rustc-env=CARGO_PKG_VERSION={}", val);
+    }
+    println!("cargo:rerun-if-env-changed=GIT_SEMVER");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/tests/RobotFramework/tests/cumulocity/inventory/inventory_update.robot
+++ b/tests/RobotFramework/tests/cumulocity/inventory/inventory_update.robot
@@ -17,6 +17,13 @@ Update Inventory data via inventory.json
     Should Be Equal    ${mo["types"][0]}    type1
     Should Be Equal    ${mo["types"][1]}    type2
 
+Inventory includes the agent fragment with version information
+    ${expected_version}=    Execute Command    tedge-mapper --version | cut -d' ' -f2    strip=${True}
+    ${mo}=    Cumulocity.Device Should Have Fragments    c8y_Agent
+    Should Be Equal    ${mo["c8y_Agent"]["name"]}        thin-edge.io
+    Should Be Equal    ${mo["c8y_Agent"]["version"]}     ${expected_version}
+    Should Be Equal    ${mo["c8y_Agent"]["url"]}         https://thin-edge.io
+
 *** Keywords ***
 
 Custom Setup


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

The `tedge-mapper` was using this to get publish the current "tedge" version to Cumulocity, for example it was producing the publishing the following fragment to Cumulocity on startup.

```json
{
  "c8y_Agent": {
    "name": "thin-edge.io",
    "url": "https://thin-edge.io",
    "version": "0.11.0-38-g246db7dd"
  }
}
```

This PR is to change where the `c8y_Agent.version` value is populated from.

The agent version now returns the value from the Rust build environment variable (package version) instead of calling the `tedge --version` binary. This removes the dependency to `tedge` and means that the `tedge-mapper` can be run in an environment where `tedge` is not installed and still report back the correct agent version to Cumulocity.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

#1991

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

