### PR TITLE
tedge-agent: move to new health topic

### DIFF
--- a/crates/core/tedge_agent/src/tedge_to_te_converter/converter.rs
+++ b/crates/core/tedge_agent/src/tedge_to_te_converter/converter.rs
@@ -2,10 +2,14 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::convert::Infallible;
 use tedge_actors::Converter;
+use tedge_api::mqtt_topics::Channel;
+use tedge_api::mqtt_topics::MqttSchema;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::Topic;
 
-pub struct TedgetoTeConverter {}
+pub struct TedgetoTeConverter {
+    mqtt_schema: MqttSchema,
+}
 
 impl Converter for TedgetoTeConverter {
     type Input = MqttMessage;
@@ -19,20 +23,56 @@ impl Converter for TedgetoTeConverter {
 }
 
 impl TedgetoTeConverter {
+    /// Creates a new converter with default prefix `"te"`.
+    #[cfg(test)]
     pub fn new() -> Self {
-        TedgetoTeConverter {}
+        Self {
+            mqtt_schema: MqttSchema::new(),
+        }
+    }
+
+    pub fn with_root(root: String) -> Self {
+        Self {
+            mqtt_schema: MqttSchema::with_root(root),
+        }
     }
 
     fn try_convert(&mut self, message: MqttMessage) -> Vec<tedge_mqtt_ext::Message> {
-        match message.topic.clone() {
+        match &message.topic {
             topic if topic.name.starts_with("tedge/measurements") => {
                 self.convert_measurement(message)
             }
             topic if topic.name.starts_with("tedge/events") => self.convert_event(message),
             topic if topic.name.starts_with("tedge/alarms") => self.convert_alarm(message),
-            topic if topic.name.starts_with("tedge/health") => {
+
+            // to be able to move different services to new health topic at different times, we
+            // selectively map services either from old to new topics, and vice versa.
+            // tedge-agent publishes on new health topic, exclude it from old mapping not to produce
+            // a publish loop
+            topic
+                if topic.name.starts_with("tedge/health")
+                    && !topic.name.contains("tedge-agent") =>
+            {
                 self.convert_health_status_message(message)
             }
+
+            // Convert messages from new topics to old topics for backward compatibility
+            topic if topic.name.starts_with(&self.mqtt_schema.root) => {
+                match self.mqtt_schema.entity_channel_of(topic) {
+                    Ok((entity_topic_id, Channel::Health))
+                        if entity_topic_id.as_str().contains("tedge-agent") =>
+                    {
+                        self.convert_new_health_status_message_to_old(message)
+                    }
+                    Ok(_) => vec![],
+                    Err(_) => vec![],
+                }
+            }
+
+            topic if topic.name.starts_with("tedge/health-check") => {
+                self.convert_health_check_command(message)
+            }
+
             _ => vec![],
         }
     }
@@ -118,19 +158,118 @@ impl TedgetoTeConverter {
         message.retain = true;
         vec![message]
     }
+
+    /// Maps health messages from a new topic scheme to the old.
+    ///
+    /// The `message` is assumed to be a health message coming from a service under a new topic
+    /// scheme. This function should be called for services already ported to the new topic scheme
+    /// and these services should be excluded from mapping old -> new, or else a message outputted
+    /// by this function will cause `convert_health_status_message`, which in turn will output
+    /// a message which will cause this function to be called again, resultin in a loop.
+    fn convert_new_health_status_message_to_old(
+        &mut self,
+        mut message: MqttMessage,
+    ) -> Vec<MqttMessage> {
+        // message fits new topic scheme
+        let topic = message.topic;
+        let (entity_topic_id, channel) = self
+            .mqtt_schema
+            .entity_channel_of(&topic)
+            .expect("topic should be confirmed to fit new schema in try_convert");
+
+        if channel != Channel::Health {
+            return vec![];
+        }
+
+        // TODO: move topic schema mapping into tedge-api
+        let topic = match entity_topic_id.as_str().split('/').collect::<Vec<&str>>()[..] {
+            ["device", "main", "service", service_name] => format!("tedge/health/{service_name}"),
+            ["device", cid, "service", service_name] => {
+                format!("tedge/health/{cid}/{service_name}")
+            }
+            // topics which do not fit a default schema are not mapped
+            _ => return vec![],
+        };
+
+        let topic = Topic::new_unchecked(&topic);
+        message.topic = topic;
+        message.retain = true;
+        vec![message]
+    }
+
+    fn convert_health_check_command(
+        &self,
+        mut message: tedge_mqtt_ext::Message,
+    ) -> Vec<tedge_mqtt_ext::Message> {
+        let topic = match message.topic.name.split('/').collect::<Vec<_>>()[..] {
+            ["tedge", "health-check"] => Topic::new_unchecked("te/device/main///cmd/health/check"),
+            ["tedge", "health-check", service_name] => Topic::new_unchecked(
+                format!("te/device/main/service/{service_name}/cmd/health/check").as_str(),
+            ),
+            _ => return vec![],
+        };
+        message.topic = topic;
+        message.retain = true;
+        vec![message]
+    }
 }
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use crate::tedge_to_te_converter::converter::TedgetoTeConverter;
     use tedge_mqtt_ext::MqttMessage;
     use tedge_mqtt_ext::Topic;
 
     #[test]
-
     fn convert_incoming_wrong_topic() {
         let mqtt_message = MqttMessage::new(&Topic::new_unchecked("tedge///MyCustomAlarm"), "");
         let mut converter = TedgetoTeConverter::new();
         let res = converter.try_convert(mqtt_message);
         assert!(res.is_empty())
+    }
+
+    /// Ensures that private method `convert_new_health_status_message_to_old` only converts new
+    /// health messages to old messages for updated components.
+    // this test will have to be altered as components are updated to work with new health topics
+    #[test]
+    fn converts_health_status_messages_for_agent() {
+        let mut converter = TedgetoTeConverter::new();
+
+        let entities_incorrect = [
+            "device/main/service/other-service",
+            "device/child001/service/other-service",
+            "factory01/hallA/packaging/belt001",
+        ];
+
+        for topic in entities_incorrect {
+            let topic = converter
+                .mqtt_schema
+                .topic_for(&topic.parse().unwrap(), &Channel::Health);
+            let message = MqttMessage::new(&topic, "");
+
+            assert_eq!(converter.convert(&message).unwrap(), vec![]);
+        }
+
+        let topic = converter.mqtt_schema.topic_for(
+            &"device/main/service/tedge-agent".parse().unwrap(),
+            &Channel::Health,
+        );
+        let message = MqttMessage::new(&topic, "");
+        let expected_topic = "tedge/health/tedge-agent";
+        let messages = converter.convert(&message).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].topic.name, expected_topic);
+
+        let topic = converter.mqtt_schema.topic_for(
+            &"device/child001/service/tedge-agent".parse().unwrap(),
+            &Channel::Health,
+        );
+        let message = MqttMessage::new(&topic, "");
+        let expected_topic = "tedge/health/child001/tedge-agent";
+        let messages = converter.convert(&message).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].topic.name, expected_topic);
     }
 }

--- a/crates/core/tedge_api/src/health.rs
+++ b/crates/core/tedge_api/src/health.rs
@@ -1,11 +1,95 @@
 use std::process;
+use std::sync::Arc;
 
+use crate::mqtt_topics::ServiceTopicId;
 use mqtt_channel::Message;
 use mqtt_channel::PubChannel;
 use mqtt_channel::Topic;
 use mqtt_channel::TopicFilter;
 use serde_json::json;
 use time::OffsetDateTime;
+
+/// Encodes a valid health topic.
+///
+/// Health topics are topics on which messages about health status of services are published. To be
+/// able to send health messages, a health topic needs to be constructed for a given entity.
+// TODO: replace `Arc<str>` with `ServiceTopicId` after we're done with transition to new topics
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceHealthTopic(Arc<str>);
+
+impl ServiceHealthTopic {
+    pub fn new(service: ServiceTopicId) -> Self {
+        ServiceHealthTopic(Arc::from(format!("te/{}/status/health", service.as_str())))
+    }
+
+    pub fn from_old_topic(topic: String) -> Result<Self, HealthTopicError> {
+        match topic.split('/').collect::<Vec<&str>>()[..] {
+            ["tedge", "health", _service_name] => {}
+            ["tedge", "health", _child_id, _service_name] => {}
+            _ => return Err(HealthTopicError),
+        }
+
+        Ok(Self(Arc::from(topic)))
+    }
+
+    pub fn is_health_topic(topic: &str) -> bool {
+        matches!(
+            topic.split('/').collect::<Vec<&str>>()[..],
+            ["te", _, _, _, _, "status", "health"]
+        )
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub async fn send_health_status(&self, responses: &mut impl PubChannel) {
+        let response_topic_health = Topic::new_unchecked(self.as_str());
+
+        let health_status = json!({
+            "status": "up",
+            "pid": process::id(),
+            "time": OffsetDateTime::now_utc().unix_timestamp(),
+        })
+        .to_string();
+
+        let health_message = Message::new(&response_topic_health, health_status).with_retain();
+        let _ = responses.send(health_message).await;
+    }
+
+    pub fn down_message(&self) -> Message {
+        Message {
+            topic: Topic::new_unchecked(self.as_str()),
+            payload: json!({
+                "status": "down",
+                "pid": process::id()})
+            .to_string()
+            .into(),
+            qos: mqtt_channel::QoS::AtLeastOnce,
+            retain: true,
+        }
+    }
+
+    pub fn up_message(&self) -> Message {
+        let response_topic_health = Topic::new_unchecked(self.as_str());
+
+        let health_status = json!({
+            "status": "up",
+            "pid": process::id(),
+            "time": OffsetDateTime::now_utc().unix_timestamp(),
+        })
+        .to_string();
+
+        Message::new(&response_topic_health, health_status)
+            .with_qos(mqtt_channel::QoS::AtLeastOnce)
+            .with_retain()
+    }
+}
+
+#[derive(Debug)]
+pub struct HealthTopicError;
+
+// TODO: remove below functions once components moved to new health topics
 
 pub fn health_check_topics(daemon_name: &str) -> TopicFilter {
     vec![

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -748,7 +748,7 @@ impl CumulocityConverter {
 
             Channel::Command {
                 operation: OperationType::LogUpload,
-                cmd_id,
+                cmd_id: Some(cmd_id),
             } => {
                 self.handle_log_upload_state_change(&source, cmd_id, message)
                     .await?

--- a/crates/extensions/c8y_mapper_ext/src/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/log_upload.rs
@@ -61,7 +61,7 @@ impl CumulocityConverter {
         let cmd_id = nanoid!();
         let channel = Channel::Command {
             operation: OperationType::LogUpload,
-            cmd_id: cmd_id.clone(),
+            cmd_id: Some(cmd_id.clone()),
         };
         let topic = self.mqtt_schema.topic_for(&target.topic_id, &channel);
 

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -1285,7 +1285,7 @@ async fn mapper_converts_smartrest_logfile_req_to_log_upload_cmd_for_main_device
 
     if let Channel::Command {
         operation: OperationType::LogUpload,
-        cmd_id,
+        cmd_id: Some(cmd_id),
     } = channel
     {
         // Validate the topic name
@@ -1352,7 +1352,7 @@ async fn mapper_converts_smartrest_logfile_req_to_log_upload_cmd_for_child_devic
 
     if let Channel::Command {
         operation: OperationType::LogUpload,
-        cmd_id,
+        cmd_id: Some(cmd_id),
     } = channel
     {
         // Validate the topic name

--- a/crates/extensions/tedge_health_ext/src/actor.rs
+++ b/crates/extensions/tedge_health_ext/src/actor.rs
@@ -4,30 +4,31 @@ use tedge_actors::MessageReceiver;
 use tedge_actors::RuntimeError;
 use tedge_actors::Sender;
 use tedge_actors::SimpleMessageBox;
+use tedge_api::health::ServiceHealthTopic;
 use tedge_mqtt_ext::MqttMessage;
 
-use tedge_api::health::health_status_down_message;
-use tedge_api::health::health_status_up_message;
-
 pub struct HealthMonitorActor {
-    daemon_name: String,
+    health_topic: ServiceHealthTopic,
     messages: SimpleMessageBox<MqttMessage, MqttMessage>,
 }
 
 impl HealthMonitorActor {
-    pub fn new(daemon_name: String, messages: SimpleMessageBox<MqttMessage, MqttMessage>) -> Self {
+    pub fn new(
+        health_topic: ServiceHealthTopic,
+        messages: SimpleMessageBox<MqttMessage, MqttMessage>,
+    ) -> Self {
         Self {
-            daemon_name,
+            health_topic,
             messages,
         }
     }
 
     pub fn up_health_status(&self) -> MqttMessage {
-        health_status_up_message(&self.daemon_name)
+        self.health_topic.up_message()
     }
 
     pub fn down_health_status(&self) -> MqttMessage {
-        health_status_down_message(&self.daemon_name)
+        self.health_topic.down_message()
     }
 }
 

--- a/crates/extensions/tedge_health_ext/src/lib.rs
+++ b/crates/extensions/tedge_health_ext/src/lib.rs
@@ -3,6 +3,8 @@ mod actor;
 #[cfg(test)]
 mod tests;
 
+use std::sync::Arc;
+
 use actor::HealthMonitorActor;
 use tedge_actors::Builder;
 use tedge_actors::DynSender;
@@ -13,18 +15,23 @@ use tedge_actors::RuntimeRequestSink;
 use tedge_actors::ServiceConsumer;
 use tedge_actors::ServiceProvider;
 use tedge_actors::SimpleMessageBoxBuilder;
-use tedge_api::health::health_status_down_message;
-use tedge_api::health::health_status_up_message;
+use tedge_api::health::ServiceHealthTopic;
+use tedge_api::mqtt_topics::Channel;
+use tedge_api::mqtt_topics::MqttSchema;
+use tedge_api::mqtt_topics::OperationType;
+use tedge_api::mqtt_topics::ServiceTopicId;
 use tedge_mqtt_ext::MqttConfig;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::TopicFilter;
 
 pub struct HealthMonitorBuilder {
-    service_name: String,
+    service_health_topic: ServiceHealthTopic,
     box_builder: SimpleMessageBoxBuilder<MqttMessage, MqttMessage>,
 }
 
 impl HealthMonitorBuilder {
+    /// Creates a HealthMonitorBuilder that creates a HealthMonitorActor with
+    /// old topic scheme.
     pub fn new(
         service_name: &str,
         mqtt: &mut (impl ServiceProvider<MqttMessage, MqttMessage, TopicFilter> + AsMut<MqttConfig>),
@@ -37,12 +44,65 @@ impl HealthMonitorBuilder {
         .try_into()
         .expect("Failed to create the HealthMonitorActor topic filter");
 
+        let service_health_topic =
+            ServiceHealthTopic::from_old_topic(format!("tedge/health/{service_name}")).unwrap();
+
         let mut box_builder = SimpleMessageBoxBuilder::new(service_name, 16);
         box_builder
             .set_request_sender(mqtt.connect_consumer(subscriptions, box_builder.get_sender()));
 
         let builder = HealthMonitorBuilder {
-            service_name: service_name.to_owned(),
+            service_health_topic,
+            box_builder,
+        };
+
+        // Update the MQTT config
+        *mqtt.as_mut() = builder.set_init_and_last_will(mqtt.as_mut().clone());
+
+        builder
+    }
+
+    /// Creates a HealthMonitorBuilder that creates a HealthMonitorActor with
+    /// a new topic scheme.
+    pub fn from_service_topic_id(
+        service: ServiceTopicId,
+        mqtt: &mut (impl ServiceProvider<MqttMessage, MqttMessage, TopicFilter> + AsMut<MqttConfig>),
+        // TODO: pass it less annoying way
+        mqtt_topic_root: Arc<str>,
+    ) -> Self {
+        let health_topic = ServiceHealthTopic::new(service.clone());
+
+        let mut box_builder = SimpleMessageBoxBuilder::new(service.as_str(), 16);
+
+        // passed service is in default scheme
+        let device_topic_id = service.to_device_topic_id().unwrap();
+
+        let mqtt_schema = MqttSchema::with_root(mqtt_topic_root.to_string());
+        let subscriptions = vec![
+            mqtt_schema.topic_for(
+                service.clone().entity(),
+                &Channel::Command {
+                    operation: OperationType::HealthCheck,
+                    cmd_id: None,
+                },
+            ),
+            mqtt_schema.topic_for(
+                device_topic_id.entity(),
+                &Channel::Command {
+                    operation: OperationType::HealthCheck,
+                    cmd_id: None,
+                },
+            ),
+        ]
+        .into_iter()
+        .map(|t| t.into())
+        .collect::<TopicFilter>();
+
+        box_builder
+            .set_request_sender(mqtt.connect_consumer(subscriptions, box_builder.get_sender()));
+
+        let builder = HealthMonitorBuilder {
+            service_health_topic: health_topic,
             box_builder,
         };
 
@@ -53,10 +113,11 @@ impl HealthMonitorBuilder {
     }
 
     fn set_init_and_last_will(&self, config: MqttConfig) -> MqttConfig {
-        let name = self.service_name.to_owned();
+        let name = self.service_health_topic.to_owned();
+        let _name = name.clone();
         config
-            .with_initial_message(move || health_status_up_message(&name))
-            .with_last_will_message(health_status_down_message(&self.service_name))
+            .with_initial_message(move || _name.up_message())
+            .with_last_will_message(name.down_message())
     }
 }
 
@@ -71,7 +132,7 @@ impl Builder<HealthMonitorActor> for HealthMonitorBuilder {
 
     fn try_build(self) -> Result<HealthMonitorActor, Self::Error> {
         let message_box = self.box_builder.build();
-        let actor = HealthMonitorActor::new(self.service_name, message_box);
+        let actor = HealthMonitorActor::new(self.service_health_topic, message_box);
 
         Ok(actor)
     }

--- a/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
+++ b/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
@@ -160,6 +160,8 @@ Check if a service is down
     ThinEdgeIO.Service Should Be Stopped  ${service_name}
 
     Device Should Exist                      ${DEVICE_SN}_${service_name}    show_info=False
+    # XXX: On error, this produces output of just `AssertionError` without any context. It's also difficult finding what
+    # went wrong in the logs.
     ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=down
 
     Should Be Equal    ${SERVICE["name"]}    ${service_name}


### PR DESCRIPTION
TODO
- [ ] add test checking tedge-agent works with new topics
- [ ] figure out how to handle health command not having a command_id

## Proposed changes

tedge-agent was updated to work with new health topics:

- it listens to health check command on a new topic: `te/[DEVICE_TOPIC_ID]/service/tedge-agent/cmd/health/check`
- it publishes its health status on a new topic: `te/[DEVICE_TOPIC_ID]/service/tedge-agent/status/health

### Converter

However, to still be observable and work with other components and the tests, the converter was modified to properly bridge new inputs and output topics of tedge-agent:

- `tedge/health-check` and `tedge/health-check/SERVICE_NAME` are converted into `te/device/main///cmd/health/check` and `te/device/main/service/SERVICE_NAME/cmd/health/check` respectively, so that tedge-agent receives a health check command on a topic it expects
- `te/device/main/service/tedge-agent/status/health` and `te/device/CHILD_ID/service/tedge-agent/status/health` are converted into `tedge/health/tedge-agent` and `tedge/health/CHILD_ID/tedge-agent` respectively.
- in order not to cause a loop, a previous `tedge/health/SERVICE_NAME` -> `te/...` conversion was modified to not happen if SERVICE_NAME is "tedge-agent"

### tedge-api

A new type, `ServiceHealthTopic` was introduced to denote health topics of services. Currently it is a simple string wrapper, handling both new and old health topics, but after all components are moved, it will handle only new topics.

`ServiceTopicId` and `DeviceTopicId` were added as simple wrappers of `EntityTopicId` that are confirmed to be either a service or a device.

Because `te/device/main/service/tedge-agent/cmd/health/check` doesn't have a command_id, an OperationType struct was modified to make command_id optional.
## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/2018#issuecomment-1705325553

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

