### PR TITLE
tedge-mapper-aws health message uses two different timestamp formats for up and down messages

### DIFF
--- a/crates/core/tedge_api/src/health.rs
+++ b/crates/core/tedge_api/src/health.rs
@@ -1,11 +1,11 @@
-use std::process;
-
+use clock::Clock;
+use clock::WallClock;
 use mqtt_channel::Message;
 use mqtt_channel::PubChannel;
 use mqtt_channel::Topic;
 use mqtt_channel::TopicFilter;
 use serde_json::json;
-use time::OffsetDateTime;
+use std::process;
 
 pub fn health_check_topics(daemon_name: &str) -> TopicFilter {
     vec![
@@ -17,17 +17,7 @@ pub fn health_check_topics(daemon_name: &str) -> TopicFilter {
 }
 
 pub async fn send_health_status(responses: &mut impl PubChannel, daemon_name: &str) {
-    let response_topic_health =
-        Topic::new_unchecked(format!("tedge/health/{daemon_name}").as_str());
-
-    let health_status = json!({
-        "status": "up",
-        "pid": process::id(),
-        "time": OffsetDateTime::now_utc().unix_timestamp(),
-    })
-    .to_string();
-
-    let health_message = Message::new(&response_topic_health, health_status).with_retain();
+    let health_message = health_status_up_message(daemon_name);
     let _ = responses.send(health_message).await;
 }
 
@@ -45,19 +35,33 @@ pub fn health_status_down_message(daemon_name: &str) -> Message {
 }
 
 pub fn health_status_up_message(daemon_name: &str) -> Message {
-    let response_topic_health =
-        Topic::new_unchecked(format!("tedge/health/{daemon_name}").as_str());
+    let clock = Box::new(WallClock);
+    let timestamp = clock
+        .now()
+        .format(&time::format_description::well_known::Rfc3339);
+    match timestamp {
+        Ok(time_stamp) => {
+            let health_status = json!({
+                "status": "up",
+                "pid": process::id(),
+                "time": time_stamp,
+            })
+            .to_string();
+            let response_topic_health =
+                Topic::new_unchecked(format!("tedge/health/{daemon_name}").as_str());
 
-    let health_status = json!({
-        "status": "up",
-        "pid": process::id(),
-        "time": OffsetDateTime::now_utc().unix_timestamp(),
-    })
-    .to_string();
-
-    Message::new(&response_topic_health, health_status)
-        .with_qos(mqtt_channel::QoS::AtLeastOnce)
-        .with_retain()
+            Message::new(&response_topic_health, health_status)
+                .with_qos(mqtt_channel::QoS::AtLeastOnce)
+                .with_retain()
+        }
+        Err(e) => {
+            let error_topic = Topic::new_unchecked("tedge/errors");
+            let error_msg = format!(
+                "Health message: Failed to convert timestamp to Rfc3339 format due to: {e}"
+            );
+            Message::new(&error_topic, error_msg).with_qos(mqtt_channel::QoS::AtLeastOnce)
+        }
+    }
 }
 
 pub fn is_bridge_health(topic: &str) -> bool {
@@ -71,5 +75,26 @@ pub fn is_bridge_health(topic: &str) -> bool {
         }
     } else {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::health_status_up_message;
+    #[test]
+    fn is_rfc3339_timestamp() {
+        let msg = health_status_up_message("test_daemon");
+        let health_msg_str = msg.payload_str().unwrap();
+        let deserialized_value: Value =
+            serde_json::from_str(health_msg_str).expect("Failed to parse JSON");
+        let timestamp = deserialized_value.get("time").unwrap().as_str().unwrap();
+        // The RFC3339 format pattern
+        let pattern = r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{0,}Z$";
+
+        // Use regex to check if the timestamp matches the pattern
+        let regex = regex::Regex::new(pattern).unwrap();
+        assert!(regex.is_match(timestamp));
     }
 }

--- a/crates/core/tedge_watchdog/src/error.rs
+++ b/crates/core/tedge_watchdog/src/error.rs
@@ -1,3 +1,5 @@
+use time::error::Parse;
+
 use mqtt_channel::MqttError;
 
 use tedge_config::CertificateError;
@@ -39,4 +41,10 @@ pub enum WatchdogError {
 
     #[error(transparent)]
     FromCertificateError(#[from] CertificateError),
+
+    #[error(transparent)]
+    FromTimeFormatError(#[from] time::error::Format),
+
+    #[error(transparent)]
+    ParseError(#[from] Parse),
 }


### PR DESCRIPTION
## Proposed changes

To unify the timestamps that are used across `thin-edge`, Update the `health_status_up_message` API to use RFC3339 time format rather than `unix` timestamp.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/2237

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

