### PR TITLE
Improve downloader logging behaviour and make SoftwareManager exit immediately on ^C

### DIFF
--- a/crates/core/tedge_agent/src/software_manager/actor.rs
+++ b/crates/core/tedge_agent/src/software_manager/actor.rs
@@ -13,8 +13,11 @@ use plugin_sm::plugin_manager::ExternalPlugins;
 use plugin_sm::plugin_manager::Plugins;
 use tedge_actors::fan_in_message_type;
 use tedge_actors::Actor;
+use tedge_actors::LoggingReceiver;
+use tedge_actors::LoggingSender;
 use tedge_actors::MessageReceiver;
 use tedge_actors::RuntimeError;
+use tedge_actors::RuntimeRequest;
 use tedge_actors::Sender;
 use tedge_actors::SimpleMessageBox;
 use tedge_api::OperationStatus;
@@ -29,7 +32,8 @@ use tedge_config::ConfigSettingAccessorStringExt;
 use tedge_config::SoftwarePluginDefaultSetting;
 use tedge_config::TEdgeConfigLocation;
 use tracing::error;
-use tracing::log::warn;
+use tracing::info;
+use tracing::warn;
 
 #[cfg(not(test))]
 const SUDO: &str = "sudo";
@@ -39,10 +43,31 @@ const SUDO: &str = "echo";
 fan_in_message_type!(SoftwareRequest[SoftwareUpdateRequest, SoftwareListRequest] : Debug, Eq, PartialEq);
 fan_in_message_type!(SoftwareResponse[SoftwareUpdateResponse, SoftwareListResponse] : Debug, Eq, PartialEq);
 
+/// Actor which performs software operations.
+///
+/// This actor takes as input [`SoftwareRequest`]s, and responds with
+/// [`SoftwareResponse`]es. It mainly lists and updates software. It can only
+/// process only a single [`SoftwareRequest`] at a time. On startup, it checks
+/// if there are any leftover operations from a previous run, and if so, marks
+/// them as failed.
+///
+/// Upon receiving a shutdown request, it will abort currently running
+/// operation.
 pub struct SoftwareManagerActor {
     config: SoftwareManagerConfig,
     state_repository: AgentStateRepository,
-    message_box: SimpleMessageBox<SoftwareRequest, SoftwareResponse>,
+
+    // the Option is necessary to be able to concurrently handle a request,
+    // which mutably borrows the sender, and listen on signals, which mutably
+    // borrows the receiver. By using the Option we can take its contents
+    // leaving a None in its place.
+    //
+    // If Actor::run signature was changed to consume self instead, we could
+    // freely move out the receiver and get rid of the Option.
+    //
+    // https://github.com/thin-edge/thin-edge.io/pull/2049#discussion_r1243296392
+    input_receiver: Option<LoggingReceiver<SoftwareRequest>>,
+    output_sender: LoggingSender<SoftwareResponse>,
 }
 
 #[async_trait]
@@ -74,26 +99,26 @@ impl Actor for SoftwareManagerActor {
 
         self.process_pending_sm_operation().await?;
 
-        while let Some(request) = self.message_box.recv().await {
-            match request {
-                SoftwareRequest::SoftwareUpdateRequest(request) => {
-                    if let Err(err) = self
-                        .handle_software_update_operation(&request, &mut plugins, &operation_logs)
-                        .await
-                    {
-                        error!("{:?}", err);
-                    }
-                }
-                SoftwareRequest::SoftwareListRequest(request) => {
-                    if let Err(err) = self
-                        .handle_software_list_operation(&request, &plugins, &operation_logs)
-                        .await
-                    {
-                        error!("{:?}", err);
-                    }
+        let mut input_receiver = self.input_receiver.take().ok_or(RuntimeError::ActorError(
+            anyhow::anyhow!("actor can't be run more than once").into(),
+        ))?;
+
+        while let Some(request) = input_receiver.recv().await {
+            tokio::select! {
+                _ = self.handle_request(request, &mut plugins, &operation_logs) => {}
+
+                Some(RuntimeRequest::Shutdown) = input_receiver.recv_signal() => {
+                    info!("Received shutdown request from the runtime, exiting...");
+                    // Here we could call `process_pending_sm_operation` to mark
+                    // the current operation as failed, but OperationConverter
+                    // also exited and we could hit filesystem-related race
+                    // conditions due to concurrently executing
+                    // `handle_request`, so we just exit for now
+                    break;
                 }
             }
         }
+
         Ok(())
     }
 }
@@ -108,36 +133,61 @@ impl SoftwareManagerActor {
             "software-current-operation",
         );
 
+        let (output_sender, input_receiver) = message_box.into_split();
+
         Self {
             config,
             state_repository,
-            message_box,
+            input_receiver: Some(input_receiver),
+            output_sender,
         }
+    }
+
+    async fn handle_request(
+        &mut self,
+        request: SoftwareRequest,
+        plugins: &mut ExternalPlugins,
+        operation_logs: &OperationLogs,
+    ) -> Result<(), SoftwareManagerError> {
+        match request {
+            SoftwareRequest::SoftwareUpdateRequest(request) => {
+                if let Err(err) = self
+                    .handle_software_update_operation(&request, plugins, operation_logs)
+                    .await
+                {
+                    error!("{:?}", err);
+                }
+            }
+            SoftwareRequest::SoftwareListRequest(request) => {
+                if let Err(err) = self
+                    .handle_software_list_operation(&request, plugins, operation_logs)
+                    .await
+                {
+                    error!("{:?}", err);
+                }
+            }
+        }
+        Ok(())
     }
 
     async fn process_pending_sm_operation(&mut self) -> Result<(), SoftwareManagerError> {
         let state: Result<State, _> = self.state_repository.load().await;
 
-        if let State {
+        if let Ok(State {
             operation_id: Some(id),
             operation: Some(operation),
-        } = match state {
-            Ok(state) => state,
-            Err(_) => State {
-                operation_id: None,
-                operation: None,
-            },
-        } {
+        }) = state
+        {
             match operation {
                 StateStatus::Software(SoftwareOperationVariants::Update) => {
                     let response = SoftwareRequestResponse::new(&id, OperationStatus::Failed);
-                    self.message_box
+                    self.output_sender
                         .send(SoftwareUpdateResponse { response }.into())
                         .await?;
                 }
                 StateStatus::Software(SoftwareOperationVariants::List) => {
                     let response = SoftwareRequestResponse::new(&id, OperationStatus::Failed);
-                    self.message_box
+                    self.output_sender
                         .send(SoftwareListResponse { response }.into())
                         .await?;
                 }
@@ -170,7 +220,7 @@ impl SoftwareManagerActor {
 
         // Send 'executing'
         let executing_response = SoftwareUpdateResponse::new(request);
-        self.message_box.send(executing_response.into()).await?;
+        self.output_sender.send(executing_response.into()).await?;
 
         let response = match operation_logs.new_log_file(LogKind::SoftwareUpdate).await {
             Ok(log_file) => {
@@ -185,7 +235,7 @@ impl SoftwareManagerActor {
                 failed_response
             }
         };
-        self.message_box.send(response.into()).await?;
+        self.output_sender.send(response.into()).await?;
 
         let _state: State = self.state_repository.clear().await?;
 
@@ -207,7 +257,7 @@ impl SoftwareManagerActor {
 
         // Send 'executing'
         let executing_response = SoftwareListResponse::new(request);
-        self.message_box.send(executing_response.into()).await?;
+        self.output_sender.send(executing_response.into()).await?;
 
         let response = match operation_logs.new_log_file(LogKind::SoftwareList).await {
             Ok(log_file) => plugins.list(request, log_file).await,
@@ -218,7 +268,7 @@ impl SoftwareManagerActor {
                 failed_response
             }
         };
-        self.message_box.send(response.into()).await?;
+        self.output_sender.send(response.into()).await?;
 
         let _state: State = self.state_repository.clear().await?;
 

--- a/crates/core/tedge_api/src/error.rs
+++ b/crates/core/tedge_api/src/error.rs
@@ -16,7 +16,11 @@ pub enum TopicError {
 #[derive(thiserror::Error, Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
 pub enum SoftwareError {
     #[error("DownloadError error: {reason:?} for {url:?}")]
-    DownloadError { reason: String, url: String },
+    DownloadError {
+        reason: String,
+        url: String,
+        source_err: String,
+    },
 
     #[error("Failed to finalize updates for {software_type:?}")]
     Finalize {

--- a/tests/RobotFramework/requirements/requirements.adapter-docker.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-docker.txt
@@ -1,1 +1,1 @@
-robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.3.0
+robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.4.3

--- a/tests/RobotFramework/requirements/requirements.adapter-local.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-local.txt
@@ -1,1 +1,1 @@
-robotframework-devicelibrary[local] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.3.0
+robotframework-devicelibrary[local] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.4.3

--- a/tests/RobotFramework/requirements/requirements.adapter-ssh.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-ssh.txt
@@ -1,2 +1,2 @@
-robotframework-devicelibrary[ssh] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.3.0
+robotframework-devicelibrary[ssh] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.4.3
 robotframework-sshlibrary~=3.8.0

--- a/tests/RobotFramework/tests/cumulocity/software.robot
+++ b/tests/RobotFramework/tests/cumulocity/software.robot
@@ -16,20 +16,24 @@ Install software via Cumulocity
     Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
     Device Should Have Installed Software    c8y-remote-access-plugin
 
-# TODO: make it not flaky
 tedge-agent should terminate on SIGINT while downloading file
-    # we download a file which is 500M, but tmpfs at /tmp is only 64M, so we
+    [Documentation]    Since this test uses external urls it will be retried to
+        ...            reduce the flakiness caused by unavailability of that resource
+    [Tags]    test:retry(3)
+    # we download a file which is 1GB, but tmpfs at /tmp is only 64M, so we
     # have to change tmp.path to be able to store the download
+    ${start_time}=    Get Unix Timestamp
     Execute Command                          chmod 777 /root
     Execute Command                          tedge config set tmp.path /root
     Restart Service                          tedge-agent
-    ${OPERATION}=    Install Software        test-very-large-software,1.0,https://t493319102.eu-latest.cumulocity.com/inventory/binaries/28057693
+    ${OPERATION}=    Install Software        test-very-large-software,1.0,https://speed.hetzner.de/1GB.bin
 
     # waiting for the download to start (so, for "Downloading: ...") to appear
     # in the log, but I have no clue how to do "wait until log contains ..."
+    Logs Should Contain    text=download::download: Downloading file from url    date_from=${start_time}
     Operation Should Not Be PENDING          ${OPERATION}
 
-    # timeout of 5s would be nice
+    # Service should stop within 5s
     Stop tedge-agent
 
 Software list should only show currently installed software and not candidates

--- a/tests/RobotFramework/tests/cumulocity/software.robot
+++ b/tests/RobotFramework/tests/cumulocity/software.robot
@@ -16,6 +16,22 @@ Install software via Cumulocity
     Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
     Device Should Have Installed Software    c8y-remote-access-plugin
 
+# TODO: make it not flaky
+tedge-agent should terminate on SIGINT while downloading file
+    # we download a file which is 500M, but tmpfs at /tmp is only 64M, so we
+    # have to change tmp.path to be able to store the download
+    Execute Command                          chmod 777 /root
+    Execute Command                          tedge config set tmp.path /root
+    Restart Service                          tedge-agent
+    ${OPERATION}=    Install Software        test-very-large-software,1.0,https://t493319102.eu-latest.cumulocity.com/inventory/binaries/28057693
+
+    # waiting for the download to start (so, for "Downloading: ...") to appear
+    # in the log, but I have no clue how to do "wait until log contains ..."
+    Operation Should Not Be PENDING          ${OPERATION}
+
+    # timeout of 5s would be nice
+    Stop tedge-agent
+
 Software list should only show currently installed software and not candidates
     ${EXPECTED_VERSION}=    Execute Command    dpkg -s tedge | grep "^Version: " | cut -d' ' -f2    strip=True
     Device Should Have Installed Software    tedge,^${EXPECTED_VERSION}::apt$        timeout=120
@@ -31,3 +47,7 @@ Custom Setup
     ${timestamp}=        Get Unix Timestamp
     Restart Service    tedge-mapper-c8y
     Should Have MQTT Messages    tedge/health/tedge-mapper-c8y    date_from=${timestamp}
+
+Stop tedge-agent
+    [Timeout]                                5 seconds
+    Stop Service                             tedge-agent


### PR DESCRIPTION
## Proposed changes

This PR is a follow-up to #1966, improving on some things that came up during the partial download demo.

- added more logging statements to keep track of what the downloader is doing
- fixed mistakenly lowered backoff delay and added a method to customize the backoff for testing
- tweaked error handling in plugin_sm to print error causes
- made SoftwareManager immediately process shutdown requests, even if an operation is in progress.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments


