### PR TITLE
Add try_get() and try_get_by_external_id() to entity_store

### DIFF
--- a/crates/core/tedge_api/src/entity_store.rs
+++ b/crates/core/tedge_api/src/entity_store.rs
@@ -164,10 +164,25 @@ impl EntityStore {
         self.entities.get(entity_topic_id)
     }
 
-    /// Returns information for an entity under a given device/service id .
+    /// Tries to get information about an entity under a given MQTT entity topic identifier.
+    pub fn try_get(&self, entity_topic_id: &EntityTopicId) -> Result<&EntityMetadata, Error> {
+        self.get(entity_topic_id)
+            .ok_or_else(|| Error::UnknownEntity(entity_topic_id.to_string()))
+    }
+
+    /// Returns information for an entity under a given device/service id.
     pub fn get_by_external_id(&self, external_id: &EntityExternalId) -> Option<&EntityMetadata> {
         let topic_id = self.entity_id_index.get(external_id)?;
         self.get(topic_id)
+    }
+
+    /// Tries to get information for an entity under a given device/service id.
+    pub fn try_get_by_external_id(
+        &self,
+        external_id: &EntityExternalId,
+    ) -> Result<&EntityMetadata, Error> {
+        self.get_by_external_id(external_id)
+            .ok_or_else(|| Error::UnknownEntity(external_id.into()))
     }
 
     /// Returns the MQTT identifier of the main device.

--- a/crates/core/tedge_api/src/entity_store.rs
+++ b/crates/core/tedge_api/src/entity_store.rs
@@ -164,7 +164,8 @@ impl EntityStore {
         self.entities.get(entity_topic_id)
     }
 
-    /// Tries to get information about an entity under a given MQTT entity topic identifier.
+    /// Tries to get information about an entity using its `EntityTopicId`,
+    /// returning an error if the entity is not registered.
     pub fn try_get(&self, entity_topic_id: &EntityTopicId) -> Result<&EntityMetadata, Error> {
         self.get(entity_topic_id)
             .ok_or_else(|| Error::UnknownEntity(entity_topic_id.to_string()))
@@ -176,7 +177,8 @@ impl EntityStore {
         self.get(topic_id)
     }
 
-    /// Tries to get information for an entity under a given device/service id.
+    /// Tries to get information about an entity using its `EntityExternalId`,
+    /// returning an error if the entity is not registered.
     pub fn try_get_by_external_id(
         &self,
         external_id: &EntityExternalId,

--- a/crates/extensions/c8y_mapper_ext/src/error.rs
+++ b/crates/extensions/c8y_mapper_ext/src/error.rs
@@ -130,11 +130,8 @@ pub enum ConversionError {
 #[derive(thiserror::Error, Debug)]
 #[allow(clippy::enum_variant_names)]
 pub enum CumulocityMapperError {
-    #[error("Unknown device id: '{device_id}'")]
-    UnknownDevice { device_id: String },
-
-    #[error("Unregistered device topic: '{topic_id}'")]
-    UnregisteredDevice { topic_id: String },
+    #[error(transparent)]
+    FromEntityStore(#[from] tedge_api::entity_store::Error),
 
     #[error(transparent)]
     InvalidTopicError(#[from] tedge_api::TopicError),


### PR DESCRIPTION
## Proposed changes
As commented in https://github.com/thin-edge/thin-edge.io/pull/2303#discussion_r1356364285, we have many patterns using `get()` or `get_by_external_id()` and map them `None` to `Err`. We should stop the same mapping every time.

The new API methods return `Error::UnknownEntity` instead of `None`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2303 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

