### PR TITLE
Tedge operation plugins to migrate legacy config file contents

### DIFF
--- a/crates/extensions/tedge_config_manager/src/lib.rs
+++ b/crates/extensions/tedge_config_manager/src/lib.rs
@@ -7,6 +7,7 @@ mod tests;
 
 use actor::*;
 pub use config::*;
+use std::fs::rename;
 use std::path::PathBuf;
 use tedge_actors::futures::channel::mpsc;
 use tedge_actors::Builder;
@@ -88,8 +89,21 @@ impl ConfigManagerBuilder {
     }
 
     pub fn init(config: &ConfigManagerConfig) -> Result<(), FileError> {
+        if config.plugin_config_path.exists() {
+            return Ok(());
+        }
+
         // creating plugin config parent dir
         create_directory_with_defaults(&config.plugin_config_dir)?;
+
+        let legacy_plugin_config = config
+            .config_dir
+            .join("c8y")
+            .join("c8y-configuration-plugin.toml");
+        if legacy_plugin_config.exists() {
+            rename(legacy_plugin_config, &config.plugin_config_path)?;
+            return Ok(());
+        }
 
         // create tedge-configuration-plugin.toml
         let example_config = r#"# Add the configurations to be managed by tedge-configuration-plugin

--- a/crates/extensions/tedge_log_manager/src/lib.rs
+++ b/crates/extensions/tedge_log_manager/src/lib.rs
@@ -8,6 +8,7 @@ mod tests;
 pub use actor::*;
 pub use config::*;
 use log_manager::LogPluginConfig;
+use std::fs::rename;
 use std::path::PathBuf;
 use tedge_actors::adapt;
 use tedge_actors::Builder;
@@ -70,8 +71,18 @@ impl LogManagerBuilder {
     }
 
     pub fn init(config: &LogManagerConfig) -> Result<(), FileError> {
+        if config.plugin_config_path.exists() {
+            return Ok(());
+        }
+
         // creating plugin config parent dir
         create_directory_with_defaults(&config.plugin_config_dir)?;
+
+        let legacy_plugin_config = config.config_dir.join("c8y").join("c8y-log-plugin.toml");
+        if legacy_plugin_config.exists() {
+            rename(legacy_plugin_config, &config.plugin_config_path)?;
+            return Ok(());
+        }
 
         // creating tedge-log-plugin.toml
         let example_config = r#"# Add the list of log files that should be managed by tedge-log-plugin

--- a/tests/RobotFramework/requirements/requirements.txt
+++ b/tests/RobotFramework/requirements/requirements.txt
@@ -2,7 +2,7 @@ dateparser~=1.1.7
 paho-mqtt~=1.6.1
 python-dotenv~=0.20.0
 robotframework~=6.0.0
-robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.23.2
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.26.0
 robotframework-debuglibrary~=2.3.0
 robotframework-jsonlibrary~=0.5
 robotframework-pabot~=2.13.0

--- a/tests/RobotFramework/tests/cumulocity/configuration/backward_compatibility.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/backward_compatibility.robot
@@ -3,21 +3,23 @@ Resource            ../../../resources/common.resource
 Library             ThinEdgeIO
 Library             Cumulocity
 
-Suite Teardown      Get Logs    name=${PARENT_SN}
+Test Teardown      Get Logs    name=${DEVICE_SN}
 
-Test Tags          theme:configuration    theme:childdevices
+Test Tags          theme:configuration    theme:installation
 
-*** Test Cases ***                DEVICE        EXTERNALID                        CONFIG_TYPE       DEVICE_FILE                  FILE                                PERMISSION    OWNERSHIP
+*** Test Cases ***
 
-Get Configuration from Device
-    ${parent_sn}=    Setup    skip_bootstrap=True
-    Set Suite Variable    $PARENT_SN    ${parent_sn}
+Migrate Legacy Configuration Files
+    ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
+    Set Suite Variable    $DEVICE_SN
 
     # Copy old c8y-configuration-plugin's config file before bootstrapping
+    ThinEdgeIO.Execute Command    rm -f /etc/tedge/plugins/*
     ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y-configuration-plugin.toml    /etc/tedge/c8y/
     ThinEdgeIO.Transfer To Device    ${CURDIR}/config1.json         /etc/
 
     # Bootstrap the tedge-config-plugin so that it picks up the old c8y-configuration-plugin.toml
     Execute Command    ./bootstrap.sh
+    Cumulocity.Device Should Exist    ${DEVICE_SN}
     ${operation}=    Cumulocity.Get Configuration    TEST_CONFIG
-    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}    timeout=120
+    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}

--- a/tests/RobotFramework/tests/cumulocity/configuration/backward_compatibility.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/backward_compatibility.robot
@@ -1,0 +1,23 @@
+*** Settings ***
+Resource            ../../../resources/common.resource
+Library             ThinEdgeIO
+Library             Cumulocity
+
+Suite Teardown      Get Logs    name=${PARENT_SN}
+
+Test Tags          theme:configuration    theme:childdevices
+
+*** Test Cases ***                DEVICE        EXTERNALID                        CONFIG_TYPE       DEVICE_FILE                  FILE                                PERMISSION    OWNERSHIP
+
+Get Configuration from Device
+    ${parent_sn}=    Setup    skip_bootstrap=True
+    Set Suite Variable    $PARENT_SN    ${parent_sn}
+
+    # Copy old c8y-configuration-plugin's config file before bootstrapping
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y-configuration-plugin.toml    /etc/tedge/c8y/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/config1.json         /etc/
+
+    # Bootstrap the tedge-config-plugin so that it picks up the old c8y-configuration-plugin.toml
+    Execute Command    ./bootstrap.sh
+    ${operation}=    Cumulocity.Get Configuration    TEST_CONFIG
+    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}    timeout=120

--- a/tests/RobotFramework/tests/cumulocity/configuration/c8y-configuration-plugin.toml
+++ b/tests/RobotFramework/tests/cumulocity/configuration/c8y-configuration-plugin.toml
@@ -1,0 +1,3 @@
+files = [
+    { path = '/etc/config1.json', type = 'TEST_CONFIG', user = 'tedge', group = 'tedge', mode = 0o640 },
+]

--- a/tests/RobotFramework/tests/cumulocity/log/backward_compatibility.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/backward_compatibility.robot
@@ -1,0 +1,29 @@
+*** Settings ***
+Resource            ../../../resources/common.resource
+Library             ThinEdgeIO
+Library             Cumulocity
+
+Test Teardown      Get Logs    name=${DEVICE_SN}
+
+Test Tags          theme:troubleshooting    theme:installation
+
+*** Test Cases ***
+
+Migrate Legacy Configuration Files
+    ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
+    Set Suite Variable    $DEVICE_SN
+
+    # Copy old c8y-log-plugin's config file before bootstrapping
+    ThinEdgeIO.Execute Command    rm -f /etc/tedge/plugins/*
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/tedge-log-plugin.toml    /etc/tedge/c8y/c8y-log-plugin.toml
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/example.log    /var/log/example/
+    # touch file again to change last modified timestamp, otherwise the logfile retrieval could be outside of the requested range
+    Execute Command
+    ...    chown root:root /etc/tedge/c8y/c8y-log-plugin.toml /var/log/example/example.log && touch /var/log/example/example.log
+
+    # Bootstrap the tedge-log-plugin so that it picks up the old c8y-log-plugin.toml
+    Execute Command    ./bootstrap.sh
+    Cumulocity.Device Should Exist    ${DEVICE_SN}
+
+    ${operation}=    Cumulocity.Get Log File    example
+    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}


### PR DESCRIPTION
## Proposed changes

The `tedge-config-plugin` and `tedge-log-plugin` will migrate their legacy counterparts' configuration files, if found during initialization.

- [x] tedge-config-plugin code update
- [x] tedge-log-plugin code update
- [x] System tests


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

