### PR TITLE
Tedge ops plugins init use async move_file

### DIFF
--- a/plugins/tedge_configuration_plugin/src/lib.rs
+++ b/plugins/tedge_configuration_plugin/src/lib.rs
@@ -141,7 +141,8 @@ async fn run_with(
         &mut fs_watch_actor,
         &mut downloader_actor,
         &mut uploader_actor,
-    )?;
+    )
+    .await?;
 
     // Shutdown on SIGINT
     let signal_actor = SignalActor::builder(&runtime.get_handle());

--- a/plugins/tedge_log_plugin/src/lib.rs
+++ b/plugins/tedge_log_plugin/src/lib.rs
@@ -132,7 +132,8 @@ async fn run_with(
         &mut mqtt_actor,
         &mut fs_watch_actor,
         &mut uploader_actor,
-    )?;
+    )
+    .await?;
 
     // Shutdown on SIGINT
     let signal_actor = SignalActor::builder(&runtime.get_handle());


### PR DESCRIPTION
## Proposed changes

Follow-up of #2399 to use async `tedge_utils::file::move_file` API instead if `std::fs::rename` to move config files.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

