### PR TITLE
tedge legacy health messages are not being republished on the te/ topic with the retained flag

### DIFF
--- a/crates/core/tedge_agent/src/tedge_to_te_converter/converter.rs
+++ b/crates/core/tedge_agent/src/tedge_to_te_converter/converter.rs
@@ -78,6 +78,7 @@ impl TedgetoTeConverter {
         alarm.insert("severity".to_string(), severity.into());
         message.topic = te_topic;
         message.payload = serde_json::to_string(&alarm)?.into();
+        message.retain = true;
         Ok(vec![message])
     }
 
@@ -111,6 +112,7 @@ impl TedgetoTeConverter {
             _ => return vec![],
         };
         message.topic = topic;
+        message.retain = true;
         vec![message]
     }
 

--- a/crates/core/tedge_agent/src/tedge_to_te_converter/tests.rs
+++ b/crates/core/tedge_agent/src/tedge_to_te_converter/tests.rs
@@ -227,12 +227,14 @@ async fn convert_incoming_main_device_service_health_status() -> Result<(), DynE
     let mqtt_message = MqttMessage::new(
         &Topic::new_unchecked("tedge/health/myservice"),
         r#"{""pid":1234,"status":"up","time":1674739912}"#,
-    );
+    )
+    .with_retain();
 
     let expected_mqtt_message = MqttMessage::new(
         &Topic::new_unchecked("te/device/main/service/myservice/status/health"),
         r#"{""pid":1234,"status":"up","time":1674739912}"#,
-    );
+    )
+    .with_retain();
 
     mqtt_box.send(mqtt_message).await?;
 
@@ -250,12 +252,14 @@ async fn convert_incoming_child_device_service_health_status() -> Result<(), Dyn
     let mqtt_message = MqttMessage::new(
         &Topic::new_unchecked("tedge/health/child/myservice"),
         r#"{""pid":1234,"status":"up","time":1674739912}"#,
-    );
+    )
+    .with_retain();
 
     let expected_mqtt_message = MqttMessage::new(
         &Topic::new_unchecked("te/device/child/service/myservice/status/health"),
         r#"{""pid":1234,"status":"up","time":1674739912}"#,
-    );
+    )
+    .with_retain();
 
     mqtt_box.send(mqtt_message).await?;
 


### PR DESCRIPTION
## Proposed changes

- Enforce the retain flag when the `tedge` messages are republished on `te` topics 
- integration tests 


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/2147#

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

