### PR TITLE
Retry http requests to c8y fails with the response status code 401,403 and 404

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,7 @@ dependencies = [
  "async-trait",
  "c8y_api",
  "download",
+ "http",
  "log",
  "mqtt_channel",
  "tedge_actors",
@@ -1335,9 +1336,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -1691,9 +1692,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2402,9 +2403,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pharos"
@@ -4301,9 +4302,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/crates/core/c8y_api/src/json_c8y.rs
+++ b/crates/core/c8y_api/src/json_c8y.rs
@@ -17,7 +17,7 @@ use time::OffsetDateTime;
 
 const EMPTY_STRING: &str = "";
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct C8yCreateEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -42,7 +42,7 @@ pub struct C8yEventResponse {
     pub id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct C8yManagedObject {
     pub id: String,
@@ -98,7 +98,7 @@ impl From<SoftwareModule> for C8ySoftwareModuleItem {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct C8yUpdateSoftwareListResponse {
     #[serde(rename = "c8y_SoftwareList")]

--- a/crates/extensions/c8y_config_manager/src/tests.rs
+++ b/crates/extensions/c8y_config_manager/src/tests.rs
@@ -105,7 +105,7 @@ async fn test_config_upload_tedge_device() -> Result<(), DynError> {
         .assert_received([UploadConfigFile {
             config_path: test_config_path.into(),
             config_type: test_config_type.to_string(),
-            child_device_id: None,
+            device_id,
         }])
         .await;
 
@@ -511,7 +511,7 @@ async fn test_child_device_successful_config_snapshot_response_mapping() -> Resu
                 .join("config_snapshot")
                 .join(test_config_type),
             config_type: test_config_type.into(),
-            child_device_id: Some(child_device_id.into()),
+            device_id: child_device_id.into(),
         }])
         .await;
 
@@ -585,7 +585,7 @@ async fn test_child_config_snapshot_successful_response_without_uploaded_file_ma
                 .join("config_snapshot")
                 .join(test_config_type),
             config_type: test_config_type.into(),
-            child_device_id: Some(child_device_id.into()),
+            device_id: child_device_id.into(),
         }])
         .await;
 

--- a/crates/extensions/c8y_config_manager/src/upload.rs
+++ b/crates/extensions/c8y_config_manager/src/upload.rs
@@ -90,7 +90,7 @@ impl ConfigUploadManager {
                     self.upload_config_file(
                         Path::new(config_file_path.as_str()),
                         &config_upload_request.config_type,
-                        None,
+                        config_upload_request.device,
                         message_box,
                     )
                     .await
@@ -334,7 +334,7 @@ impl ConfigUploadManager {
             .upload_config_file(
                 Path::new(&uploaded_config_file_path),
                 &config_response.get_config_type(),
-                Some(config_response.get_child_id()),
+                config_response.get_child_id(),
                 message_box,
             )
             .await?;
@@ -357,12 +357,12 @@ impl ConfigUploadManager {
         &mut self,
         config_file_path: &Path,
         config_type: &str,
-        child_device_id: Option<String>,
+        device_id: String,
         message_box: &mut ConfigManagerMessageBox,
     ) -> Result<String, ConfigManagementError> {
         let url = message_box
             .c8y_http_proxy
-            .upload_config_file(config_file_path, config_type, child_device_id)
+            .upload_config_file(config_file_path, config_type, device_id)
             .await?;
         Ok(url)
     }

--- a/crates/extensions/c8y_firmware_manager/src/config.rs
+++ b/crates/extensions/c8y_firmware_manager/src/config.rs
@@ -52,7 +52,7 @@ impl FirmwareManagerConfig {
         let firmware_update_response_topics =
             TopicFilter::new_unchecked(FIRMWARE_UPDATE_RESPONSE_TOPICS);
 
-        let c8y_end_point = C8yEndPoint::new(&c8y_url, &tedge_device_id, "not used");
+        let c8y_end_point = C8yEndPoint::new(&c8y_url, &tedge_device_id);
 
         Self {
             tedge_device_id,

--- a/crates/extensions/c8y_http_proxy/Cargo.toml
+++ b/crates/extensions/c8y_http_proxy/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 async-trait = "0.1"
 c8y_api = { path = "../../core/c8y_api" }
 download = { path = "../../common/download" }
+http = "0.2"
 log = "0.4"
 mqtt_channel = { path = "../../common/mqtt_channel" }
 tedge_actors = { path = "../../core/tedge_actors" }

--- a/crates/extensions/c8y_http_proxy/src/handle.rs
+++ b/crates/extensions/c8y_http_proxy/src/handle.rs
@@ -3,6 +3,7 @@ use crate::messages::C8YRestRequest;
 use crate::messages::C8YRestResponse;
 use crate::messages::C8YRestResult;
 use crate::messages::GetJwtToken;
+use crate::messages::SoftwareListResponse;
 use crate::messages::UploadConfigFile;
 use crate::messages::UploadLogBinary;
 use c8y_api::json_c8y::C8yCreateEvent;
@@ -49,8 +50,14 @@ impl C8YHttpProxy {
     pub async fn send_software_list_http(
         &mut self,
         c8y_software_list: C8yUpdateSoftwareListResponse,
+        device_id: String,
     ) -> Result<(), C8YRestError> {
-        let request: C8YRestRequest = c8y_software_list.into();
+        let request: C8YRestRequest = SoftwareListResponse {
+            c8y_software_list,
+            device_id,
+        }
+        .into();
+
         match self.c8y.await_response(request).await? {
             Ok(C8YRestResponse::Unit(_)) => Ok(()),
             unexpected => Err(unexpected.into()),
@@ -61,12 +68,12 @@ impl C8YHttpProxy {
         &mut self,
         log_type: &str,
         log_content: &str,
-        child_device_id: Option<String>,
+        device_id: String,
     ) -> Result<String, C8YRestError> {
         let request: C8YRestRequest = UploadLogBinary {
             log_type: log_type.to_string(),
             log_content: log_content.to_string(),
-            child_device_id,
+            device_id,
         }
         .into();
         match self.c8y.await_response(request).await? {
@@ -79,12 +86,12 @@ impl C8YHttpProxy {
         &mut self,
         config_path: &Path,
         config_type: &str,
-        child_device_id: Option<String>,
+        device_id: String,
     ) -> Result<String, C8YRestError> {
         let request: C8YRestRequest = UploadConfigFile {
             config_path: config_path.to_owned(),
             config_type: config_type.to_string(),
-            child_device_id,
+            device_id,
         }
         .into();
         match self.c8y.await_response(request).await? {

--- a/crates/extensions/c8y_http_proxy/src/messages.rs
+++ b/crates/extensions/c8y_http_proxy/src/messages.rs
@@ -6,7 +6,7 @@ use tedge_actors::ChannelError;
 use tedge_http_ext::HttpError;
 use tedge_utils::file::PermissionEntry;
 
-fan_in_message_type!(C8YRestRequest[GetJwtToken, C8yCreateEvent, C8yUpdateSoftwareListResponse, UploadLogBinary, UploadConfigFile, DownloadFile]: Debug, PartialEq, Eq);
+fan_in_message_type!(C8YRestRequest[GetJwtToken, C8yCreateEvent, SoftwareListResponse, UploadLogBinary, UploadConfigFile, DownloadFile]: Debug, PartialEq, Eq);
 //HIPPO Rename EventId to String as there could be many other String responses as well and this macro doesn't allow another String variant
 fan_in_message_type!(C8YRestResponse[EventId, Unit]: Debug);
 
@@ -44,17 +44,23 @@ pub type C8YRestResult = Result<C8YRestResponse, C8YRestError>;
 pub struct GetJwtToken;
 
 #[derive(Debug, PartialEq, Eq)]
+pub struct SoftwareListResponse {
+    pub c8y_software_list: C8yUpdateSoftwareListResponse,
+    pub device_id: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub struct UploadLogBinary {
     pub log_type: String,
     pub log_content: String,
-    pub child_device_id: Option<String>,
+    pub device_id: String,
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct UploadConfigFile {
     pub config_path: PathBuf,
     pub config_type: String,
-    pub child_device_id: Option<String>,
+    pub device_id: String,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/extensions/c8y_http_proxy/src/tests.rs
+++ b/crates/extensions/c8y_http_proxy/src/tests.rs
@@ -2,6 +2,7 @@ use crate::credentials::ConstJwtRetriever;
 use crate::handle::C8YHttpProxy;
 use crate::C8YHttpConfig;
 use crate::C8YHttpProxyBuilder;
+use c8y_api::json_c8y::C8yUpdateSoftwareListResponse;
 use c8y_api::json_c8y::InternalIdResponse;
 use std::path::PathBuf;
 use tedge_actors::Actor;
@@ -46,10 +47,258 @@ async fn c8y_http_proxy_requests_the_device_internal_id_on_start() {
     tokio::spawn(async move {
         // NOTE: this is done in the background because this call awaits for the response.
         proxy
-            .upload_log_binary("test.log", "some log content", None)
+            .upload_log_binary("test.log", "some log content", "device-001".into())
             .await
             .unwrap();
     });
+
+    // then the upload request received by c8y is related to the internal id
+    c8y.assert_recv(Some(
+        HttpRequestBuilder::post(format!("https://{c8y_host}/event/events/"))
+            .bearer_auth(token)
+            .header("content-type", "application/json")
+            .header("accept", "application/json")
+            .build()
+            .unwrap(),
+    ))
+    .await;
+}
+
+#[tokio::test]
+async fn retry_internal_id_on_expired_jwt() {
+    let c8y_host = "c8y.tenant.io";
+    let device_id = "device-001";
+    let token = "JWT token";
+    let external_id = "external-device-001";
+    let tmp_dir = "/tmp";
+
+    let (mut proxy, mut c8y) =
+        spawn_c8y_http_proxy(c8y_host.into(), device_id.into(), tmp_dir.into(), token).await;
+
+    // Even before any request is sent to the c8y_proxy
+    // the proxy requests over HTTP the internal device id.
+    let init_request = HttpRequestBuilder::get(format!(
+        "https://{c8y_host}/identity/externalIds/c8y_Serial/{device_id}"
+    ))
+    .bearer_auth(token)
+    .build()
+    .unwrap();
+    c8y.assert_recv(Some(init_request)).await;
+
+    // Cumulocity returns unauthorized error (401), because the jwt token has expired
+    let c8y_response = HttpResponseBuilder::new().status(401).build().unwrap();
+    c8y.send(Ok(c8y_response)).await.unwrap();
+    c8y.assert_recv(Some(
+        HttpRequestBuilder::get(format!(
+            "https://{c8y_host}/identity/externalIds/c8y_Serial/{device_id}"
+        ))
+        .bearer_auth(token)
+        .build()
+        .unwrap(),
+    ))
+    .await;
+    // Mapper retries to get the internal device id, after getting a fresh jwt token
+    let c8y_response = HttpResponseBuilder::new()
+        .status(200)
+        .json(&InternalIdResponse::new(device_id, external_id))
+        .build()
+        .unwrap();
+    c8y.send(Ok(c8y_response)).await.unwrap();
+
+    // This internal id is then used by the proxy for subsequent requests.
+    // For instance, if the proxy upload a log file
+    tokio::spawn(async move {
+        // NOTE: this is done in the background because this call awaits for the response.
+        proxy
+            .upload_log_binary("test.log", "some log content", "device-001".into())
+            .await
+            .unwrap();
+    });
+
+    // then the upload request received by c8y is related to the internal id
+    c8y.assert_recv(Some(
+        HttpRequestBuilder::post(format!("https://{c8y_host}/event/events/"))
+            .bearer_auth(token)
+            .header("content-type", "application/json")
+            .header("accept", "application/json")
+            .build()
+            .unwrap(),
+    ))
+    .await;
+}
+
+#[tokio::test]
+async fn retry_software_list_once_with_fresh_internal_id() {
+    let c8y_host = "c8y.tenant.io";
+    let device_id = "device-001";
+    let token = "JWT token";
+    let external_id = "external-device-001";
+    let tmp_dir = "/tmp";
+
+    let (mut proxy, mut c8y) =
+        spawn_c8y_http_proxy(c8y_host.into(), device_id.into(), tmp_dir.into(), token).await;
+
+    // Even before any request is sent to the c8y_proxy
+    // the proxy requests over HTTP the internal device id.
+    let _init_request = HttpRequestBuilder::get(format!(
+        "https://{c8y_host}/identity/externalIds/c8y_Serial/{device_id}"
+    ))
+    .bearer_auth(token)
+    .build()
+    .unwrap();
+    // skip the message
+    c8y.recv().await;
+
+    // Cumulocity returns the internal device id
+    let c8y_response = HttpResponseBuilder::new()
+        .status(200)
+        .json(&InternalIdResponse::new(device_id, external_id))
+        .build()
+        .unwrap();
+    c8y.send(Ok(c8y_response)).await.unwrap();
+
+    // This internal id is then used by the proxy for subsequent requests.
+    // Create  the  software list and publish
+    let c8y_software_list = C8yUpdateSoftwareListResponse::default();
+
+    tokio::spawn(async move {
+        // NOTE: this is done in the background because this call awaits for the response.
+        proxy
+            .send_software_list_http(c8y_software_list, device_id.into())
+            .await
+    });
+
+    let c8y_software_list = C8yUpdateSoftwareListResponse::default();
+    // then the upload request received by c8y is related to the internal id
+    c8y.assert_recv(Some(
+        HttpRequestBuilder::put(format!(
+            "https://{c8y_host}/inventory/managedObjects/{device_id}"
+        ))
+        .header("content-type", "application/json")
+        .header("accept", "application/json")
+        .bearer_auth(token)
+        .json(&c8y_software_list)
+        .build()
+        .unwrap(),
+    ))
+    .await;
+
+    // The software list upload fails because the device identified with internal id not found
+    let c8y_response = HttpResponseBuilder::new()
+        .status(404)
+        .json(&InternalIdResponse::new(device_id, external_id))
+        .build()
+        .unwrap();
+    c8y.send(Ok(c8y_response)).await.unwrap();
+
+    // Now the mapper gets a new internal id for the specific device id
+    c8y.assert_recv(Some(
+        HttpRequestBuilder::get(format!(
+            "https://{c8y_host}/identity/externalIds/c8y_Serial/{device_id}"
+        ))
+        .bearer_auth(token)
+        .build()
+        .unwrap(),
+    ))
+    .await;
+
+    // Cumulocity returns the internal device id, after retrying with the fresh jwt token
+    let c8y_response = HttpResponseBuilder::new()
+        .status(200)
+        .json(&InternalIdResponse::new(device_id, external_id))
+        .build()
+        .unwrap();
+    c8y.send(Ok(c8y_response)).await.unwrap();
+
+    let c8y_software_list = C8yUpdateSoftwareListResponse::default();
+    // then the upload request received by c8y is related to the internal id
+    c8y.assert_recv(Some(
+        HttpRequestBuilder::put(format!(
+            "https://{c8y_host}/inventory/managedObjects/{device_id}"
+        ))
+        .bearer_auth(token)
+        .header("content-type", "application/json")
+        .header("accept", "application/json")
+        .json(&c8y_software_list)
+        .build()
+        .unwrap(),
+    ))
+    .await;
+}
+
+#[tokio::test]
+async fn auto_retry_upload_log_binary_when_internal_id_expires() {
+    let c8y_host = "c8y.tenant.io";
+    let device_id = "device-001";
+    let token = "JWT token";
+    let external_id = "external-device-001";
+    let tmp_dir = "/tmp";
+
+    let (mut proxy, mut c8y) =
+        spawn_c8y_http_proxy(c8y_host.into(), device_id.into(), tmp_dir.into(), token).await;
+
+    // Even before any request is sent to the c8y_proxy
+    // the proxy requests over HTTP the internal device id.
+    let init_request = HttpRequestBuilder::get(format!(
+        "https://{c8y_host}/identity/externalIds/c8y_Serial/{device_id}"
+    ))
+    .bearer_auth(token)
+    .build()
+    .unwrap();
+    c8y.assert_recv(Some(init_request)).await;
+    // Cumulocity returns the internal device id
+    let c8y_response = HttpResponseBuilder::new()
+        .status(200)
+        .json(&InternalIdResponse::new(device_id, external_id))
+        .build()
+        .unwrap();
+    c8y.send(Ok(c8y_response)).await.unwrap();
+    // This internal id is then used by the proxy for subsequent requests.
+    // For instance, if the proxy upload a log file
+    tokio::spawn(async move {
+        // NOTE: this is done in the background because this call awaits for the response.
+        proxy
+            .upload_log_binary("test.log", "some log content", "device-001".into())
+            .await
+            .unwrap();
+    });
+    // then the upload request received by c8y is related to the internal id
+    c8y.assert_recv(Some(
+        HttpRequestBuilder::post(format!("https://{c8y_host}/event/events/"))
+            .bearer_auth(token)
+            .header("content-type", "application/json")
+            .header("accept", "application/json")
+            .build()
+            .unwrap(),
+    ))
+    .await;
+
+    // Creating the event over http failed due to the device is NOT_FOUND
+    let c8y_response = HttpResponseBuilder::new()
+        .status(404)
+        .json(&InternalIdResponse::new(device_id, external_id))
+        .build()
+        .unwrap();
+    c8y.send(Ok(c8y_response)).await.unwrap();
+
+    // Mapper retries the call with internal id
+    let c8y_response = HttpResponseBuilder::new()
+        .status(200)
+        .json(&InternalIdResponse::new(device_id, external_id))
+        .build()
+        .unwrap();
+    c8y.send(Ok(c8y_response)).await.unwrap();
+
+    // Now there is a request to get the internal id
+    c8y.assert_recv(Some(
+        HttpRequestBuilder::get(format!(
+            "https://{c8y_host}/identity/externalIds/c8y_Serial/{device_id}"
+        ))
+        .bearer_auth(token)
+        .build()
+        .unwrap(),
+    ))
+    .await;
 
     // then the upload request received by c8y is related to the internal id
     c8y.assert_recv(Some(

--- a/crates/extensions/c8y_log_manager/src/actor.rs
+++ b/crates/extensions/c8y_log_manager/src/actor.rs
@@ -271,7 +271,11 @@ impl LogManagerActor {
 
         let upload_event_url = self
             .http_proxy
-            .upload_log_binary(&smartrest_request.log_type, &log_content, None)
+            .upload_log_binary(
+                &smartrest_request.log_type,
+                &log_content,
+                self.config.device_id.clone(),
+            )
             .await?;
 
         let successful = LogfileRequest::successful(Some(upload_event_url))?;
@@ -786,7 +790,7 @@ mod tests {
             Some(C8YRestRequest::UploadLogBinary(UploadLogBinary {
                 log_type: "type_two".to_string(),
                 log_content: "filename: file_c\nSome content\n".to_string(),
-                child_device_id: None
+                device_id: "SUT".into()
             }))
         );
 

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -1302,7 +1302,7 @@ fn spawn_dummy_c8y_http_proxy(mut http: SimpleMessageBox<C8YRestRequest, C8YRest
                         )))
                         .await;
                 }
-                Some(C8YRestRequest::C8yUpdateSoftwareListResponse(_)) => {
+                Some(C8YRestRequest::SoftwareListResponse(_)) => {
                     let _ = http
                         .send(Ok(c8y_http_proxy::messages::C8YRestResponse::Unit(())))
                         .await;


### PR DESCRIPTION
## Proposed changes

When an HTTP interaction with `Cumulocity` fails with 

- status code 401 or 403, then get the renewed `JWT` token and retry the HTTP request.
- status code 404 then get the new `internal-id` and retry the HTTP request.
- use map inside the `C8yEndPoint` to cache `child_internal_id` and `main_device_internal id`. Also, cache the `token` in `C8yEndPoint`

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/1201

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

