### PR TITLE
fix(packaging): use release suffix in version dependency to avoid version mismatches

### DIFF
--- a/configuration/package_manifests/virtual/nfpm.tedge-full.yaml
+++ b/configuration/package_manifests/virtual/nfpm.tedge-full.yaml
@@ -38,17 +38,19 @@ overrides:
         - c8y-firmware-plugin = ${GIT_SEMVER}
   rpm:
     depends:
+        # FIXME: Work out a better way to reference the full package specific version which includes the release number (-1) suffix
+        # without having to manually add it
         - ca-certificates
-        - tedge = ${GIT_SEMVER}
-        - tedge-mapper = ${GIT_SEMVER}
-        - tedge-agent = ${GIT_SEMVER}
-        - tedge-watchdog = ${GIT_SEMVER}
+        - tedge = ${GIT_SEMVER}-1
+        - tedge-mapper = ${GIT_SEMVER}-1
+        - tedge-agent = ${GIT_SEMVER}-1
+        - tedge-watchdog = ${GIT_SEMVER}-1
         # tedge-apt-plugin does not make sense on rpm
-        # - tedge-apt-plugin = ${GIT_SEMVER}
-        - tedge-log-plugin = ${GIT_SEMVER}
-        - c8y-configuration-plugin = ${GIT_SEMVER}
-        - c8y-remote-access-plugin = ${GIT_SEMVER}
-        - c8y-firmware-plugin = ${GIT_SEMVER}
+        # - tedge-apt-plugin = ${GIT_SEMVER}-1
+        - tedge-log-plugin = ${GIT_SEMVER}-1
+        - c8y-configuration-plugin = ${GIT_SEMVER}-1
+        - c8y-remote-access-plugin = ${GIT_SEMVER}-1
+        - c8y-firmware-plugin = ${GIT_SEMVER}-1
   deb:
     depends:
         - tedge (= ${GIT_SEMVER})

--- a/configuration/package_manifests/virtual/nfpm.tedge-minimal.yaml
+++ b/configuration/package_manifests/virtual/nfpm.tedge-minimal.yaml
@@ -30,8 +30,10 @@ overrides:
         - tedge-mapper = ${GIT_SEMVER}
   rpm:
     depends:
-        - tedge = ${GIT_SEMVER}
-        - tedge-mapper = ${GIT_SEMVER}
+        # FIXME: Work out a better way to reference the full package specific version which includes the release number (-1) suffix
+        # without having to manually add it
+        - tedge = ${GIT_SEMVER}-1
+        - tedge-mapper = ${GIT_SEMVER}-1
   deb:
     depends:
         - tedge (= ${GIT_SEMVER})


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fixing a problem with the rpm virtual packages `tedge-full` and `tedge-minimal` version requirement which caused a mismatch in the expected and actual versions.

Changes to nfpm v2.33.1 enforced the usage of the release suffix for rpm packages causing the mismatch.

Unfortunately this fix is not the cleanest, but is in place to quickly fix the rpm packages in cloudsmith. Whilst it is not critical to have this fix, once a more reliable way to determine the rpm specific version number prior to building the package, it should be used in place of hard coding the suffix.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

https://github.com/thin-edge/thin-edge.io/issues/2285

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

