### PR TITLE
Improve ConnectUrl parse error message

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/models/connect_url.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/connect_url.rs
@@ -12,7 +12,7 @@ pub struct ConnectUrl {
 
 #[derive(thiserror::Error, Debug)]
 #[error(
-    "Provided URL: '{input}' contains scheme or port.
+    "Could not parse provided URL: '{input}' as a valid domain name.
          Provided URL should contain only domain, eg: 'subdomain.cumulocity.com'."
 )]
 pub struct InvalidConnectUrl {


### PR DESCRIPTION

## Proposed changes

Previous error message was incorrect because there are other reasons for parsing to fail than containing scheme or port, e.g. if the value is empty, resulting in an message:

Provided URL: '' contains scheme or port
    Provided URL should contain only domain, eg: 'subdomain.cumulocity.com'.

The new message is now more generic, suggestion in the second line should be sufficient to pinpoint the cause of the error by the user.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

As a side note, we probably shouln't call that a URL if we only expect some parts of the URL. Domain, address, or host would perhaps be better names.

