### PR TITLE
Add a custom error message for invalid use of `default(value = ...)` in `define_tedge_config!`

### DIFF
--- a/crates/common/tedge_config_macros/impl/src/lib.rs
+++ b/crates/common/tedge_config_macros/impl/src/lib.rs
@@ -202,4 +202,18 @@ mod tests {
         })
         .unwrap();
     }
+
+    #[test]
+    fn error_message_suggests_fix_in_case_of_invalid_value() {
+        assert_eq!(generate_configuration(quote! {
+            http: {
+                #[tedge_config(default(value = Ipv4Addr::LOCALHOST))]
+                address: Ipv4Addr,
+            },
+        })
+                       .unwrap_err()
+                       .to_string(),
+                   "Unexpected expression, `default(value = ...)` expects a literal.\n\
+            Perhaps you want to use `#[tedge_config(default(variable = \"Ipv4Addr::LOCALHOST\"))]`?");
+    }
 }


### PR DESCRIPTION
## Proposed changes
https://github.com/thin-edge/thin-edge.io/pull/2398/files/313cc0efaac938fe47b1267d63a3d89cbb31c312..954da3d0246b6e6db4b5cd3d41421f5864ad9088#r1380338718 highlighted a usability issue with `define_tedge_config` and default values, which can either be provided using `default(value = true)` or `default(variable = "Ipv4Addr::LOCALHOST")`. The distinction between these two formats is important, but subtle.

This PR adds a custom error message for the case which caused confusion, pointing the user towards a suggested solution. See the screenshot below (or the added test) for the error that appears:

![image](https://github.com/thin-edge/thin-edge.io/assets/30299230/ba50a23e-b4c3-4321-92b7-4eb6ae8a3261)


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

