### PR TITLE
Use serde tag enum representation for CommandStatus

### DIFF
--- a/crates/core/tedge_agent/src/restart_manager/tests.rs
+++ b/crates/core/tedge_agent/src/restart_manager/tests.rs
@@ -36,7 +36,6 @@ async fn test_pending_restart_operation() -> Result<(), DynError> {
             cmd_id: "1234".to_string(),
             payload: RestartCommandPayload {
                 status: CommandStatus::Successful,
-                reason: "".to_string(),
             },
         }])
         .await;
@@ -60,8 +59,9 @@ async fn test_pending_restart_operation_failed() -> Result<(), DynError> {
             target: EntityTopicId::default_main_device(),
             cmd_id: "1234".to_string(),
             payload: RestartCommandPayload {
-                status: CommandStatus::Failed,
-                reason: "The agent has been restarted but not the device".to_string(),
+                status: CommandStatus::Failed {
+                    reason: "The agent has been restarted but not the device".to_string(),
+                },
             },
         }])
         .await;
@@ -86,7 +86,6 @@ async fn test_pending_restart_operation_successful() -> Result<(), DynError> {
             cmd_id: "1234".to_string(),
             payload: RestartCommandPayload {
                 status: CommandStatus::Successful,
-                reason: "".to_string(),
             },
         }])
         .await;
@@ -109,7 +108,6 @@ async fn test_new_restart_operation() -> Result<(), DynError> {
             cmd_id: "1234".to_string(),
             payload: RestartCommandPayload {
                 status: CommandStatus::Init,
-                reason: "".to_string(),
             },
         })
         .await?;

--- a/crates/core/tedge_agent/src/tedge_operation_converter/tests.rs
+++ b/crates/core/tedge_agent/src/tedge_operation_converter/tests.rs
@@ -108,7 +108,6 @@ async fn convert_incoming_restart_request() -> Result<(), DynError> {
             cmd_id: "random".to_string(),
             payload: RestartCommandPayload {
                 status: CommandStatus::Init,
-                reason: "".to_string(),
             },
         }])
         .await;
@@ -196,7 +195,6 @@ async fn convert_outgoing_restart_response() -> Result<(), DynError> {
         cmd_id: "abc".to_string(),
         payload: RestartCommandPayload {
             status: CommandStatus::Executing,
-            reason: "".to_string(),
         },
     };
     restart_box.send(executing_response).await?;

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -1060,10 +1060,10 @@ impl CumulocityConverter {
                     Message::new(&topic, smartrest_set_operation),
                 ])
             }
-            CommandStatus::Failed => {
+            CommandStatus::Failed { ref reason } => {
                 let smartrest_set_operation = SmartRestSetOperationToFailed::new(
                     CumulocitySupportedOperations::C8yRestartRequest,
-                    format!("Restart Failed: {}", command.reason()),
+                    format!("Restart Failed: {}", reason),
                 )
                 .to_smartrest()?;
                 Ok(vec![

--- a/crates/extensions/c8y_mapper_ext/src/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/log_upload.rs
@@ -78,7 +78,6 @@ impl CumulocityConverter {
             date_to: log_request.date_to,
             search_text: log_request.search_text,
             lines: log_request.lines,
-            reason: None,
         };
 
         // Command messages must be retained
@@ -157,10 +156,10 @@ impl CumulocityConverter {
                     .with_qos(QoS::AtLeastOnce);
                 vec![c8y_notification, clean_operation]
             }
-            CommandStatus::Failed => {
+            CommandStatus::Failed { ref reason } => {
                 let smartrest_operation_status = SmartRestSetOperationToFailed::new(
                     CumulocitySupportedOperations::C8yLogFileRequest,
-                    response.reason.clone().unwrap_or_default(),
+                    reason.clone(),
                 )
                 .to_smartrest()?;
                 let c8y_notification = Message::new(&smartrest_topic, smartrest_operation_status);

--- a/crates/extensions/tedge_config_manager/src/actor.rs
+++ b/crates/extensions/tedge_config_manager/src/actor.rs
@@ -116,7 +116,7 @@ impl ConfigManagerActor {
                     self.handle_config_snapshot_request(&message.topic, request)
                         .await?;
                 }
-                CommandStatus::Successful | CommandStatus::Failed => {}
+                CommandStatus::Successful | CommandStatus::Failed { .. } => {}
             },
             Ok(Some(ConfigOperation::Update(request))) => match request.status {
                 CommandStatus::Init => {
@@ -132,7 +132,7 @@ impl ConfigManagerActor {
                     self.handle_config_update_request(&message.topic, request)
                         .await?;
                 }
-                CommandStatus::Successful | CommandStatus::Failed => {}
+                CommandStatus::Successful | CommandStatus::Failed { .. } => {}
             },
             Ok(None) => {}
             Err(ConfigManagementError::InvalidTopicError) => {

--- a/crates/extensions/tedge_config_manager/src/tests.rs
+++ b/crates/extensions/tedge_config_manager/src/tests.rs
@@ -325,7 +325,7 @@ async fn request_config_snapshot_that_does_not_exist() -> Result<(), anyhow::Err
         mqtt.recv().await,
         Some(MqttMessage::new(
             &config_topic,
-            r#"{"status":"failed","tedgeUrl":"http://127.0.0.1:3000/tedge/file-transfer/main/config-snapshot/type_five-1234","type":"type_five","reason":"Handling of operation failed with The requested config_type type_five is not defined in the plugin configuration file."}"#
+            r#"{"status":"failed","reason":"Handling of operation failed with The requested config_type type_five is not defined in the plugin configuration file.","tedgeUrl":"http://127.0.0.1:3000/tedge/file-transfer/main/config-snapshot/type_five-1234","type":"type_five"}"#
         ).with_retain())
     );
 
@@ -378,7 +378,7 @@ async fn put_config_snapshot_without_permissions() -> Result<(), anyhow::Error> 
             mqtt.recv().await,
             Some(MqttMessage::new(
                 &config_topic,
-                r#"{"status":"failed","tedgeUrl":"http://127.0.0.1:3000/tedge/file-transfer/main/config-snapshot/type_two-1234","type":"type_two","reason":"Handling of operation failed with Failed with HTTP error status 403 Forbidden"}"#
+                r#"{"status":"failed","reason":"Handling of operation failed with Failed with HTTP error status 403 Forbidden","tedgeUrl":"http://127.0.0.1:3000/tedge/file-transfer/main/config-snapshot/type_two-1234","type":"type_two"}"#
             ).with_retain())
         );
 

--- a/crates/extensions/tedge_log_manager/src/actor.rs
+++ b/crates/extensions/tedge_log_manager/src/actor.rs
@@ -99,7 +99,7 @@ impl LogManagerActor {
                         self.handle_logfile_request_operation(&message.topic, request)
                             .await?;
                     }
-                    CommandStatus::Successful | CommandStatus::Failed => {
+                    CommandStatus::Successful | CommandStatus::Failed { .. } => {
                         self.config.current_operations.remove(&message.topic.name);
                     }
                 },

--- a/crates/extensions/tedge_log_manager/src/tests.rs
+++ b/crates/extensions/tedge_log_manager/src/tests.rs
@@ -262,7 +262,7 @@ async fn request_logtype_that_does_not_exist() -> Result<(), anyhow::Error> {
         mqtt.recv().await,
         Some(MqttMessage::new(
             &logfile_topic,
-            r#"{"status":"failed","tedgeUrl":"http://127.0.0.1:3000/tedge/file-transfer/main/log_upload/type_four-1234","type":"type_four","dateFrom":"1970-01-01T00:00:00Z","dateTo":"1970-01-01T00:00:30Z","lines":1000,"reason":"Handling of operation failed with No such file or directory for log type: type_four"}"#
+            r#"{"status":"failed","reason":"Handling of operation failed with No such file or directory for log type: type_four","tedgeUrl":"http://127.0.0.1:3000/tedge/file-transfer/main/log_upload/type_four-1234","type":"type_four","dateFrom":"1970-01-01T00:00:00Z","dateTo":"1970-01-01T00:00:30Z","lines":1000}"#
         ).with_retain())
     );
 
@@ -316,7 +316,7 @@ async fn put_logfiles_without_permissions() -> Result<(), anyhow::Error> {
             mqtt.recv().await,
             Some(MqttMessage::new(
                 &logfile_topic,
-                r#"{"status":"failed","tedgeUrl":"http://127.0.0.1:3000/tedge/file-transfer/main/log_upload/type_two-1234","type":"type_two","dateFrom":"1970-01-01T00:00:00Z","dateTo":"1970-01-01T00:00:30Z","lines":1000,"reason":"Handling of operation failed with Failed with HTTP error status 403 Forbidden"}"#
+                r#"{"status":"failed","reason":"Handling of operation failed with Failed with HTTP error status 403 Forbidden","tedgeUrl":"http://127.0.0.1:3000/tedge/file-transfer/main/log_upload/type_two-1234","type":"type_two","dateFrom":"1970-01-01T00:00:00Z","dateTo":"1970-01-01T00:00:30Z","lines":1000}"#
             ).with_retain())
         );
 
@@ -422,7 +422,7 @@ async fn read_log_from_file_that_does_not_exist() -> Result<(), anyhow::Error> {
         mqtt.recv().await,
         Some(MqttMessage::new(
             &logfile_topic,
-            r#"{"status":"failed","tedgeUrl":"http://127.0.0.1:3000/tedge/file-transfer/main/log_upload/type_three-1234","type":"type_three","dateFrom":"1970-01-01T00:00:00Z","dateTo":"1970-01-01T00:00:30Z","lines":1000,"reason":"Handling of operation failed with No such file or directory for log type: type_three"}"#
+            r#"{"status":"failed","reason":"Handling of operation failed with No such file or directory for log type: type_three","tedgeUrl":"http://127.0.0.1:3000/tedge/file-transfer/main/log_upload/type_three-1234","type":"type_three","dateFrom":"1970-01-01T00:00:00Z","dateTo":"1970-01-01T00:00:30Z","lines":1000}"#
         ).with_retain())
     );
 


### PR DESCRIPTION
As suggested by @Bravo555 with https://github.com/thin-edge/thin-edge.io/pull/2245#discussion_r1332923226, the reason field makes sense only for a Failed command.

## Proposed changes

Attached the `reason` field to the only case where it makes sense: a `Failed` command.

```
#[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Clone)]
#[serde(rename_all = "camelCase", tag = "status")]
pub enum CommandStatus {
    Init,
    Executing,
    Successful,
    Failed { reason: String },
}
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

