### PR TITLE
Fix 2311: don't publish c8y register message twice

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/actor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/actor.rs
@@ -134,7 +134,7 @@ impl C8yMapperActor {
                         external_id: None,
                         r#type: EntityType::ChildDevice,
                         parent: None,
-                        payload: json!({ "name": child_id }),
+                        other: json!({ "name": child_id }),
                     };
                     self.converter
                         .register_and_convert_entity(&child_device_reg_msg)


### PR DESCRIPTION


## Proposed changes

To solve the issue, registration message conversion was changed to only convert if the registration message affected any entities. An update is considered to affect an entity if the entity was previously registered and the update changes any part of entity metadata (i.e. is different from a previous one) or adds or removes children of a device.

As part of the fix, it was necessary to change the `EntityRegistrationMessage::payload` field. It was renamed to `other` and made to not include `@id`, `@type`, `@parent`, etc. fields that are already direct fields of `EntityRegistrationMessage`.

A test `does_not_duplicate_global_registration_2311` was added to ensure the fix had intended effect. The fix was confirmed to turn the test from red to green.

One non-intuitive part is that the registration of a brand new entity is not considered to affect that new entity. Instead, adding or removing any entity always affects the main device, since it's the root parent of all other entities, so the cloud registration message is sent because the main device is updated. In the future, after we update entity store we might instead dynamically parse affected entities returned by the update function to determine which cloud registration messages to send upstream. It would then make sense to revise the decision that registering a new entity is not considered by the entity store to affect that entity.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2311

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
