### PR TITLE
ci: remove usage of actions-rs/toolchain@v1 as it is not actively maintained

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -93,10 +93,11 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
 
       - name: Run cargo-udeps
         uses: aig787/cargo-udeps-action@v1
@@ -202,12 +203,17 @@ jobs:
         uses: actions/checkout@v3
       
       # Nightly toolchain is needed for cargo fmt since issue: https://github.com/thin-edge/thin-edge.io/issues/1660
+      # dtolnay/rust-toolchain is preferred over actions-rs/toolchain is currently not maintained and currently using
+      # deprecated GHA api (see https://github.com/actions-rs/toolchain/issues/219).
+      # However since dtolnay/rust-toolchain does not support the 'override' option, an additional call to
+      # rustup override is required (see https://github.com/dtolnay/rust-toolchain/issues/29#issuecomment-1412903426)
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
+        id: toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
           components: rustfmt
-          override: true
+      - run: rustup override set ${{steps.toolchain.outputs.name}}
 
       - name: Cargo fmt --version
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Replace the usage of [actions-rs/toolchain@v1](https://github.com/actions-rs/toolchain) as it is no longer maintained and it uses deprecated GitHub Actions API.

The PR switches to using [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) provides similar functionality, however requires an additional step when using the nightly toolchain because it does not support the override option.

**Warning**

This does not solve all of the deprecation notices, but reduces any coming from `actions-rs/toolchain@v1`.

**References**

* [actions-rs/toolchain usage of deprecated GHA API](https://github.com/actions-rs/toolchain/issues/219)
* [dtolnay/rust-toolchain override option workaround](https://github.com/dtolnay/rust-toolchain/issues/29#issuecomment-1412903426)


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

An example of the GitHub deprecated notices are visible from the [PR checks run](https://github.com/thin-edge/thin-edge.io/actions/runs/5143205330).

<img width="1434" alt="image" src="https://github.com/thin-edge/thin-edge.io/assets/3029781/afb41887-22b3-49f8-b66f-a2608f5c866d">

