### PR TITLE
Kill scripts still running after a timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3911,6 +3911,7 @@ name = "tedge_script_ext"
 version = "0.13.1"
 dependencies = [
  "async-trait",
+ "nix",
  "shell-words",
  "tedge_actors",
  "tokio",

--- a/crates/extensions/tedge_script_ext/Cargo.toml
+++ b/crates/extensions/tedge_script_ext/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }
+nix = { workspace = true }
 shell-words = { workspace = true }
 tedge_actors = { workspace = true }
 tokio = { workspace = true, default_features = false, features = ["process"] }

--- a/crates/extensions/tedge_script_ext/src/lib.rs
+++ b/crates/extensions/tedge_script_ext/src/lib.rs
@@ -1,6 +1,7 @@
 pub use shell_words::ParseError;
 use std::process::Output;
 use std::process::Stdio;
+use std::time::Duration;
 use tedge_actors::Concurrent;
 use tedge_actors::Server;
 use tedge_actors::ServerActorBuilder;
@@ -13,16 +14,47 @@ pub struct ScriptActor;
 pub struct Execute {
     pub command: String,
     pub args: Vec<String>,
+    pub timeouts: Option<(Duration, Duration)>,
 }
 
 impl Execute {
+    /// Parse the command line into a program and its arguments
     pub fn try_new(command_line: &str) -> Result<Self, ParseError> {
         let mut args = shell_words::split(command_line)?;
         if args.is_empty() {
             Err(ParseError)
         } else {
             let command = args.remove(0);
-            Ok(Execute { command, args })
+            let timeouts = None;
+            Ok(Execute {
+                command,
+                args,
+                timeouts,
+            })
+        }
+    }
+
+    /// Give the process a graceful timeout to run, timeout after which a SIGTERM is sent
+    pub fn with_graceful_timeout(self, graceful_timeout: Duration) -> Self {
+        let timeouts = match self.timeouts {
+            None => (graceful_timeout, Duration::from_secs(5)),
+            Some((_, forceful_timeout)) => (graceful_timeout, forceful_timeout),
+        };
+        Self {
+            timeouts: Some(timeouts),
+            ..self
+        }
+    }
+
+    /// Give the process an extra forceful timeout to exit on SIGTERM, timeout after which a SIGTKILL is sent
+    pub fn with_forceful_timeout_extension(self, forceful_timeout: Duration) -> Self {
+        let timeouts = match self.timeouts {
+            None => (Duration::from_secs(15), forceful_timeout),
+            Some((graceful_timeout, _)) => (graceful_timeout, forceful_timeout),
+        };
+        Self {
+            timeouts: Some(timeouts),
+            ..self
         }
     }
 }
@@ -37,12 +69,43 @@ impl Server for ScriptActor {
     }
 
     async fn handle(&mut self, message: Self::Request) -> Self::Response {
-        tokio::process::Command::new(message.command)
+        let child = tokio::process::Command::new(message.command)
             .args(message.args)
             .stdin(Stdio::null())
-            .output()
-            .await
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        match (child.id(), message.timeouts) {
+            (_, None) | (None, _) => child.wait_with_output().await,
+            (Some(pid), Some((graceful_timeout, forceful_timeout))) => {
+                tokio::select! {
+                    response = child.wait_with_output() => response,
+                    not_killed = kill_on_timeout(pid, graceful_timeout, forceful_timeout) => Err(not_killed),
+                }
+            }
+        }
     }
+}
+
+async fn kill_on_timeout(
+    pid: u32,
+    graceful_timeout: Duration,
+    forceful_timeout: Duration,
+) -> std::io::Error {
+    let pid = nix::unistd::Pid::from_raw(pid as nix::libc::pid_t);
+
+    tokio::time::sleep(graceful_timeout).await;
+    let _ = nix::sys::signal::kill(pid, nix::sys::signal::SIGTERM);
+
+    tokio::time::sleep(forceful_timeout).await;
+    let _ = nix::sys::signal::kill(pid, nix::sys::signal::SIGKILL);
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "failed to kill the process after timeout",
+    )
 }
 
 impl ScriptActor {
@@ -53,6 +116,7 @@ impl ScriptActor {
 
 #[cfg(test)]
 mod tests {
+    use std::os::unix::process::ExitStatusExt;
     use std::time::Duration;
     use tedge_actors::ClientMessageBox;
 
@@ -64,7 +128,8 @@ mod tests {
             Execute::try_new(r#"python -c "print('Hello world!')""#),
             Ok(Execute {
                 command: "python".to_string(),
-                args: vec!["-c".to_string(), "print('Hello world!')".to_string()]
+                args: vec!["-c".to_string(), "print('Hello world!')".to_string()],
+                timeouts: None,
             })
         )
     }
@@ -76,6 +141,7 @@ mod tests {
             .await_response(Execute {
                 command: "echo".to_owned(),
                 args: vec!["A message".to_owned()],
+                timeouts: None,
             })
             .await
             .unwrap()
@@ -88,8 +154,7 @@ mod tests {
 
     #[tokio::test]
     async fn script_stdin_is_closed() {
-        let actor = spawn_script_actor();
-        let mut actor = actor;
+        let mut actor = spawn_script_actor();
         let command = Execute::try_new("cat").unwrap();
         let output = tokio::time::timeout(Duration::from_secs(1), actor.await_response(command))
             .await
@@ -100,6 +165,60 @@ mod tests {
         assert!(output.status.success());
         assert!(output.stdout.is_empty());
         assert!(output.stderr.is_empty());
+    }
+
+    #[tokio::test]
+    async fn script_is_given_enough_time() {
+        let mut actor = spawn_script_actor();
+        let command = Execute::try_new("echo hello world")
+            .unwrap()
+            .with_graceful_timeout(Duration::from_secs(1));
+        let output = tokio::time::timeout(Duration::from_secs(5), actor.await_response(command))
+            .await
+            .expect("execution timeout")
+            .expect("result send error")
+            .expect("execution error");
+
+        assert!(output.status.success());
+        assert_eq!(output.status.code(), Some(0));
+        assert_eq!(output.status.signal(), None);
+        assert_eq!(String::from_utf8(output.stdout).unwrap(), "hello world\n");
+    }
+
+    #[tokio::test]
+    async fn script_is_gracefully_killed() {
+        let mut actor = spawn_script_actor();
+        let command = Execute::try_new("sleep 10")
+            .unwrap()
+            .with_graceful_timeout(Duration::from_secs(1));
+        let output = tokio::time::timeout(Duration::from_secs(5), actor.await_response(command))
+            .await
+            .expect("execution timeout")
+            .expect("result send error")
+            .expect("execution error");
+
+        assert!(!output.status.success());
+        assert!(output.status.code().is_none());
+        assert_eq!(output.status.signal(), Some(15));
+    }
+
+    #[tokio::test]
+    async fn script_is_forcefully_killed() {
+        let mut actor = spawn_script_actor();
+        let command_line = r#"/usr/bin/env bash -c "trap 'echo ignore SIGTERM' SIGTERM; while true; do sleep 1; done""#;
+        let command = Execute::try_new(command_line)
+            .unwrap()
+            .with_graceful_timeout(Duration::from_secs(1))
+            .with_forceful_timeout_extension(Duration::from_secs(1));
+        let output = tokio::time::timeout(Duration::from_secs(5), actor.await_response(command))
+            .await
+            .expect("execution timeout")
+            .expect("result send error")
+            .expect("execution error");
+
+        assert!(!output.status.success());
+        assert!(output.status.code().is_none());
+        assert_eq!(output.status.signal(), Some(9));
     }
 
     fn spawn_script_actor() -> ClientMessageBox<Execute, std::io::Result<Output>> {


### PR DESCRIPTION
## Proposed changes

Add two optional timeouts to script execution:
- If the script is still running after the graceful_timeout, the process is sent a SIGTERM
- If the script is still running after the forceful_timeout, the process is sent a SIGKILL

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

