### PR TITLE
Add test to check if incorrect MQTT payload is going to close the MQTT connection

### DIFF
--- a/tests/RobotFramework/tests/MQTT_health_check/mqtt_connection_status_with_incorrect_payload.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/mqtt_connection_status_with_incorrect_payload.robot
@@ -1,0 +1,25 @@
+*** Settings ***
+Resource    ../../resources/common.resource
+Library    ThinEdgeIO
+
+Test Tags    theme:troubleshooting    theme:monitoring    theme:c8y
+Suite Setup       Setup
+Suite Teardown    Get Logs
+
+
+*** Test Cases ***
+
+Send incorrect mqtt payload
+    Execute Command    tedge mqtt pub 'tedge/commands/req/software/list' '{"ids": "100"}'
+    ${output}=    Execute Command    systemctl status tedge-agent.service
+    Should Not Contain    ${output}    INFO mqtt_channel::connection: MQTT connection closed
+
+Send incorrect mqtt payload again
+    Execute Command    tedge mqtt pub 'tedge/commands/req/software/list' '{"ids": "100"}'
+    ${output}=    Execute Command    systemctl status tedge-agent.service
+    Should Not Contain    ${output}    INFO mqtt_channel::connection: MQTT connection closed
+
+Send incorrect mqtt payload third time
+    Execute Command    tedge mqtt pub 'tedge/commands/req/software/list' '{"ids": "100"}'
+    ${output}=    Execute Command    systemctl status tedge-agent.service
+    Should Not Contain    ${output}    INFO mqtt_channel::connection: MQTT connection closed


### PR DESCRIPTION
Add test to check if incorect MQTT payload is going to close the MQTT connection

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

