### PR TITLE
fix(build): use fixed ziglang 0.10.1 due to build issue with 0.11.0

### DIFF
--- a/ci/build_scripts/build.sh
+++ b/ci/build_scripts/build.sh
@@ -153,9 +153,13 @@ fi
 # Allow users to install zig by other package managers
 if ! zig --help &>/dev/null; then
     if ! python3 -m ziglang --help &>/dev/null; then
-        pip3 install ziglang
+        # Fix version, as 0.11.0 does not build
+        pip3 install ziglang==0.10.1.post1
     fi
 fi
+
+# Display zig version to help with debugging
+echo "zig version: $(zig version ||:)"
 
 if [ -z "$ARCH" ]; then
     # If no target has been given, choose the target triple based on the


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

A newly released version of zig (used to build the project) causes build errors (unsure of it is a zig issue or a cargo-zigbuild issue).

For now enforcing a fixed version, 0.10.1.

**Example of error**

The error can be view on this [run](https://github.com/thin-edge/thin-edge.io/actions/runs/5760900709)

And an extert from a local build (using ziglang 0.11.0) is shown below.

```
   Compiling c8y-device-management v0.12.0 (/Users/reubenmiller/dev/projects/tedge/code/fork-docs/thin-edge.io/crates/bin/c8y-device-management)
error: linking with `/Users/reubenmiller/Library/Caches/cargo-zigbuild/0.17.0/zigcc-aarch64-unknown-linux-musl.sh` failed: exit status: 1
  |
  = note: LC_ALL="C" PATH="/Users/reubenmiller/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin:/Users/reubenmiller/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/self-contained:/Users/reubenmiller/homebrew/lib/python3.11/site-packages/ziglang:/Users/reubenmiller/.nvm/versions/node/v16.20.0/bin:/Users/reubenmiller/go/bin:/Users/reubenmiller/.gem/ruby/2.6.0/bin:/Users/reubenmiller/.local/bin:/Users/reubenmiller/homebrew/bin:/Users/reubenmiller/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/reubenmiller/.nvm/versions/node/v16.20.0/bin:/Users/reubenmiller/go/bin:/Users/reubenmiller/.gem/ruby/2.6.0/bin:/Users/reubenmiller/.local/bin:/Users/reubenmiller/homebrew/bin:/Users/reubenmiller/homebrew/sbin:/Users/reubenmiller/.cargo/bin" VSLANG="1033" "/Users/reubenmiller/Library/Caches/cargo-zigbuild/0.17.0/zigcc-aarch64-unknown-linux-musl.sh" "/Users/reubenmiller/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/crt1.o" "/Users/reubenmiller/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/crti.o" "/Users/reubenmiller/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/crtbegin.o" "/var/folders/wn/06nj6dqj07db9tbsh_094wnr0000gn/T/rustcI76qPN/symbols.o" "/Users/reubenmiller/dev/projects/tedge/code/fork-docs/thin-edge.io/target/aarch64-unknown-linux-musl/release/deps/tedge_apt_plugin-7ab3b63bf7802a60.tedge_apt_plugin.83263cc3-cgu.0.rcgu.o" "-Wl,--as-needed" "-L" "/Users/reubenmiller/dev/projects/tedge/code/fork-docs/thin-edge.io/target/aarch64-unknown-linux-musl/release/deps" "-L" "/Users/reubenmiller/dev/projects/tedge/code/fork-docs/thin-edge.io/target/release/deps" "-L" "/Users/reubenmiller/dev/projects/tedge/code/fork-docs/thin-edge.io/target/aarch64-unknown-linux-musl/release/build/ring-5f5de5359cbae5d7/out" "-L" "/Users/reubenmiller/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-unknown-linux-musl/lib" "-Wl,-Bstatic" "/var/folders/wn/06nj6dqj07db9tbsh_094wnr0000gn/T/rustcI76qPN/libring-d067ef4392861a30.rlib" "-lunwind" "-lc" "/Users/reubenmiller/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-unknown-linux-musl/lib/libcompiler_builtins-0a28d23d76fcec1d.rlib" "-Wl,-Bdynamic" "-Wl,--eh-frame-hdr" "-Wl,-znoexecstack" "-nostartfiles" "-L" "/Users/reubenmiller/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-unknown-linux-musl/lib" "-L" "/Users/reubenmiller/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained" "-o" "/Users/reubenmiller/dev/projects/tedge/code/fork-docs/thin-edge.io/target/aarch64-unknown-linux-musl/release/deps/tedge_apt_plugin-7ab3b63bf7802a60" "-Wl,--gc-sections" "-static" "-no-pie" "-Wl,-zrelro,-znow" "-Wl,--strip-all" "-nodefaultlibs" "/Users/reubenmiller/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/crtend.o" "/Users/reubenmiller/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-unknown-linux-musl/lib/self-contained/crtn.o"
  = note: In file included from /Users/reubenmiller/homebrew/lib/python3.11/site-packages/ziglang/lib/libc/musl/crt/rcrt1.c:3:
          /Users/reubenmiller/homebrew/lib/python3.11/site-packages/ziglang/lib/libc/musl/crt/../ldso/dlstart.c:146:20: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a subsequent definition [-Wdeprecated-non-prototype]
                  GETFUNCSYM(&dls2, __dls2, base+dyn[DT_PLTGOT]);
                                    ^
          /Users/reubenmiller/homebrew/lib/python3.11/site-packages/ziglang/lib/libc/musl/crt/rcrt1.c:11:13: note: conflicting prototype is here
          hidden void __dls2(unsigned char *base, size_t *sp)
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

A comment has been left on a similar error in the ziglang repo. https://github.com/ziglang/zig/issues/15610#issuecomment-1665437628

