### PR TITLE
Fix device_id lookup while sending large events over HTTP #2234

### DIFF
--- a/crates/core/tedge/src/cli/mqtt/mod.rs
+++ b/crates/core/tedge/src/cli/mqtt/mod.rs
@@ -5,3 +5,5 @@ mod cli;
 mod error;
 mod publish;
 mod subscribe;
+
+const MAX_PACKET_SIZE: usize = 10 * 1024 * 1024;

--- a/crates/core/tedge/src/cli/mqtt/publish.rs
+++ b/crates/core/tedge/src/cli/mqtt/publish.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 use tedge_config::MqttAuthClientConfig;
 
 const DEFAULT_QUEUE_CAPACITY: usize = 10;
+use super::MAX_PACKET_SIZE;
 
 pub struct MqttPublishCommand {
     pub host: String,
@@ -47,6 +48,7 @@ impl Command for MqttPublishCommand {
 fn publish(cmd: &MqttPublishCommand) -> Result<(), MqttError> {
     let mut options = MqttOptions::new(cmd.client_id.as_str(), &cmd.host, cmd.port);
     options.set_clean_session(true);
+    options.set_max_packet_size(MAX_PACKET_SIZE, MAX_PACKET_SIZE);
 
     if cmd.ca_file.is_some() || cmd.ca_dir.is_some() {
         let mut root_store = RootCertStore::empty();

--- a/crates/core/tedge/src/cli/mqtt/subscribe.rs
+++ b/crates/core/tedge/src/cli/mqtt/subscribe.rs
@@ -13,7 +13,7 @@ use rumqttc::QoS;
 use tedge_config::MqttAuthClientConfig;
 
 const DEFAULT_QUEUE_CAPACITY: usize = 10;
-const MAX_PACKET_SIZE: usize = 1048575;
+use super::MAX_PACKET_SIZE;
 
 pub struct MqttSubscribeCommand {
     pub host: String,

--- a/crates/extensions/c8y_http_proxy/src/actor.rs
+++ b/crates/extensions/c8y_http_proxy/src/actor.rs
@@ -297,11 +297,14 @@ impl C8YHttpProxyActor {
                 extras: c8y_event.extras.clone(),
             }
         };
-        self.send_event_internal(
-            c8y_event.source.clone().unwrap_or_default().id,
-            create_event,
-        )
-        .await
+
+        // If the incoming event does not have any source mentioned explicitly,
+        // it is associated to the main device by default.
+        let device_id = c8y_event
+            .source
+            .map_or_else(|| self.end_point.device_id.clone(), |v| v.id);
+
+        self.send_event_internal(device_id, create_event).await
     }
 
     async fn send_software_list_http(

--- a/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry.robot
@@ -42,6 +42,19 @@ Thin-edge devices support sending custom events
     Log    ${events}
 
 
+Thin-edge devices support sending large events
+    Execute Command    tedge mqtt pub te/device/main///e/largeEvent "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(printf -- 'x%.0s' {1..1000000})")"
+    ${events}=    Device Should Have Event/s    expected_text=Large event    with_attachment=False    minimum=1    maximum=1    type=largeEvent    fragment=large_text_field
+    Log    ${events}
+
+
+Thin-edge devices support sending large events using legacy api
+    [Tags]    legacy
+    Execute Command    tedge mqtt pub tedge/events/largeEvent2 "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(printf -- 'x%.0s' {1..1000000})")"
+    ${events}=    Device Should Have Event/s    expected_text=Large event    with_attachment=False    minimum=1    maximum=1    type=largeEvent2    fragment=large_text_field
+    Log    ${events}
+
+
 Thin-edge devices support sending custom events overriding the type
     Execute Command    tedge mqtt pub te/device/main///e/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
     ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=otherType    fragment=someOtherCustomFragment


### PR DESCRIPTION
## Proposed changes

Fix the tedge device's internal ID lookup while sending large events over HTTP, when the payload doesn't contain the `source` field.

A small adjustment was also included to increase the max packet size in the `tedge mqtt pub|sub` commands as these are used in the tests to verify the fix. Before the the `tedge mqtt pub` was using the default package size. Now the `tedge mqtt pub|sub` have aligned the default packet size with the tedge-agent, to 10MB.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2234

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

