### PR TITLE
Add reference documentation for `c8y_auth_proxy`

### DIFF
--- a/docs/src/references/tedge-cumulocity-proxy.md
+++ b/docs/src/references/tedge-cumulocity-proxy.md
@@ -17,8 +17,9 @@ configuration
 
 For example, you can access the current tenant information
 at [http://127.0.0.1:8001/c8y/tenant/currentTenant](http://127.0.0.1:8001/c8y/tenant/currentTenant)
-from the machine running `tedge-mapper`. The server supports all possible request methods (
-e.g. `HEAD`/`GET`/`PUT`/`PATCH`/`DELETE`).
+from the machine running `tedge-mapper`.
+The server supports all public REST APIs of Cumulocity, and all possible request methods
+(e.g. `HEAD`/`GET`/`PUT`/`PATCH`/`DELETE`).
 There is no need to provide an `Authorization` header (or any other authentication method) when accessing the API.
 If an `Authorization` header is provided, this will be used to authenticate the request instead of the device JWT.
 

--- a/docs/src/references/tedge-cumulocity-proxy.md
+++ b/docs/src/references/tedge-cumulocity-proxy.md
@@ -6,22 +6,27 @@ sidebar_position: 12
 
 # Thin Edge Cumulocity Proxy
 
-The `tedge-mapper` (when running in `c8y` mode) hosts a proxy server to access the Cumulocity HTTP API as the thin-edge
-device. It automatically handles authenticating with a JWT, avoiding the need for clients to support MQTT to retrieve
-this information.
+The `tedge-mapper` (when running in `c8y` mode) hosts a proxy server to access the Cumulocity HTTP API from the
+thin-edge device.
+It automatically handles authenticating with a JWT, avoiding the need for clients to support MQTT to retrieve this
+information.
 
-The API can be accessed at `http://{ip}:8001/c8y/{c8y-endpoint}`. `ip` is configured using
-the `c8y.proxy.bind.address` configuration (the default value is `127.0.0.1`) and the port can be changed by
-setting `c8y.proxy.bind.port`.
+The API can be accessed at `http://{ip}:8001/c8y/{c8y-endpoint}`. `ip` is configured using the `c8y.proxy.bind.address`
+configuration
+(the default value is `127.0.0.1`) and the port can be changed by setting `c8y.proxy.bind.port`.
 
 For example, you can access the current tenant information
-at [http://127.0.0.1:8001/c8y/tenant/currentTenant](http://127.0.0.1:8001/c8y/tenant/currentTenant) from the
-machine running `tedge-mapper`. The server supports all possible request methods (
+at [http://127.0.0.1:8001/c8y/tenant/currentTenant](http://127.0.0.1:8001/c8y/tenant/currentTenant)
+from the machine running `tedge-mapper`. The server supports all possible request methods (
 e.g. `HEAD`/`GET`/`PUT`/`PATCH`/`DELETE`).
+There is no need to provide an `Authorization` header (or any other authentication method) when accessing the API.
+If an `Authorization` header is provided, this will be used to authenticate the request instead of the device JWT.
 
-At the time of writing, this service is unauthenticated and does not support incoming HTTPS connections (when the
-request is forwarded to Cumulocity, however, this will use HTTPS). Due to the underlying JWT handling in Cumulocity,
-requests to the proxy API are occasionally spuriously rejected with a `401 Not Authorized` status code. The proxy server
-currently forwards this response directly to the client, as well as all other errors responses from Cumulocity. If there
-is an error connecting to Cumulocity to make the request, a plain text response with the status code `502 Bad Gateway`
-will be returned.
+At the time of writing, this service is unauthenticated and does not support incoming HTTPS connections
+(when the request is forwarded to Cumulocity, however, this will use HTTPS).
+Due to the underlying JWT handling in Cumulocity, requests to the proxy API are occasionally spuriously rejected with
+a `401 Not Authorized` status code.
+The proxy server currently forwards this response directly to the client, as well as all other errors responses from
+Cumulocity.
+If there is an error connecting to Cumulocity to make the request, a plain text response with the status
+code `502 Bad Gateway` will be returned.

--- a/docs/src/references/tedge-cumulocity-proxy.md
+++ b/docs/src/references/tedge-cumulocity-proxy.md
@@ -1,0 +1,27 @@
+---
+title: Thin Edge Cumulocity HTTP Proxy
+tags: [ Reference, HTTP, Cumulocity ]
+sidebar_position: 12
+---
+
+# Thin Edge Cumulocity Proxy
+
+The `tedge-mapper` (when running in `c8y` mode) hosts a proxy server to access the Cumulocity HTTP API as the thin-edge
+device. It automatically handles authenticating with a JWT, avoiding the need for clients to support MQTT to retrieve
+this information.
+
+The API can be accessed at `http://{ip}:8001/c8y/{c8y-endpoint}`. `ip` is configured using
+the `c8y.proxy.bind.address` configuration (the default value is `127.0.0.1`) and the port can be changed by
+setting `c8y.proxy.bind.port`.
+
+For example, you can access the current tenant information
+at [http://127.0.0.1:8001/c8y/tenant/currentTenant](http://127.0.0.1:8001/c8y/tenant/currentTenant) from the
+machine running `tedge-mapper`. The server supports all possible request methods (
+e.g. `HEAD`/`GET`/`PUT`/`PATCH`/`DELETE`).
+
+At the time of writing, this service is unauthenticated and does not support incoming HTTPS connections (when the
+request is forwarded to Cumulocity, however, this will use HTTPS). Due to the underlying JWT handling in Cumulocity,
+requests to the proxy API are occasionally spuriously rejected with a `401 Not Authorized` status code. The proxy server
+currently forwards this response directly to the client, as well as all other errors responses from Cumulocity. If there
+is an error connecting to Cumulocity to make the request, a plain text response with the status code `502 Bad Gateway`
+will be returned.


### PR DESCRIPTION
## Proposed changes
This PR adds some public facing documentation for c8y_auth_proxy, so customers know it exists and can make use of it if they wish. It also improves the proxy's handling of large bodies, proactively checking the JWT is valid before making the real request.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2174

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

