### PR TITLE
Fix the wrong exit code after the cloud connection test failure

### DIFF
--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -64,13 +64,8 @@ impl Command for ConnectCommand {
                         println!("Connection check to {} cloud is successful.\n", cloud);
                         Ok(())
                     }
-                    Ok(DeviceStatus::Unknown) | Err(_) => {
-                        println!(
-                            "Connection check to {} cloud failed.\n",
-                            self.cloud.as_str()
-                        );
-                        Ok(())
-                    }
+                    Ok(DeviceStatus::Unknown) => Err(ConnectError::UnknownDeviceStatus.into()),
+                    Err(err) => Err(err.into()),
                 };
             } else {
                 return Err((ConnectError::DeviceNotConnected {
@@ -283,7 +278,6 @@ fn check_device_status_c8y(tedge_config: &TEdgeConfig) -> Result<DeviceStatus, C
         Ok(DeviceStatus::Unknown)
     } else {
         // The request has not even been sent
-        println!("\nMake sure mosquitto is running.");
         Err(ConnectError::TimeoutElapsedError)
     }
 }
@@ -359,7 +353,6 @@ fn check_device_status_azure(tedge_config: &TEdgeConfig) -> Result<DeviceStatus,
         Ok(DeviceStatus::Unknown)
     } else {
         // The request has not even been sent
-        println!("Make sure mosquitto is running.");
         Err(ConnectError::TimeoutElapsedError)
     }
 }
@@ -426,7 +419,6 @@ fn check_device_status_aws(tedge_config: &TEdgeConfig) -> Result<DeviceStatus, C
         Ok(DeviceStatus::Unknown)
     } else {
         // The request has not even been sent
-        println!("Make sure mosquitto is running.");
         Err(ConnectError::TimeoutElapsedError)
     }
 }

--- a/crates/core/tedge/src/cli/connect/error.rs
+++ b/crates/core/tedge/src/cli/connect/error.rs
@@ -48,6 +48,9 @@ pub enum ConnectError {
     #[error("Device is not connected to {cloud} cloud")]
     DeviceNotConnected { cloud: String },
 
+    #[error("Unknown device status")]
+    UnknownDeviceStatus,
+
     #[error(
         "The JWT token received from Cumulocity is invalid.\nToken: {token}\nReason: {reason}"
     )]


### PR DESCRIPTION
## Proposed changes
This PR fixes an issue of returning exit code 0 when the connection test for any cloud fails. Additionally, I removed redundant messages, which will now be covered by returned error messages.
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2170
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

