### PR TITLE
Improve error handling and fix query string handling

### DIFF
--- a/crates/extensions/c8y_auth_proxy/src/server.rs
+++ b/crates/extensions/c8y_auth_proxy/src/server.rs
@@ -149,7 +149,7 @@ async fn respond_to(
     let mut res = send_request(body, token.clone())
         .await
         .into_diagnostic()
-        .wrap_err_with(|| format!("making proxied requst to {destination}"))?;
+        .wrap_err_with(|| format!("making proxied request to {destination}"))?;
 
     if res.status() == StatusCode::UNAUTHORIZED {
         token = retrieve_token.not_matching(Some(&token)).await;

--- a/crates/extensions/c8y_auth_proxy/src/server.rs
+++ b/crates/extensions/c8y_auth_proxy/src/server.rs
@@ -157,7 +157,7 @@ async fn respond_to(
             res = send_request(Body::from(body), token.clone())
                 .await
                 .into_diagnostic()
-                .wrap_err_with(|| format!("making proxied requst to {destination}"))?;
+                .wrap_err_with(|| format!("making proxied request to {destination}"))?;
         }
     }
     let te_header = res.headers_mut().remove("transfer-encoding");

--- a/crates/extensions/c8y_auth_proxy/src/tokens.rs
+++ b/crates/extensions/c8y_auth_proxy/src/tokens.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use c8y_http_proxy::credentials::JwtRetriever;
 use tokio::sync::Mutex;
+use tracing::info;
 
 #[derive(Clone)]
 pub struct SharedTokenManager(Arc<Mutex<TokenManager>>);
@@ -41,6 +42,7 @@ impl TokenManager {
     }
 
     async fn refresh(&mut self) -> Arc<str> {
+        info!("Refreshing JWT");
         self.cached = Some(self.recv.await_response(()).await.unwrap().unwrap().into());
         self.cached.as_ref().unwrap().clone()
     }

--- a/crates/extensions/c8y_auth_proxy/src/tokens.rs
+++ b/crates/extensions/c8y_auth_proxy/src/tokens.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use c8y_http_proxy::credentials::JwtRetriever;
 use tokio::sync::Mutex;
-use tracing::info;
 
 #[derive(Clone)]
 pub struct SharedTokenManager(Arc<Mutex<TokenManager>>);
@@ -42,7 +41,6 @@ impl TokenManager {
     }
 
     async fn refresh(&mut self) -> Arc<str> {
-        info!("Refreshing JWT");
         self.cached = Some(self.recv.await_response(()).await.unwrap().unwrap().into());
         self.cached.as_ref().unwrap().clone()
     }


### PR DESCRIPTION
## Proposed changes
Refactor the handler to make it more idiomatic axum code, and fix the handling of query strings (i.e. pass them through to Cumulocity) in `c8y_auth_proxy`.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/2282

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

