### PR TITLE
Add workflow to upload coverage report on pushes to main

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,8 +7,10 @@ coverage:
     # ref: https://docs.codecov.com/docs/commit-status
     project:
       default:
-        # Avoid false negatives
-        threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true
 
 # Test files aren't important for coverage
 ignore:

--- a/.github/workflows/head_coverage.yml
+++ b/.github/workflows/head_coverage.yml
@@ -1,0 +1,51 @@
+# Upload code coverage report every time there is a push to the main branch.
+#
+# Codecov guides suggest uploading coverage for push and pull_request events.
+# pull-request-checks.yml only runs on PRs though, and when coverage upload only
+# happens there, it has an effect of codecov patch reports not picking up the
+# latest HEAD and displaying coverage changes that have already been made in
+# previous PRs. To fix this, we upload report every time we push to main, which
+# also happens when a PR gets merged.
+
+name: Upload HEAD coverage
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  head-coverage:
+    name: Upload HEAD coverage
+    runs-on: ubuntu-20.04
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Enable toolchain via github action
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Enable cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: cargo install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: cargo llvm-cov
+        run: cargo llvm-cov --no-fail-fast --locked --all-features --all-targets --codecov --output-path codecov.json
+
+      # https://github.com/rust-lang/cargo/issues/6669
+      - name: cargo test --doc
+        run: cargo test --locked --all-features --doc
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true


### PR DESCRIPTION
## Proposed changes

Codecov guides suggest uploading coverage for push and pull_request events. `pull-request-checks.yml` only runs on PRs though, and when coverage upload only happens there, it has an effect of codecov patch reports not picking up the latest HEAD and displaying coverage changes that have already been made in previous PRs. To fix this, we upload report every time we push to main, which also happens when a PR gets merged.

Also, because coverage data that we get from llvm-cov is somewhat noisy and unrelated changes can randomly increase or decrease coverage, failing PR checks, we disable blocking checks for the time being. Once we tune codecov to a sufficient degree, we can reenable them.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

https://docs.codecov.com/docs/commit-status#informational
