### PR TITLE
Modify Actor trait to take `self` instead of `&mut self`

### DIFF
--- a/crates/common/batcher/src/driver.rs
+++ b/crates/common/batcher/src/driver.rs
@@ -67,7 +67,7 @@ impl<B: Batchable> Actor for BatchDriver<B> {
     }
 
     /// Start the batching - runs until receiving a Flush message
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         loop {
             let message = match self.time_to_next_timer() {
                 TimeTo::Unbounded => self.recv(None),
@@ -259,7 +259,7 @@ mod tests {
         let test_box = box_builder.new_client_box(NoConfig);
         let driver_box = box_builder.build();
 
-        let mut driver = BatchDriver::new(batcher, driver_box);
+        let driver = BatchDriver::new(batcher, driver_box);
         tokio::spawn(async move { driver.run().await });
 
         test_box

--- a/crates/core/tedge_actors/src/builders.rs
+++ b/crates/core/tedge_actors/src/builders.rs
@@ -434,7 +434,7 @@ pub trait ServiceConsumer<Request: Message, Response: Message, Config> {
 ///         "My Actor"
 ///     }
 ///
-///     async fn run(&mut self) -> Result<(), RuntimeError> {
+///     async fn run(mut self) -> Result<(), RuntimeError> {
 ///         while let Some(input) = self.messages.recv().await {
 ///             let output = input * 2;
 ///             self.messages.send(output).await?;

--- a/crates/core/tedge_actors/src/converter.rs
+++ b/crates/core/tedge_actors/src/converter.rs
@@ -131,7 +131,7 @@ impl<C: Converter> Actor for ConvertingActor<C> {
         &self.name
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         let init_messages = self.init_messages()?;
         self.send(init_messages).await?;
 

--- a/crates/core/tedge_actors/src/examples/calculator.rs
+++ b/crates/core/tedge_actors/src/examples/calculator.rs
@@ -39,7 +39,7 @@ impl Actor for Calculator {
         "Calculator"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         while let Some(op) = self.messages.recv().await {
             // Process in turn each input message
             let from = self.state;

--- a/crates/core/tedge_actors/src/examples/calculator_server.rs
+++ b/crates/core/tedge_actors/src/examples/calculator_server.rs
@@ -54,7 +54,7 @@ impl Actor for Player {
         &self.name
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         // Send a first identity `Operation` to see where we are.
         self.messages.send(Operation::Add(0)).await?;
 

--- a/crates/core/tedge_actors/src/examples/mod.rs
+++ b/crates/core/tedge_actors/src/examples/mod.rs
@@ -24,7 +24,7 @@
 //!         &self.name
 //!     }
 //!
-//!     async fn run(&mut self) -> Result<(), RuntimeError> {
+//!     async fn run(mut self) -> Result<(), RuntimeError> {
 //!         // Send a first identity `Operation` to see where we are.
 //!         self.messages.send(Operation::Add(0)).await?;
 //!

--- a/crates/core/tedge_actors/src/lib.rs
+++ b/crates/core/tedge_actors/src/lib.rs
@@ -66,7 +66,7 @@
 //!     /// However, there are no constraints on the behavior of an actor.
 //!     /// A more sophisticated actor might send output messages independently of any request
 //!     /// or process concurrently several requests.
-//!     async fn run(&mut self)-> Result<(), RuntimeError>  {
+//!     async fn run(mut self)-> Result<(), RuntimeError>  {
 //!         while let Some(op) = self.messages.recv().await {
 //!             // Process in turn each input message
 //!             let from = self.state;
@@ -286,7 +286,7 @@
 //!         todo!()
 //!     }
 //!
-//!     async fn run(&mut self) -> Result<(), RuntimeError> {
+//!     async fn run(mut self) -> Result<(), RuntimeError> {
 //!         todo!()
 //!     }
 //! }

--- a/crates/core/tedge_actors/src/run_actor.rs
+++ b/crates/core/tedge_actors/src/run_actor.rs
@@ -38,8 +38,8 @@ impl RunActor {
         self.actor.name()
     }
 
-    pub async fn run(mut self) -> Result<(), RuntimeError> {
-        self.actor.run().await
+    pub async fn run(self) -> Result<(), RuntimeError> {
+        self.actor.run_boxed().await
     }
 }
 

--- a/crates/core/tedge_actors/src/runtime.rs
+++ b/crates/core/tedge_actors/src/runtime.rs
@@ -309,7 +309,7 @@ mod tests {
             "Echo"
         }
 
-        async fn run(&mut self) -> Result<(), RuntimeError> {
+        async fn run(mut self) -> Result<(), RuntimeError> {
             while let Some(message) = self.messages.recv().await {
                 match message {
                     EchoMessage::String(message) => {
@@ -338,7 +338,7 @@ mod tests {
             "Ending"
         }
 
-        async fn run(&mut self) -> Result<(), RuntimeError> {
+        async fn run(self) -> Result<(), RuntimeError> {
             Ok(())
         }
     }
@@ -357,7 +357,7 @@ mod tests {
             "Panic"
         }
 
-        async fn run(&mut self) -> Result<(), RuntimeError> {
+        async fn run(self) -> Result<(), RuntimeError> {
             panic!("Oh dear");
         }
     }

--- a/crates/core/tedge_actors/src/servers/actors.rs
+++ b/crates/core/tedge_actors/src/servers/actors.rs
@@ -28,7 +28,7 @@ impl<S: Server> Actor for ServerActor<S> {
         self.server.name()
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         let server = &mut self.server;
         while let Some((client_id, request)) = self.messages.recv().await {
             tokio::select! {
@@ -66,7 +66,7 @@ impl<S: Server + Clone> Actor for ConcurrentServerActor<S> {
         self.server.name()
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         while let Some((client_id, request)) = self.messages.recv().await {
             // Spawn the request
             let mut server = self.server.clone();

--- a/crates/core/tedge_actors/src/servers/builders.rs
+++ b/crates/core/tedge_actors/src/servers/builders.rs
@@ -153,7 +153,7 @@ impl<S: Server, K> ServerActorBuilder<S, K> {
 impl<S: Server> ServerActorBuilder<S, Sequential> {
     pub async fn run(self) -> Result<(), RuntimeError> {
         let messages = self.box_builder.build();
-        let mut actor = ServerActor::new(self.server, messages);
+        let actor = ServerActor::new(self.server, messages);
 
         actor.run().await
     }
@@ -162,7 +162,7 @@ impl<S: Server> ServerActorBuilder<S, Sequential> {
 impl<S: Server + Clone> ServerActorBuilder<S, Concurrent> {
     pub async fn run(self) -> Result<(), RuntimeError> {
         let messages = self.box_builder.build();
-        let mut actor = ConcurrentServerActor::new(self.server, messages);
+        let actor = ConcurrentServerActor::new(self.server, messages);
 
         actor.run().await
     }

--- a/crates/core/tedge_actors/src/tests.rs
+++ b/crates/core/tedge_actors/src/tests.rs
@@ -32,7 +32,7 @@ async fn spawn_sleep_service() -> SimpleMessageBox<(ClientId, u64), (ClientId, u
     let mut box_builder = SimpleMessageBoxBuilder::new("test", 16);
     let handle = box_builder.new_client_box(NoConfig);
     let messages = box_builder.build();
-    let mut actor = ServerActor::new(service, messages);
+    let actor = ServerActor::new(service, messages);
 
     tokio::spawn(async move { actor.run().await });
 
@@ -49,7 +49,7 @@ async fn spawn_concurrent_sleep_service(
 
     let handle = handle_builder.build();
     let messages = ConcurrentServerMessageBox::new(max_concurrency, box_builder.build());
-    let mut actor = ConcurrentServerActor::new(service, messages);
+    let actor = ConcurrentServerActor::new(service, messages);
 
     tokio::spawn(async move { actor.run().await });
 

--- a/crates/core/tedge_agent/src/file_transfer_server/actor.rs
+++ b/crates/core/tedge_agent/src/file_transfer_server/actor.rs
@@ -25,7 +25,7 @@ impl Actor for FileTransferServerActor {
         "HttpFileTransferServer"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         let http_config = self.config.clone();
         let server = http_file_transfer_server(&http_config)?;
 
@@ -100,7 +100,7 @@ mod tests {
 
         // Spawn HTTP file transfer server
         let builder = FileTransferServerBuilder::new(http_config);
-        let mut actor = builder.build();
+        let actor = builder.build();
         tokio::spawn(async move { actor.run().await });
 
         // Create PUT request to file transfer service

--- a/crates/core/tedge_agent/src/restart_manager/actor.rs
+++ b/crates/core/tedge_agent/src/restart_manager/actor.rs
@@ -46,7 +46,7 @@ impl Actor for RestartManagerActor {
         "RestartManagerActor"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         if let Some(response) = self.process_pending_restart_operation().await {
             self.message_box.send(response).await?;
         }

--- a/crates/core/tedge_agent/src/restart_manager/tests.rs
+++ b/crates/core/tedge_agent/src/restart_manager/tests.rs
@@ -138,7 +138,7 @@ async fn spawn_restart_manager(
 
     let converter_box = converter_builder.build().with_timeout(TEST_TIMEOUT_MS);
 
-    let mut restart_actor = restart_actor_builder.build();
+    let restart_actor = restart_actor_builder.build();
     tokio::spawn(async move { restart_actor.run().await });
 
     Ok(converter_box)

--- a/crates/core/tedge_agent/src/software_manager/actor.rs
+++ b/crates/core/tedge_agent/src/software_manager/actor.rs
@@ -75,7 +75,7 @@ impl Actor for SoftwareManagerActor {
         "SoftwareManagerActor"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         let operation_logs = OperationLogs::try_new(self.config.log_dir.clone().into())
             .map_err(SoftwareManagerError::FromOperationsLogs)?;
 

--- a/crates/core/tedge_agent/src/software_manager/tests.rs
+++ b/crates/core/tedge_agent/src/software_manager/tests.rs
@@ -165,7 +165,7 @@ async fn spawn_software_manager(
 
     let converter_box = converter_builder.build().with_timeout(TEST_TIMEOUT_MS);
 
-    let mut software_actor = software_actor_builder.build();
+    let software_actor = software_actor_builder.build();
     tokio::spawn(async move { software_actor.run().await });
 
     Ok(converter_box)

--- a/crates/core/tedge_agent/src/tedge_operation_converter/actor.rs
+++ b/crates/core/tedge_agent/src/tedge_operation_converter/actor.rs
@@ -39,7 +39,7 @@ impl Actor for TedgeOperationConverterActor {
         "TedgeOperationConverter"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         self.publish_operation_capabilities().await?;
 
         while let Some(input) = self.input_receiver.recv().await {

--- a/crates/core/tedge_agent/src/tedge_operation_converter/tests.rs
+++ b/crates/core/tedge_agent/src/tedge_operation_converter/tests.rs
@@ -239,7 +239,7 @@ async fn spawn_mqtt_operation_converter(
     let restart_box = restart_builder.build().with_timeout(TEST_TIMEOUT_MS);
     let mqtt_message_box = mqtt_builder.build().with_timeout(TEST_TIMEOUT_MS);
 
-    let mut converter_actor = converter_actor_builder.build();
+    let converter_actor = converter_actor_builder.build();
     tokio::spawn(async move { converter_actor.run().await });
 
     Ok((software_box, restart_box, mqtt_message_box))

--- a/crates/extensions/c8y_auth_proxy/src/actor.rs
+++ b/crates/extensions/c8y_auth_proxy/src/actor.rs
@@ -86,7 +86,7 @@ impl Actor for C8yAuthProxy {
         "C8yAuthProxy"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         let server = Server::try_init(self.app_state.clone(), self.bind_address, self.bind_port)
             .map_err(BoxError::from)?
             .wait();

--- a/crates/extensions/c8y_config_manager/src/actor.rs
+++ b/crates/extensions/c8y_config_manager/src/actor.rs
@@ -351,7 +351,7 @@ impl Actor for ConfigManagerActor {
         "ConfigManager"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         self.publish_supported_config_types().await?;
         self.get_pending_operations_from_cloud().await?;
 

--- a/crates/extensions/c8y_config_manager/src/tests.rs
+++ b/crates/extensions/c8y_config_manager/src/tests.rs
@@ -1014,7 +1014,7 @@ async fn spawn_config_manager(
     let c8y_proxy_message_box = c8y_proxy_builder.build();
     let timer_message_box = timer_builder.build();
 
-    let mut actor = config_manager_builder.build();
+    let actor = config_manager_builder.build();
     let _join_handle = tokio::spawn(async move { actor.run().await });
 
     Ok((mqtt_message_box, c8y_proxy_message_box, timer_message_box))

--- a/crates/extensions/c8y_firmware_manager/src/actor.rs
+++ b/crates/extensions/c8y_firmware_manager/src/actor.rs
@@ -76,7 +76,7 @@ impl Actor for FirmwareManagerActor {
     // 2. Operation timeouts from the TimerActor for requests for which the child devices don't respond within the timeout window
     // 3. Download results from the DownloaderActor for firmware download requests
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         self.resend_operations_to_child_device().await?;
         // TODO: We need a dedicated actor to publish 500 later.
         self.get_pending_operations_from_cloud().await?;

--- a/crates/extensions/c8y_firmware_manager/src/tests.rs
+++ b/crates/extensions/c8y_firmware_manager/src/tests.rs
@@ -744,7 +744,7 @@ async fn spawn_firmware_manager(
     let timer_message_box = timer_builder.build();
     let downloader_message_box = downloader_builder.build().with_timeout(TEST_TIMEOUT_MS);
 
-    let mut firmware_manager_actor = firmware_manager_builder.build();
+    let firmware_manager_actor = firmware_manager_builder.build();
     let handle = tokio::spawn(async move { firmware_manager_actor.run().await });
 
     Ok((

--- a/crates/extensions/c8y_http_proxy/src/actor.rs
+++ b/crates/extensions/c8y_http_proxy/src/actor.rs
@@ -78,7 +78,7 @@ impl Actor for C8YHttpProxyActor {
         "C8Y-REST"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         self.init().await.map_err(Box::new)?;
 
         while let Some((client_id, request)) = self.peers.clients.recv().await {

--- a/crates/extensions/c8y_http_proxy/src/tests.rs
+++ b/crates/extensions/c8y_http_proxy/src/tests.rs
@@ -178,7 +178,7 @@ async fn retry_internal_id_on_expired_jwt_with_mock() {
         tmp_dir: tmp_dir.into(),
     };
     let c8y_proxy_actor = C8YHttpProxyBuilder::new(config, &mut http_actor, &mut jwt);
-    let mut jwt_actor = ServerActor::new(DynamicJwtRetriever { count: 0 }, jwt.build());
+    let jwt_actor = ServerActor::new(DynamicJwtRetriever { count: 0 }, jwt.build());
 
     tokio::spawn(async move { http_actor.run().await });
     tokio::spawn(async move { jwt_actor.run().await });
@@ -242,7 +242,7 @@ async fn retry_create_event_on_expired_jwt_with_mock() {
         tmp_dir: tmp_dir.into(),
     };
     let c8y_proxy_actor = C8YHttpProxyBuilder::new(config, &mut http_actor, &mut jwt);
-    let mut jwt_actor = ServerActor::new(DynamicJwtRetriever { count: 1 }, jwt.build());
+    let jwt_actor = ServerActor::new(DynamicJwtRetriever { count: 1 }, jwt.build());
 
     tokio::spawn(async move { http_actor.run().await });
     tokio::spawn(async move { jwt_actor.run().await });
@@ -468,7 +468,7 @@ async fn spawn_c8y_http_proxy(
     let mut c8y_proxy_actor = C8YHttpProxyBuilder::new(config, &mut http, &mut jwt);
     let proxy = C8YHttpProxy::new("C8Y", &mut c8y_proxy_actor);
 
-    let mut jwt_actor = ServerActor::new(
+    let jwt_actor = ServerActor::new(
         ConstJwtRetriever {
             token: token.to_string(),
         },
@@ -477,7 +477,7 @@ async fn spawn_c8y_http_proxy(
 
     tokio::spawn(async move { jwt_actor.run().await });
     tokio::spawn(async move {
-        let mut actor = c8y_proxy_actor.build();
+        let actor = c8y_proxy_actor.build();
         let _ = actor.run().await;
     });
 

--- a/crates/extensions/c8y_log_manager/src/actor.rs
+++ b/crates/extensions/c8y_log_manager/src/actor.rs
@@ -221,7 +221,7 @@ impl Actor for LogManagerActor {
         "LogManager"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         self.reload_supported_log_types().await.unwrap();
         self.get_pending_operations_from_cloud().await.unwrap();
 
@@ -407,7 +407,7 @@ mod tests {
         SimpleMessageBox<NoMessage, FsWatchEvent>,
     ) {
         let (actor_builder, mqtt, http, fs) = new_log_manager_builder(temp_dir);
-        let mut actor = actor_builder.build();
+        let actor = actor_builder.build();
         tokio::spawn(async move { actor.run().await });
         (mqtt, http, fs)
     }

--- a/crates/extensions/c8y_mapper_ext/src/actor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/actor.rs
@@ -66,7 +66,7 @@ impl Actor for C8yMapperActor {
         "CumulocityMapper"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         let init_messages = self.converter.init_messages();
         for init_message in init_messages.into_iter() {
             self.mqtt_publisher.send(init_message).await?;

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -2337,7 +2337,7 @@ pub(crate) async fn spawn_c8y_mapper_actor(
     )
     .unwrap();
 
-    let mut actor = c8y_mapper_builder.build();
+    let actor = c8y_mapper_builder.build();
     tokio::spawn(async move { actor.run().await });
 
     (

--- a/crates/extensions/collectd_ext/src/actor.rs
+++ b/crates/extensions/collectd_ext/src/actor.rs
@@ -30,7 +30,7 @@ impl Actor for CollectdActor {
         "collectd"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         while let Some(message) = self.messages.recv().await {
             match CollectdMessage::parse_from(&message) {
                 Ok(collectd_message) => {

--- a/crates/extensions/tedge_config_manager/src/actor.rs
+++ b/crates/extensions/tedge_config_manager/src/actor.rs
@@ -59,7 +59,7 @@ impl Actor for ConfigManagerActor {
         "ConfigManager"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         self.reload_supported_config_types().await?;
 
         while let Some(event) = self.input_receiver.recv().await {

--- a/crates/extensions/tedge_config_manager/src/tests.rs
+++ b/crates/extensions/tedge_config_manager/src/tests.rs
@@ -120,7 +120,7 @@ fn spawn_config_manager_actor(
     UploaderMessageBox,
 ) {
     let (actor_builder, mqtt, fs, downloader, uploader) = new_config_manager_builder(temp_dir);
-    let mut actor = actor_builder.build();
+    let actor = actor_builder.build();
     tokio::spawn(async move { actor.run().await });
     (mqtt, fs, downloader, uploader)
 }

--- a/crates/extensions/tedge_file_system_ext/src/lib.rs
+++ b/crates/extensions/tedge_file_system_ext/src/lib.rs
@@ -121,7 +121,7 @@ impl Actor for FsWatchActor {
         "FsWatcher"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         let mut fs_notify = NotifyStream::try_default().map_err(Box::new)?;
         for (watch_path, _) in self.messages.get_watch_dirs().iter() {
             if let Err(err) = fs_notify.add_watcher(watch_path) {
@@ -180,7 +180,7 @@ mod tests {
 
         fs_actor_builder.register_peer(ttd.to_path_buf(), client_builder.get_sender());
 
-        let mut actor = fs_actor_builder.build();
+        let actor = fs_actor_builder.build();
         let client_box = client_builder.build();
 
         tokio::spawn(async move { actor.run().await });

--- a/crates/extensions/tedge_health_ext/src/actor.rs
+++ b/crates/extensions/tedge_health_ext/src/actor.rs
@@ -37,7 +37,7 @@ impl Actor for HealthMonitorActor {
         "HealthMonitorActor"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         self.messages.send(self.up_health_status()).await?;
         while let Some(_message) = self.messages.recv().await {
             {

--- a/crates/extensions/tedge_health_ext/src/tests.rs
+++ b/crates/extensions/tedge_health_ext/src/tests.rs
@@ -70,7 +70,7 @@ async fn spawn_a_health_check_actor(
 
     let health_actor = HealthMonitorBuilder::new(service_to_be_monitored, &mut health_mqtt_builder);
 
-    let mut actor = health_actor.build();
+    let actor = health_actor.build();
     tokio::spawn(async move { actor.run().await });
 
     health_mqtt_builder.build()

--- a/crates/extensions/tedge_log_manager/src/actor.rs
+++ b/crates/extensions/tedge_log_manager/src/actor.rs
@@ -54,7 +54,7 @@ impl Actor for LogManagerActor {
         "LogManager"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         self.reload_supported_log_types().await?;
 
         while let Some(event) = self.messages.recv().await {

--- a/crates/extensions/tedge_log_manager/src/tests.rs
+++ b/crates/extensions/tedge_log_manager/src/tests.rs
@@ -127,7 +127,7 @@ fn spawn_log_manager_actor(
     UploaderMessageBox,
 ) {
     let (actor_builder, mqtt, fs, uploader) = new_log_manager_builder(temp_dir);
-    let mut actor = actor_builder.build();
+    let actor = actor_builder.build();
     tokio::spawn(async move { actor.run().await });
     (mqtt, fs, uploader)
 }

--- a/crates/extensions/tedge_mqtt_ext/src/tests.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/tests.rs
@@ -183,6 +183,6 @@ async fn communicate_over_mqtt() {
 }
 
 async fn mqtt_actor(builder: MqttActorBuilder) {
-    let mut mqtt_actor = builder.build();
+    let mqtt_actor = builder.build();
     mqtt_actor.run().await.unwrap()
 }

--- a/crates/extensions/tedge_signal_ext/src/lib.rs
+++ b/crates/extensions/tedge_signal_ext/src/lib.rs
@@ -69,7 +69,7 @@ impl Actor for SignalActor {
         "Signal-Handler"
     }
 
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         let mut signals = Signals::new([SIGTERM, SIGINT, SIGQUIT]).unwrap(); // FIXME
         loop {
             tokio::select! {

--- a/crates/extensions/tedge_timer_ext/src/actor.rs
+++ b/crates/extensions/tedge_timer_ext/src/actor.rs
@@ -196,7 +196,7 @@ impl Actor for TimerActor {
     ///
     /// When an explicit [RuntimeRequest::Shutdown] is received,
     /// all the pending timers are simply aborted.
-    async fn run(&mut self) -> Result<(), RuntimeError> {
+    async fn run(mut self) -> Result<(), RuntimeError> {
         loop {
             if let Some(current) = self.current_timer.take() {
                 let time_elapsed = current.sleep;

--- a/crates/extensions/tedge_timer_ext/src/tests.rs
+++ b/crates/extensions/tedge_timer_ext/src/tests.rs
@@ -149,7 +149,7 @@ async fn spawn_timer_actor<T: Message>(
     let signal_sender = builder.get_signal_sender();
 
     tokio::spawn(async move {
-        let mut actor = builder.build();
+        let actor = builder.build();
         let _ = actor.run().await;
     });
 


### PR DESCRIPTION
## Proposed changes
In #2327, some changes have been made that assume we only run `MqttActor::run` once. As far as I can tell, we only ever want to run actors once, but some complexity around calling consuming methods (i.e. those which take an owned `self` argument) from `Box<dyn Actor>` prevented us from doing that. I've managed to work around this and modified `Actor::run` to receive `self` instead of `&mut self`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

