### PR TITLE
pass config location to plugin-sm from agent

### DIFF
--- a/crates/core/plugin_sm/tests/plugin_manager.rs
+++ b/crates/core/plugin_sm/tests/plugin_manager.rs
@@ -6,6 +6,7 @@ mod tests {
     use std::fs::File;
     use std::path::PathBuf;
     use std::str::FromStr;
+    use tedge_config::TEdgeConfigLocation;
     use tempfile::NamedTempFile;
 
     #[test]
@@ -15,7 +16,8 @@ mod tests {
         let plugin_dir = temp_dir.path().to_owned();
 
         // Call open and load to register all plugins from given directory.
-        let mut plugins = ExternalPlugins::open(plugin_dir, None, None).unwrap();
+        let mut plugins =
+            ExternalPlugins::open(plugin_dir, None, None, TEdgeConfigLocation::default()).unwrap();
         let _ = plugins.load();
 
         // Plugins registry should not register any plugin as no files in the directory are present.
@@ -33,7 +35,8 @@ mod tests {
         let plugin_dir = temp_dir.path().to_owned();
 
         // Call open and load to register all plugins from given directory.
-        let mut plugins = ExternalPlugins::open(plugin_dir, None, None).unwrap();
+        let mut plugins =
+            ExternalPlugins::open(plugin_dir, None, None, TEdgeConfigLocation::default()).unwrap();
         let _ = plugins.load();
 
         // Registry has registered no plugins.
@@ -51,7 +54,8 @@ mod tests {
         let plugin_dir = temp_dir.path().to_owned();
 
         // Call open and load to register all plugins from given directory.
-        let mut plugins = ExternalPlugins::open(plugin_dir, None, None).unwrap();
+        let mut plugins =
+            ExternalPlugins::open(plugin_dir, None, None, TEdgeConfigLocation::default()).unwrap();
         let _ = plugins.load();
 
         // Check if registry has loaded plugin of type `test`.
@@ -97,7 +101,8 @@ mod tests {
         let plugin_dir = temp_dir.path().to_owned();
 
         // Call open and load to register all plugins from given directory.
-        let mut plugins = ExternalPlugins::open(plugin_dir, None, None).unwrap();
+        let mut plugins =
+            ExternalPlugins::open(plugin_dir, None, None, TEdgeConfigLocation::default()).unwrap();
         let _ = plugins.load();
 
         // Plugin registry shall have registered plugin with name as the file in plugin directory.
@@ -130,9 +135,13 @@ mod tests {
         let _res = std::fs::copy(get_dummy_plugin_path(), plugin3.path());
         let (_, _path) = plugin3.keep().unwrap();
 
-        let mut plugins =
-            ExternalPlugins::open(plugin_dir.into_path(), Some(plugin_name2.clone()), None)
-                .unwrap();
+        let mut plugins = ExternalPlugins::open(
+            plugin_dir.into_path(),
+            Some(plugin_name2.clone()),
+            None,
+            TEdgeConfigLocation::default(),
+        )
+        .unwrap();
         plugins.load().unwrap();
 
         assert_eq!(
@@ -158,7 +167,13 @@ mod tests {
             .to_owned();
         let (_, _path) = plugin.keep().unwrap();
 
-        let mut plugins = ExternalPlugins::open(plugin_dir.into_path(), None, None).unwrap();
+        let mut plugins = ExternalPlugins::open(
+            plugin_dir.into_path(),
+            None,
+            None,
+            TEdgeConfigLocation::default(),
+        )
+        .unwrap();
         plugins.load().unwrap();
 
         assert_eq!(
@@ -174,7 +189,12 @@ mod tests {
         let plugin_file_path = plugin_dir.path().join("apt");
         let _ = File::create(plugin_file_path).unwrap();
 
-        let result = ExternalPlugins::open(plugin_dir.into_path(), Some("dummy".into()), None)?;
+        let result = ExternalPlugins::open(
+            plugin_dir.into_path(),
+            Some("dummy".into()),
+            None,
+            TEdgeConfigLocation::default(),
+        )?;
         assert!(result.empty());
         assert!(result.default().is_none());
 

--- a/crates/core/tedge_agent/src/software_manager/actor.rs
+++ b/crates/core/tedge_agent/src/software_manager/actor.rs
@@ -59,6 +59,7 @@ impl Actor for SoftwareManagerActor {
             &self.config.sm_plugins_dir,
             self.config.default_plugin_type.clone(),
             Some(SUDO.into()),
+            self.config.config_location.clone(),
         )
         .map_err(|err| RuntimeError::ActorError(Box::new(err)))?;
 


### PR DESCRIPTION
## Proposed changes
This is follow up PR to #1961 that solve the issue with tedge config. Previously it was assumed that tedge config is in default location, now it is delivered from agent. 
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#1961
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

