### PR TITLE
fix: support sending previously cleared twin property value

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/actor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/actor.rs
@@ -160,7 +160,10 @@ impl C8yMapperActor {
                         external_id: Some(child_external_id),
                         r#type: EntityType::ChildDevice,
                         parent: None,
-                        other: json!({ "name": child_name }),
+                        other: json!({ "name": child_name })
+                            .as_object()
+                            .unwrap()
+                            .to_owned(),
                     };
                     match self
                         .converter

--- a/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
@@ -150,7 +150,7 @@ mod tests {
             external_id: None,
             r#type: EntityType::Service,
             parent: None,
-            other: serde_json::json!({}),
+            other: serde_json::Map::new(),
         };
 
         entity_store

--- a/crates/extensions/tedge_health_ext/src/lib.rs
+++ b/crates/extensions/tedge_health_ext/src/lib.rs
@@ -76,7 +76,10 @@ impl HealthMonitorBuilder {
             external_id: None,
             r#type: EntityType::Service,
             parent: Some(service.device_topic_id.entity().clone()),
-            other: serde_json::json!({ "type": service_type }),
+            other: serde_json::json!({ "type": service_type })
+                .as_object()
+                .unwrap()
+                .to_owned(),
         };
         let registration_message = registration_message.to_mqtt_message(mqtt_schema);
 

--- a/crates/extensions/tedge_mqtt_ext/src/test_helpers.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/test_helpers.rs
@@ -72,7 +72,7 @@ where
     );
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MessagePayloadMatcher {
     StringMessage(&'static str),
     JsonMessage(serde_json::Value),

--- a/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry.robot
@@ -169,6 +169,23 @@ Thin-edge device supports sending inventory data via tedge topic to root fragmen
     Should Be Equal    ${mo["type"]}    thin-edge.io
     Should Be Equal    ${mo["name"]}    ${DEVICE_SN}
 
+
+Previously cleared property should be sent to cloud when set again #2365
+    [Tags]    \#2365
+    Cumulocity.Set Device    ${DEVICE_SN}
+
+    # set initial value
+    Execute Command    tedge mqtt pub --retain "te/device/main///twin/subtype" '"LinuxDeviceA"'
+    Device Should Have Fragment Values    subtype\=LinuxDeviceA
+
+    # Clear
+    Execute Command    tedge mqtt pub --retain "te/device/main///twin/subtype" ''
+    Managed Object Should Not Have Fragments    subtype
+
+    # Set to same value prior to clearing it
+    Execute Command    tedge mqtt pub --retain "te/device/main///twin/subtype" '"LinuxDeviceA"'
+    Device Should Have Fragment Values    subtype\=LinuxDeviceA
+
 #
 # Services
 #


### PR DESCRIPTION
## Proposed changes

The bug was caused by the mapper not removing the cleared fragment from its local inventory cache, when a clear twin data message is received. When the old value existed in the cache, the duplicate message that came after the clear message was getting ignored, because it is the same as the existing value.

Support setting twin property after it has been cleared.

Tasks:

* [x] System test
* [x] Rust implementation

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2365

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

