### PR TITLE
c8y-log-plugin fails to upload binary due to 401 error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,12 +676,16 @@ dependencies = [
  "download",
  "http",
  "log",
+ "mockito",
  "mqtt_channel",
+ "serde",
+ "serde_json",
  "tedge_actors",
  "tedge_config",
  "tedge_http_ext",
  "tedge_utils",
  "thiserror",
+ "time",
  "tokio",
 ]
 

--- a/crates/extensions/c8y_http_proxy/Cargo.toml
+++ b/crates/extensions/c8y_http_proxy/Cargo.toml
@@ -24,6 +24,10 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 
 [dev-dependencies]
+mockito = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tedge_http_ext = { workspace = true, features = [
     "test_helpers",
 ] }
+time = { workspace = true }


### PR DESCRIPTION
## Proposed changes

While retrying the HTTP call on the expired jwt token, use the freshly retrieved token for authentication in the subsequent HTTP calls.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/2222

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

