### PR TITLE
fix(tedge init): add missing group permissions on base config_dir

### DIFF
--- a/crates/core/tedge/src/cli/init.rs
+++ b/crates/core/tedge/src/cli/init.rs
@@ -24,7 +24,11 @@ impl TEdgeInitCmd {
         let config_dir = self.context.config_location.tedge_config_root_path.clone();
         create_directory(
             &config_dir,
-            PermissionEntry::new(Some(self.user.clone()), None, Some(0o775)),
+            PermissionEntry::new(
+                Some(self.user.clone()),
+                Some(self.group.clone()),
+                Some(0o775),
+            ),
         )?;
 
         create_directory(

--- a/tests/RobotFramework/tests/customizing/tedge_init.robot
+++ b/tests/RobotFramework/tests/customizing/tedge_init.robot
@@ -34,7 +34,7 @@ Tedge init and check creation of folders
 Check ownership of the folders
     [Documentation]    Running tedge init has created the folders assigning default user/group
     ...    this test step is confirming the default values for user/group
-    Check Owner of Directory    /etc/tedge    tedge:root
+    Check Owner of Directory    /etc/tedge    tedge:tedge
     Check Owner of Directory    /etc/tedge/mosquitto-conf    mosquitto:mosquitto
     Check Owner of Directory    /etc/tedge/operations    tedge:tedge
     Check Owner of Directory    /etc/tedge/plugins    tedge:tedge
@@ -46,7 +46,7 @@ Change user/group and check the change
     [Documentation]    Running tedge init --user <user> --group <group>  is setting custom user/group
     ...    this test step is confirming the custom values for user/group
     Execute Command    sudo tedge init --user petertest --group petertest
-    Check Owner of Directory    /etc/tedge    petertest:root
+    Check Owner of Directory    /etc/tedge    petertest:petertest
     Check Owner of Directory    /etc/tedge/mosquitto-conf    mosquitto:mosquitto
     Check Owner of Directory    /etc/tedge/operations    petertest:petertest
     Check Owner of Directory    /etc/tedge/plugins    petertest:petertest
@@ -58,7 +58,7 @@ Tedge init and check if default values are restored
     [Documentation]    Running tedge init after setting custom user/group should restore the default user/group
     ...    this test step is confirming the default values for user/group
     Execute Command    sudo tedge init
-    Check Owner of Directory    /etc/tedge    tedge:root
+    Check Owner of Directory    /etc/tedge    tedge:tedge
     Check Owner of Directory    /etc/tedge/mosquitto-conf    mosquitto:mosquitto
     Check Owner of Directory    /etc/tedge/operations    tedge:tedge
     Check Owner of Directory    /etc/tedge/plugins    tedge:tedge


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix/add group permissions on the config dir (e.g. `/etc/tedge`) creation when calling the `tedge init` command.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

