### PR TITLE
fix(test-framework): Fix Should Have MQTT Messages keyword for payload pattern matching

### DIFF
--- a/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
+++ b/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
@@ -365,7 +365,9 @@ class ThinEdgeIO(DeviceLibrary):
             try:
                 message = json.loads(line)
                 if "message" in message:
-                    if message_pattern_re is None or message_pattern_re.match(message):
+                    if message_pattern_re is None or message_pattern_re.match(
+                        message["message"]["payload"]
+                    ):
                         messages.append(message)
             except Exception as ex:
                 log.debug("ignoring non-json entry. %s", ex)
@@ -466,14 +468,13 @@ class ThinEdgeIO(DeviceLibrary):
     ) -> List[Dict[str, Any]]:
         # log.info("Checking mqtt messages for topic: %s", topic)
         if message_contains:
-            message_pattern = re.escape(message_contains)
+            message_pattern = r".*" + re.escape(message_contains) + r".*"
 
         items = self.mqtt_match_messages(
             topic=topic,
             date_from=date_from,
             date_to=date_to,
             message_pattern=message_pattern,
-            message_contains=message_contains,
             **kwargs,
         )
 

--- a/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
+++ b/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
@@ -388,7 +388,7 @@ class ThinEdgeIO(DeviceLibrary):
     #
     @keyword("Service Health Status Should Be Up")
     def assert_service_health_status_up(self, service: str) -> Dict[str, Any]:
-        """ Checks if the Service Health Status is up
+        """Checks if the Service Health Status is up
 
         *Example:*
         | `Service Health Status Should Be Up` | | | | | tedge-mapper-c8y |
@@ -408,12 +408,10 @@ class ThinEdgeIO(DeviceLibrary):
     def _assert_health_status(self, service: str, status: str) -> Dict[str, Any]:
         # if mqtt.client.auth.ca_file or mqtt.client.auth.ca_dir is set, we pass setting
         # value to mosquitto_sub
-        mqtt_config_options = self.execute_command(f"tedge config list",
-            stdout=True,
-            stderr=False,
-            ignore_exit_code=True
+        mqtt_config_options = self.execute_command(
+            f"tedge config list", stdout=True, stderr=False, ignore_exit_code=True
         )
-        
+
         server_auth = ""
         if "mqtt.client.auth.ca_file" in mqtt_config_options:
             server_auth = "--cafile /etc/mosquitto/ca_certificates/ca.crt"

--- a/tests/RobotFramework/tests/library/test-mqtt.robot
+++ b/tests/RobotFramework/tests/library/test-mqtt.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Resource    ../../resources/common.resource
+Library    Cumulocity
+Library    ThinEdgeIO    adapter=docker
+
+Test Tags    theme:testing
+Test Setup    Setup
+Test Teardown    Get Logs
+
+*** Test Cases ***
+
+It checks MQTT messages using a pattern
+    ${DEVICE_SN}                         Setup
+    Device Should Exist                  ${DEVICE_SN}
+    Execute Command            tedge mqtt pub 'custom/message' '{"status":"executing"}'
+    Should Have MQTT Messages    custom/message    message_pattern=.*executing.*
+    Should Have MQTT Messages    custom/message    message_contains=executing


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix the handling of the `Should Have MQTT Messages` keyword when using the `message_pattern` or `message_contains` payload pattern matching. Previously there was a bug which lead to the pattern matching always failing to find any results.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

