### PR TITLE
Events for c8y are consumed from te/+/+/+/+/e/+

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -372,8 +372,8 @@ define_tedge_config! {
         mqtt: HostPort<MQTT_TLS_PORT>,
 
         /// Set of MQTT topics the Cumulocity mapper should subscribe to
-        #[tedge_config(example = "tedge/alarms/#,te/+/+/+/+/m/+")]
-        #[tedge_config(default(value = "te/+/+/+/+/m/+,tedge/alarms/+/+,tedge/alarms/+/+/+,tedge/events/+,tedge/events/+/+,tedge/health/+,tedge/health/+/+"))]
+        #[tedge_config(example = "tedge/alarms/#,te/+/+/+/+/m/+,te/+/+/+/+/e/+")]
+        #[tedge_config(default(value = "te/+/+/+/+/m/+,te/+/+/+/+/e/+,tedge/alarms/+/+,tedge/alarms/+/+/+,tedge/health/+,tedge/health/+/+"))]
         topics: TemplatesSet,
 
         enable: {

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -141,10 +141,9 @@ impl C8yMapperConfig {
     pub fn default_external_topic_filter() -> TopicFilter {
         vec![
             "te/+/+/+/+/m/+",
+            "te/+/+/+/+/e/+",
             "tedge/alarms/+/+",
             "tedge/alarms/+/+/+",
-            "tedge/events/+",
-            "tedge/events/+/+",
             "tedge/health/+",
             "tedge/health/+/+",
         ]

--- a/tests/RobotFramework/tests/cumulocity/telemetry/child_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/child_device_telemetry.robot
@@ -21,14 +21,20 @@ Child devices support sending custom measurements
 
 
 Child devices support sending custom events
-    Execute Command    tedge mqtt pub tedge/events/myCustomType1/${CHILD_SN} '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///e/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
     ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=myCustomType1    fragment=someOtherCustomFragment
     Log    ${events}
 
 
 Child devices support sending custom events overriding the type
-    Execute Command    tedge mqtt pub tedge/events/myCustomType/${CHILD_SN} '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///e/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
     ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=otherType    fragment=someOtherCustomFragment
+    Log    ${events}
+
+
+ Child devices support sending custom events without type in topic
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///e/ '{"text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=ThinEdgeEvent    fragment=someOtherCustomFragment
     Log    ${events}
 
 

--- a/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry.robot
@@ -27,14 +27,20 @@ Thin-edge devices support sending custom measurements
 
 
 Thin-edge devices support sending custom events
-    Execute Command    tedge mqtt pub tedge/events/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    Execute Command    tedge mqtt pub te/device/main///e/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
     ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=myCustomType1    fragment=someOtherCustomFragment
     Log    ${events}
 
 
 Thin-edge devices support sending custom events overriding the type
-    Execute Command    tedge mqtt pub tedge/events/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    Execute Command    tedge mqtt pub te/device/main///e/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
     ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=otherType    fragment=someOtherCustomFragment
+    Log    ${events}
+
+
+Thin-edge devices support sending custom events without type in topic
+    Execute Command    tedge mqtt pub te/device/main///e/ '{"text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=ThinEdgeEvent    fragment=someOtherCustomFragment
     Log    ${events}
 
 

--- a/tests/RobotFramework/tests/mqtt/custom_sub_topics_tedge-mapper-c8y.robot
+++ b/tests/RobotFramework/tests/mqtt/custom_sub_topics_tedge-mapper-c8y.robot
@@ -12,7 +12,7 @@ Test Tags           theme:mqtt    theme:c8y
 
 *** Test Cases ***
 Publish events to subscribed topic
-    Execute Command    tedge mqtt pub tedge/events/event-type '{"text": "Event"}'
+    Execute Command    tedge mqtt pub te/device/main///e/event-type '{"text": "Event"}'
     Should Have MQTT Messages    c8y/s/us    message_pattern=400,event-type,"Event",*
 
 Publish measurements to unsubscribed topic
@@ -24,7 +24,7 @@ Publish measurements to unsubscribed topic
 *** Keywords ***
 Custom Setup
     Setup
-    Execute Command    sudo tedge config set c8y.topics tedge/events/+
+    Execute Command    sudo tedge config set c8y.topics te/+/+/+/+/e/+
     Execute Command    sudo systemctl restart tedge-mapper-c8y.service
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-c8y
 

--- a/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
+++ b/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
@@ -105,7 +105,7 @@ set/unset c8y.topics
     ${unset}    Execute Command    tedge config list
     Should Contain
     ...    ${unset}
-    ...    c8y.topics=["te/+/+/+/+/m/+", "tedge/alarms/+/+", "tedge/alarms/+/+/+", "tedge/events/+", "tedge/events/+/+", "tedge/health/+", "tedge/health/+/+"]
+    ...    c8y.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "tedge/alarms/+/+", "tedge/alarms/+/+/+", "tedge/health/+", "tedge/health/+/+"]
 
 set/unset az.root_cert_path
     Execute Command    sudo tedge config set az.root_cert_path /etc/ssl/certs1    # Changing az.root_cert_path


### PR DESCRIPTION
## Proposed changes
Events for **c8y** should be consumed from the mqtt topic `te/+/+/+/+/e/+` instead of `tedge/events/#`. 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2214 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

