### PR TITLE
Health status on AWS and Azure mappers

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -420,7 +420,7 @@ define_tedge_config! {
 
         /// Set of MQTT topics the Azure IoT mapper should subscribe to
         #[tedge_config(example = "te/+/+/+/+/a/+,te/+/+/+/+/m/+,te/+/+/+/+/e/+")]
-        #[tedge_config(default(value = "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+,tedge/health/+,tedge/health/+/+"))]
+        #[tedge_config(default(value = "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+,te/+/+/+/+/status/health"))]
         topics: TemplatesSet,
     },
 
@@ -444,7 +444,7 @@ define_tedge_config! {
 
         /// Set of MQTT topics the AWS IoT mapper should subscribe to
         #[tedge_config(example = "te/+/+/+/+/a/+,te/+/+/+/+/m/+,te/+/+/+/+/e/+")]
-        #[tedge_config(default(value = "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+,tedge/health/+,tedge/health/+/+"))]
+        #[tedge_config(default(value = "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+,te/+/+/+/+/status/health"))]
         topics: TemplatesSet,
     },
 

--- a/crates/core/tedge/src/cli/connect/bridge_config_aws.rs
+++ b/crates/core/tedge/src/cli/connect/bridge_config_aws.rs
@@ -2,6 +2,8 @@ use crate::cli::connect::BridgeConfig;
 use camino::Utf8PathBuf;
 use tedge_config::ConnectUrl;
 
+const MOSQUITTO_BRIDGE_TOPIC: &str = "te/device/main/service/mosquitto-aws-bridge/status/health";
+
 #[derive(Debug, Eq, PartialEq)]
 pub struct BridgeConfigAwsParams {
     pub connect_url: ConnectUrl,
@@ -62,7 +64,7 @@ impl From<BridgeConfigAwsParams> for BridgeConfig {
             local_clean_session: false,
             notifications: true,
             notifications_local_only: true,
-            notification_topic: "tedge/health/mosquitto-aws-bridge".into(),
+            notification_topic: MOSQUITTO_BRIDGE_TOPIC.into(),
             bridge_attempt_unsubscribe: false,
             topics: vec![
                 pub_msg_topic,
@@ -117,7 +119,7 @@ fn test_bridge_config_from_aws_params() -> anyhow::Result<()> {
         local_clean_session: false,
         notifications: true,
         notifications_local_only: true,
-        notification_topic: "tedge/health/mosquitto-aws-bridge".into(),
+        notification_topic: MOSQUITTO_BRIDGE_TOPIC.into(),
         bridge_attempt_unsubscribe: false,
     };
 

--- a/crates/core/tedge/src/cli/connect/bridge_config_azure.rs
+++ b/crates/core/tedge/src/cli/connect/bridge_config_azure.rs
@@ -2,6 +2,8 @@ use crate::cli::connect::BridgeConfig;
 use camino::Utf8PathBuf;
 use tedge_config::ConnectUrl;
 
+const MOSQUITTO_BRIDGE_TOPIC: &str = "te/device/main/service/mosquitto-az-bridge/status/health";
+
 #[derive(Debug, Eq, PartialEq)]
 pub struct BridgeConfigAzureParams {
     pub connect_url: ConnectUrl,
@@ -54,7 +56,7 @@ impl From<BridgeConfigAzureParams> for BridgeConfig {
             local_clean_session: false,
             notifications: true,
             notifications_local_only: true,
-            notification_topic: "tedge/health/mosquitto-az-bridge".into(),
+            notification_topic: MOSQUITTO_BRIDGE_TOPIC.into(),
             bridge_attempt_unsubscribe: false,
             topics: vec![
                 // See Azure IoT Hub documentation for detailed explanation on the topics
@@ -117,7 +119,7 @@ fn test_bridge_config_from_azure_params() -> anyhow::Result<()> {
         local_clean_session: false,
         notifications: true,
         notifications_local_only: true,
-        notification_topic: "tedge/health/mosquitto-az-bridge".into(),
+        notification_topic: MOSQUITTO_BRIDGE_TOPIC.into(),
         bridge_attempt_unsubscribe: false,
     };
 

--- a/crates/core/tedge_api/src/health.rs
+++ b/crates/core/tedge_api/src/health.rs
@@ -5,7 +5,6 @@ use clock::Clock;
 use clock::WallClock;
 use mqtt_channel::Message;
 use mqtt_channel::Topic;
-use mqtt_channel::TopicFilter;
 use serde_json::json;
 use std::process;
 use std::sync::Arc;
@@ -77,17 +76,6 @@ impl ServiceHealthTopic {
 
 #[derive(Debug)]
 pub struct HealthTopicError;
-
-// TODO: remove below functions once components moved to new health topics
-
-pub fn health_check_topics(daemon_name: &str) -> TopicFilter {
-    vec![
-        "tedge/health-check".into(),
-        format!("tedge/health-check/{daemon_name}"),
-    ]
-    .try_into()
-    .expect("Invalid topic filter")
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/tedge_api/src/health.rs
+++ b/crates/core/tedge_api/src/health.rs
@@ -89,20 +89,6 @@ pub fn health_check_topics(daemon_name: &str) -> TopicFilter {
     .expect("Invalid topic filter")
 }
 
-pub fn is_bridge_health(topic: &str) -> bool {
-    if topic.starts_with("tedge/health") {
-        let substrings: Vec<String> = topic.split('/').map(String::from).collect();
-        if substrings.len() > 2 {
-            let bridge_splits: Vec<&str> = substrings[2].split('-').collect();
-            matches!(bridge_splits[..], ["mosquitto", _, "bridge"])
-        } else {
-            false
-        }
-    } else {
-        false
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/core/tedge_mapper/src/core/mapper.rs
+++ b/crates/core/tedge_mapper/src/core/mapper.rs
@@ -23,11 +23,9 @@ pub async fn start_basic_actors(
     //Instantiate health monitor actor
     let service = Service {
         service_topic_id: ServiceTopicId::new(
-            format!("device/main/service/{mapper_name}")
-                .parse::<EntityTopicId>()
-                .unwrap(),
+            EntityTopicId::default_main_service(mapper_name).unwrap(),
         ),
-        device_topic_id: DeviceTopicId::new("device/main//".parse::<EntityTopicId>().unwrap()),
+        device_topic_id: DeviceTopicId::new(EntityTopicId::default_main_device()),
     };
     let mqtt_schema = MqttSchema::with_root(config.mqtt.topic_root.clone());
     let health_actor = HealthMonitorBuilder::from_service_topic_id(

--- a/crates/extensions/c8y_firmware_manager/src/config.rs
+++ b/crates/extensions/c8y_firmware_manager/src/config.rs
@@ -7,12 +7,10 @@ use camino::Utf8PathBuf;
 use std::net::IpAddr;
 use std::path::Path;
 use std::time::Duration;
-use tedge_api::health::health_check_topics;
 use tedge_api::path::DataDir;
 use tedge_config::TEdgeConfig;
 use tedge_mqtt_ext::TopicFilter;
 
-const PLUGIN_SERVICE_NAME: &str = "c8y-firmware-plugin";
 const FIRMWARE_UPDATE_RESPONSE_TOPICS: &str = "tedge/+/commands/res/firmware_update";
 
 /// Configuration of the Firmware Manager
@@ -23,7 +21,6 @@ pub struct FirmwareManagerConfig {
     pub tmp_dir: Utf8PathBuf,
     pub data_dir: DataDir,
     pub c8y_request_topics: TopicFilter,
-    pub health_check_topics: TopicFilter,
     pub firmware_update_response_topics: TopicFilter,
     pub timeout_sec: Duration,
     pub c8y_end_point: C8yEndPoint,
@@ -42,7 +39,6 @@ impl FirmwareManagerConfig {
         let local_http_host = format!("{}:{}", local_http_address, local_http_port);
 
         let c8y_request_topics = C8yTopic::SmartRestRequest.into();
-        let health_check_topics = health_check_topics(PLUGIN_SERVICE_NAME);
         let firmware_update_response_topics =
             TopicFilter::new_unchecked(FIRMWARE_UPDATE_RESPONSE_TOPICS);
 
@@ -54,7 +50,6 @@ impl FirmwareManagerConfig {
             tmp_dir,
             data_dir,
             c8y_request_topics,
-            health_check_topics,
             firmware_update_response_topics,
             timeout_sec,
             c8y_end_point,

--- a/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
@@ -28,6 +28,8 @@ pub fn convert_health_status_message(
     let mut mqtt_messages: Vec<Message> = Vec::new();
 
     // If not Bridge health status
+    // FIXME: can also match "device/bridge//" or "/device/main/service/my_custom_bridge"
+    // should match ONLY the single mapper bridge
     if entity.topic_id.as_str().contains("bridge") {
         return mqtt_messages;
     }

--- a/tests/RobotFramework/tests/aws/aws_telemetry.robot
+++ b/tests/RobotFramework/tests/aws/aws_telemetry.robot
@@ -62,7 +62,6 @@ Publish health status message for main device service
 *** Keywords ***
 Custom Setup
     Setup
-    # Execute Command    sudo tedge config set aws.topics "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+"
     Execute Command    sudo systemctl start tedge-mapper-aws.service
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-aws
 

--- a/tests/RobotFramework/tests/aws/aws_telemetry.robot
+++ b/tests/RobotFramework/tests/aws/aws_telemetry.robot
@@ -55,11 +55,14 @@ Publish child device alarm to te alarm topic with alarm type
     Execute Command    tedge mqtt pub te/device/child///a/alarm-type '{"severity":"major","text": "someone logged-in"}'
     Should Have MQTT Messages    aws/td/device:child/a/alarm-type   message_contains="major"    date_from=${timestamp}   minimum=1    maximum=1
 
+Publish health status message for main device service
+    Execute Command    tedge mqtt pub te/device/main/service/test-service/status/health '{"status":"up"}'
+    Should Have MQTT Messages    aws/td/device:main:service:test-service/status/health    message_contains="status":"up"
 
 *** Keywords ***
 Custom Setup
     Setup
-    Execute Command    sudo tedge config set aws.topics "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+"
+    # Execute Command    sudo tedge config set aws.topics "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+"
     Execute Command    sudo systemctl start tedge-mapper-aws.service
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-aws
 

--- a/tests/RobotFramework/tests/azure/azure_telemetry.robot
+++ b/tests/RobotFramework/tests/azure/azure_telemetry.robot
@@ -67,11 +67,14 @@ Publish child device alarm to te alarm topic with alarm type
     Execute Command    tedge mqtt pub te/device/child///a/alarm-type '{"severity":"minor","text": "someone logged-in"}'
     Should Have MQTT Messages    az/messages/events/#   message_contains="minor"    date_from=${timestamp}   minimum=1    maximum=1
 
+Publish health status message for main device service
+    Execute Command    tedge mqtt pub te/device/main/service/test-service/status/health '{"status":"up"}'
+    Should Have MQTT Messages    az/messages/events/    message_contains="status":"up"
 
 *** Keywords ***
 Custom Setup
     Setup
-    Execute Command    sudo tedge config set az.topics "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+"
+    # Execute Command    sudo tedge config set az.topics "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+"
     Execute Command    sudo systemctl restart tedge-mapper-az.service
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-az
 

--- a/tests/RobotFramework/tests/azure/azure_telemetry.robot
+++ b/tests/RobotFramework/tests/azure/azure_telemetry.robot
@@ -74,7 +74,6 @@ Publish health status message for main device service
 *** Keywords ***
 Custom Setup
     Setup
-    # Execute Command    sudo tedge config set az.topics "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+"
     Execute Command    sudo systemctl restart tedge-mapper-az.service
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-az
 

--- a/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
+++ b/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
@@ -129,7 +129,7 @@ set/unset az.topics
     ${unset}    Execute Command    tedge config list
     Should Contain
     ...    ${unset}
-    ...    az.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "tedge/health/+", "tedge/health/+/+"]
+    ...    az.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
 
 set/unset aws.topics
     Execute Command    sudo tedge config set aws.topics topic1,topic2    # Changing aws.topics
@@ -142,7 +142,7 @@ set/unset aws.topics
     ${unset}    Execute Command    tedge config list
     Should Contain
     ...    ${unset}
-    ...    aws.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "tedge/health/+", "tedge/health/+/+"]
+    ...    aws.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
 
 set/unset aws.url
     Execute Command    sudo tedge config set aws.url your-endpoint.amazonaws.com    # Changing aws.url


### PR DESCRIPTION
## Proposed changes

This PR completes the migration to new health topics. Besides switching over AWS and Azure mappers to new health status topics, some leftovers of old health check topics were also removed.

`tedge/health/` and `tedge/health-check` topics now no longer appear in the integration test log (besides the test checking upgradability from previous version, which is expected).

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- #2351

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Next step will be to change or add relevant documentation related to health status/check messages and the health checking mechanism, as described in #2348.
