### PR TITLE
log entry erroneously set to ERROR when handling device/services registered with custom topic schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,7 @@ dependencies = [
  "c8y_auth_proxy",
  "c8y_http_proxy",
  "camino",
+ "capture-logger",
  "clock",
  "json-writer",
  "logged_command",
@@ -800,6 +801,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "capture-logger"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "605a59c5054ce9e87cd329251bcc4c04579d5edbd206b1e4c45fbfe24b13ff82"
+dependencies = [
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ certificate = { path = "crates/common/certificate" }
 clap = { version = "4.4", features = ["cargo", "derive"] }
 clock = { path = "crates/common/clock" }
 collectd_ext = { path = "crates/extensions/collectd_ext" }
+capture-logger = "0.1"
 csv = "1.1"
 darling = "0.20"
 doku = "0.21"

--- a/crates/core/tedge_api/src/entity_store.rs
+++ b/crates/core/tedge_api/src/entity_store.rs
@@ -586,7 +586,7 @@ pub enum Error {
     #[error("The specified entity {0} does not exist in the store")]
     UnknownEntity(String),
 
-    #[error("The specified topic id {0} does not match the default topic scheme: 'device/<device-id>/service/<service-id>'")]
+    #[error("Auto registration of the entity with topic id {0} failed as it does not match the default topic scheme: 'device/<device-id>/service/<service-id>'. Try explicit registration instead.")]
     NonDefaultTopicScheme(EntityTopicId),
 
     #[error(transparent)]

--- a/crates/extensions/c8y_mapper_ext/Cargo.toml
+++ b/crates/extensions/c8y_mapper_ext/Cargo.toml
@@ -47,9 +47,11 @@ tracing = { workspace = true }
 [dev-dependencies]
 assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
+capture-logger = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 tedge_actors = { workspace = true, features = ["test-helpers"] }
 tedge_mqtt_ext = { workspace = true, features = ["test-helpers"] }
 tedge_test_utils = { workspace = true }
 test-case = { workspace = true }
+

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -903,7 +903,20 @@ impl CumulocityConverter {
                 // if device is unregistered register using auto-registration
                 if self.entity_store.get(&source).is_none() {
                     let auto_registration_messages =
-                        self.entity_store.auto_register_entity(&source)?;
+                        match self.entity_store.auto_register_entity(&source) {
+                            Ok(auto_registration_messages) => auto_registration_messages,
+                            Err(e) => match e {
+                                Error::NonDefaultTopicScheme(eid) => {
+                                    debug!("{}", Error::NonDefaultTopicScheme(eid.clone()));
+                                    return Ok(vec![self.new_error_message(
+                                        ConversionError::FromEntityStoreError(
+                                            entity_store::Error::NonDefaultTopicScheme(eid),
+                                        ),
+                                    )]);
+                                }
+                                e => return Err(e.into()),
+                            },
+                        };
                     for auto_registration_message in &auto_registration_messages {
                         registration_messages.append(
                             &mut self.register_and_convert_entity(auto_registration_message)?,
@@ -2948,6 +2961,28 @@ pub(crate) mod tests {
                 )],
             );
         }
+    }
+
+    #[tokio::test]
+    async fn try_auto_registration_on_custom_topic() -> Result<(), anyhow::Error> {
+        use capture_logger::begin_capture;
+        use capture_logger::pop_captured;
+        let tmp_dir = TempTedgeDir::new();
+        let (mut converter, _http_proxy) = create_c8y_converter(&tmp_dir).await;
+
+        let alarm_topic = "te/custom/child2///m/";
+        let alarm_payload = json!({ "text": "" }).to_string();
+        let alarm_message = Message::new(&Topic::new_unchecked(alarm_topic), alarm_payload);
+        begin_capture();
+        let res = converter.try_convert(&alarm_message).await.unwrap();
+        let expected_err_msg = Message::new(&Topic::new_unchecked("te/errors"), "Auto registration of the entity with topic id custom/child2// failed as it does not match the default topic scheme: 'device/<device-id>/service/<service-id>'. Try explicit registration instead.");
+        assert_eq!(res[0], expected_err_msg);
+        let expected_log = "Auto registration of the entity with topic id custom/child2// failed as it does not match the default topic scheme: 'device/<device-id>/service/<service-id>'. Try explicit registration instead.";
+        // skip other log messages
+        pop_captured().unwrap().message();
+        pop_captured().unwrap().message();
+        assert_eq!(pop_captured().unwrap().message(), expected_log);
+        Ok(())
     }
 
     pub(crate) async fn create_c8y_converter(


### PR DESCRIPTION
## Proposed changes

When using a topic that is not covered by auto registration, `topic schema` the `auto_register_entity` must not return an error but it must log the message at the `debug` level.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/2426

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

