### PR TITLE
CI: Free some disk space by deleting unneeded SDKs

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -224,6 +224,19 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true' }}
     steps:
+      - name: Check disk space before setting up
+        run: df -BM
+
+      - name: Reclaim some disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf /opt/hostedtoolcache
+
+      - name: Check disk space after freeing
+        run: df -BM
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -256,6 +269,9 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: false
+
+      - name: Check disk space after completing workflow
+        run: df -BM
 
   shellcheck:
     name: Shellcheck

--- a/crates/common/download/src/download.rs
+++ b/crates/common/download/src/download.rs
@@ -492,7 +492,6 @@ mod tests {
     use tokio::net::TcpListener;
 
     #[tokio::test]
-    #[ignore = "fails CI because of lack of disk space"]
     async fn downloader_download_content_no_auth() {
         let mut server = mockito::Server::new();
         let _mock1 = server
@@ -522,7 +521,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "fails CI because of lack of disk space"]
     async fn downloader_download_to_target_path() {
         let temp_dir = tempdir().unwrap();
 
@@ -575,7 +573,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "fails CI because of lack of disk space"]
     async fn returns_proper_errors_for_invalid_filenames() {
         let temp_dir = tempdir().unwrap();
         std::env::set_current_dir(temp_dir.path()).unwrap();
@@ -620,7 +617,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "fails CI because of lack of disk space"]
     async fn writing_to_existing_file() {
         let temp_dir = tempdir().unwrap();
         let mut server = mockito::Server::new();
@@ -647,7 +643,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "fails CI because of lack of disk space"]
     async fn downloader_download_with_reasonable_content_length() {
         let file = create_file_with_size(10 * 1024 * 1024).unwrap();
         let file_path = file.into_temp_path();
@@ -676,7 +671,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "fails CI because of lack of disk space"]
     async fn downloader_download_verify_file_content() {
         let file = create_file_with_size(10).unwrap();
 

--- a/crates/extensions/tedge_downloader_ext/src/tests.rs
+++ b/crates/extensions/tedge_downloader_ext/src/tests.rs
@@ -9,7 +9,6 @@ use tokio::time::timeout;
 const TEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[tokio::test]
-#[ignore = "fails CI because of lack of disk space"]
 async fn download_without_auth() -> Result<(), DynError> {
     let ttd = TempTedgeDir::new();
     let mut server = mockito::Server::new();
@@ -42,7 +41,6 @@ async fn download_without_auth() -> Result<(), DynError> {
 }
 
 #[tokio::test]
-#[ignore = "fails CI because of lack of disk space"]
 async fn download_with_auth() -> Result<(), DynError> {
     let ttd = TempTedgeDir::new();
     let mut server = mockito::Server::new();


### PR DESCRIPTION


## Proposed changes

By removing SDKs for other languages that we don't need, about 15GB of disk space was freed. `download` crate tests should no longer fail due to lack of disk space. As such, the tests have been reenabled.

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #2208
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

