### PR TITLE
Replace device.type config option with an enum

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/models/device_type.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/device_type.rs
@@ -1,0 +1,49 @@
+use std::fmt::Display;
+use std::str::FromStr;
+
+use doku::Document;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Document)]
+pub enum DeviceType {
+    ThinEdgeDevice,
+    ChildDevice,
+}
+
+impl Default for DeviceType {
+    fn default() -> Self {
+        Self::ThinEdgeDevice
+    }
+}
+
+impl FromStr for DeviceType {
+    type Err = DeviceTypeError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "thin-edge.io" => Ok(Self::ThinEdgeDevice),
+            "child-device" => Ok(Self::ChildDevice),
+            _ => Err(DeviceTypeError),
+        }
+    }
+}
+
+impl DeviceType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::ThinEdgeDevice => "thin-edge.io",
+            Self::ChildDevice => "child-device",
+        }
+    }
+}
+
+impl Display for DeviceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, Copy)]
+#[error("Provided string is not a valid device type")]
+pub struct DeviceTypeError;

--- a/crates/common/tedge_config/src/tedge_config_cli/models/mod.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/mod.rs
@@ -1,4 +1,5 @@
 pub mod connect_url;
+mod device_type;
 pub mod flag;
 pub mod host_port;
 pub mod ipaddress;
@@ -10,6 +11,7 @@ pub const HTTPS_PORT: u16 = 443;
 pub const MQTT_TLS_PORT: u16 = 8883;
 
 pub use self::connect_url::*;
+pub use self::device_type::*;
 pub use self::flag::*;
 #[doc(inline)]
 pub use self::host_port::HostPort;

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -1,3 +1,4 @@
+use super::models::DeviceType;
 use crate::ConnectUrl;
 use crate::HostPort;
 use crate::Seconds;
@@ -337,9 +338,9 @@ define_tedge_config! {
         cert_path: Utf8PathBuf,
 
         /// The default device type
-        #[tedge_config(example = "thin-edge.io", default(value = "thin-edge.io"))]
+        #[tedge_config(example = "thin-edge.io", default(function = Default::default))]
         #[tedge_config(rename = "type")]
-        ty: String,
+        ty: DeviceType,
     },
 
     c8y: {

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config_repository.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config_repository.rs
@@ -192,7 +192,7 @@ type = "a-service-type""#;
 
         assert_eq!(reader.device.cert_path, "/tedge/device-cert.pem");
         assert_eq!(reader.device.key_path, "/tedge/device-key.pem");
-        assert_eq!(reader.device.ty, "a-device");
+        assert_eq!(reader.device.ty.as_str(), "a-device");
         assert_eq!(u16::from(reader.mqtt.bind.port), 1886);
         assert_eq!(u16::from(reader.mqtt.client.port), 1885);
     }

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -106,7 +106,7 @@ impl Command for ConnectCommand {
             &updated_mosquitto_config,
             self.service_manager.as_ref(),
             &self.config_location,
-            device_type,
+            device_type.as_str(),
         ) {
             Ok(()) => println!("Successfully created bridge connection!\n"),
             Err(ConnectError::SystemServiceError(

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -73,7 +73,7 @@ impl C8yMapperConfig {
         let logs_path = tedge_config.logs.path.clone();
         let data_dir = tedge_config.data.path.clone();
         let device_id = tedge_config.device.id.try_read(tedge_config)?.to_string();
-        let device_type = tedge_config.device.ty.clone();
+        let device_type = tedge_config.device.ty;
         let service_type = tedge_config.service.ty.clone();
         let c8y_host = tedge_config.c8y_url().or_config_not_set()?.to_string();
         let tedge_http_address = tedge_config.http.bind.address;
@@ -105,7 +105,7 @@ impl C8yMapperConfig {
             logs_path,
             data_dir,
             device_id,
-            device_type,
+            device_type.to_string(),
             service_type,
             c8y_host,
             tedge_http_host,


### PR DESCRIPTION
## Proposed changes

This PR replaces `device.type` config option with an enum with 2 values: `ThinEdgeDevice` and `ChildDevice`.

I didn't know what this option is for, and if it could be used to determine whether a device we're running on is a child device or not, or if there are any other values valid or invalid for this option at all, as `type` name suggests that not every valid string may be a valid type. Tried to see if the set of possible values for this setting is in the thin-edge Documentation, I found [a table on a health monitoring page](https://thin-edge.github.io/thin-edge.io/operate/c8y/c8y_service_monitoring/#configuring-the-default-service-type) that seemed to suggest that `Thin-edge-device` and `Child-device` are valid values for this setting. But I also found [a Cumulocity Smartrest 2.0 reference section](https://cumulocity.com/guides/reference/smartrest-two/#100), according to which device type can be any string, but I still have no idea what it means.

The tests are failing though, so it seems this setting is also used in other ways.

As such, I think that we should discuss if this is intended state, and if so, maybe adding some documentation to clarify the purpose of this setting. Also if this setting should remain in its current state, where any string is a valid value, I'd like to ask if there is any other setting to determine if a current device is a child device, or should such settings be added?


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

