### PR TITLE
Exit with code 0 if service manager not present

### DIFF
--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -101,13 +101,19 @@ impl Command for ConnectCommand {
 
         let device_type = &config.device.ty;
 
-        new_bridge(
+        match new_bridge(
             &bridge_config,
             &updated_mosquitto_config,
             self.service_manager.as_ref(),
             &self.config_location,
             device_type,
-        )?;
+        ) {
+            Ok(()) => println!("Successfully created bridge connection!\n"),
+            Err(ConnectError::SystemServiceError(
+                SystemServiceError::ServiceManagerUnavailable { .. },
+            )) => return Ok(()),
+            Err(err) => return Err(err.into()),
+        }
 
         match self.check_connection(&config) {
             Ok(DeviceStatus::AlreadyExists) => {
@@ -484,8 +490,6 @@ fn new_bridge(
         clean_up(config_location, bridge_config)?;
         return Err(err.into());
     }
-
-    println!("Successfully created bridge connection!\n");
 
     Ok(())
 }


### PR DESCRIPTION
## Proposed changes
This PR changes exit code to `0` and prevents from running tedge components if service manager is not present.
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2172
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

