### PR TITLE
Do not change XIDs of child devices created via ops dir watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3713,6 +3713,7 @@ dependencies = [
  "csv",
  "download",
  "json-writer",
+ "log",
  "maplit",
  "mockall",
  "mqtt_channel",

--- a/crates/core/tedge_api/Cargo.toml
+++ b/crates/core/tedge_api/Cargo.toml
@@ -14,6 +14,7 @@ clock = { workspace = true }
 csv = { workspace = true }
 download = { workspace = true }
 json-writer = { workspace = true }
+log = { workspace = true }
 mqtt_channel = { workspace = true }
 nanoid = { workspace = true }
 serde = { workspace = true }

--- a/crates/core/tedge_api/src/mqtt_topics.rs
+++ b/crates/core/tedge_api/src/mqtt_topics.rs
@@ -42,6 +42,7 @@ use std::str::FromStr;
 ///     topic.name
 /// );
 /// ```
+#[derive(Clone)]
 pub struct MqttSchema {
     pub root: String,
 }

--- a/crates/extensions/c8y_mapper_ext/src/error.rs
+++ b/crates/extensions/c8y_mapper_ext/src/error.rs
@@ -5,6 +5,7 @@ use c8y_api::smartrest::error::SmartRestSerializerError;
 use c8y_http_proxy::messages::C8YRestError;
 use plugin_sm::operation_logs::OperationLogsError;
 use std::path::PathBuf;
+use tedge_api::entity_store::InvalidExternalIdError;
 use tedge_api::serialize::ThinEdgeJsonSerializationError;
 use tedge_config::TEdgeConfigError;
 use tedge_mqtt_ext::MqttError;
@@ -121,6 +122,9 @@ pub enum ConversionError {
 
     #[error(transparent)]
     FromEntityStoreError(#[from] tedge_api::entity_store::Error),
+
+    #[error(transparent)]
+    InvalidExternalIdError(#[from] InvalidExternalIdError),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/extensions/c8y_mapper_ext/src/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/log_upload.rs
@@ -204,11 +204,7 @@ impl CumulocityConverter {
         let dir_path = match device.r#type {
             EntityType::MainDevice => self.ops_dir.clone(),
             EntityType::ChildDevice => {
-                let child_dir_name = if let Some(child_local_id) = topic_id.default_device_name() {
-                    child_local_id
-                } else {
-                    device.external_id.as_ref()
-                };
+                let child_dir_name = device.external_id.as_ref();
                 self.ops_dir.clone().join(child_dir_name)
             }
             EntityType::Service => {

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
@@ -89,7 +89,7 @@ Restart Firmware plugin
     ThinEdgeIO.Restart Service    c8y-firmware-plugin.service
 
 Child device delete firmware file
-    Set Device Context    ${CHILD_ID}
+    Set Device Context    ${CHILD_SN}
     Execute Command    sudo rm -f firmware1
 
 Create child device
@@ -98,9 +98,9 @@ Create child device
     ...    If the order is opposite, the child device name will start with "MQTT Device".
     Set Device Context    ${PARENT_SN}
     Sleep    3s
-    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_ID}
+    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_SN}
     Sleep    3s
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Firmware    /etc/tedge/operations/c8y/${CHILD_ID}/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Firmware    /etc/tedge/operations/c8y/${CHILD_SN}/
     Cumulocity.Device Should Exist    ${CHILD_SN}
 
 Validate child Name
@@ -152,7 +152,7 @@ Validate firmware update request
     Set Suite Variable    $cache_key    ${cache_key[0]}
 
 Child device response on update request
-    Set Device Context    ${CHILD_ID}
+    Set Device Context    ${CHILD_SN}
     Set Test Variable    $topic_res    tedge/${CHILD_SN}/commands/res/firmware_update
 
     Execute Command    mosquitto_pub -h ${PARENT_IP} -t ${topic_res} -m '{"id":"${op_id}", "status":"executing"}'
@@ -172,6 +172,5 @@ Custom Setup
     Set Suite Variable    $PARENT_IP    ${parent_ip}
 
     # Child
-    ${child_id}=    Setup    skip_bootstrap=True
-    Set Suite Variable    $CHILD_ID    ${child_id}
-    Set Suite Variable    $CHILD_SN    ${PARENT_SN}:device:${CHILD_ID}
+    ${child_sn}=    Setup    skip_bootstrap=True
+    Set Suite Variable    $CHILD_SN    ${child_sn}

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device_retry.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device_retry.robot
@@ -30,9 +30,8 @@ Firmware plugin supports restart via service manager #1932
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Set Suite Variable    $CHILD_ID    ${DEVICE_SN}_child1
-    Set Suite Variable    $CHILD_SN    ${DEVICE_SN}:device:${CHILD_ID}
-    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_ID}
+    Set Suite Variable    $CHILD_SN    ${DEVICE_SN}_child1
+    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_SN}
     Restart Service    tedge-mapper-c8y
     Device Should Exist                      ${DEVICE_SN}
     Device Should Exist                      ${CHILD_SN}

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
@@ -23,13 +23,13 @@ Successful log operation
 
 *** Keywords ***
 Setup Child Device
-    ThinEdgeIO.Set Device Context    ${CHILD_ID}
+    ThinEdgeIO.Set Device Context    ${CHILD_SN}
     Execute Command    sudo dpkg -i packages/tedge_*.deb
 
     Execute Command    sudo tedge config set mqtt.client.host ${PARENT_IP}
     Execute Command    sudo tedge config set mqtt.client.port 1883
     Execute Command    sudo tedge config set mqtt.topic_root te
-    Execute Command    sudo tedge config set mqtt.device_topic_id "device/${CHILD_ID}//"
+    Execute Command    sudo tedge config set mqtt.device_topic_id "device/${CHILD_SN}//"
 
     # Install plugin after the default settings have been updated to prevent it from starting up as the main plugin
     Execute Command    sudo dpkg -i packages/tedge-log-plugin*.deb
@@ -57,8 +57,8 @@ Custom Setup
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-c8y
 
     # Child
-    ${CHILD_ID}=    Setup    skip_bootstrap=${True}
-    Set Suite Variable    $CHILD_ID
-    Set Suite Variable    $CHILD_SN    ${PARENT_SN}:device:${CHILD_ID}
+    ${CHILD_SN}=    Setup    skip_bootstrap=${True}
+    Set Suite Variable    $CHILD_SN
+    Set Suite Variable    $CHILD_XID    ${PARENT_SN}:device:${CHILD_SN}
     Setup Child Device
-    Cumulocity.Device Should Exist    ${CHILD_SN}
+    Cumulocity.Device Should Exist    ${CHILD_XID}

--- a/tests/RobotFramework/tests/cumulocity/registration/device_registration.robot
+++ b/tests/RobotFramework/tests/cumulocity/registration/device_registration.robot
@@ -18,30 +18,30 @@ Main device registration
 
 
 Child device registration
-    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_ID}
+    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_SN}
     Restart Service    tedge-mapper-c8y
 
     # Check registration
     ${child_mo}=    Device Should Exist        ${CHILD_SN}
-    ${child_mo}=    Cumulocity.Device Should Have Fragment Values    name\=${CHILD_ID}
+    ${child_mo}=    Cumulocity.Device Should Have Fragment Values    name\=${CHILD_SN}
     Should Be Equal    ${child_mo["owner"]}    device_${DEVICE_SN}    # The parent is the owner of the child
-    Should Be Equal    ${child_mo["name"]}     ${CHILD_ID}
+    Should Be Equal    ${child_mo["name"]}     ${CHILD_SN}
 
     # Check child device relationship
     Cumulocity.Set Device    ${DEVICE_SN}
     Cumulocity.Should Be A Child Device Of Device    ${CHILD_SN}
 
 Register child device with defaults via MQTT
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_ID}//' '{"@type":"child-device"}'
-    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${CHILD_SN}    child_name=${CHILD_SN}    child_type=thin-edge.io-child
+    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device"}'
+    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${CHILD_XID}    child_name=${CHILD_XID}    child_type=thin-edge.io-child
 
 Register child device with custom name and type via MQTT
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_ID}//' '{"@type":"child-device","name":"${CHILD_ID}","type":"linux-device-Aböut"}'
-    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${CHILD_SN}    child_name=${CHILD_ID}    child_type=linux-device-Aböut
+    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","name":"${CHILD_SN}","type":"linux-device-Aböut"}'
+    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${CHILD_XID}    child_name=${CHILD_SN}    child_type=linux-device-Aböut
 
 Register child device with custom id via MQTT
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_ID}//' '{"@type":"child-device","@id":"custom-${CHILD_SN}","name":"custom-${CHILD_ID}"}'
-    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=custom-${CHILD_SN}    child_name=custom-${CHILD_ID}    child_type=thin-edge.io-child
+    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"custom-${CHILD_XID}","name":"custom-${CHILD_SN}"}'
+    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=custom-${CHILD_XID}    child_name=custom-${CHILD_SN}    child_type=thin-edge.io-child
 
 Register nested child device using default topic schema via MQTT
     ${child_level1}=    Get Random Name
@@ -65,14 +65,14 @@ Register nested child device using default topic schema via MQTT
 
 
 Register service on a child device via MQTT
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_ID}//' '{"@type":"child-device","name":"${CHILD_ID}","type":"linux-device-Aböut"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_ID}/service/custom-app' '{"@type":"service","@parent":"device/${CHILD_ID}//","name":"custom-app","type":"custom-type"}'
+    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","name":"${CHILD_SN}","type":"linux-device-Aböut"}'
+    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}/service/custom-app' '{"@type":"service","@parent":"device/${CHILD_SN}//","name":"custom-app","type":"custom-type"}'
 
     # Check child registration
-    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${CHILD_SN}    child_name=${CHILD_ID}    child_type=linux-device-Aböut
+    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${CHILD_XID}    child_name=${CHILD_SN}    child_type=linux-device-Aböut
 
     # Check service registration
-    Check Service    child_sn=${CHILD_SN}    service_sn=${CHILD_SN}:service:custom-app    service_name=custom-app    service_type=custom-type    service_status=up
+    Check Service    child_sn=${CHILD_XID}    service_sn=${CHILD_XID}:service:custom-app    service_name=custom-app    service_type=custom-type    service_status=up
 
 
 Register devices using custom MQTT schema
@@ -133,9 +133,9 @@ Check Service
 
 
 Test Setup
-    ${CHILD_ID}=    Get Random Name
-    Set Test Variable    $CHILD_ID
-    Set Test Variable    $CHILD_SN    ${DEVICE_SN}:device:${CHILD_ID}
+    ${CHILD_SN}=    Get Random Name
+    Set Test Variable    $CHILD_SN
+    Set Test Variable    $CHILD_XID    ${DEVICE_SN}:device:${CHILD_SN}
 
     ThinEdgeIO.Set Device Context    ${DEVICE_SN}
 

--- a/tests/RobotFramework/tests/cumulocity/restart/restart_device_child.robot
+++ b/tests/RobotFramework/tests/cumulocity/restart/restart_device_child.robot
@@ -61,13 +61,13 @@ Default restart timeout supports the default 60 second delay of the linux shutdo
 
 *** Keywords ***
 Setup Child Device
-    ThinEdgeIO.Set Device Context    ${CHILD_ID}
+    ThinEdgeIO.Set Device Context    ${CHILD_SN}
     Execute Command    sudo dpkg -i packages/tedge_*.deb
 
     Execute Command    sudo tedge config set mqtt.client.host ${PARENT_IP}
     Execute Command    sudo tedge config set mqtt.client.port 1883
     Execute Command    sudo tedge config set mqtt.topic_root te
-    Execute Command    sudo tedge config set mqtt.device_topic_id "device/${CHILD_ID}//"
+    Execute Command    sudo tedge config set mqtt.device_topic_id "device/${CHILD_SN}//"
 
     # Install plugin after the default settings have been updated to prevent it from starting up as the main plugin
     Execute Command    sudo dpkg -i packages/tedge-agent*.deb
@@ -100,11 +100,11 @@ Custom Setup
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-c8y
 
     # Child
-    ${CHILD_ID}=    Setup    skip_bootstrap=${True}
-    Set Suite Variable    $CHILD_ID
-    Set Suite Variable    $CHILD_SN    ${PARENT_SN}:device:${CHILD_ID}
+    ${CHILD_SN}=    Setup    skip_bootstrap=${True}
+    Set Suite Variable    $CHILD_SN
+    Set Suite Variable    $CHILD_XID    ${PARENT_SN}:device:${CHILD_SN}
     Setup Child Device
-    Cumulocity.Device Should Exist    ${CHILD_SN}
+    Cumulocity.Device Should Exist    ${CHILD_XID}
 
 Test Teardown
     Get Logs    name=${PARENT_SN}

--- a/tests/RobotFramework/tests/cumulocity/telemetry/c8y_child_alarms_rpi.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/c8y_child_alarms_rpi.robot
@@ -13,30 +13,30 @@ Suite Teardown         Get Logs
 
 ${DEVICE_SN}
 ${CHILD_SN}
-${CHILD_ID}
+${CHILD_XID}
 
 
 *** Test Cases ***
 
 Define Child device 1 ID
-    Set Suite Variable    $CHILD_ID    child01
-    Set Suite Variable    $CHILD_SN    ${DEVICE_SN}:device:${CHILD_ID}
+    Set Suite Variable    $CHILD_SN    child01
+    Set Suite Variable    $CHILD_XID    ${DEVICE_SN}:device:${CHILD_SN}
 
 Normal case when the child device does not exist on c8y cloud
     # Sending child alarm
-    Execute Command    sudo tedge mqtt pub 'te/device/${CHILD_ID}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-01T05:30:45+00:00" }' -q 2 -r
+    Execute Command    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-01T05:30:45+00:00" }' -q 2 -r
     # Check Child device creation
     Set Device    ${DEVICE_SN}
-    Should Be A Child Device Of Device    ${CHILD_SN}
+    Should Be A Child Device Of Device    ${CHILD_XID}
 
     # Check created alarm
-    Set Device    ${CHILD_SN}
+    Set Device    ${CHILD_XID}
     ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    # Should be the only alarm there
     ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    expected_text=Temperature is very high    type=temperature_high    severity=CRITICAL
 
 Normal case when the child device already exists
 #Sending child alarm again
-    Execute Command    sudo tedge mqtt pub 'te/device/${CHILD_ID}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-02T05:30:45+00:00" }' -q 2 -r
+    Execute Command    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-02T05:30:45+00:00" }' -q 2 -r
 
 #Check created second alarm
     ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    updated_after=2021-01-02
@@ -44,7 +44,7 @@ Normal case when the child device already exists
 
 Reconciliation when the new alarm message arrives, restart the mapper
     Execute Command    sudo systemctl stop tedge-mapper-c8y.service
-    Execute Command    sudo tedge mqtt pub 'te/device/${CHILD_ID}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-03T05:30:45+00:00" }' -q 2 -r
+    Execute Command    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-03T05:30:45+00:00" }' -q 2 -r
     Execute Command    sudo systemctl start tedge-mapper-c8y.service
 
     # Check created second alarm
@@ -53,7 +53,7 @@ Reconciliation when the new alarm message arrives, restart the mapper
 
 Reconciliation when the alarm that is cleared
     Execute Command    sudo systemctl stop tedge-mapper-c8y.service
-    Execute Command    sudo tedge mqtt pub 'te/device/${CHILD_ID}///a/temperature_high' '' -q 2 -r
+    Execute Command    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '' -q 2 -r
     Execute Command    sudo systemctl start tedge-mapper-c8y.service
     Device Should Not Have Alarm/s
 

--- a/tests/RobotFramework/tests/cumulocity/telemetry/child_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/child_device_telemetry.robot
@@ -9,57 +9,57 @@ Test Teardown    Get Logs
 
 *** Test Cases ***
 Child devices support sending simple measurements
-    Execute Command    tedge mqtt pub te/device/${CHILD_ID}///m/ '{ "temperature": 25 }'
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///m/ '{ "temperature": 25 }'
     ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=ThinEdgeMeasurement    value=temperature    series=temperature
     Log    ${measurements}
 
 
 
 Child devices support sending simple measurements with custom type in topic
-    Execute Command    tedge mqtt pub te/device/${CHILD_ID}///m/CustomType_topic '{ "temperature": 25 }'
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///m/CustomType_topic '{ "temperature": 25 }'
     ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomType_topic    value=temperature    series=temperature
     Log    ${measurements}
 
 
 Child devices support sending simple measurements with custom type in payload
-    Execute Command    tedge mqtt pub te/device/${CHILD_ID}///m/CustomType_topic '{ "type":"CustomType_payload","temperature": 25 }'
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///m/CustomType_topic '{ "type":"CustomType_payload","temperature": 25 }'
     ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomType_payload    value=temperature    series=temperature
     Log    ${measurements}
 
 Child devices support sending custom measurements
-    Execute Command    tedge mqtt pub te/device/${CHILD_ID}///m/ '{ "current": {"L1": 9.5, "L2": 1.3} }'
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///m/ '{ "current": {"L1": 9.5, "L2": 1.3} }'
     ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=ThinEdgeMeasurement    value=current    series=L1
     Log    ${measurements}
 
 
 Child devices support sending custom events
-    Execute Command    tedge mqtt pub te/device/${CHILD_ID}///e/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///e/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
     ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=myCustomType1    fragment=someOtherCustomFragment
     Log    ${events}
 
 
 Child devices support sending custom events overriding the type
-    Execute Command    tedge mqtt pub te/device/${CHILD_ID}///e/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///e/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
     ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=otherType    fragment=someOtherCustomFragment
     Log    ${events}
 
 
  Child devices support sending custom events without type in topic
-    Execute Command    tedge mqtt pub te/device/${CHILD_ID}///e/ '{"text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///e/ '{"text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
     ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=ThinEdgeEvent    fragment=someOtherCustomFragment
     Log    ${events}
 
 
 Child devices support sending custom alarms #1699
     [Tags]    \#1699
-    Execute Command    tedge mqtt pub te/device/${CHILD_ID}///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
     ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=CRITICAL    minimum=1    maximum=1    type=myCustomAlarmType
     Should Be Equal    ${alarms[0]["someOtherCustomFragment"]["nested"]["value"]}    extra info
     Log    ${alarms}
 
 
 Child devices support sending alarms using text fragment
-    Execute Command    tedge mqtt pub te/device/${CHILD_ID}///a/childAlarmType1 '{ "severity": "critical", "text": "Some test alarm" }'
+    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///a/childAlarmType1 '{ "severity": "critical", "text": "Some test alarm" }'
     ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=CRITICAL    minimum=1    maximum=1    type=childAlarmType1
     Log    ${alarms}
 
@@ -84,9 +84,8 @@ Child device supports sending custom child device measurements directly to c8y
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Set Suite Variable    $CHILD_ID    ${DEVICE_SN}_child1
-    Set Suite Variable    $CHILD_SN    ${DEVICE_SN}:device:${CHILD_ID}
-    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_ID}
+    Set Suite Variable    $CHILD_SN    ${DEVICE_SN}_child1
+    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_SN}
     Restart Service    tedge-mapper-c8y
     Device Should Exist                      ${DEVICE_SN}
     Device Should Exist                      ${CHILD_SN}

--- a/tests/RobotFramework/tests/customizing/data_path_config.robot
+++ b/tests/RobotFramework/tests/customizing/data_path_config.robot
@@ -38,8 +38,7 @@ Validate updated data path used by c8y-firmware-plugin
 Custom Setup
     ${PARENT_SN}=    Setup
     Set Suite Variable    $PARENT_SN
-    Set Suite Variable    $CHILD_ID    ${PARENT_SN}_child
-    Set Suite Variable    $CHILD_SN    ${PARENT_SN}:device:${CHILD_ID}
+    Set Suite Variable    $CHILD_SN    ${PARENT_SN}_child
     Execute Command    sudo mkdir /var/test
     Execute Command    sudo chown tedge:tedge /var/test
     Execute Command    sudo tedge config set data.path /var/test
@@ -50,9 +49,9 @@ Custom Teardown
     Get Logs
 
 Bootstrap child device with firmware operation support
-    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_ID}
+    Execute Command    mkdir -p /etc/tedge/operations/c8y/${CHILD_SN}
     Sleep    3s
-    Execute Command    touch /etc/tedge/operations/c8y/${CHILD_ID}/c8y_Firmware
+    Execute Command    touch /etc/tedge/operations/c8y/${CHILD_SN}/c8y_Firmware
     Sleep    3s
     Cumulocity.Device Should Exist    ${CHILD_SN}
 


### PR DESCRIPTION
## Proposed changes

The XIDs (external IDs) of devices created using the operations directory file watcher mechanism were changed in #2266 breaking backward compatibility. So, reverting those changes. As the file watcher mechanism was a lower level API specifically designed for C8y, it makes sense to keep the directory name and XID the same.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

