### PR TITLE
Clearing an alarm causes an EOL error

### DIFF
--- a/tests/RobotFramework/tests/tedge_to_te_converter/convert_tedge_topics_to_te_topics.robot
+++ b/tests/RobotFramework/tests/tedge_to_te_converter/convert_tedge_topics_to_te_topics.robot
@@ -3,31 +3,52 @@ Documentation       Purpose of this test is to verify that tedge-agent converts 
 
 Resource            ../../resources/common.resource
 Library             ThinEdgeIO
+Library             JSONLibrary
 
 Suite Setup         Custom Setup
 Suite Teardown      Custom Teardown
 
 Test Tags           theme:mqtt    theme:tedge to te
 
-Library             JSONLibrary
-
-
 *** Test Cases ***
 Convert main device measurement topic
+    Execute Command    tedge mqtt pub tedge/measurements ''
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/measurements    minimum=1    maximum=1
+    ${messages_te}=    Should Have MQTT Messages    te/device/main///m/    minimum=1    maximum=1
+    Should Be Equal    ${messages_tedge}  ${messages_te}    
+
+Convert main device empty measurement topic
     Execute Command    tedge mqtt pub tedge/measurements '{"temperature":25}'
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/measurements    minimum=1    maximum=1
+    ${messages_te}=    Should Have MQTT Messages    te/device/main///m/    minimum=1    maximum=1
+    Should Be Equal    ${messages_tedge}  ${messages_te}
     Should Have MQTT Messages    te/device/main///m/    message_pattern={"temperature":25}
-
-
+   
 Convert child device measurement topic
     Execute Command    tedge mqtt pub tedge/measurements/child '{"temperature":25}'
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/measurements/child   minimum=1    maximum=1
+    ${messages_te}=    Should Have MQTT Messages    te/device/child///m/    minimum=1    maximum=1
+    Should Be Equal    ${messages_tedge}  ${messages_te}
     Should Have MQTT Messages    te/device/child///m/    message_pattern={"temperature":25}
 
 Convert main device event topic
     Execute Command    tedge mqtt pub tedge/events/login_event '{"text":"someone logedin"}'
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event   minimum=1    maximum=1
+    ${messages_te}=    Should Have MQTT Messages    te/device/main///e/login_event    minimum=1    maximum=1
+    Should Be Equal    ${messages_tedge}  ${messages_te}
     Should Have MQTT Messages    te/device/main///e/login_event    message_pattern={"text":"someone logedin"}
+
+Convert main device empty event topic
+    Execute Command    tedge mqtt pub tedge/events/login_event ''
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event   minimum=1    maximum=1
+    ${messages_te}=    Should Have MQTT Messages    te/device/main///e/login_event    minimum=1    maximum=1
+    Should Be Equal    ${messages_tedge}  ${messages_te}      
 
 Convert child device event topic
     Execute Command    tedge mqtt pub tedge/events/login_event/child '{"text":"someone logedin"}'
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event/child   minimum=1    maximum=1
+    ${messages_te}=    Should Have MQTT Messages    te/device/child///e/login_event    minimum=1    maximum=1
+    Should Be Equal    ${messages_tedge}  ${messages_te}
     Should Have MQTT Messages    te/device/child///e/login_event    message_pattern={"text":"someone logedin"}
 
 Convert main device alarm topic
@@ -50,18 +71,32 @@ Convert child device alarm topic
     ${messages}=    Should Have MQTT Messages    te/device/child///a/test_alarm    minimum=1     maximum=1
     ${message}=    Convert String To Json    ${messages[0]}
     Should Be Equal    ${message["severity"]}    major
+
+
+Convert clear alarm topic
+    Execute Command    tedge mqtt pub tedge/alarms/major/test_alarm/child '' -q 2 -r
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/alarms/major/test_alarm/child    minimum=1    maximum=1
+    ${messages_te}=    Should Have MQTT Messages    te/device/child///a/test_alarm    minimum=1    maximum=1
+    Should Be Equal    ${messages_tedge}  ${messages_te}
+    
+Convert empty alarm message
+    Execute Command    tedge mqtt pub tedge/alarms/major/test_alarm/child {} -q 2 -r
+    ${messages}=    Should Have MQTT Messages    te/device/child///a/test_alarm    minimum=1     maximum=1
+    ${message}=    Convert String To Json    ${messages[0]}
+    Should Be Equal    ${message["severity"]}    major
    
 
 Convert main device service health topic
     Execute Command    tedge mqtt pub tedge/health/main-service '{"pid":1234,"status":"up"}' -q 2 -r
-    ${messages}=    Should Have MQTT Messages    te/device/main/service/main-service/status/health    minimum=1     maximum=1
-    ${message}=    Convert String To Json    ${messages[0]}
-    Should Be Equal As Numbers    ${message["pid"]}    1234
-    Should Be Equal    ${message["status"]}    up
-
-
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/health/main-service    minimum=1    maximum=1
+    ${messages_te}=    Should Have MQTT Messages    te/device/main/service/main-service/status/health    minimum=1    maximum=1
+    Should Be Equal    ${messages_tedge}  ${messages_te}
+    
 Convert child device service health topic
     Execute Command    tedge mqtt pub tedge/health/child/child-service '{"pid":1234,"status":"up"}' -q 2 -r
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/health/child/child-service    minimum=1    maximum=1
+    ${messages_te}=    Should Have MQTT Messages     te/device/child/service/child-service/status/health      minimum=1    maximum=1
+    Should Be Equal    ${messages_tedge}  ${messages_te}
     ${messages}=    Should Have MQTT Messages    te/device/child/service/child-service/status/health    minimum=1     maximum=1
     ${message}=    Convert String To Json    ${messages[0]}
     Should Be Equal As Numbers    ${message["pid"]}    1234


### PR DESCRIPTION
## Proposed changes

The `tedge-to-te` topic converter was not properly handling the `alarm` clear message. This PR addresses this issue.

Also, added the tests that cover all the missing topic conversion cases like empty messages, empty topics, Unsupported topics, etc.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/2151

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

