### PR TITLE
Fix AwsConverter and AzConverter not being killed by JSON parse error

### DIFF
--- a/crates/extensions/aws_mapper_ext/src/converter.rs
+++ b/crates/extensions/aws_mapper_ext/src/converter.rs
@@ -1,6 +1,8 @@
 use clock::Clock;
+use log::error;
 use serde_json::Map;
 use serde_json::Value;
+use std::convert::Infallible;
 use tedge_actors::Converter;
 use tedge_api::serialize::ThinEdgeJsonSerializer;
 use tedge_mqtt_ext::MqttMessage;
@@ -49,14 +51,8 @@ impl AwsConverter {
         .try_into()
         .unwrap()
     }
-}
 
-impl Converter for AwsConverter {
-    type Error = ConversionError;
-    type Input = MqttMessage;
-    type Output = MqttMessage;
-
-    fn convert(&mut self, input: &Self::Input) -> Result<Vec<Self::Output>, Self::Error> {
+    fn try_convert(&mut self, input: &MqttMessage) -> Result<Vec<MqttMessage>, ConversionError> {
         let default_timestamp = self.add_timestamp.then(|| self.clock.now());
 
         // serialize with ThinEdgeJson for measurements, for alarms and events just add the timestamp
@@ -96,19 +92,37 @@ impl Converter for AwsConverter {
         self.size_threshold.validate(&output)?;
         Ok(vec![(output)])
     }
+
+    fn wrap_errors(
+        &self,
+        messages_or_err: Result<Vec<MqttMessage>, ConversionError>,
+    ) -> Vec<MqttMessage> {
+        messages_or_err.unwrap_or_else(|error| vec![self.new_error_message(error)])
+    }
+
+    fn new_error_message(&self, error: ConversionError) -> MqttMessage {
+        error!("Mapping error: {}", error);
+        MqttMessage::new(&Topic::new_unchecked("tedge/errors"), error.to_string())
+    }
+}
+
+impl Converter for AwsConverter {
+    type Input = MqttMessage;
+    type Output = MqttMessage;
+    type Error = Infallible;
+
+    fn convert(&mut self, input: &Self::Input) -> Result<Vec<Self::Output>, Self::Error> {
+        let messages_or_err = self.try_convert(input);
+        Ok(self.wrap_errors(messages_or_err))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::converter::AwsConverter;
-    use crate::converter::*;
-
+    use super::*;
     use assert_json_diff::*;
     use assert_matches::*;
-    use clock::Clock;
     use serde_json::json;
-    use tedge_mqtt_ext::MqttMessage;
-    use tedge_mqtt_ext::Topic;
     use time::macros::datetime;
 
     struct TestClock;
@@ -119,22 +133,57 @@ mod tests {
         }
     }
 
-    #[test]
-    fn converting_invalid_json_is_invalid() {
-        let mut converter = AwsConverter::new(false, Box::new(TestClock));
-
-        let input = "This is not Thin Edge JSON";
-        let result = converter.convert(&new_tedge_message(input));
-
-        assert_matches!(result, Err(ConversionError::FromThinEdgeJsonParser(_)))
-    }
-
     fn new_tedge_message(input: &str) -> MqttMessage {
         MqttMessage::new(&Topic::new_unchecked("tedge/measurements"), input)
     }
 
     fn extract_first_message_payload(mut messages: Vec<MqttMessage>) -> String {
         messages.pop().unwrap().payload_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn convert_error() {
+        let mut converter = AwsConverter::new(true, Box::new(TestClock));
+
+        let input = "Invalid JSON";
+
+        let output = converter.convert(&new_tedge_message(input)).unwrap();
+
+        assert_eq!(output.first().unwrap().topic.name, "tedge/errors");
+        assert_eq!(
+            extract_first_message_payload(output),
+            "Invalid JSON: expected value at line 1 column 1: `Invalid JSON\n`"
+        );
+    }
+
+    #[test]
+    fn try_convert_invalid_json_returns_error() {
+        let mut converter = AwsConverter::new(false, Box::new(TestClock));
+
+        let input = "This is not Thin Edge JSON";
+        let result = converter.try_convert(&new_tedge_message(input));
+
+        assert_matches!(result, Err(ConversionError::FromThinEdgeJsonParser(_)))
+    }
+
+    #[test]
+    fn try_convert_exceeding_threshold_returns_error() {
+        let mut converter =
+            AwsConverter::new(false, Box::new(TestClock)).with_threshold(SizeThreshold(1));
+
+        let _topic = "tedge/measurements".to_string();
+        let input = r#"{"temperature": 21.3}"#;
+        let _input_size = input.len();
+        let result = converter.try_convert(&new_tedge_message(input));
+
+        assert_matches!(
+            result,
+            Err(ConversionError::SizeThresholdExceeded {
+                topic: _topic,
+                actual_size: _input_size,
+                threshold: 1
+            })
+        );
     }
 
     #[test]
@@ -227,26 +276,6 @@ mod tests {
             serde_json::from_str::<serde_json::Value>(&extract_first_message_payload(output))
                 .unwrap(),
             expected_output
-        );
-    }
-
-    #[tokio::test]
-    async fn exceeding_threshold_returns_error() {
-        let mut converter =
-            AwsConverter::new(false, Box::new(TestClock)).with_threshold(SizeThreshold(1));
-
-        let _topic = "tedge/measurements".to_string();
-        let input = r#"{"temperature": 21.3}"#;
-        let _input_size = input.len();
-        let result = converter.convert(&new_tedge_message(input));
-
-        assert_matches!(
-            result,
-            Err(ConversionError::SizeThresholdExceeded {
-                topic: _topic,
-                actual_size: _input_size,
-                threshold: 1
-            })
         );
     }
 }


### PR DESCRIPTION
## Proposed changes
As I discovered during different work, https://github.com/thin-edge/thin-edge.io/pull/2033#discussion_r1235795859, aws-mapper and az-mapper should not stop converter actor when it fails to deserialize JSON.

This PR fixes the bug.

### How to reproduce the bug?
Publish invalid JSON payload to `tedge/measurements` topic in both mappers.
You will see Converter Actor died from the mapper log.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
Part 3 of #1969 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

