### PR TITLE
Fix integer underflow in EntityTopicId parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,3 +167,4 @@ lto = true
 opt-level = "z"
 panic = "abort"
 strip = "symbols"
+overflow-checks = true


### PR DESCRIPTION
## Proposed changes

In a typical case of a fencepost error, segments were confused with segment separators and thus in topics with 4 slashes erroneously passed the "topic has max of 4 segments" check. This would later cause an underflow when generated missing topic segments, leading to a string of size near `usize::MAX` being allocated.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

As for the error itself, I can identify 3 potential causes:

1. No overflow checks in release mode. This is addressed in this PR by enabling overflow checks in release profile. thin-edge isn't really math-heavy, so I doubt it will impact performance, but it can provide additional safety.
2. Lacking test coverage. The error conditions producing `Result::Error` variants were not sufficiently tested. This is also addressed by this PR.
3. And i think the one we should think a bit about: the decision to automatically pad `EntityTopicId` with slashes if not enough are provided.

   It perhaps unnecessarily complicates the function and it may be used incorrectly by clients who expect `EntityTopicId` to be the same as the input they provided.
   This decision was motivated by [this table](https://thin-edge.github.io/thin-edge.io/next/references/mqtt-api/#group-identifier) in the documentation which specifies that only the first 2 levels are required. When joining `EntityTopicId` with a channel one has to add slashes if fewer than 4 levels were used, so I decided to do this on construction, but since a user can register entities manually, then registration on topic `devices/main` would result in a `EntityTopicId("devices/main//")` being created, which is a completely different topic.
   So as it stands, current `EntityTopicId` implementation is invalid and either it will have to be changed to support number of levels `2..=4`, or remove the feature of not having to fill in all the levels of the MQTT topic identifier portion.
   If we expect a large discussion on this topic, I can create a new issue for it.