### PR TITLE
Use default(variable = "AutoFlag::Auto")

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/models/auto.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/auto.rs
@@ -17,22 +17,6 @@ pub struct InvalidAutoFlag {
     input: String,
 }
 
-impl From<bool> for AutoFlag {
-    fn from(value: bool) -> Self {
-        if value {
-            AutoFlag::True
-        } else {
-            AutoFlag::False
-        }
-    }
-}
-
-impl From<&str> for AutoFlag {
-    fn from(value: &str) -> Self {
-        FromStr::from_str(value).unwrap_or(AutoFlag::False)
-    }
-}
-
 impl FromStr for AutoFlag {
     type Err = InvalidAutoFlag;
 

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -403,7 +403,7 @@ define_tedge_config! {
             include: {
                 /// Set the bridge local clean session flag (this requires mosquitto >= 2.0.0)
                 #[tedge_config(note = "If set to 'auto', this cleans the local session accordingly the detected version of mosquitto.")]
-                #[tedge_config(example = "auto", default(value = "auto"))]
+                #[tedge_config(example = "auto", default(variable = "AutoFlag::Auto"))]
                 local_cleansession: AutoFlag,
             }
         },


### PR DESCRIPTION
Simple follow up task suggested here https://github.com/thin-edge/thin-edge.io/pull/2398#discussion_r1380463768

## Proposed changes

- Use default(variable = "AutoFlag::Auto") for `c8y.bridge.include.local_cleansession`
- Remove `impl From<&str> for AutoFlag` as no more required.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

