### PR TITLE
The mapper must not forward expired JWT tokens to the agent

### DIFF
--- a/crates/extensions/c8y_http_proxy/src/actor.rs
+++ b/crates/extensions/c8y_http_proxy/src/actor.rs
@@ -85,6 +85,13 @@ impl Actor for C8YHttpProxyActor {
                     .await
                     .map(|response| response.into()),
 
+                C8YRestRequest::GetFreshJwtToken(_) => {
+                    self.end_point.token = None;
+                    self.get_and_set_jwt_token()
+                        .await
+                        .map(|response| response.into())
+                }
+
                 C8YRestRequest::C8yCreateEvent(request) => self
                     .create_event(request)
                     .await

--- a/crates/extensions/c8y_http_proxy/src/handle.rs
+++ b/crates/extensions/c8y_http_proxy/src/handle.rs
@@ -2,6 +2,7 @@ use crate::messages::C8YRestError;
 use crate::messages::C8YRestRequest;
 use crate::messages::C8YRestResponse;
 use crate::messages::C8YRestResult;
+use crate::messages::GetFreshJwtToken;
 use crate::messages::GetJwtToken;
 use crate::messages::SoftwareListResponse;
 use crate::messages::UploadConfigFile;
@@ -33,6 +34,16 @@ impl C8YHttpProxy {
 
     pub async fn get_jwt_token(&mut self) -> Result<String, C8YRestError> {
         let request: C8YRestRequest = GetJwtToken.into();
+
+        match self.c8y.await_response(request).await? {
+            Ok(C8YRestResponse::EventId(id)) => Ok(id),
+            unexpected => Err(unexpected.into()),
+        }
+    }
+
+    pub async fn get_fresh_jwt_token(&mut self) -> Result<String, C8YRestError> {
+        let request: C8YRestRequest = GetFreshJwtToken.into();
+
         match self.c8y.await_response(request).await? {
             Ok(C8YRestResponse::EventId(id)) => Ok(id),
             unexpected => Err(unexpected.into()),

--- a/crates/extensions/c8y_http_proxy/src/messages.rs
+++ b/crates/extensions/c8y_http_proxy/src/messages.rs
@@ -6,7 +6,7 @@ use tedge_actors::ChannelError;
 use tedge_http_ext::HttpError;
 use tedge_utils::file::PermissionEntry;
 
-fan_in_message_type!(C8YRestRequest[GetJwtToken, C8yCreateEvent, SoftwareListResponse, UploadLogBinary, UploadConfigFile, DownloadFile]: Debug, PartialEq, Eq);
+fan_in_message_type!(C8YRestRequest[GetJwtToken, GetFreshJwtToken, C8yCreateEvent, SoftwareListResponse, UploadLogBinary, UploadConfigFile, DownloadFile]: Debug, PartialEq, Eq);
 //HIPPO Rename EventId to String as there could be many other String responses as well and this macro doesn't allow another String variant
 fan_in_message_type!(C8YRestResponse[EventId, Unit]: Debug);
 
@@ -42,6 +42,9 @@ pub type C8YRestResult = Result<C8YRestResponse, C8YRestError>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct GetJwtToken;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct GetFreshJwtToken;
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct SoftwareListResponse {

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -464,7 +464,8 @@ impl CumulocityConverter {
             .from_smartrest(smartrest)?
             .to_thin_edge_json()?;
 
-        let token = self.http_proxy.get_jwt_token().await?;
+        // Pass the fresh token to the tedge-agent as it cannot request a new one
+        let token = self.http_proxy.get_fresh_jwt_token().await?;
 
         software_update_request
             .update_list

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -12,6 +12,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 use std::time::Duration;
+use std::time::SystemTime;
 use tedge_actors::test_helpers::MessageReceiverExt;
 use tedge_actors::Actor;
 use tedge_actors::Builder;
@@ -109,6 +110,38 @@ async fn mapper_publishes_software_update_request() {
         )],
     )
     .await;
+}
+
+#[tokio::test]
+async fn mapper_publishes_software_update_request_with_new_token() {
+    // The test assures SM Mapper correctly receives software update request smartrest message on `c8y/s/ds`
+    // and converts it to thin-edge json message published on `tedge/commands/req/software/update` with new JWT token.
+    let (mqtt, http, _fs, _timer) = spawn_c8y_mapper_actor(&TempTedgeDir::new(), true).await;
+    spawn_dummy_c8y_http_proxy(http);
+
+    let mut mqtt = mqtt.with_timeout(TEST_TIMEOUT_MS);
+
+    mqtt.skip(6).await; //Skip all init messages
+
+    // Simulate c8y_SoftwareUpdate SmartREST request
+    mqtt.send(MqttMessage::new(
+        &C8yTopic::downstream_topic(),
+        "528,test-device,test-very-large-software,2.0,https://test.c8y.io,install",
+    ))
+    .await
+    .expect("Send failed");
+    let first_request = mqtt.recv().await.unwrap();
+    // Simulate c8y_SoftwareUpdate SmartREST request
+    mqtt.send(MqttMessage::new(
+        &C8yTopic::downstream_topic(),
+        "528,test-device,test-very-large-software,2.0,https://test.c8y.io,install",
+    ))
+    .await
+    .expect("Send failed");
+    let second_request = mqtt.recv().await.unwrap();
+
+    // Both software update requests will have different tokens in it. So, they are not equal.
+    assert_ne!(first_request, second_request);
 }
 
 #[tokio::test]
@@ -1354,6 +1387,14 @@ fn spawn_dummy_c8y_http_proxy(mut http: SimpleMessageBox<C8YRestRequest, C8YRest
                     let _ = http
                         .send(Ok(c8y_http_proxy::messages::C8YRestResponse::EventId(
                             "dummy-token".into(),
+                        )))
+                        .await;
+                }
+                Some(C8YRestRequest::GetFreshJwtToken(_)) => {
+                    let now = SystemTime::now();
+                    let _ = http
+                        .send(Ok(c8y_http_proxy::messages::C8YRestResponse::EventId(
+                            format!("dummy-token-{:?}", now),
                         )))
                         .await;
                 }


### PR DESCRIPTION
## Proposed changes
As the `tedge-agent` can't request the `new jwt` token, a new `jwt` token has to be sent to the `tedge-agent` with the `software update`  request.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/2175

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

