### PR TITLE
Fix auto-registration of child device op dirs #2389

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -754,7 +754,16 @@ impl CumulocityConverter {
             };
 
             let child_name = self.default_device_name_from_external_id(&child_external_id);
-            let child_topic_id = EntityTopicId::default_child_device(&child_name).unwrap();
+            let child_topic_id = match EntityTopicId::default_child_device(&child_name) {
+                Ok(topic_id) => topic_id,
+                Err(err) => {
+                    error!(
+                        "Child device directory: {} ignored due to {}",
+                        &child_name, err
+                    );
+                    continue;
+                }
+            };
             let child_device_reg_msg = EntityRegistrationMessage {
                 topic_id: child_topic_id,
                 external_id: Some(child_external_id.clone()),

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -752,14 +752,15 @@ impl CumulocityConverter {
                     continue;
                 }
             };
-            let child_topic_id =
-                EntityTopicId::default_child_device(child_external_id.as_ref()).unwrap();
+
+            let child_name = self.default_device_name_from_external_id(&child_external_id);
+            let child_topic_id = EntityTopicId::default_child_device(&child_name).unwrap();
             let child_device_reg_msg = EntityRegistrationMessage {
                 topic_id: child_topic_id,
                 external_id: Some(child_external_id.clone()),
                 r#type: EntityType::ChildDevice,
                 parent: None,
-                other: json!({ "name": child_external_id.as_ref() })
+                other: json!({ "name": child_name })
                     .as_object()
                     .unwrap()
                     .to_owned(),

--- a/tests/RobotFramework/tests/cumulocity/registration/device_registration.robot
+++ b/tests/RobotFramework/tests/cumulocity/registration/device_registration.robot
@@ -110,6 +110,57 @@ Register devices using custom MQTT schema
     Cumulocity.Set Device    ${DEVICE_SN}
     Cumulocity.Device Should Have Measurements    type=gateway_stats    minimum=1    maximum=1
 
+
+Register tedge-agent when tedge-mapper-c8y is not running #2389
+    [Teardown]    Start Service    tedge-mapper-c8y
+    Device Should Exist    ${DEVICE_SN}
+
+    Stop Service    tedge-mapper-c8y
+    Execute Command    cmd=timeout 5 env TEDGE_RUN_LOCK_FILES=false tedge-agent --mqtt-device-topic-id device/offlinechild1//    ignore_exit_code=${True}
+    Start Service    tedge-mapper-c8y
+
+    Should Be A Child Device Of Device    ${DEVICE_SN}:device:offlinechild1
+    Should Have MQTT Messages    te/device/offlinechild1//    minimum=1
+
+    Device Should Exist    ${DEVICE_SN}:device:offlinechild1
+    Cumulocity.Restart Device
+    Should Have MQTT Messages    te/device/offlinechild1///cmd/restart/+
+
+
+Register tedge-configuration-plugin when tedge-mapper-c8y is not running #2389
+    [Teardown]    Start Service    tedge-mapper-c8y
+    Device Should Exist    ${DEVICE_SN}
+
+    Stop Service    tedge-mapper-c8y
+    Execute Command    cmd=timeout 5 tedge-configuration-plugin --mqtt-device-topic-id device/offlinechild2//    ignore_exit_code=${True}
+    Start Service    tedge-mapper-c8y
+
+    Should Be A Child Device Of Device    ${DEVICE_SN}:device:offlinechild2
+    Should Have MQTT Messages    te/device/offlinechild2//    minimum=1
+
+    Device Should Exist    ${DEVICE_SN}:device:offlinechild2
+    Cumulocity.Get Configuration    dummy1
+    Should Have MQTT Messages    te/device/offlinechild2///cmd/config_snapshot/+
+
+
+Register tedge-log-plugin when tedge-mapper-c8y is not running #2389
+    [Teardown]    Start Service    tedge-mapper-c8y
+    Device Should Exist    ${DEVICE_SN}
+
+    Stop Service    tedge-mapper-c8y
+    Execute Command    cmd=timeout 5 tedge-log-plugin --mqtt-device-topic-id device/offlinechild3//    ignore_exit_code=${True}
+    Start Service    tedge-mapper-c8y
+
+    Should Be A Child Device Of Device    ${DEVICE_SN}:device:offlinechild3
+    Should Have MQTT Messages    te/device/offlinechild3//    minimum=1
+
+    Device Should Exist    ${DEVICE_SN}:device:offlinechild3
+    Cumulocity.Create Operation
+    ...    description=Log file request
+    ...    fragments={"c8y_LogfileRequest":{"dateFrom":"2023-01-01T01:00:00+0000","dateTo":"2023-01-02T01:00:00+0000","logFile":"example1","searchText":"first","maximumLines":10}}
+    Should Have MQTT Messages    te/device/offlinechild3///cmd/log_upload/+
+
+
 *** Keywords ***
 
 Check Child Device


### PR DESCRIPTION
## Proposed changes

If the child device directory the child device operation directories follow the default external id naming scheme, they are auto-registered with the right topic id and name derived from that external id.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2389

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

