### PR TITLE
Check if sudo is available when using tedge agent operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,6 +3520,7 @@ dependencies = [
  "tokio",
  "toml 0.7.6",
  "tracing",
+ "which",
 ]
 
 [[package]]

--- a/crates/core/plugin_sm/src/plugin.rs
+++ b/crates/core/plugin_sm/src/plugin.rs
@@ -229,12 +229,13 @@ impl ExternalPluginCommand {
     pub fn new(
         name: impl Into<SoftwareType>,
         path: impl Into<PathBuf>,
+        sudo: Option<PathBuf>,
         max_packages: u32,
     ) -> ExternalPluginCommand {
         ExternalPluginCommand {
             name: name.into(),
             path: path.into(),
-            sudo: Some("sudo".into()),
+            sudo,
             max_packages,
         }
     }

--- a/crates/core/plugin_sm/src/plugin_manager.rs
+++ b/crates/core/plugin_sm/src/plugin_manager.rs
@@ -205,6 +205,7 @@ impl ExternalPlugins {
                         let plugin = ExternalPluginCommand::new(
                             plugin_name,
                             &path,
+                            self.sudo.clone(),
                             config.software.plugin.max_packages,
                         );
                         self.plugin_map.insert(plugin_name.into(), plugin);

--- a/crates/core/plugin_sm/tests/plugin.rs
+++ b/crates/core/plugin_sm/tests/plugin.rs
@@ -237,6 +237,7 @@ mod tests {
         let plugin = ExternalPluginCommand::new(
             "test",
             &dummy_plugin_path,
+            None,
             config.software.plugin.max_packages,
         );
         assert_eq!(plugin.name, "test");
@@ -250,7 +251,7 @@ mod tests {
     fn plugin_check_module_type_both_same() {
         let dummy_plugin_path = get_dummy_plugin_path();
 
-        let plugin = ExternalPluginCommand::new("test", dummy_plugin_path, 100);
+        let plugin = ExternalPluginCommand::new("test", dummy_plugin_path, None, 100);
 
         let module = SoftwareModule {
             module_type: Some("test".into()),
@@ -274,7 +275,7 @@ mod tests {
         let dummy_plugin_path = get_dummy_plugin_path();
 
         // Create new plugin in the registry with name `test`.
-        let plugin = ExternalPluginCommand::new("test", dummy_plugin_path, 100);
+        let plugin = ExternalPluginCommand::new("test", dummy_plugin_path, None, 100);
 
         // Create test module with name `test2`.
         let module = SoftwareModule {
@@ -304,7 +305,7 @@ mod tests {
         // Create dummy plugin.
         let dummy_plugin_path = get_dummy_plugin_path();
 
-        let plugin = ExternalPluginCommand::new("test", dummy_plugin_path, 100);
+        let plugin = ExternalPluginCommand::new("test", dummy_plugin_path, None, 100);
 
         // Create software module without an explicit type.
         let module = SoftwareModule {

--- a/crates/core/tedge_agent/Cargo.toml
+++ b/crates/core/tedge_agent/Cargo.toml
@@ -35,6 +35,7 @@ time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 toml = { workspace = true }
 tracing = { workspace = true }
+which = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/crates/core/tedge_agent/src/software_manager/actor.rs
+++ b/crates/core/tedge_agent/src/software_manager/actor.rs
@@ -11,6 +11,7 @@ use plugin_sm::operation_logs::LogKind;
 use plugin_sm::operation_logs::OperationLogs;
 use plugin_sm::plugin_manager::ExternalPlugins;
 use plugin_sm::plugin_manager::Plugins;
+use std::path::PathBuf;
 use tedge_actors::fan_in_message_type;
 use tedge_actors::Actor;
 use tedge_actors::LoggingReceiver;
@@ -31,6 +32,7 @@ use tedge_config::TEdgeConfigError;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
+use which::which;
 
 #[cfg(not(test))]
 const SUDO: &str = "sudo";
@@ -77,10 +79,12 @@ impl Actor for SoftwareManagerActor {
         let operation_logs = OperationLogs::try_new(self.config.log_dir.clone().into())
             .map_err(SoftwareManagerError::FromOperationsLogs)?;
 
+        let sudo: Option<PathBuf> = which(SUDO).ok();
+
         let mut plugins = ExternalPlugins::open(
             &self.config.sm_plugins_dir,
             self.config.default_plugin_type.clone(),
-            Some(SUDO.into()),
+            sudo,
             self.config.config_location.clone(),
         )
         .map_err(|err| RuntimeError::ActorError(Box::new(err)))?;

--- a/tests/RobotFramework/tests/cumulocity/restart/on_shutdown.sh
+++ b/tests/RobotFramework/tests/cumulocity/restart/on_shutdown.sh
@@ -2,4 +2,8 @@
 set -e
 tedge mqtt pub --qos 0 tedge/events/boot_event "$(printf '{"text": "Warning device is about to reboot!", "type": "device_boot"}')" 2>/dev/null
 sleep 5
-sudo shutdown -r now
+if command -v sudo >/dev/null 2>&1; then
+    sudo shutdown -r now
+else
+    shutdown -r now
+fi

--- a/tests/RobotFramework/tests/cumulocity/restart/restart_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/restart/restart_device.robot
@@ -6,7 +6,7 @@ Library    DebugLibrary
 
 Test Tags    theme:c8y    theme:troubleshooting
 Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Teardown    Custom Teardown
 
 *** Test Cases ***
 
@@ -15,7 +15,21 @@ Supports restarting the device
     ${operation}=    Cumulocity.Restart Device
     Operation Should Be SUCCESSFUL    ${operation}    timeout=180
 
+Supports restarting the device without sudo and running as root
+    Set Service User    tedge-agent    root
+    Execute Command    mv /usr/bin/sudo /usr/bin/sudo.bak
+    ${operation}=    Cumulocity.Restart Device
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=180
+
+
 *** Keywords ***
+
+Set Service User
+    [Arguments]    ${SERVICE_NAME}    ${SERVICE_USER}
+    Execute Command    mkdir -p /etc/systemd/system/${SERVICE_NAME}.service.d/
+    Execute Command    cmd=printf "[Service]\nUser = ${SERVICE_USER}" | sudo tee /etc/systemd/system/${SERVICE_NAME}.service.d/10-user.conf
+    Execute Command    systemctl daemon-reload
+    Restart Service    ${SERVICE_NAME}
 
 Custom Setup
     ${DEVICE_SN}=    Setup
@@ -26,3 +40,8 @@ Custom Setup
     Execute Command    apt-get install -y systemd-sysv && chmod a+x /usr/bin/*.sh && chmod 644 /etc/systemd/system/*.service && systemctl enable on_startup.service
     Execute Command    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /usr/bin/on_shutdown.sh' > /etc/sudoers.d/tedge
     Execute Command    cmd=sed -i 's|reboot =.*|reboot = ["/usr/bin/on_shutdown.sh"]|g' /etc/tedge/system.toml
+
+Custom Teardown
+    # Restore sudo in case if the tests are run on a device (and not in a container)
+    Execute Command    [ -f /usr/bin/sudo.bak ] && mv /usr/bin/sudo.bak /usr/bin/sudo || true
+    Get Logs


### PR DESCRIPTION
## Proposed changes
This PR add improvements to `tedge agent` modules that run `command`. They run the `sudo` command only if it is available. If it is not, module try to run command without `sudo` and pass error if occurred. More in #2096 
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #2096 
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

