### PR TITLE
Add certificate based authentication to c8y-auth-proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,18 +41,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "anstream"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -64,15 +64,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
 dependencies = [
  "utf8parse",
 ]
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -104,6 +104,12 @@ checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 dependencies = [
  "backtrace",
 ]
+
+[[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "asn1-rs"
@@ -127,7 +133,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
  "synstructure",
@@ -139,7 +145,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -163,7 +169,7 @@ dependencies = [
  "anstyle",
  "bstr",
  "doc-comment",
- "predicates 3.0.3",
+ "predicates 3.0.4",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -177,9 +183,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compat"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b48b4ff0c2026db683dea961cd8ea874737f56cffca86fa84415eaddc51c00d"
+checksum = "f68a707c1feb095d8c07f8a65b9f506b117d30af431cab89374357de7c11461b"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -212,13 +218,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.73"
+version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -250,9 +256,12 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "autocfg"
@@ -337,9 +346,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
 dependencies = [
  "heck",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447f28c85900215cc1bea282f32d4a2f22d55c5a300afdfbc661c8d6a632e063"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -409,9 +438,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "batcher"
@@ -446,9 +475,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "block-buffer"
@@ -461,32 +490,38 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "c79ad7fb2dd38f3dabd76b09c6a5a20c038fc0213ef1e9afd30eb777f120f019"
 dependencies = [
  "memchr",
- "regex-automata 0.3.7",
+ "regex-automata 0.4.3",
  "serde",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "bytemuck"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 dependencies = [
  "serde",
 ]
@@ -602,7 +637,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "toml 0.7.6",
+ "toml 0.7.8",
  "url",
  "ws_stream_tungstenite",
 ]
@@ -632,7 +667,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "toml 0.7.6",
+ "toml 0.7.8",
  "tracing",
 ]
 
@@ -640,20 +675,31 @@ dependencies = [
 name = "c8y_auth_proxy"
 version = "0.12.0"
 dependencies = [
+ "assert_matches",
  "axum",
+ "axum-server",
  "c8y_http_proxy",
+ "camino",
  "env_logger",
  "futures",
  "hyper",
  "miette",
  "mockito",
+ "rcgen",
  "reqwest",
+ "ring 0.16.20",
+ "rustls",
+ "rustls-pemfile",
  "tedge_actors",
  "tedge_config",
+ "tedge_config_macros",
  "tedge_http_ext",
  "tokio",
+ "tokio-rustls",
+ "tower",
  "tracing",
  "url",
+ "x509-parser 0.14.0",
 ]
 
 [[package]]
@@ -676,7 +722,7 @@ dependencies = [
  "tedge_utils",
  "thiserror",
  "tokio",
- "toml 0.7.6",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -789,7 +835,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "toml 0.7.6",
+ "toml 0.7.8",
  "tracing",
 ]
 
@@ -838,9 +884,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.2"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -848,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
 dependencies = [
  "anstream",
  "anstyle",
@@ -865,9 +911,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
 dependencies = [
  "heck",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -997,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
 dependencies = [
  "csv-core",
  "itoa",
@@ -1009,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
 ]
@@ -1044,7 +1090,7 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "strsim",
  "syn 1.0.109",
@@ -1058,10 +1104,10 @@ checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "strsim",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1083,7 +1129,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1108,10 +1154,11 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -1137,9 +1184,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1172,7 +1219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74073dd10495ce912909655131925b0459d49363751b93676148d843097fe825"
 dependencies = [
  "darling 0.13.4",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -1188,6 +1235,7 @@ name = "download"
 version = "0.12.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "backoff",
  "log",
  "mockito",
@@ -1196,6 +1244,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tedge_actors",
  "tedge_utils",
  "tempfile",
  "test-case",
@@ -1250,23 +1299,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
- "errno-dragonfly",
  "libc",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -1280,22 +1318,22 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "figment"
-version = "0.10.10"
+version = "0.10.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4547e226f4c9ab860571e070a9034192b3175580ecea38da34fcdb53a018c9a5"
+checksum = "a014ac935975a70ad13a3bff2463b1c1b083b35ae4cb6309cfc59476aa7a181f"
 dependencies = [
  "atomic",
  "parking_lot",
  "pear",
  "serde",
  "tempfile",
- "toml 0.7.6",
+ "toml 0.8.2",
  "uncased",
  "version_check",
 ]
@@ -1308,7 +1346,7 @@ checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
 ]
 
@@ -1326,6 +1364,7 @@ name = "flockfile"
 version = "0.12.0"
 dependencies = [
  "assert_matches",
+ "miette",
  "nix",
  "tempfile",
  "thiserror",
@@ -1430,9 +1469,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1545,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "heck"
@@ -1557,15 +1596,24 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "http"
@@ -1674,12 +1722,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -1750,6 +1798,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,15 +1869,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linked-hash-map"
@@ -1830,15 +1887,15 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1866,7 +1923,7 @@ dependencies = [
  "tedge_utils",
  "thiserror",
  "time",
- "toml 0.7.6",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -1906,15 +1963,15 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.6.1"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f478948fd84d9f8e86967bf432640e46adfb5a4bd4f14ef7e864ab38220534ae"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "memoffset"
@@ -1951,7 +2008,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "hyper",
  "indexmap 1.9.3",
  "ipnet",
@@ -1969,9 +2026,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2016,9 +2073,9 @@ version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2076,22 +2133,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "mockito"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c762b6267c4593555bb38f1df19e9318985bc4de60b5e8462890856a9a5b4c"
+checksum = "f8d3038e23466858569c2d30a537f691fa0d53b51626630ae08262943e3bbb8b"
 dependencies = [
  "assert-json-diff",
  "colored",
  "futures",
  "hyper",
- "lazy_static",
  "log",
  "rand",
  "regex",
@@ -2228,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
  "libm",
@@ -2257,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -2328,13 +2384,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -2368,10 +2424,10 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da9f0f13dac8069c139e8300a6510e3f4143ecf5259c60b116a9b271b4ca0d54"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "proc-macro2-diagnostics",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2391,9 +2447,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
+checksum = "c022f1e7b65d6a24c0dbbd5fb344c66881bc01f3e5ae74a1c8100f2f985d98a4"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2402,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bee7be22ce7918f641a33f08e3f43388c7656772244e2bbb2477f44cc9021a"
+checksum = "35513f630d46400a977c4cb58f78e1bfbe01434316e60c37d27b9ad6139c66d8"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2412,22 +2468,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1511785c5e98d79a05e8a6bc34b4ac2168a0e3e92161862030ad84daa223141"
+checksum = "bc9fc1b9e7057baba189b5c626e2d6f40681ae5b6eb064dc7c7834101ec8123a"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.3"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42f0394d3123e33353ca5e1e89092e533d2cc490389f2bd6131c43c634ebc5f"
+checksum = "1df74e9e7ec4053ceb980e7c0c8bd3594e977fde1af91daba9c928e8e8c6708d"
 dependencies = [
  "once_cell",
  "pest",
@@ -2459,9 +2515,9 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2506,6 +2562,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2519,7 +2581,7 @@ checksum = "59230a63c37f3e18569bdb90e4a89cbf5bf8b06fea0b84e65ea10cc4df47addd"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.5",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -2527,13 +2589,13 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
 dependencies = [
  "anstyle",
  "difflib",
- "itertools",
+ "itertools 0.11.0",
  "predicates-core",
 ]
 
@@ -2560,7 +2622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
  "version_check",
@@ -2572,7 +2634,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "version_check",
 ]
@@ -2588,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2601,28 +2663,28 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
  "version_check",
  "yansi 1.0.0-rc.1",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
- "byteorder",
+ "bit-vec",
+ "bitflags 2.4.1",
  "lazy_static",
  "num-traits",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2665,7 +2727,7 @@ version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
 ]
 
 [[package]]
@@ -2723,7 +2785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6413f3de1edee53342e6138e75b56d32e7bc6e332b3bd62d497b1929d4cfbcdd"
 dependencies = [
  "pem",
- "ring",
+ "ring 0.16.20",
  "time",
  "yasna",
  "zeroize",
@@ -2739,15 +2801,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.4"
+name = "redox_syscall"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.7",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2761,13 +2832,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.7"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2783,12 +2854,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
-name = "reqwest"
-version = "0.11.20"
+name = "regex-syntax"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "reqwest"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2811,6 +2888,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "system-configuration",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -2833,9 +2911,23 @@ dependencies = [
  "libc",
  "once_cell",
  "spin 0.5.2",
- "untrusted",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb0205304757e5d899b9c2e448b867ffd03ae7f988002e47cd24954391394d0b"
+dependencies = [
+ "cc",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2891,7 +2983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
 dependencies = [
  "cfg-if",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "rustc_version",
  "syn 1.0.109",
@@ -2910,7 +3002,7 @@ dependencies = [
  "log",
  "rustls-native-certs",
  "rustls-pemfile",
- "rustls-webpki 0.100.2",
+ "rustls-webpki 0.100.3",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -2932,7 +3024,7 @@ dependencies = [
  "parking_lot",
  "rand",
  "rustls-pemfile",
- "rustls-webpki 0.101.4",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
  "slab",
@@ -2980,11 +3072,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.10"
+version = "0.38.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6248e1caa625eb708e266e06159f135e8c26f2bb7ceb72dc4b2766d0340964"
+checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2993,13 +3085,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki 0.101.4",
+ "ring 0.17.5",
+ "rustls-webpki 0.101.7",
  "sct",
 ]
 
@@ -3021,27 +3113,27 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.3",
+ "base64 0.21.4",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.2"
+version = "0.100.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98ff011474fa39949b7e5c0428f9b4937eda7da7848bbb947786b7be0b27dab"
+checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.5",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3112,8 +3204,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
- "ring",
- "untrusted",
+ "ring 0.16.20",
+ "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -3141,28 +3233,28 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3176,9 +3268,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -3236,7 +3328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1b95bb2f4f624565e8fe8140c789af7e2082c0e0561b5a82a1b678baa9703dc"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "rustversion",
  "syn 1.0.109",
@@ -3255,9 +3347,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3266,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3290,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -3336,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -3357,15 +3449,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smawk"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
@@ -3379,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -3415,7 +3507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "rustversion",
  "syn 1.0.109",
@@ -3423,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "supports-color"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4950e7174bffabe99455511c39707310e7e9b440364a2fcb1cc21521be57b354"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
 dependencies = [
  "is-terminal",
  "is_ci",
@@ -3466,18 +3558,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "unicode-ident",
 ]
@@ -3494,10 +3586,31 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3516,6 +3629,7 @@ dependencies = [
  "clap",
  "doku",
  "hyper",
+ "miette",
  "mockito",
  "mqtt_tests",
  "nix",
@@ -3540,7 +3654,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "tokio",
- "toml 0.7.6",
+ "toml 0.7.8",
  "tracing",
  "url",
  "which",
@@ -3561,6 +3675,8 @@ dependencies = [
  "log",
  "path-clean",
  "plugin_sm",
+ "rcgen",
+ "reqwest",
  "routerify",
  "serde",
  "serde_json",
@@ -3577,7 +3693,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "toml 0.7.6",
+ "toml 0.7.8",
  "tracing",
  "which",
 ]
@@ -3662,6 +3778,7 @@ dependencies = [
  "clock",
  "collectd_ext",
  "flockfile",
+ "miette",
  "mqtt_channel",
  "tedge_actors",
  "tedge_api",
@@ -3706,6 +3823,7 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
+ "miette",
  "thiserror",
  "tokio",
 ]
@@ -3755,7 +3873,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror",
- "toml 0.7.6",
+ "toml 0.7.8",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3781,18 +3899,18 @@ version = "0.12.0"
 dependencies = [
  "darling 0.20.3",
  "heck",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "tedge_config_macros-macro"
 version = "0.12.0"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
  "tedge_config_macros-impl",
 ]
 
@@ -3818,7 +3936,7 @@ dependencies = [
  "tedge_utils",
  "thiserror",
  "tokio",
- "toml 0.7.6",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -3950,7 +4068,7 @@ dependencies = [
  "anyhow",
  "camino",
  "tempfile",
- "toml 0.7.6",
+ "toml 0.7.8",
 ]
 
 [[package]]
@@ -4005,17 +4123,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.0",
- "redox_syscall",
+ "fastrand 2.0.1",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
 ]
@@ -4053,7 +4171,7 @@ checksum = "e45b7bf6e19353ddd832745c8fcf77a17a93171df7151187f26623f2b75b5b26"
 dependencies = [
  "cfg-if",
  "proc-macro-error",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
  "syn 1.0.109",
 ]
@@ -4071,22 +4189,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -4101,14 +4219,15 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
  "itoa",
  "libc",
  "num_threads",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -4116,15 +4235,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
 dependencies = [
  "time-core",
 ]
@@ -4146,9 +4265,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4158,7 +4277,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -4169,9 +4288,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -4186,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4209,14 +4328,26 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
@@ -4230,11 +4361,24 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.0.2",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap 2.0.2",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4271,11 +4415,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -4284,20 +4427,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4367,9 +4510,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
@@ -4400,9 +4543,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4421,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-xid"
@@ -4442,6 +4585,12 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "upload"
@@ -4500,9 +4649,9 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "value-bag"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
+checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
 
 [[package]]
 name = "version_check"
@@ -4521,9 +4670,9 @@ dependencies = [
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -4563,9 +4712,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -4597,9 +4746,9 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2 1.0.69",
  "quote 1.0.33",
- "syn 2.0.29",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4635,13 +4784,14 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.4.0"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
 dependencies = [
  "either",
- "libc",
+ "home",
  "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -4672,9 +4822,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]
@@ -4819,9 +4969,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.5.15"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
 dependencies = [
  "memchr",
 ]
@@ -4843,7 +4993,7 @@ source = "git+https://github.com/swanandx/ws_stream_tungstenite?rev=1dc6b3f52672
 dependencies = [
  "async-tungstenite",
  "async_io_stream",
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "futures-core",
  "futures-io",
  "futures-sink",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ rand = "0.8"
 rcgen = { version = "0.9", features = ["pem", "zeroize"] }
 regex = "1.4"
 reqwest = { version = "0.11", default-features = false }
+ring = "0.16"
 routerify = "3.0"
 rpassword = "5.0"
 rstest = "0.16.0"

--- a/crates/common/download/Cargo.toml
+++ b/crates/common/download/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
+async-trait = { workspace = true }
 backoff = { workspace = true }
 log = { workspace = true }
 nix = { workspace = true }
@@ -19,6 +20,7 @@ reqwest = { workspace = true, features = [
 ] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+tedge_actors = { workspace = true }
 tedge_utils = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }

--- a/crates/common/download/src/lib.rs
+++ b/crates/common/download/src/lib.rs
@@ -45,7 +45,11 @@
 mod download;
 mod error;
 
-pub use crate::download::Auth;
+pub use crate::download::AnonymisedAuth;
+pub use crate::download::ClientAuth;
 pub use crate::download::DownloadInfo;
 pub use crate::download::Downloader;
+pub use crate::download::IdentityInjector;
+pub use crate::download::NeverAuth;
+pub use crate::download::RequiredAuth;
 pub use crate::error::DownloadError;

--- a/crates/common/flockfile/Cargo.toml
+++ b/crates/common/flockfile/Cargo.toml
@@ -9,6 +9,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
+miette = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/common/flockfile/src/unix.rs
+++ b/crates/common/flockfile/src/unix.rs
@@ -1,3 +1,4 @@
+use miette::Diagnostic;
 use nix::errno::Errno::EACCES;
 use nix::errno::Errno::EAGAIN;
 use nix::fcntl::flock;
@@ -18,7 +19,7 @@ use tracing::warn;
 
 const LOCK_CHILD_DIRECTORY: &str = "lock/";
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Diagnostic)]
 pub enum FlockfileError {
     #[error("Couldn't create file lock.")]
     FromIo {

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -395,7 +395,16 @@ define_tedge_config! {
                 /// The port used for the local Cumulocity HTTP proxy
                 #[tedge_config(example = "8001", default(value = 8001u16))]
                 port: u16,
-            }
+            },
+
+            /// The certificate file which is used by proxy listener
+            #[tedge_config(default(from_optional_key="mqtt.external.cert_file"))]
+            #[doku(as = "PathBuf")]
+            cert_file: Utf8PathBuf,
+
+            #[tedge_config(default(from_optional_key="mqtt.external.key_file"))]
+            #[doku(as = "PathBuf")]
+            key_file: Utf8PathBuf,
         }
     },
 

--- a/crates/core/c8y_api/src/smartrest/smartrest_deserializer.rs
+++ b/crates/core/c8y_api/src/smartrest/smartrest_deserializer.rs
@@ -1,6 +1,7 @@
 use crate::smartrest::error::SmartRestDeserializerError;
 use csv::ReaderBuilder;
 use download::DownloadInfo;
+use download::RequiredAuth;
 use serde::de::Error;
 use serde::Deserialize;
 use serde::Deserializer;
@@ -89,7 +90,7 @@ impl SmartRestUpdateSoftware {
         &self,
         target: &EntityTopicId,
         cmd_id: String,
-    ) -> Result<SoftwareUpdateCommand, SmartRestDeserializerError> {
+    ) -> Result<SoftwareUpdateCommand<RequiredAuth>, SmartRestDeserializerError> {
         let mut request = SoftwareUpdateCommand::new(target, cmd_id);
         for module in self.modules() {
             match module.action.clone().try_into()? {
@@ -156,7 +157,7 @@ impl SmartRestUpdateSoftwareModule {
         }
     }
 
-    fn get_url(&self) -> Option<DownloadInfo> {
+    fn get_url<Auth>(&self) -> Option<DownloadInfo<Auth>> {
         match &self.url {
             Some(url) if url.trim().is_empty() => None,
             Some(url) => Some(DownloadInfo::new(url.as_str())),

--- a/crates/core/plugin_sm/src/plugin_manager.rs
+++ b/crates/core/plugin_sm/src/plugin_manager.rs
@@ -2,6 +2,8 @@ use crate::log_file::LogFile;
 use crate::plugin::ExternalPluginCommand;
 use crate::plugin::Plugin;
 use crate::plugin::LIST;
+use download::AnonymisedAuth;
+use download::ClientAuth;
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::ErrorKind;
@@ -250,11 +252,13 @@ impl ExternalPlugins {
 
     pub async fn process(
         &self,
-        request: SoftwareUpdateCommand,
+        request: SoftwareUpdateCommand<ClientAuth>,
         mut log_file: LogFile,
         download_path: &Path,
-    ) -> SoftwareUpdateCommand {
-        let mut response = request.clone().with_status(CommandStatus::Executing);
+    ) -> SoftwareUpdateCommand<AnonymisedAuth> {
+        let mut response: SoftwareUpdateCommand<AnonymisedAuth> = request
+            .clone_anonymise_auth()
+            .with_status(CommandStatus::Executing);
         let logger = log_file.buffer();
         let mut error_count = 0;
 

--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -21,6 +21,7 @@ certificate = { workspace = true }
 clap = { workspace = true, features = ["cargo", "derive", "string", "unstable-styles"] }
 doku = { workspace = true }
 hyper = { workspace = true, default-features = false }
+miette = { workspace = true, features = ["fancy"] }
 nix = { workspace = true }
 pad = { workspace = true }
 reqwest = { workspace = true, features = [

--- a/crates/core/tedge/src/main.rs
+++ b/crates/core/tedge/src/main.rs
@@ -23,7 +23,11 @@ fn main() -> anyhow::Result<()> {
     let opt = parse_multicall_if_known(&executable_name);
     match opt {
         TEdgeOptMulticall::Component(Component::TedgeMapper(mapper_opt)) => {
-            block_on(tedge_mapper::run(mapper_opt))
+            if let Err(err) = block_on(tedge_mapper::run(mapper_opt)) {
+                eprintln!("Error running tedge-mapper:\n{err:?}");
+                std::process::exit(101);
+            }
+            Ok(())
         }
         TEdgeOptMulticall::Component(Component::TedgeAgent(opt)) => block_on(tedge_agent::run(opt)),
         TEdgeOptMulticall::Component(Component::TedgeLogPlugin(opt)) => {

--- a/crates/core/tedge_actors/Cargo.toml
+++ b/crates/core/tedge_actors/Cargo.toml
@@ -18,6 +18,7 @@ test-helpers = []
 async-trait = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
+miette = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, default_features = false, features = [
     "sync",

--- a/crates/core/tedge_actors/src/errors.rs
+++ b/crates/core/tedge_actors/src/errors.rs
@@ -17,7 +17,7 @@ pub enum ChannelError {
 }
 
 /// Error raised during runtime by actors as well as the runtime
-#[derive(Error, Debug)]
+#[derive(Error, Debug, miette::Diagnostic)]
 pub enum RuntimeError {
     #[error(transparent)]
     ActorError(#[from] DynError),

--- a/crates/core/tedge_actors/src/macros.rs
+++ b/crates/core/tedge_actors/src/macros.rs
@@ -27,7 +27,7 @@
 /// ```
 #[macro_export]
 macro_rules! fan_in_message_type {
-    ( $t:ident [ $( $x:ident ),* ] : $( $d:ident ),*) => {
+    ( $t:ident [ $( $x:ident $(< $x_gen:ident >)? ),* ] : $( $d:ident ),*) => {
         #[derive(
             $(
                 $d,
@@ -35,12 +35,12 @@ macro_rules! fan_in_message_type {
         )]
         pub enum $t {
             $(
-                $x($x),
+                $x($x $(<$x_gen>)? ),
             )*
         }
         $(
-            impl From<$x> for $t {
-                fn from(m: $x) -> $t {
+            impl From<$x $(<$x_gen>)?> for $t {
+                fn from(m: $x $(<$x_gen>)?) -> $t {
                     $t::$x(m)
                 }
             }

--- a/crates/core/tedge_agent/Cargo.toml
+++ b/crates/core/tedge_agent/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = { workspace = true }
 log = { workspace = true }
 path-clean = { workspace = true }
 plugin_sm = { workspace = true }
+reqwest = { workspace = true }
 routerify = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -38,6 +39,7 @@ tracing = { workspace = true }
 which = { workspace = true }
 
 [dev-dependencies]
+rcgen = { workspace = true }
 serial_test = { workspace = true }
 tedge_actors = { workspace = true, features = ["test-helpers"] }
 tedge_mqtt_ext = { workspace = true, features = ["test-helpers"] }

--- a/crates/core/tedge_agent/src/software_manager/builder.rs
+++ b/crates/core/tedge_agent/src/software_manager/builder.rs
@@ -1,5 +1,6 @@
-use crate::software_manager::actor::SoftwareCommand;
 use crate::software_manager::actor::SoftwareManagerActor;
+use crate::software_manager::actor::SoftwareRequest;
+use crate::software_manager::actor::SoftwareResponse;
 use crate::software_manager::config::SoftwareManagerConfig;
 use tedge_actors::Builder;
 use tedge_actors::DynSender;
@@ -12,7 +13,7 @@ use tedge_actors::SimpleMessageBoxBuilder;
 
 pub struct SoftwareManagerBuilder {
     config: SoftwareManagerConfig,
-    message_box: SimpleMessageBoxBuilder<SoftwareCommand, SoftwareCommand>,
+    message_box: SimpleMessageBoxBuilder<SoftwareRequest, SoftwareResponse>,
 }
 
 impl SoftwareManagerBuilder {
@@ -26,12 +27,12 @@ impl SoftwareManagerBuilder {
     }
 }
 
-impl ServiceProvider<SoftwareCommand, SoftwareCommand, NoConfig> for SoftwareManagerBuilder {
+impl ServiceProvider<SoftwareRequest, SoftwareResponse, NoConfig> for SoftwareManagerBuilder {
     fn connect_consumer(
         &mut self,
         config: NoConfig,
-        response_sender: DynSender<SoftwareCommand>,
-    ) -> DynSender<SoftwareCommand> {
+        response_sender: DynSender<SoftwareResponse>,
+    ) -> DynSender<SoftwareRequest> {
         self.message_box.connect_consumer(config, response_sender)
     }
 }

--- a/crates/core/tedge_agent/src/software_manager/tests.rs
+++ b/crates/core/tedge_agent/src/software_manager/tests.rs
@@ -1,4 +1,5 @@
-use crate::software_manager::actor::SoftwareCommand;
+use crate::software_manager::actor::SoftwareRequest;
+use crate::software_manager::actor::SoftwareResponse;
 use crate::software_manager::builder::SoftwareManagerBuilder;
 use crate::software_manager::config::SoftwareManagerConfig;
 use std::time::Duration;
@@ -80,11 +81,11 @@ async fn test_new_software_update_operation() -> Result<(), DynError> {
     converter_box.send(command.into()).await?;
 
     match converter_box.recv().await.unwrap() {
-        SoftwareCommand::SoftwareUpdateCommand(res) => {
+        SoftwareResponse::SoftwareUpdateCommand(res) => {
             assert_eq!(res.cmd_id, "random");
             assert_eq!(res.status(), CommandStatus::Executing);
         }
-        SoftwareCommand::SoftwareListCommand(_) => {
+        SoftwareResponse::SoftwareListCommand(_) => {
             panic!("Received SoftwareListCommand")
         }
     }
@@ -138,8 +139,8 @@ async fn test_new_software_list_operation() -> Result<(), DynError> {
 
 async fn spawn_software_manager(
     tmp_dir: &TempTedgeDir,
-) -> Result<TimedMessageBox<SimpleMessageBox<SoftwareCommand, SoftwareCommand>>, DynError> {
-    let mut converter_builder: SimpleMessageBoxBuilder<SoftwareCommand, SoftwareCommand> =
+) -> Result<TimedMessageBox<SimpleMessageBox<SoftwareResponse, SoftwareRequest>>, DynError> {
+    let mut converter_builder: SimpleMessageBoxBuilder<_, _> =
         SimpleMessageBoxBuilder::new("Converter", 5);
 
     let config = SoftwareManagerConfig::new(

--- a/crates/core/tedge_api/src/error.rs
+++ b/crates/core/tedge_api/src/error.rs
@@ -4,6 +4,7 @@ use crate::software::SoftwareType;
 use crate::software::SoftwareVersion;
 use csv;
 
+use download::AnonymisedAuth;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -13,6 +14,7 @@ pub enum TopicError {
     UnknownTopic { topic: String },
 }
 
+// TODO this probably should actually have auth information removed
 #[derive(thiserror::Error, Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
 pub enum SoftwareError {
     #[error("DownloadError error: {reason:?} for {url:?}")]
@@ -30,7 +32,7 @@ pub enum SoftwareError {
 
     #[error("Failed to install {module:?}")]
     Install {
-        module: Box<SoftwareModule>,
+        module: Box<SoftwareModule<AnonymisedAuth>>,
         reason: String,
     },
 
@@ -57,7 +59,7 @@ pub enum SoftwareError {
 
     #[error("Failed to uninstall {module:?}")]
     Remove {
-        module: Box<SoftwareModule>,
+        module: Box<SoftwareModule<AnonymisedAuth>>,
         reason: String,
     },
 

--- a/crates/core/tedge_api/src/lib.rs
+++ b/crates/core/tedge_api/src/lib.rs
@@ -58,11 +58,11 @@ mod tests {
         );
 
         assert_eq!(
-            SoftwareUpdateCommand::capability_message(&mqtt_schema, &device).topic,
+            SoftwareUpdateCommand::<NeverAuth>::capability_message(&mqtt_schema, &device).topic,
             Topic::new_unchecked("te/device/main///cmd/software_update")
         );
         assert_eq!(
-            SoftwareUpdateCommand::new(&device, cmd_id.clone())
+            SoftwareUpdateCommand::<RequiredAuth>::new(&device, cmd_id.clone())
                 .command_message(&mqtt_schema)
                 .topic,
             Topic::new_unchecked("te/device/main///cmd/software_update/abc")
@@ -304,7 +304,7 @@ mod tests {
     fn creating_a_software_update_request() {
         let device = EntityTopicId::default_child_device("abc").unwrap();
         let cmd_id = "123".to_string();
-        let mut request = SoftwareUpdateCommand::new(&device, cmd_id);
+        let mut request = SoftwareUpdateCommand::<RequiredAuth>::new(&device, cmd_id);
 
         request.add_updates(
             "debian",
@@ -393,7 +393,7 @@ mod tests {
     fn creating_a_software_update_request_grouping_updates_per_plugin() {
         let device = EntityTopicId::default_child_device("abc").unwrap();
         let cmd_id = "123".to_string();
-        let mut request = SoftwareUpdateCommand::new(&device, cmd_id);
+        let mut request = SoftwareUpdateCommand::<RequiredAuth>::new(&device, cmd_id);
 
         request.add_update(SoftwareModuleUpdate::install(SoftwareModule {
             module_type: Some("debian".to_string()),
@@ -470,7 +470,7 @@ mod tests {
     fn creating_a_software_update_request_grouping_updates_per_plugin_using_default() {
         let device = EntityTopicId::default_child_device("abc").unwrap();
         let cmd_id = "123".to_string();
-        let mut request = SoftwareUpdateCommand::new(&device, cmd_id);
+        let mut request = SoftwareUpdateCommand::<RequiredAuth>::new(&device, cmd_id);
 
         request.add_update(SoftwareModuleUpdate::install(SoftwareModule {
             module_type: None, // I.e. default
@@ -588,10 +588,13 @@ mod tests {
                 cmd_id: "123".to_string()
             }
         );
-        let request =
-            SoftwareUpdateCommand::try_from(device, "123".to_string(), json_request.as_bytes())
-                .expect("Failed to deserialize")
-                .expect("Some command");
+        let request = SoftwareUpdateCommand::<RequiredAuth>::try_from(
+            device,
+            "123".to_string(),
+            json_request.as_bytes(),
+        )
+        .expect("Failed to deserialize")
+        .expect("Some command");
 
         assert_eq!(
             request.modules_types(),
@@ -646,7 +649,7 @@ mod tests {
     fn creating_a_software_update_response() {
         let device = EntityTopicId::default_child_device("abc").unwrap();
         let cmd_id = "123".to_string();
-        let request = SoftwareUpdateCommand::new(&device, cmd_id);
+        let request = SoftwareUpdateCommand::<RequiredAuth>::new(&device, cmd_id);
 
         let response = request.with_status(CommandStatus::Executing);
 
@@ -665,9 +668,13 @@ mod tests {
         let json_response = r#"{
                 "status": "executing"
             }"#;
-        let response = SoftwareUpdateCommand::try_from(device, cmd_id, json_response.as_bytes())
-            .expect("Failed to deserialize")
-            .expect("some command");
+        let response = SoftwareUpdateCommand::<RequiredAuth>::try_from(
+            device,
+            cmd_id,
+            json_response.as_bytes(),
+        )
+        .expect("Failed to deserialize")
+        .expect("some command");
         assert_eq!(response.cmd_id, "123".to_string());
         assert_eq!(response.status(), CommandStatus::Executing);
     }
@@ -712,9 +719,13 @@ mod tests {
                 }
             ]
         }"#;
-        let request = SoftwareUpdateCommand::try_from(device, cmd_id, json_request.as_bytes())
-            .expect("Failed to deserialize")
-            .expect("Some command");
+        let request = SoftwareUpdateCommand::<RequiredAuth>::try_from(
+            device,
+            cmd_id,
+            json_request.as_bytes(),
+        )
+        .expect("Failed to deserialize")
+        .expect("Some command");
         let response = request.with_status(CommandStatus::Successful);
 
         let expected_json = r#"{

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -23,6 +23,7 @@ clap = { workspace = true }
 clock = { workspace = true }
 collectd_ext = { workspace = true }
 flockfile = { workspace = true }
+miette = { workspace = true }
 mqtt_channel = { workspace = true }
 tedge_actors = { workspace = true }
 tedge_api = { workspace = true }

--- a/crates/core/tedge_mapper/src/aws/mapper.rs
+++ b/crates/core/tedge_mapper/src/aws/mapper.rs
@@ -27,7 +27,7 @@ impl TEdgeComponent for AwsMapper {
         &self,
         tedge_config: TEdgeConfig,
         _config_dir: &Path,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), miette::Error> {
         let (mut runtime, mut mqtt_actor) =
             start_basic_actors(self.session_name(), &tedge_config).await?;
         let clock = Box::new(WallClock);

--- a/crates/core/tedge_mapper/src/az/mapper.rs
+++ b/crates/core/tedge_mapper/src/az/mapper.rs
@@ -27,7 +27,7 @@ impl TEdgeComponent for AzureMapper {
         &self,
         tedge_config: TEdgeConfig,
         _config_dir: &Path,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), miette::Error> {
         let (mut runtime, mut mqtt_actor) =
             start_basic_actors(self.session_name(), &tedge_config).await?;
         let mqtt_schema = MqttSchema::with_root(tedge_config.mqtt.topic_root.clone());

--- a/crates/core/tedge_mapper/src/collectd/mapper.rs
+++ b/crates/core/tedge_mapper/src/collectd/mapper.rs
@@ -36,7 +36,7 @@ impl TEdgeComponent for CollectdMapper {
         &self,
         tedge_config: TEdgeConfig,
         _config_dir: &Path,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), miette::Error> {
         let (mut runtime, mut mqtt_actor) =
             start_basic_actors(self.session_name(), &tedge_config).await?;
 

--- a/crates/core/tedge_mapper/src/core/component.rs
+++ b/crates/core/tedge_mapper/src/core/component.rs
@@ -1,19 +1,21 @@
 use async_trait::async_trait;
+use miette::IntoDiagnostic;
 use std::path::Path;
 use tedge_config::TEdgeConfig;
 
 #[async_trait]
 pub trait TEdgeComponent: Sync + Send {
     fn session_name(&self) -> &str;
-    async fn start(&self, tedge_config: TEdgeConfig, cfg_dir: &Path) -> Result<(), anyhow::Error>;
+    async fn start(&self, tedge_config: TEdgeConfig, cfg_dir: &Path) -> Result<(), miette::Error>;
 
-    fn mqtt_config(&self) -> Result<mqtt_channel::Config, anyhow::Error> {
+    fn mqtt_config(&self) -> Result<mqtt_channel::Config, miette::Error> {
         let config_repository =
             tedge_config::TEdgeConfigRepository::new(tedge_config::TEdgeConfigLocation::default());
-        let tedge_config = config_repository.load()?;
+        let tedge_config = config_repository.load().into_diagnostic()?;
 
         let mqtt_config = tedge_config
-            .mqtt_config()?
+            .mqtt_config()
+            .into_diagnostic()?
             .with_session_name(self.session_name())
             .with_clean_session(false);
 

--- a/crates/core/tedge_mapper/src/core/mapper.rs
+++ b/crates/core/tedge_mapper/src/core/mapper.rs
@@ -1,3 +1,4 @@
+use miette::IntoDiagnostic;
 #[cfg(test)]
 use std::result::Result::Ok;
 use tedge_actors::Runtime;
@@ -14,7 +15,7 @@ use tedge_signal_ext::SignalActor;
 pub async fn start_basic_actors(
     mapper_name: &str,
     config: &TEdgeConfig,
-) -> Result<(Runtime, MqttActorBuilder), anyhow::Error> {
+) -> Result<(Runtime, MqttActorBuilder), miette::Error> {
     let runtime_events_logger = None;
     let mut runtime = Runtime::try_new(runtime_events_logger).await?;
 
@@ -46,8 +47,8 @@ pub async fn start_basic_actors(
 async fn get_mqtt_actor(
     session_name: &str,
     tedge_config: &TEdgeConfig,
-) -> Result<MqttActorBuilder, anyhow::Error> {
-    let mqtt_config = tedge_config.mqtt_config()?;
+) -> Result<MqttActorBuilder, miette::Error> {
+    let mqtt_config = tedge_config.mqtt_config().into_diagnostic()?;
 
     Ok(MqttActorBuilder::new(
         mqtt_config.with_session_name(session_name),

--- a/crates/core/tedge_mapper/src/main.rs
+++ b/crates/core/tedge_mapper/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> miette::Result<()> {
     let mapper_opt = tedge_mapper::MapperOpt::parse();
     tedge_mapper::run(mapper_opt).await
 }

--- a/crates/extensions/c8y_auth_proxy/Cargo.toml
+++ b/crates/extensions/c8y_auth_proxy/Cargo.toml
@@ -11,18 +11,29 @@ repository = { workspace = true }
 
 [dependencies]
 axum = { workspace = true, features = ["macros"] }
+axum-server = { version = "0.5.1", features = ["tls-rustls"] }
 c8y_http_proxy = { workspace = true }
+camino = { workspace = true }
 futures = { workspace = true }
 hyper = { workspace = true }
 miette = { workspace = true }
+rcgen = { workspace = true }
 reqwest = { workspace = true, features = ["stream"] }
+ring = { workspace = true }
+rustls = { workspace = true }
+rustls-pemfile = "1.0.3"
 tedge_actors = { workspace = true }
 tedge_config = { workspace = true }
+tedge_config_macros = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "process", "io-util"] }
+tokio-rustls = "0.24.1"
+tower = "0.4.13"
 tracing = { workspace = true }
 url = { workspace = true }
+x509-parser = { workspace = true }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 env_logger = { workspace = true }
 mockito = { workspace = true }
 tedge_http_ext = { workspace = true, features = ["test_helpers" ] }

--- a/crates/extensions/c8y_auth_proxy/src/actor.rs
+++ b/crates/extensions/c8y_auth_proxy/src/actor.rs
@@ -4,8 +4,12 @@ use std::net::IpAddr;
 use axum::async_trait;
 use c8y_http_proxy::credentials::C8YJwtRetriever;
 use c8y_http_proxy::credentials::JwtRetriever;
+use camino::Utf8PathBuf;
 use futures::channel::mpsc;
 use futures::StreamExt;
+use miette::miette;
+use miette::Context;
+use miette::IntoDiagnostic;
 use tedge_actors::Actor;
 use tedge_actors::Builder;
 use tedge_actors::DynSender;
@@ -14,12 +18,17 @@ use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
 use tedge_actors::Sequential;
 use tedge_actors::ServerActorBuilder;
-use tedge_config::ConfigNotSet;
+use tedge_config::ReadableKey::C8yProxyCertFile;
+use tedge_config::ReadableKey::C8yProxyKeyFile;
+use tedge_config::ReadableKey::DeviceCertPath;
+use tedge_config::ReadableKey::DeviceKeyPath;
 use tedge_config::TEdgeConfig;
 use tracing::info;
 
 use crate::server::AppState;
 use crate::server::Server;
+use crate::tls::load_cert;
+use crate::tls::load_pkey;
 use crate::tokens::TokenManager;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
@@ -28,6 +37,9 @@ pub struct C8yAuthProxyBuilder {
     app_state: AppState,
     bind_address: IpAddr,
     bind_port: u16,
+    certificate_der: Vec<Vec<u8>>,
+    key_der: Vec<u8>,
+    ca_dir: Option<Utf8PathBuf>,
     signal_sender: mpsc::Sender<RuntimeRequest>,
     signal_receiver: mpsc::Receiver<RuntimeRequest>,
 }
@@ -36,13 +48,20 @@ impl C8yAuthProxyBuilder {
     pub fn try_from_config(
         config: &TEdgeConfig,
         jwt: &mut ServerActorBuilder<C8YJwtRetriever, Sequential>,
-    ) -> Result<Self, ConfigNotSet> {
+    ) -> miette::Result<Self> {
         let app_state = AppState {
-            target_host: format!("https://{}", config.c8y.http.or_config_not_set()?).into(),
+            target_host: format!(
+                "https://{}",
+                config.c8y.http.or_config_not_set().into_diagnostic()?
+            )
+            .into(),
             token_manager: TokenManager::new(JwtRetriever::new("C8Y-PROXY => JWT", jwt)).shared(),
         };
         let bind = &config.c8y.proxy.bind;
         let (signal_sender, signal_receiver) = mpsc::channel(10);
+        let (certificate_der, key_der) = load_certificate_and_key(config)?;
+
+        let ca_dir = config.mqtt.external.ca_path.or_none().map(<_>::to_owned);
 
         Ok(Self {
             app_state,
@@ -50,7 +69,35 @@ impl C8yAuthProxyBuilder {
             bind_port: bind.port,
             signal_sender,
             signal_receiver,
+            certificate_der,
+            key_der,
+            ca_dir,
         })
+    }
+}
+
+fn load_certificate_and_key(config: &TEdgeConfig) -> miette::Result<(Vec<Vec<u8>>, Vec<u8>)> {
+    let paths = tedge_config_macros::all_or_nothing((
+        config.c8y.proxy.cert_file.as_ref(),
+        config.c8y.proxy.key_file.as_ref(),
+    ))
+    .map_err(|e| miette!("{e}"))?;
+
+    match paths {
+        Some((external_cert_file, external_key_file)) => Ok((
+            load_cert(external_cert_file).with_context(|| {
+                format!("reading certificate configured in {C8yProxyCertFile:?}")
+            })?,
+            load_pkey(external_key_file).with_context(|| {
+                format!("reading private key configured in `{C8yProxyKeyFile}`")
+            })?,
+        )),
+        None => Ok((
+            load_cert(&config.device.cert_path)
+                .with_context(|| format!("reading certificate configured in `{DeviceCertPath}`"))?,
+            load_pkey(&config.device.key_path)
+                .with_context(|| format!("reading private key configured in `{DeviceKeyPath}`"))?,
+        )),
     }
 }
 
@@ -63,6 +110,9 @@ impl Builder<C8yAuthProxy> for C8yAuthProxyBuilder {
             bind_address: self.bind_address,
             bind_port: self.bind_port,
             signal_receiver: self.signal_receiver,
+            certificate_der: self.certificate_der,
+            key_der: self.key_der,
+            ca_dir: self.ca_dir,
         })
     }
 }
@@ -77,6 +127,9 @@ pub struct C8yAuthProxy {
     app_state: AppState,
     bind_address: IpAddr,
     bind_port: u16,
+    certificate_der: Vec<Vec<u8>>,
+    key_der: Vec<u8>,
+    ca_dir: Option<Utf8PathBuf>,
     signal_receiver: mpsc::Receiver<RuntimeRequest>,
 }
 
@@ -87,9 +140,16 @@ impl Actor for C8yAuthProxy {
     }
 
     async fn run(mut self) -> Result<(), RuntimeError> {
-        let server = Server::try_init(self.app_state.clone(), self.bind_address, self.bind_port)
-            .map_err(BoxError::from)?
-            .wait();
+        let server = Server::try_init(
+            self.app_state,
+            self.bind_address,
+            self.bind_port,
+            self.certificate_der,
+            self.key_der,
+            self.ca_dir,
+        )
+        .map_err(BoxError::from)?
+        .wait();
         tokio::select! {
             result = server => {
                 info!("Done");

--- a/crates/extensions/c8y_auth_proxy/src/lib.rs
+++ b/crates/extensions/c8y_auth_proxy/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod actor;
 mod body;
 mod server;
+mod tls;
 mod tokens;
 pub mod url;

--- a/crates/extensions/c8y_auth_proxy/src/tls.rs
+++ b/crates/extensions/c8y_auth_proxy/src/tls.rs
@@ -1,0 +1,165 @@
+use axum::middleware::AddExtension;
+use axum::Extension;
+use axum_server::accept::Accept;
+use axum_server::tls_rustls::RustlsAcceptor;
+use axum_server::tls_rustls::RustlsConfig;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
+use futures::future::BoxFuture;
+use miette::miette;
+use miette::Context;
+use miette::IntoDiagnostic;
+use rustls::server::AllowAnyAnonymousOrAuthenticatedClient;
+use rustls::server::AllowAnyAuthenticatedClient;
+use rustls::server::ClientCertVerifier;
+use rustls::Certificate;
+use rustls::PrivateKey;
+use rustls::RootCertStore;
+use rustls::ServerConfig;
+use rustls_pemfile::Item;
+use std::fs::File;
+use std::io;
+use std::io::BufReader;
+use std::sync::Arc;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio_rustls::server::TlsStream;
+use tower::Layer;
+use x509_parser::prelude::FromDer;
+use x509_parser::prelude::X509Certificate;
+
+#[derive(Debug, Clone)]
+pub struct Acceptor {
+    inner: RustlsAcceptor,
+}
+
+#[derive(Debug, Clone)]
+pub struct TlsData {
+    pub common_name: Option<Arc<str>>,
+}
+
+impl Acceptor {
+    pub fn new(config: ServerConfig) -> Self {
+        Self {
+            inner: RustlsAcceptor::new(RustlsConfig::from_config(Arc::new(config))),
+        }
+    }
+}
+
+impl<I, S> Accept<I, S> for Acceptor
+where
+    I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    S: Send + 'static,
+{
+    type Stream = TlsStream<I>;
+    type Service = AddExtension<S, TlsData>;
+    type Future = BoxFuture<'static, io::Result<(Self::Stream, Self::Service)>>;
+
+    fn accept(&self, stream: I, service: S) -> Self::Future {
+        let acceptor = self.inner.clone();
+
+        Box::pin(async move {
+            let (stream, service) = acceptor.accept(stream, service).await?;
+            let server_conn = stream.get_ref().1;
+            let cert =
+                (|| X509Certificate::from_der(&server_conn.peer_certificates()?.first()?.0).ok())();
+            let certificate_info = TlsData {
+                common_name: common_name(cert.as_ref()).map(Arc::from),
+            };
+            let service = Extension(certificate_info).layer(service);
+
+            Ok((stream, service))
+        })
+    }
+}
+
+pub fn common_name<'a>(cert: Option<&'a (&[u8], X509Certificate)>) -> Option<&'a str> {
+    cert?.1.subject.iter_common_name().next()?.as_str().ok()
+}
+
+/// Load the SSL configuration for rustls
+pub fn get_ssl_config(
+    certificate_chain: Vec<Vec<u8>>,
+    key_der: Vec<u8>,
+    ca_dir: Option<Utf8PathBuf>,
+) -> miette::Result<ServerConfig> {
+    // Trusted CA for client certificates
+    let mut roots = RootCertStore::empty();
+    let verifier = if let Some(ca_dir) = &ca_dir {
+        let mut ders = Vec::new();
+        for file in ca_dir
+            .read_dir_utf8()
+            .into_diagnostic()
+            .wrap_err_with(|| format!("reading {ca_dir}"))?
+        {
+            let file = file.unwrap();
+            // TODO cope with symlinked dirs
+            if file.file_type().map_or(true, |file| file.is_dir()) {
+                continue;
+            }
+            let mut path = ca_dir.clone().to_path_buf();
+            path.push(file.file_name());
+            let Ok(mut pem_file) = File::open(&path).map(BufReader::new) else {
+                continue;
+            };
+            if let Some(value) = rustls_pemfile::certs(&mut pem_file)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("reading {path}"))
+                .unwrap()
+                .into_iter()
+                .next()
+            {
+                ders.push(value);
+            };
+        }
+        roots.add_parsable_certificates(&ders);
+        Arc::new(AllowAnyAuthenticatedClient::new(roots)) as Arc<dyn ClientCertVerifier>
+    } else {
+        Arc::new(AllowAnyAnonymousOrAuthenticatedClient::new(roots))
+    };
+
+    let server_cert = certificate_chain.into_iter().map(Certificate).collect();
+    let server_key = PrivateKey(key_der);
+
+    ServerConfig::builder()
+        .with_safe_defaults()
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(server_cert, server_key)
+        .into_diagnostic()
+        .wrap_err("invalid key or certificate")
+}
+
+/// Load the server certificate
+pub fn load_cert(filename: &Utf8Path) -> miette::Result<Vec<Vec<u8>>> {
+    let certfile = File::open(filename)
+        .into_diagnostic()
+        .with_context(|| format!("cannot open certificate file: {filename:?}"))?;
+    let mut reader = BufReader::new(certfile);
+    rustls_pemfile::certs(&mut reader)
+        .into_diagnostic()
+        .with_context(|| format!("parsing PEM-encoded certificate from {filename:?}"))
+}
+
+/// Load the server private key
+pub fn load_pkey(filename: &Utf8Path) -> miette::Result<Vec<u8>> {
+    let keyfile = File::open(filename)
+        .into_diagnostic()
+        .with_context(|| format!("cannot open key file {filename:?}"))?;
+    let mut reader = BufReader::new(keyfile);
+    rustls_pemfile::read_one(&mut reader)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("reading PEM-encoded private key from {filename:?}"))?
+        .ok_or(miette!(
+            "expected private key in {filename:?}, but found no PEM-encoded data"
+        ))
+        .and_then(|item| match item {
+            Item::ECKey(key) | Item::PKCS8Key(key) | Item::RSAKey(key) => Ok(key),
+            Item::Crl(_) => Err(miette!("expected private key in {filename}, found a CRL")),
+            Item::X509Certificate(_) => Err(miette!(
+                "expected private key in {filename:?}, found an X509 certificate"
+            )),
+            item => Err(miette!(
+                "expected private key in {filename:?}, found an unknown PEM-encoded item: {item:?}"
+            )),
+        })
+}

--- a/crates/extensions/c8y_firmware_manager/src/actor.rs
+++ b/crates/extensions/c8y_firmware_manager/src/actor.rs
@@ -27,7 +27,7 @@ use tedge_actors::RuntimeRequest;
 use tedge_actors::Sender;
 use tedge_actors::WrappedInput;
 use tedge_api::topic::get_child_id_from_child_topic;
-use tedge_api::Auth;
+use tedge_api::ClientAuth;
 use tedge_api::OperationStatus;
 use tedge_downloader_ext::DownloadRequest;
 use tedge_downloader_ext::DownloadResult;
@@ -254,7 +254,7 @@ impl FirmwareManagerActor {
             {
                 if let Ok(token) = self.message_box.jwt_retriever.await_response(()).await? {
                     DownloadRequest::new(firmware_url, cache_file_path.as_std_path())
-                        .with_auth(Auth::new_bearer(&token))
+                        .with_auth(ClientAuth::Bearer(token))
                 } else {
                     return Err(FirmwareManagementError::NoJwtToken);
                 }

--- a/crates/extensions/c8y_firmware_manager/src/tests.rs
+++ b/crates/extensions/c8y_firmware_manager/src/tests.rs
@@ -18,7 +18,7 @@ use tedge_actors::RuntimeError;
 use tedge_actors::Sender;
 use tedge_actors::SimpleMessageBox;
 use tedge_actors::SimpleMessageBoxBuilder;
-use tedge_api::Auth;
+use tedge_api::ClientAuth;
 use tedge_api::DownloadError;
 use tedge_downloader_ext::DownloadResponse;
 use tedge_mqtt_ext::Topic;
@@ -325,7 +325,7 @@ async fn create_download_request_with_c8y_auth() -> Result<(), DynError> {
     );
     assert_eq!(
         download_request.auth,
-        Some(Auth::Bearer(String::from(token)))
+        Some(ClientAuth::Bearer(String::from(token)))
     );
 
     Ok(())

--- a/crates/extensions/c8y_http_proxy/src/actor.rs
+++ b/crates/extensions/c8y_http_proxy/src/actor.rs
@@ -21,7 +21,7 @@ use c8y_api::json_c8y::C8yManagedObject;
 use c8y_api::json_c8y::InternalIdResponse;
 use c8y_api::smartrest::error::SMCumulocityMapperError;
 use c8y_api::OffsetDateTime;
-use download::Auth;
+use download::ClientAuth;
 use download::DownloadInfo;
 use download::Downloader;
 use http::status::StatusCode;
@@ -458,7 +458,7 @@ impl C8YHttpProxyActor {
     }
 
     async fn download_file(&mut self, request: DownloadFile) -> Result<Unit, C8YRestError> {
-        let mut download_info: DownloadInfo = request.download_url.as_str().into();
+        let mut download_info: DownloadInfo<ClientAuth> = request.download_url.as_str().into();
         // If the provided url is c8y, add auth
         if self
             .end_point
@@ -466,7 +466,7 @@ impl C8YHttpProxyActor {
             .is_some()
         {
             let token = self.get_and_set_jwt_token().await?;
-            download_info.auth = Some(Auth::new_bearer(token.as_str()));
+            download_info.auth = Some(ClientAuth::Bearer(token));
         }
 
         info!(target: self.name(), "Downloading from: {:?}", download_info.url());

--- a/crates/extensions/c8y_mapper_ext/src/inventory.rs
+++ b/crates/extensions/c8y_mapper_ext/src/inventory.rs
@@ -173,6 +173,7 @@ mod tests {
     use crate::converter::tests::create_c8y_converter;
     use serde_json::json;
     use tedge_mqtt_ext::test_helpers::assert_messages_matching;
+    use tedge_mqtt_ext::test_helpers::MessagePayloadMatcher;
     use tedge_mqtt_ext::Message;
     use tedge_mqtt_ext::Topic;
     use tedge_test_utils::fs::TempTedgeDir;
@@ -394,7 +395,7 @@ mod tests {
             Message::new(&Topic::new_unchecked(twin_topic), twin_payload.to_string());
         let inventory_messages = converter.convert(&twin_message).await;
 
-        let expected_message = (
+        let expected_message: (&'static str, MessagePayloadMatcher) = (
             "c8y/inventory/managedObjects/update/test-device",
             json!({
                 "device_os": {

--- a/crates/extensions/tedge_downloader_ext/src/actor.rs
+++ b/crates/extensions/tedge_downloader_ext/src/actor.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use download::Auth;
+use download::ClientAuth;
 use download::DownloadError;
 use download::DownloadInfo;
 use download::Downloader;
@@ -17,7 +17,7 @@ use tedge_utils::file::PermissionEntry;
 pub struct DownloadRequest {
     pub url: String,
     pub file_path: PathBuf,
-    pub auth: Option<Auth>,
+    pub auth: Option<ClientAuth>,
     pub permission: Option<PermissionEntry>,
 }
 
@@ -31,7 +31,7 @@ impl DownloadRequest {
         }
     }
 
-    pub fn with_auth(self, auth: Auth) -> Self {
+    pub fn with_auth(self, auth: ClientAuth) -> Self {
         Self {
             auth: Some(auth),
             ..self

--- a/crates/extensions/tedge_downloader_ext/src/tests.rs
+++ b/crates/extensions/tedge_downloader_ext/src/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use download::Auth;
+use download::ClientAuth;
 use std::time::Duration;
 use tedge_actors::ClientMessageBox;
 use tedge_test_utils::fs::TempTedgeDir;
@@ -52,8 +52,8 @@ async fn download_with_auth() {
 
     let target_path = ttd.path().join("downloaded_file");
     let server_url = server.url();
-    let download_request =
-        DownloadRequest::new(&server_url, &target_path).with_auth(Auth::Bearer("token".into()));
+    let download_request = DownloadRequest::new(&server_url, &target_path)
+        .with_auth(ClientAuth::Bearer("token".into()));
 
     let mut requester = spawn_downloader_actor().await;
 


### PR DESCRIPTION
## Proposed changes
This adds HTTPS support and (opt-in) certificate-based authentication to the c8y auth proxy.

At the moment this is a draft PR as the agent currently doesn't handle the device certificate not being present. It also doesn't yet document the API changes (HTTP -> HTTPS), nor does it touch the integration tests.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

When the only authentication scheme available for software updates was bearer tokens, the mapper simply supplied the token along with the request, which the agent would simply use. As this adds certificate authentication, the mapper requires the agent to also use certificate authentication (if configured). This has the advantage of us being able to delegate authentication largely to a trusted library, but does add complexity in the agent code and adds possible error states, due to the way certificates need to be configured.

The most significant changes to the agent centre around the generic authentication strategy supported by `DownloadInfo`. `DownloadInfo` has been modified to support an incoming request from the mapper (which would simply tell the agent to use a certificate, if required), a request that is being processed (at which point the agent will add the required certificate) and a response (which has the authentication anonymised for security/because we cannot clone `reqwest::Identity`, which represents the certificate/key pair in use).

Due to this complexity, it may be desirable to add an alternative authentication scheme to the auth proxy. This could involve the mapper generating its own bearer token, and the agent consuming this as it does currently. This would ensure backwards compatibility with the existing software update API (if someone is using a custom agent implementation). It would also remove the burden of the agent (possibly) needing to supply certificates, which is difficult to handle errors for proactively before a user attempts to e.g. update software and finds the agent configuration is broken. The difficulty arises from the fact certificates may not be required, either due to not specifying trusted certificates for the auth proxy, or not connecting thin-edge to Cumulocity (in which case the auth proxy isn't running). If the mapper could decide itself how to authenticate a request to itself (e.g. by creating a JWT using the certificate used for the HTTPS connection), this alleviates the need for the agent to care how the request should be authenticated. Certificate-based authentication would still be useful for thin-edge users to connect to the API themselves (if no certificates are provided, the mapper could just disable authentication entirely, both for external users and agents).