### PR TITLE
Add support for `config-dir` flag

### DIFF
--- a/plugins/c8y_remote_access_plugin/src/input.rs
+++ b/plugins/c8y_remote_access_plugin/src/input.rs
@@ -4,6 +4,9 @@ use miette::ensure;
 use miette::miette;
 use miette::Context;
 use serde::Deserialize;
+use std::path::PathBuf;
+use tedge_config::TEdgeConfigLocation;
+use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 
 use crate::csv::deserialize_csv_record;
 
@@ -21,8 +24,12 @@ pub struct RemoteAccessConnect {
 name = clap::crate_name!(),
 version = clap::crate_version!(),
 about = clap::crate_description!(),
+arg_required_else_help(true),
 )]
-struct Cli {
+pub struct Cli {
+    #[arg(long = "config-dir", default_value = DEFAULT_TEDGE_CONFIG_PATH)]
+    config_dir: PathBuf,
+
     #[arg(long)]
     /// Complete the installation of c8y-configuration-plugin by declaring the supported operation.
     init: bool,
@@ -40,6 +47,12 @@ struct Cli {
     child: Option<String>,
 }
 
+impl Cli {
+    pub fn get_config_location(&self) -> TEdgeConfigLocation {
+        TEdgeConfigLocation::from_custom_root(&self.config_dir)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum Command {
     Init,
@@ -48,8 +61,8 @@ pub enum Command {
     Connect(RemoteAccessConnect),
 }
 
-pub fn parse_arguments() -> miette::Result<Command> {
-    Cli::parse().try_into()
+pub fn parse_arguments(cli: Cli) -> miette::Result<Command> {
+    cli.try_into()
 }
 
 impl TryFrom<Cli> for Command {

--- a/plugins/c8y_remote_access_plugin/src/main.rs
+++ b/plugins/c8y_remote_access_plugin/src/main.rs
@@ -2,12 +2,13 @@ use std::process::Stdio;
 
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
+use clap::Parser;
 use futures::future::try_select;
 use futures::future::Either;
+use input::parse_arguments;
 use miette::Context;
 use miette::IntoDiagnostic;
 use tedge_config::TEdgeConfig;
-use tedge_config::TEdgeConfigLocation;
 use tedge_config::TEdgeConfigRepository;
 use tedge_utils::file::create_directory_with_user_group;
 use tedge_utils::file::create_file_with_user_group;
@@ -27,13 +28,16 @@ mod proxy;
 
 #[tokio::main]
 async fn main() -> miette::Result<()> {
-    let config_dir = TEdgeConfigLocation::default();
+    let opt = input::Cli::parse();
+
+    let config_dir = opt.get_config_location();
+
     let tedge_config = TEdgeConfigRepository::new(config_dir.clone())
         .load()
         .into_diagnostic()
         .context("Reading tedge config")?;
 
-    let command = input::parse_arguments()?;
+    let command = parse_arguments(opt)?;
 
     match command {
         Command::Init => declare_supported_operation(config_dir.tedge_config_root_path())


### PR DESCRIPTION
## Proposed changes
This PR add support for `config-dir` flag in c8y-remote-access-plugin
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2112
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

