### PR TITLE
Fix panic in tedge_config macro when `-` present in field name

### DIFF
--- a/crates/common/tedge_config_macros/impl/src/lib.rs
+++ b/crates/common/tedge_config_macros/impl/src/lib.rs
@@ -43,7 +43,7 @@ pub fn generate_configuration(tokens: TokenStream) -> Result<TokenStream, syn::E
             field.examples.iter().enumerate().map(move |(n, example)| {
                 let name = quote::format_ident!(
                     "example_value_can_be_deserialized_for_{}_example_{n}",
-                    key.join("_")
+                    key.join("_").replace('-', "_")
                 );
                 let span = example.span();
                 let example = example.as_ref();
@@ -187,5 +187,19 @@ mod tests {
             },
         })
         .is_err());
+    }
+
+    #[test]
+    fn can_contain_hyphen_separated_fields() {
+        generate_configuration(quote! {
+            device: {
+                #[tedge_config(rename = "type")]
+                ty: String,
+
+                #[tedge_config(rename = "hyphen-separated-field", example = "hsf")]
+                hyphen_separated_field: String
+            },
+        })
+        .unwrap();
     }
 }


### PR DESCRIPTION

## Proposed changes

`#[tedge_config(rename = "name-with-hyphens")]` panicked because of hyphens in the rename field. This occured because a test that was being generated to test that field did not remove hyphens from the identifier name, e.g:

> error: proc macro panicked
> ...
>     = help: message:
`"example_value_can_be_deserialized_for_run_name-with-hyphens_example_0"` is not a valid identifier

Was fixed by replacing hyphens with underscores in identifier name.


<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

