### PR TITLE
Don't exit ConfigManager if error processing event and improve config snapshot error message

### DIFF
--- a/crates/common/download/src/download.rs
+++ b/crates/common/download/src/download.rs
@@ -179,7 +179,8 @@ impl Downloader {
             target_file_path,
             self.target_permission.clone(),
         )
-        .await?;
+        .await
+        .map_err(FileError::from)?;
 
         Ok(())
     }

--- a/crates/extensions/c8y_config_manager/src/upload.rs
+++ b/crates/extensions/c8y_config_manager/src/upload.rs
@@ -36,6 +36,7 @@ use tedge_timer_ext::SetTimeout;
 use tedge_utils::file::create_directory_with_user_group;
 use tedge_utils::file::create_file_with_user_group;
 use tedge_utils::file::move_file;
+use tedge_utils::file::FileError;
 use tedge_utils::file::PermissionEntry;
 
 pub struct ConfigUploadManager {
@@ -301,7 +302,9 @@ impl ConfigUploadManager {
                     config_response.get_child_id()
                 );
                 let path_to = Path::new(path_to);
-                move_file(path_from, path_to, PermissionEntry::default()).await?;
+                move_file(path_from, path_to, PermissionEntry::default())
+                    .await
+                    .map_err(FileError::from)?;
             }
             // send 119
             let child_plugin_config = PluginConfig::new(Path::new(&format!(

--- a/crates/extensions/c8y_firmware_manager/src/actor.rs
+++ b/crates/extensions/c8y_firmware_manager/src/actor.rs
@@ -36,6 +36,7 @@ use tedge_mqtt_ext::Topic;
 use tedge_timer_ext::SetTimeout;
 use tedge_timer_ext::Timeout;
 use tedge_utils::file::move_file;
+use tedge_utils::file::FileError;
 use tedge_utils::file::PermissionEntry;
 
 use crate::config::FirmwareManagerConfig;
@@ -334,7 +335,8 @@ impl FirmwareManagerActor {
                 &cache_file_path,
                 PermissionEntry::new(None, None, None),
             )
-            .await?;
+            .await
+            .map_err(FileError::from)?;
         }
 
         let symlink_path =


### PR DESCRIPTION
## Proposed changes

This PR makes ConfigManager actor no longer unsuccessfully exit if there's an error processing event, instead it just logs it and continues processing events. Previous behaviour was not optimal for e.g. processing config snapshot messages, where an error doesn't really put the actor in an unrecoverable state, so IMO there's no reason to exit. The new behaviour was applied to all possible errors when processing events, so if there are any event-related errors where it is crucial to terminate the actor, please let me know.

Also the error message was improved when we try to copy the child device configuration file from file transfer directory to the `/etc/tedge/c8y/` directory. If the configuration file was not uploaded via HTTP (`PUT http://127.0.0.1:8000/tedge/file-transfer/child/c8y-configuration-plugin`), sending a config snapshot MQTT message resulted in an unhelpful error:
`ERROR Runtime: Actor ConfigManager-6 has finished unsuccessfully: ActorError(FromFile(FromIoError(Os { code: 2, kind: NotFound, message: "No such file or directory" })))`

Now when copying files, in the error we report the source, the destination, and source error:
`Error processing event: FromFile(FileMove(FileMoveError { src: "/var/tedge/file-transfer/child1/c8y-configuration-plugin", dest: "/etc/tedge/c8y/child1/c8y-configuration-plugin.toml", source: No such file or directory (os error 2) }))`

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #2036

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments



