### PR TITLE
tedge-agent creates /var/tedge/cache directory on start-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ dependencies = [
  "async-trait",
  "c8y_api",
  "c8y_http_proxy",
+ "camino",
  "log",
  "mockall",
  "nanoid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3694,6 +3694,7 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "camino",
  "clock",
  "csv",
  "download",

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -20,6 +20,7 @@ use tedge_actors::MessageSink;
 use tedge_actors::MessageSource;
 use tedge_actors::Runtime;
 use tedge_api::mqtt_topics::EntityTopicId;
+use tedge_api::path::DataDir;
 use tedge_health_ext::HealthMonitorBuilder;
 use tedge_mqtt_ext::MqttActorBuilder;
 use tedge_mqtt_ext::MqttConfig;
@@ -41,7 +42,7 @@ pub struct AgentConfig {
     pub run_dir: Utf8PathBuf,
     pub use_lock: bool,
     pub log_dir: Utf8PathBuf,
-    pub data_dir: Utf8PathBuf,
+    pub data_dir: DataDir,
     pub mqtt_device_topic_id: EntityTopicId,
     pub mqtt_topic_root: Arc<str>,
 }
@@ -75,7 +76,7 @@ impl AgentConfig {
             .with_session_name(mqtt_session_name);
 
         // HTTP config
-        let data_dir = tedge_config.data.path.clone();
+        let data_dir: DataDir = tedge_config.data.path.clone().into();
         let http_bind_address = tedge_config.http.bind.address;
         let http_port = tedge_config.http.bind.port;
 
@@ -140,7 +141,8 @@ impl Agent {
         create_directory_with_defaults(self.config.config_dir.join(".agent"))?;
         create_directory_with_defaults(self.config.log_dir.clone())?;
         create_directory_with_defaults(self.config.data_dir.clone())?;
-        create_directory_with_defaults(self.config.http_config.file_transfer_dir_as_string())?;
+        create_directory_with_defaults(self.config.http_config.data_dir.file_transfer_dir())?;
+        create_directory_with_defaults(self.config.http_config.data_dir.cache_dir())?;
 
         Ok(())
     }

--- a/crates/core/tedge_agent/src/file_transfer_server/actor.rs
+++ b/crates/core/tedge_agent/src/file_transfer_server/actor.rs
@@ -95,7 +95,7 @@ mod tests {
         let ttd = TempTedgeDir::new();
 
         let http_config = HttpConfig::default()
-            .with_data_dir(ttd.utf8_path_buf())
+            .with_data_dir(ttd.utf8_path_buf().into())
             .with_port(4000);
 
         // Spawn HTTP file transfer server
@@ -146,7 +146,7 @@ mod tests {
         let ttd = TempTedgeDir::new();
 
         let http_config = HttpConfig::default()
-            .with_data_dir(ttd.utf8_path_buf())
+            .with_data_dir(ttd.utf8_path_buf().into())
             .with_port(3746);
         let config_clone = http_config.clone();
 

--- a/crates/core/tedge_agent/src/file_transfer_server/http_rest.rs
+++ b/crates/core/tedge_agent/src/file_transfer_server/http_rest.rs
@@ -11,8 +11,7 @@ use routerify::RouterService;
 use std::net::IpAddr;
 use std::net::SocketAddr;
 use tedge_actors::futures::StreamExt;
-use tedge_api::DEFAULT_DATA_PATH;
-use tedge_api::DEFAULT_FILE_TRANSFER_DIR_NAME;
+use tedge_api::path::DataDir;
 use tedge_utils::paths::create_directories;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
@@ -23,7 +22,7 @@ const HTTP_FILE_TRANSFER_PORT: u16 = 8000;
 pub struct HttpConfig {
     pub bind_address: SocketAddr,
     pub file_transfer_uri: String,
-    pub data_dir: Utf8PathBuf,
+    pub data_dir: DataDir,
 }
 
 impl Default for HttpConfig {
@@ -31,7 +30,7 @@ impl Default for HttpConfig {
         HttpConfig {
             bind_address: ([127, 0, 0, 1], HTTP_FILE_TRANSFER_PORT).into(),
             file_transfer_uri: "/tedge/".into(),
-            data_dir: DEFAULT_DATA_PATH.into(),
+            data_dir: DataDir::default(),
         }
     }
 }
@@ -44,7 +43,7 @@ impl HttpConfig {
         }
     }
 
-    pub fn with_data_dir(self, data_dir: Utf8PathBuf) -> HttpConfig {
+    pub fn with_data_dir(self, data_dir: DataDir) -> HttpConfig {
         Self { data_dir, ..self }
     }
 
@@ -59,10 +58,6 @@ impl HttpConfig {
 
     pub fn file_transfer_end_point(&self) -> String {
         format!("{}file-transfer/*", self.file_transfer_uri)
-    }
-
-    pub fn file_transfer_dir_as_string(&self) -> Utf8PathBuf {
-        self.data_dir.join(DEFAULT_FILE_TRANSFER_DIR_NAME)
     }
 
     /// Return the path of the file associated to the given `uri`
@@ -348,7 +343,7 @@ mod test {
         let ttd = TempTedgeDir::new();
         let tempdir_path = ttd.utf8_path_buf();
         let http_config = HttpConfig::default()
-            .with_data_dir(tempdir_path)
+            .with_data_dir(tempdir_path.into())
             .with_port(3333);
         let server = http_file_transfer_server(&http_config).unwrap();
         (ttd, server)

--- a/crates/core/tedge_api/Cargo.toml
+++ b/crates/core/tedge_api/Cargo.toml
@@ -9,6 +9,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
+camino = { workspace = true }
 clock = { workspace = true }
 csv = { workspace = true }
 download = { workspace = true }

--- a/crates/core/tedge_api/src/lib.rs
+++ b/crates/core/tedge_api/src/lib.rs
@@ -31,9 +31,6 @@ pub use messages::SoftwareUpdateRequest;
 pub use messages::SoftwareUpdateResponse;
 pub use software::*;
 
-pub const DEFAULT_DATA_PATH: &str = "/var/tedge";
-pub const DEFAULT_FILE_TRANSFER_DIR_NAME: &str = "file-transfer";
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/tedge_api/src/lib.rs
+++ b/crates/core/tedge_api/src/lib.rs
@@ -10,6 +10,7 @@ pub mod measurement;
 pub mod messages;
 pub mod mqtt_topics;
 pub mod parser;
+pub mod path;
 pub mod serialize;
 mod software;
 pub mod topic;

--- a/crates/core/tedge_api/src/path.rs
+++ b/crates/core/tedge_api/src/path.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 /// Default is /var/tedge.
 /// All directories under the root data directory must be listed here.
 #[derive(Debug, Clone)]
-pub struct DataDir(pub Utf8PathBuf);
+pub struct DataDir(Utf8PathBuf);
 
 impl Default for DataDir {
     fn default() -> Self {
@@ -17,6 +17,12 @@ impl Default for DataDir {
 impl From<Utf8PathBuf> for DataDir {
     fn from(path: Utf8PathBuf) -> Self {
         DataDir(path)
+    }
+}
+
+impl From<DataDir> for Utf8PathBuf {
+    fn from(value: DataDir) -> Self {
+        value.0
     }
 }
 
@@ -44,11 +50,6 @@ impl DataDir {
     /// ```
     pub fn join(&self, path: impl AsRef<Utf8Path>) -> Utf8PathBuf {
         self.0.join(path.as_ref().to_path_buf())
-    }
-
-    /// Return `Utf8PathBuf` of the given `DataDir`.
-    pub fn utf8_path_buf(&self) -> Utf8PathBuf {
-        self.0.clone()
     }
 
     /// Return `Utf8PathBuf` to ThinEdge file transfer repository.

--- a/crates/core/tedge_api/src/path.rs
+++ b/crates/core/tedge_api/src/path.rs
@@ -1,0 +1,95 @@
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+use std::path::Path;
+
+/// Representation of ThinEdge data directory.
+/// Default is /var/tedge.
+/// All directories under the root data directory must be listed here.
+#[derive(Debug, Clone)]
+pub struct DataDir(pub Utf8PathBuf);
+
+impl Default for DataDir {
+    fn default() -> Self {
+        DataDir("/var/tedge".into())
+    }
+}
+
+impl From<Utf8PathBuf> for DataDir {
+    fn from(path: Utf8PathBuf) -> Self {
+        DataDir(path)
+    }
+}
+
+impl AsRef<Path> for DataDir {
+    fn as_ref(&self) -> &Path {
+        self.0.as_std_path()
+    }
+}
+
+impl DataDir {
+    /// Crete `DataDir` from `Utf8PathBuf`.
+    pub fn new(path: Utf8PathBuf) -> Self {
+        DataDir::from(path)
+    }
+
+    /// Creates an owned `Utf8PathBuf` with `path` adjoined to `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use camino::Utf8PathBuf;
+    /// use tedge_api::path::DataDir;
+    ///
+    /// assert_eq!(DataDir::default().join("foo"), Utf8PathBuf::from("/var/tedge/foo"));
+    /// ```
+    pub fn join(&self, path: impl AsRef<Utf8Path>) -> Utf8PathBuf {
+        self.0.join(path.as_ref().to_path_buf())
+    }
+
+    /// Return `Utf8PathBuf` of the given `DataDir`.
+    pub fn utf8_path_buf(&self) -> Utf8PathBuf {
+        self.0.clone()
+    }
+
+    /// Return `Utf8PathBuf` to ThinEdge file transfer repository.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use camino::Utf8PathBuf;
+    /// use tedge_api::path::DataDir;
+    ///
+    /// assert_eq!(DataDir::default().file_transfer_dir(), Utf8PathBuf::from("/var/tedge/file-transfer"));
+    /// ```
+    pub fn file_transfer_dir(&self) -> Utf8PathBuf {
+        self.0.join("file-transfer")
+    }
+
+    /// Return `Utf8PathBuf` to ThinEdge file cache repository.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use camino::Utf8PathBuf;
+    /// use tedge_api::path::DataDir;
+    ///
+    /// assert_eq!(DataDir::default().cache_dir(), Utf8PathBuf::from("/var/tedge/cache"));
+    /// ```
+    pub fn cache_dir(&self) -> Utf8PathBuf {
+        self.0.join("cache")
+    }
+
+    /// Return `Utf8PathBuf` to ThinEdge file firmware repository.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use camino::Utf8PathBuf;
+    /// use tedge_api::path::DataDir;
+    ///
+    /// assert_eq!(DataDir::default().firmware_dir(), Utf8PathBuf::from("/var/tedge/firmware"));
+    /// ```
+    pub fn firmware_dir(&self) -> Utf8PathBuf {
+        self.0.join("firmware")
+    }
+}

--- a/crates/extensions/c8y_config_manager/src/config.rs
+++ b/crates/extensions/c8y_config_manager/src/config.rs
@@ -49,7 +49,7 @@ impl ConfigManagerConfig {
         let plugin_config_dir = config_dir.join(DEFAULT_OPERATION_DIR_NAME);
         let plugin_config_path = plugin_config_dir.join(DEFAULT_PLUGIN_CONFIG_FILE_NAME);
 
-        let file_transfer_dir = data_dir.file_transfer_dir().as_std_path().to_path_buf();
+        let file_transfer_dir = data_dir.file_transfer_dir().into();
 
         let c8y_request_topics: TopicFilter = C8yTopic::SmartRestRequest.into();
         let config_snapshot_response_topics: TopicFilter =

--- a/crates/extensions/c8y_config_manager/src/config.rs
+++ b/crates/extensions/c8y_config_manager/src/config.rs
@@ -4,7 +4,7 @@ use c8y_api::smartrest::topic::C8yTopic;
 use std::net::IpAddr;
 use std::path::Path;
 use std::path::PathBuf;
-use tedge_api::DEFAULT_FILE_TRANSFER_DIR_NAME;
+use tedge_api::path::DataDir;
 use tedge_config::ReadError;
 use tedge_config::TEdgeConfig;
 use tedge_mqtt_ext::TopicFilter;
@@ -36,7 +36,7 @@ impl ConfigManagerConfig {
     pub fn new(
         config_dir: PathBuf,
         tmp_dir: PathBuf,
-        data_dir: PathBuf,
+        data_dir: DataDir,
         device_id: String,
         mqtt_host: String,
         mqtt_port: u16,
@@ -49,7 +49,7 @@ impl ConfigManagerConfig {
         let plugin_config_dir = config_dir.join(DEFAULT_OPERATION_DIR_NAME);
         let plugin_config_path = plugin_config_dir.join(DEFAULT_PLUGIN_CONFIG_FILE_NAME);
 
-        let file_transfer_dir = data_dir.join(DEFAULT_FILE_TRANSFER_DIR_NAME);
+        let file_transfer_dir = data_dir.file_transfer_dir().as_std_path().to_path_buf();
 
         let c8y_request_topics: TopicFilter = C8yTopic::SmartRestRequest.into();
         let config_snapshot_response_topics: TopicFilter =
@@ -78,10 +78,10 @@ impl ConfigManagerConfig {
         config_dir: impl AsRef<Path>,
         tedge_config: &TEdgeConfig,
     ) -> Result<ConfigManagerConfig, ReadError> {
-        let config_dir: PathBuf = config_dir.as_ref().into();
+        let config_dir = config_dir.as_ref().into();
         let device_id = tedge_config.device.id.try_read(tedge_config)?.to_string();
         let tmp_dir = tedge_config.tmp.path.as_std_path().to_path_buf();
-        let data_dir = tedge_config.data.path.as_std_path().to_path_buf();
+        let data_dir = tedge_config.data.path.clone().into();
         let mqtt_host = tedge_config.mqtt.client.host.clone();
         let mqtt_port = tedge_config.mqtt.client.port.get();
         let tedge_http_address = tedge_config.http.bind.address;

--- a/crates/extensions/c8y_config_manager/src/tests.rs
+++ b/crates/extensions/c8y_config_manager/src/tests.rs
@@ -985,7 +985,7 @@ async fn spawn_config_manager(
     let config = ConfigManagerConfig::new(
         tedge_temp_dir.to_path_buf(),
         tedge_temp_dir.to_path_buf(),
-        tedge_temp_dir.to_path_buf(),
+        tedge_temp_dir.utf8_path_buf().into(),
         device_id.to_string(),
         tedge_host.to_string(),
         mqtt_port,

--- a/crates/extensions/c8y_firmware_manager/Cargo.toml
+++ b/crates/extensions/c8y_firmware_manager/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 async-trait = { workspace = true }
 c8y_api = { workspace = true }
 c8y_http_proxy = { workspace = true }
+camino = { workspace = true }
 log = { workspace = true }
 nanoid = { workspace = true }
 serde = { workspace = true }

--- a/crates/extensions/c8y_firmware_manager/src/actor.rs
+++ b/crates/extensions/c8y_firmware_manager/src/actor.rs
@@ -358,7 +358,7 @@ impl FirmwareManagerActor {
             attempt: 1,
         };
 
-        operation_entry.create_status_file(&self.config.firmware_dir)?;
+        operation_entry.create_status_file(self.config.data_dir.firmware_dir())?;
 
         self.publish_firmware_update_request(operation_entry)
             .await?;
@@ -440,7 +440,7 @@ impl FirmwareManagerActor {
 
         match received_status {
             OperationStatus::Successful => {
-                let status_file_path = self.config.firmware_dir.join(operation_id);
+                let status_file_path = self.config.data_dir.firmware_dir().join(operation_id);
                 let operation_entry =
                     FirmwareOperationEntry::read_from_file(status_file_path.as_path())?;
 
@@ -577,7 +577,7 @@ impl FirmwareManagerActor {
     }
 
     async fn resend_operations_to_child_device(&mut self) -> Result<(), FirmwareManagementError> {
-        let firmware_dir_path = self.config.firmware_dir.clone();
+        let firmware_dir_path = self.config.data_dir.firmware_dir().clone();
         if !firmware_dir_path.is_dir() {
             // Do nothing if the persistent store directory does not exist yet.
             return Ok(());

--- a/crates/extensions/c8y_firmware_manager/src/config.rs
+++ b/crates/extensions/c8y_firmware_manager/src/config.rs
@@ -22,9 +22,6 @@ pub struct FirmwareManagerConfig {
     pub local_http_host: String,
     pub tmp_dir: Utf8PathBuf,
     pub data_dir: DataDir,
-    pub cache_dir: Utf8PathBuf,
-    pub file_transfer_dir: Utf8PathBuf,
-    pub firmware_dir: Utf8PathBuf,
     pub c8y_request_topics: TopicFilter,
     pub health_check_topics: TopicFilter,
     pub firmware_update_response_topics: TopicFilter,
@@ -44,10 +41,6 @@ impl FirmwareManagerConfig {
     ) -> Self {
         let local_http_host = format!("{}:{}", local_http_address, local_http_port);
 
-        let cache_dir = data_dir.cache_dir();
-        let file_transfer_dir = data_dir.file_transfer_dir();
-        let firmware_dir = data_dir.firmware_dir();
-
         let c8y_request_topics = C8yTopic::SmartRestRequest.into();
         let health_check_topics = health_check_topics(PLUGIN_SERVICE_NAME);
         let firmware_update_response_topics =
@@ -60,9 +53,6 @@ impl FirmwareManagerConfig {
             local_http_host,
             tmp_dir,
             data_dir,
-            cache_dir,
-            file_transfer_dir,
-            firmware_dir,
             c8y_request_topics,
             health_check_topics,
             firmware_update_response_topics,
@@ -96,24 +86,24 @@ impl FirmwareManagerConfig {
 
     // It checks the directory exists in the system
     pub fn validate_and_get_cache_dir_path(&self) -> Result<Utf8PathBuf, FirmwareManagementError> {
-        validate_dir_exists(self.cache_dir.as_path())?;
-        Ok(self.cache_dir.clone())
+        validate_dir_exists(self.data_dir.cache_dir().as_path())?;
+        Ok(self.data_dir.cache_dir().clone())
     }
 
     // It checks the directory exists in the system
     pub fn validate_and_get_file_transfer_dir_path(
         &self,
     ) -> Result<Utf8PathBuf, FirmwareManagementError> {
-        validate_dir_exists(self.file_transfer_dir.as_path())?;
-        Ok(self.file_transfer_dir.clone())
+        validate_dir_exists(self.data_dir.file_transfer_dir().as_path())?;
+        Ok(self.data_dir.file_transfer_dir().clone())
     }
 
     // It checks the directory exists in the system
     pub fn validate_and_get_firmware_dir_path(
         &self,
     ) -> Result<Utf8PathBuf, FirmwareManagementError> {
-        validate_dir_exists(self.firmware_dir.as_path())?;
-        Ok(self.firmware_dir.clone())
+        validate_dir_exists(self.data_dir.firmware_dir().as_path())?;
+        Ok(self.data_dir.firmware_dir().clone())
     }
 }
 

--- a/crates/extensions/c8y_firmware_manager/src/lib.rs
+++ b/crates/extensions/c8y_firmware_manager/src/lib.rs
@@ -18,7 +18,6 @@ use c8y_http_proxy::credentials::JwtRequest;
 use c8y_http_proxy::credentials::JwtResult;
 use c8y_http_proxy::credentials::JwtRetriever;
 pub use config::*;
-use std::path::Path;
 use tedge_actors::futures::channel::mpsc;
 use tedge_actors::Builder;
 use tedge_actors::DynSender;
@@ -28,7 +27,7 @@ use tedge_actors::NoConfig;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
 use tedge_actors::ServiceProvider;
-use tedge_api::DEFAULT_FILE_TRANSFER_DIR_NAME;
+use tedge_api::path::DataDir;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::TopicFilter;
 use tedge_timer_ext::SetTimeout;
@@ -79,10 +78,10 @@ impl FirmwareManagerBuilder {
         })
     }
 
-    pub fn init(data_dir: &Path) -> Result<(), FileError> {
-        create_directory_with_defaults(data_dir.join("cache"))?;
-        create_directory_with_defaults(data_dir.join(DEFAULT_FILE_TRANSFER_DIR_NAME))?;
-        create_directory_with_defaults(data_dir.join("firmware"))?;
+    pub fn init(data_dir: &DataDir) -> Result<(), FileError> {
+        create_directory_with_defaults(data_dir.cache_dir())?;
+        create_directory_with_defaults(data_dir.file_transfer_dir())?;
+        create_directory_with_defaults(data_dir.firmware_dir())?;
         Ok(())
     }
 

--- a/crates/extensions/c8y_firmware_manager/src/operation.rs
+++ b/crates/extensions/c8y_firmware_manager/src/operation.rs
@@ -19,15 +19,21 @@ pub struct FirmwareOperationEntry {
 }
 
 impl FirmwareOperationEntry {
-    pub fn create_status_file(&self, firmware_dir: &Path) -> Result<(), FirmwareManagementError> {
-        let path = firmware_dir.join(&self.operation_id);
+    pub fn create_status_file(
+        &self,
+        firmware_dir: impl AsRef<Path>,
+    ) -> Result<(), FirmwareManagementError> {
+        let path = firmware_dir.as_ref().join(&self.operation_id);
         let content = serde_json::to_string(self)?;
         create_file_with_mode(path, Some(content.as_str()), 0o644)
             .map_err(FirmwareManagementError::FromFileError)
     }
 
-    pub fn overwrite_file(&self, firmware_dir: &Path) -> Result<(), FirmwareManagementError> {
-        let path = firmware_dir.join(&self.operation_id);
+    pub fn overwrite_file(
+        &self,
+        firmware_dir: impl AsRef<Path>,
+    ) -> Result<(), FirmwareManagementError> {
+        let path = firmware_dir.as_ref().join(&self.operation_id);
         let content = serde_json::to_string(self)?;
         overwrite_file(&path, &content).map_err(FirmwareManagementError::FromFileError)
     }
@@ -39,7 +45,7 @@ impl FirmwareOperationEntry {
         }
     }
 
-    pub fn read_from_file(path: &Path) -> Result<Self, FirmwareManagementError> {
+    pub fn read_from_file(path: impl AsRef<Path>) -> Result<Self, FirmwareManagementError> {
         let bytes = fs::read(path)?;
         serde_json::from_slice(&bytes).map_err(FirmwareManagementError::FromSerdeJsonError)
     }
@@ -91,7 +97,7 @@ mod tests {
         ttd.dir("firmware").file(op_id).with_raw_content(&content);
         let file_path = ttd.path().join("firmware").join(op_id);
 
-        let entry = FirmwareOperationEntry::read_from_file(&file_path).unwrap();
+        let entry = FirmwareOperationEntry::read_from_file(file_path).unwrap();
         let expected_entry = FirmwareOperationEntry {
             operation_id: "op-id".to_string(),
             child_id: "child-id".to_string(),

--- a/crates/extensions/c8y_firmware_manager/src/tests.rs
+++ b/crates/extensions/c8y_firmware_manager/src/tests.rs
@@ -714,8 +714,8 @@ async fn spawn_firmware_manager(
         device_id.to_string(),
         tedge_host,
         TEDGE_HTTP_PORT,
-        tmp_dir.to_path_buf(),
-        tmp_dir.to_path_buf(),
+        tmp_dir.utf8_path_buf(),
+        tmp_dir.utf8_path_buf().into(),
         timeout_sec,
         C8Y_HOST.into(),
     );

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -11,8 +11,8 @@ use tedge_api::mqtt_topics::ChannelFilter::CommandMetadata;
 use tedge_api::mqtt_topics::EntityFilter::AnyEntity;
 use tedge_api::mqtt_topics::MqttSchema;
 use tedge_api::mqtt_topics::OperationType;
+use tedge_api::path::DataDir;
 use tedge_api::topic::ResponseTopic;
-use tedge_api::DEFAULT_FILE_TRANSFER_DIR_NAME;
 use tedge_config::ConfigNotSet;
 use tedge_config::ReadError;
 use tedge_config::TEdgeConfig;
@@ -24,7 +24,7 @@ pub const MQTT_MESSAGE_SIZE_THRESHOLD: usize = 16184;
 pub struct C8yMapperConfig {
     pub config_dir: PathBuf,
     pub logs_path: Utf8PathBuf,
-    pub data_dir: Utf8PathBuf,
+    pub data_dir: DataDir,
     pub device_id: String,
     pub device_type: String,
     pub service_type: String,
@@ -43,7 +43,7 @@ impl C8yMapperConfig {
     pub fn new(
         config_dir: PathBuf,
         logs_path: Utf8PathBuf,
-        data_dir: Utf8PathBuf,
+        data_dir: DataDir,
         device_id: String,
         device_type: String,
         service_type: String,
@@ -55,7 +55,7 @@ impl C8yMapperConfig {
         auth_proxy_port: u16,
     ) -> Self {
         let ops_dir = config_dir.join("operations").join("c8y");
-        let file_transfer_dir = data_dir.join(DEFAULT_FILE_TRANSFER_DIR_NAME);
+        let file_transfer_dir = data_dir.file_transfer_dir();
 
         Self {
             config_dir,
@@ -82,7 +82,7 @@ impl C8yMapperConfig {
         let config_dir: PathBuf = config_dir.as_ref().into();
 
         let logs_path = tedge_config.logs.path.clone();
-        let data_dir = tedge_config.data.path.clone();
+        let data_dir: DataDir = tedge_config.data.path.clone().into();
         let device_id = tedge_config.device.id.try_read(tedge_config)?.to_string();
         let device_type = tedge_config.device.ty.clone();
         let service_type = tedge_config.service.ty.clone();

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -2312,7 +2312,7 @@ mod tests {
         let config = C8yMapperConfig::new(
             tmp_dir.to_path_buf(),
             tmp_dir.utf8_path_buf(),
-            tmp_dir.utf8_path_buf(),
+            tmp_dir.utf8_path_buf().into(),
             device_id,
             device_type,
             service_type,

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -2103,7 +2103,7 @@ async fn spawn_c8y_mapper_actor(
     let config = C8yMapperConfig::new(
         config_dir.to_path_buf(),
         config_dir.utf8_path_buf(),
-        config_dir.utf8_path_buf(),
+        config_dir.utf8_path_buf().into(),
         device_name,
         device_type,
         service_type,


### PR DESCRIPTION
## Proposed changes
This directory was introduced by c8y-firmware-plugin, however, now cloud mappers need to download files from remote. The cache directory must be used also by cloud mappers to avoid multiple file downloads for the same file.

The directory usage will be covered by robot tests during #2292 work.

In addition, to solve this comment https://github.com/thin-edge/thin-edge.io/pull/2293#discussion_r1338429388, I introduced `DataDir`(crates/core/tedge_api/src/path.rs) struct, which is a wrapper of `Utf8PathBuf` with refactoring codes.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2292 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

