### PR TITLE
Fix: plugins don't update their internal representation of config files on file change

### DIFF
--- a/crates/extensions/c8y_config_manager/src/actor.rs
+++ b/crates/extensions/c8y_config_manager/src/actor.rs
@@ -239,9 +239,7 @@ impl ConfigManagerActor {
                 )?;
 
                 if parent_dir_name.eq("c8y") {
-                    let plugin_config = PluginConfig::new(&path);
-                    let message = plugin_config.to_supported_config_types_message()?;
-                    self.messages.send(message.into()).await?;
+                    self.publish_supported_config_types().await?;
                 } else {
                     // this is a child device
                     let plugin_config = PluginConfig::new(&path);
@@ -275,8 +273,9 @@ impl ConfigManagerActor {
     }
 
     async fn publish_supported_config_types(&mut self) -> Result<(), ConfigManagementError> {
+        self.plugin_config = PluginConfig::new(self.config.plugin_config_path.as_path());
         let message = self.plugin_config.to_supported_config_types_message()?;
-        self.messages.send(message.into()).await.unwrap();
+        self.messages.send(message.into()).await?;
         Ok(())
     }
 

--- a/crates/extensions/c8y_log_manager/src/actor.rs
+++ b/crates/extensions/c8y_log_manager/src/actor.rs
@@ -187,18 +187,15 @@ impl LogManagerActor {
     }
 
     pub async fn reload_supported_log_types(&mut self) -> Result<(), anyhow::Error> {
-        let plugin_config = LogPluginConfig::new(self.config.plugin_config_path.as_path());
-        self.publish_supported_log_types(&plugin_config).await
+        self.plugin_config = LogPluginConfig::new(self.config.plugin_config_path.as_path());
+        self.publish_supported_log_types().await
     }
 
     /// updates the log types on Cumulocity
     /// sends 118,typeA,typeB,... on mqtt
-    pub async fn publish_supported_log_types(
-        &mut self,
-        plugin_config: &LogPluginConfig,
-    ) -> Result<(), anyhow::Error> {
+    pub async fn publish_supported_log_types(&mut self) -> Result<(), anyhow::Error> {
         let topic = C8yTopic::SmartRestResponse.to_topic()?;
-        let mut config_types = plugin_config.get_all_file_types();
+        let mut config_types = self.plugin_config.get_all_file_types();
         config_types.sort();
         let supported_config_types = config_types.join(",");
         let payload = format!("118,{supported_config_types}");

--- a/crates/extensions/tedge_log_manager/src/actor.rs
+++ b/crates/extensions/tedge_log_manager/src/actor.rs
@@ -222,17 +222,13 @@ impl LogManagerActor {
     }
 
     async fn reload_supported_log_types(&mut self) -> Result<(), ChannelError> {
-        let plugin_config: LogPluginConfig =
-            LogPluginConfig::new(self.config.plugin_config_path.as_path());
-        self.publish_supported_log_types(&plugin_config).await
+        self.plugin_config = LogPluginConfig::new(self.config.plugin_config_path.as_path());
+        self.publish_supported_log_types().await
     }
 
     /// updates the log types
-    async fn publish_supported_log_types(
-        &mut self,
-        plugin_config: &LogPluginConfig,
-    ) -> Result<(), ChannelError> {
-        let mut config_types = plugin_config.get_all_file_types();
+    async fn publish_supported_log_types(&mut self) -> Result<(), ChannelError> {
+        let mut config_types = self.plugin_config.get_all_file_types();
         config_types.sort();
         let payload = json!({ "types": config_types }).to_string();
         let msg = MqttMessage::new(&self.config.logtype_reload_topic, payload).with_retain();

--- a/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
+++ b/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
@@ -403,25 +403,27 @@ class ThinEdgeIO(DeviceLibrary):
     # Service Health Status
     #
     @keyword("Service Health Status Should Be Up")
-    def assert_service_health_status_up(self, service: str) -> Dict[str, Any]:
+    def assert_service_health_status_up(self, service: str, device: str = "main") -> Dict[str, Any]:
         """Checks if the Service Health Status is up
 
-        *Example:*
-        | `Service Health Status Should Be Up` | | | | | tedge-mapper-c8y |
+        *Examples:*
+
+        | `Service Health Status Should Be Up` | tedge-mapper-c8y |
+        | `Service Health Status Should Be Up` | tedge-mapper-c8y | device=child01 |
         """
-        return self._assert_health_status(service, status="up")
+        return self._assert_health_status(service, status="up", device=device)
 
     @keyword("Service Health Status Should Be Down")
-    def assert_service_health_status_down(self, service: str) -> Dict[str, Any]:
-        return self._assert_health_status(service, status="down")
+    def assert_service_health_status_down(self, service: str, device: str = "main") -> Dict[str, Any]:
+        return self._assert_health_status(service, status="down", device=device)
 
     @keyword("Service Health Status Should Be Equal")
     def assert_service_health_status_equal(
-        self, service: str, status: str
+        self, service: str, status: str, device: str = "main"
     ) -> Dict[str, Any]:
-        return self._assert_health_status(service, status=status)
+        return self._assert_health_status(service, status=status, device=device)
 
-    def _assert_health_status(self, service: str, status: str) -> Dict[str, Any]:
+    def _assert_health_status(self, service: str, status: str, device: str = "main") -> Dict[str, Any]:
         # if mqtt.client.auth.ca_file or mqtt.client.auth.ca_dir is set, we pass setting
         # value to mosquitto_sub
         mqtt_config_options = self.execute_command(
@@ -437,7 +439,7 @@ class ThinEdgeIO(DeviceLibrary):
             client_auth = "--cert /setup/client.crt --key /setup/client.key"
 
         message = self.execute_command(
-            f"mosquitto_sub -t 'tedge/health/{service}' --retained-only -C 1 -W 5 -h $(tedge config get mqtt.client.host) -p $(tedge config get mqtt.client.port) {server_auth} {client_auth}",
+            f"mosquitto_sub -t 'te/device/{device}/service/{service}/status/health' --retained-only -C 1 -W 5 -h $(tedge config get mqtt.client.host) -p $(tedge config get mqtt.client.port) {server_auth} {client_auth}",
             stdout=True,
             stderr=False,
         )

--- a/tests/RobotFramework/tests/cumulocity/configuration/config2.json
+++ b/tests/RobotFramework/tests/cumulocity/configuration/config2.json
@@ -1,0 +1,1 @@
+{"name":"configuration2"}

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -73,36 +73,47 @@ Modify configuration plugin config via local filesystem modify inplace
     Cumulocity.Should Support Configurations    ${DEFAULT_CONFIG}    /etc/tedge/tedge.toml    system.toml    CONFIG1
     Execute Command    sed -i 's/CONFIG1/CONFIG3/g' /etc/tedge/c8y/c8y-configuration-plugin.toml
     Cumulocity.Should Support Configurations    ${DEFAULT_CONFIG}    /etc/tedge/tedge.toml    system.toml    CONFIG3
+    ${operation}=    Cumulocity.Get Configuration    CONFIG3
+    Operation Should Be SUCCESSFUL    ${operation}
 
 Modify configuration plugin config via local filesystem overwrite
     Cumulocity.Should Support Configurations    ${DEFAULT_CONFIG}    /etc/tedge/tedge.toml    system.toml    CONFIG1
     ${NEW_CONFIG}=    Execute Command    sed 's/CONFIG1/CONFIG3/g' /etc/tedge/c8y/c8y-configuration-plugin.toml
     Execute Command    echo "${NEW_CONFIG}" > /etc/tedge/c8y/c8y-configuration-plugin.toml
     Cumulocity.Should Support Configurations    ${DEFAULT_CONFIG}    /etc/tedge/tedge.toml    system.toml    CONFIG3
+    ${operation}=    Cumulocity.Get Configuration    CONFIG3
+    Operation Should Be SUCCESSFUL    ${operation}
 
 Update configuration plugin config via local filesystem copy
     Cumulocity.Should Support Configurations    ${DEFAULT_CONFIG}    /etc/tedge/tedge.toml    system.toml    CONFIG1
     Transfer To Device    ${CURDIR}/c8y-configuration-plugin-updated.toml    /etc/tedge/c8y/
     Execute Command    cp /etc/tedge/c8y/c8y-configuration-plugin-updated.toml /etc/tedge/c8y/c8y-configuration-plugin.toml
     Cumulocity.Should Support Configurations    ${DEFAULT_CONFIG}    /etc/tedge/tedge.toml    system.toml    CONFIG1    Config@2.0.0
+    ${operation}=    Cumulocity.Get Configuration    Config@2.0.0
+    Operation Should Be SUCCESSFUL    ${operation}
 
 Update configuration plugin config via local filesystem move (different directory)
     Cumulocity.Should Support Configurations    ${DEFAULT_CONFIG}    /etc/tedge/tedge.toml    system.toml    CONFIG1
     Transfer To Device    ${CURDIR}/c8y-configuration-plugin-updated.toml    /etc/
     Execute Command    mv /etc/c8y-configuration-plugin-updated.toml /etc/tedge/c8y/c8y-configuration-plugin.toml
     Cumulocity.Should Support Configurations    ${DEFAULT_CONFIG}    /etc/tedge/tedge.toml    system.toml    CONFIG1    Config@2.0.0
+    ${operation}=    Cumulocity.Get Configuration    Config@2.0.0
+    Operation Should Be SUCCESSFUL    ${operation}
 
 Update configuration plugin config via local filesystem move (same directory)
     Cumulocity.Should Support Configurations    ${DEFAULT_CONFIG}    /etc/tedge/tedge.toml    system.toml    CONFIG1
     Transfer To Device    ${CURDIR}/c8y-configuration-plugin-updated.toml    /etc/tedge/c8y/
     Execute Command    mv /etc/tedge/c8y/c8y-configuration-plugin-updated.toml /etc/tedge/c8y/c8y-configuration-plugin.toml
     Cumulocity.Should Support Configurations    ${DEFAULT_CONFIG}    /etc/tedge/tedge.toml    system.toml    CONFIG1    Config@2.0.0
+    ${operation}=    Cumulocity.Get Configuration    Config@2.0.0
+    Operation Should Be SUCCESSFUL    ${operation}
 
 *** Keywords ***
 
 Test Setup
     ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y-configuration-plugin.toml    /etc/tedge/c8y/
     ThinEdgeIO.Transfer To Device    ${CURDIR}/config1.json         /etc/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/config2.json         /etc/
     Execute Command    chown root:root /etc/tedge/c8y/c8y-configuration-plugin.toml /etc/config1.json
     ThinEdgeIO.Service Health Status Should Be Up    c8y-configuration-plugin
     ThinEdgeIO.Service Health Status Should Be Up    tedge-agent

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
@@ -37,8 +37,6 @@ Setup LogFiles
     ThinEdgeIO.Transfer To Device    ${CURDIR}/example.log    /var/log/example/
     # touch file again to change last modified timestamp, otherwise the logfile retrieval could be outside of the requested range
     Execute Command    chown root:root /etc/tedge/plugins/tedge-log-plugin.toml /var/log/example/example.log && touch /var/log/example/example.log
-    # WORKAROUND: Remove restart service command once https://github.com/thin-edge/thin-edge.io/issues/2246 has been resolved
-    ThinEdgeIO.Restart Service    tedge-log-plugin
     ThinEdgeIO.Service Health Status Should Be Up    tedge-log-plugin
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-c8y
 

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
@@ -12,17 +12,19 @@ Test Tags           theme:c8y    theme:log
 
 *** Test Cases ***
 Successful log operation
-    ${end_timestamp}=    get current date    result_format=%Y-%m-%dT%H:%M:%S+0000
+    ${start_timestamp}=    Get Current Date    UTC    -24 hours    result_format=%Y-%m-%dT%H:%M:%S+0000
+    ${end_timestamp}=    Get Current Date    UTC    +60 seconds    result_format=%Y-%m-%dT%H:%M:%S+0000
     ${operation}=    Cumulocity.Create Operation
     ...    description=Log file request
-    ...    fragments={"c8y_LogfileRequest":{"dateFrom":"1970-01-01T00:00:00+0000","dateTo":"${end_timestamp}","logFile":"example","searchText":"first","maximumLines":10}}
+    ...    fragments={"c8y_LogfileRequest":{"dateFrom":"${start_timestamp}","dateTo":"${end_timestamp}","logFile":"example","searchText":"first","maximumLines":10}}
     ${operation}=    Operation Should Be SUCCESSFUL    ${operation}    timeout=120
 
 Request with non-existing log type
-    ${end_timestamp}=    get current date    result_format=%Y-%m-%dT%H:%M:%S+0000
+    ${start_timestamp}=    Get Current Date    UTC    -24 hours    result_format=%Y-%m-%dT%H:%M:%S+0000
+    ${end_timestamp}=    Get Current Date    UTC    +60 seconds    result_format=%Y-%m-%dT%H:%M:%S+0000
     ${operation}=    Cumulocity.Create Operation
     ...    description=Log file request
-    ...    fragments={"c8y_LogfileRequest":{"dateFrom":"1970-01-01T00:00:00+0000","dateTo":"${end_timestamp}","logFile":"example1","searchText":"first","maximumLines":10}}
+    ...    fragments={"c8y_LogfileRequest":{"dateFrom":"${start_timestamp}","dateTo":"${end_timestamp}","logFile":"example1","searchText":"first","maximumLines":10}}
     Operation Should Be FAILED
     ...    ${operation}
     ...    failure_reason=.*No such file or directory for log type: example1
@@ -33,7 +35,9 @@ Request with non-existing log type
 Setup LogFiles
     ThinEdgeIO.Transfer To Device    ${CURDIR}/tedge-log-plugin.toml    /etc/tedge/plugins/tedge-log-plugin.toml
     ThinEdgeIO.Transfer To Device    ${CURDIR}/example.log    /var/log/example/
-    Execute Command    chown root:root /etc/tedge/plugins/tedge-log-plugin.toml /var/log/example/example.log
+    # touch file again to change last modified timestamp, otherwise the logfile retrieval could be outside of the requested range
+    Execute Command    chown root:root /etc/tedge/plugins/tedge-log-plugin.toml /var/log/example/example.log && touch /var/log/example/example.log
+    # WORKAROUND: Remove restart service command once https://github.com/thin-edge/thin-edge.io/issues/2246 has been resolved
     ThinEdgeIO.Restart Service    tedge-log-plugin
     ThinEdgeIO.Service Health Status Should Be Up    tedge-log-plugin
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-c8y

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
@@ -12,10 +12,11 @@ Test Tags           theme:c8y    theme:log
 
 *** Test Cases ***
 Successful log operation
-    ${end_timestamp}=    get current date    result_format=%Y-%m-%dT%H:%M:%S+0000
+    ${start_timestamp}=    Get Current Date    UTC    -24 hours    result_format=%Y-%m-%dT%H:%M:%S+0000
+    ${end_timestamp}=    Get Current Date    UTC    +60 seconds    result_format=%Y-%m-%dT%H:%M:%S+0000
     ${operation}=    Cumulocity.Create Operation
     ...    description=Log file request
-    ...    fragments={"c8y_LogfileRequest":{"dateFrom":"1970-01-01T00:00:00+0000","dateTo":"${end_timestamp}","logFile":"example","searchText":"first","maximumLines":10}}
+    ...    fragments={"c8y_LogfileRequest":{"dateFrom":"${start_timestamp}","dateTo":"${end_timestamp}","logFile":"example","searchText":"first","maximumLines":10}}
     ${operation}=    Operation Should Be SUCCESSFUL    ${operation}    timeout=120
 
 
@@ -23,18 +24,23 @@ Successful log operation
 Setup Child Device
     ThinEdgeIO.Set Device Context    ${CHILD_SN}
     Execute Command    sudo dpkg -i packages/tedge_*.deb
-    Execute Command    sudo dpkg -i packages/tedge-log-plugin*.deb
 
     Execute Command    sudo tedge config set mqtt.client.host ${PARENT_IP}
     Execute Command    sudo tedge config set mqtt.client.port 1883
+    Execute Command    sudo tedge config set mqtt.topic_root te
+    Execute Command    sudo tedge config set mqtt.device_topic_id "device/${CHILD_SN}//"
+
+    # Install plugin after the default settings have been updated to prevent it from starting up as the main plugin
+    Execute Command    sudo dpkg -i packages/tedge-log-plugin*.deb
 
     ThinEdgeIO.Transfer To Device    ${CURDIR}/tedge-log-plugin.toml    /etc/tedge/plugins/tedge-log-plugin.toml
     ThinEdgeIO.Transfer To Device    ${CURDIR}/example.log    /var/log/example/
-    Execute Command    chown root:root /etc/tedge/plugins/tedge-log-plugin.toml /var/log/example/example.log
-    ThinEdgeIO.Stop Service    tedge-log-plugin
-    Execute Command    cmd=sed -i 's|ExecStart=.*|ExecStart=/usr/bin/tedge-log-plugin --mqtt-topic-root te --mqtt-device-topic-id "device/${CHILD_SN}//"|g' /lib/systemd/system/tedge-log-plugin.service && sudo systemctl daemon-reload
-    ThinEdgeIO.Start Service    tedge-log-plugin
-    ThinEdgeIO.Service Health Status Should Be Up    tedge-log-plugin
+    Execute Command    chown root:root /etc/tedge/plugins/tedge-log-plugin.toml /var/log/example/example.log && touch /var/log/example/example.log
+
+    # WORKAROUND: Remove restart service command once https://github.com/thin-edge/thin-edge.io/issues/2246 has been resolved
+    ThinEdgeIO.Restart Service    tedge-log-plugin
+    # WORKAROUND: Uncomment next line once https://github.com/thin-edge/thin-edge.io/issues/2253 has been resolved
+    # ThinEdgeIO.Service Health Status Should Be Up    tedge-log-plugin    device=${CHILD_SN}
 
 Custom Setup
     # Parent

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
@@ -37,8 +37,6 @@ Setup Child Device
     ThinEdgeIO.Transfer To Device    ${CURDIR}/example.log    /var/log/example/
     Execute Command    chown root:root /etc/tedge/plugins/tedge-log-plugin.toml /var/log/example/example.log && touch /var/log/example/example.log
 
-    # WORKAROUND: Remove restart service command once https://github.com/thin-edge/thin-edge.io/issues/2246 has been resolved
-    ThinEdgeIO.Restart Service    tedge-log-plugin
     # WORKAROUND: Uncomment next line once https://github.com/thin-edge/thin-edge.io/issues/2253 has been resolved
     # ThinEdgeIO.Service Health Status Should Be Up    tedge-log-plugin    device=${CHILD_SN}
 


### PR DESCRIPTION
## Proposed changes
Fix the problem of not updating the internal representation of config files. This applies to all plugins that use `FsFileWatcher`: 
-  `tedge-log-plugin`
-  `c8y-log-plugin`
- `c8y-configuration-plugin`

Additionally this PR fixes unsafe `unwrap` while sending mqtt message inside the  `c8y-configuration-plugin` (that could lead to rust panic if there was any problem with MQTT actor)

The integration tests were also extended to cover these scenarios to ensure it functions as expected (taken from https://github.com/thin-edge/thin-edge.io/pull/2260):

* add library function to check service status of child devices and switch to new tedge interface
* use recent timestamp instead of 1970 as this is more aligned to how the UI behaves
* fix timestamp bug where the tests were using a fixed timezone which meant that the local time was being erroneously cast to UTC leading to unexpected dateFrom/dateTo values
* use tedge config to control `te` topic instead of flags
* add notes about when workarounds in tests can be removed

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #2246
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

