### PR TITLE
Create aggregated log file in temp dir #2443

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1839,6 +1839,7 @@ dependencies = [
  "filetime",
  "glob",
  "log",
+ "rand",
  "serde",
  "tedge_test_utils",
  "tedge_utils",

--- a/crates/common/log_manager/Cargo.toml
+++ b/crates/common/log_manager/Cargo.toml
@@ -12,6 +12,7 @@ repository = { workspace = true }
 easy_reader = { workspace = true }
 glob = { workspace = true }
 log = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tedge_utils = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -51,6 +51,7 @@ pub struct AgentConfig {
     pub restart_config: RestartManagerConfig,
     pub sw_update_config: SoftwareManagerConfig,
     pub config_dir: Utf8PathBuf,
+    pub tmp_dir: Utf8PathBuf,
     pub run_dir: Utf8PathBuf,
     pub use_lock: bool,
     pub log_dir: Utf8PathBuf,
@@ -70,6 +71,7 @@ impl AgentConfig {
         let tedge_config = config_repository.load()?;
 
         let config_dir = tedge_config_location.tedge_config_root_path.clone();
+        let tmp_dir = tedge_config.tmp.path.clone();
 
         let mqtt_topic_root = cliopts
             .mqtt_topic_root
@@ -118,6 +120,7 @@ impl AgentConfig {
             restart_config,
             sw_update_config,
             config_dir,
+            tmp_dir,
             run_dir,
             use_lock,
             data_dir,
@@ -239,6 +242,7 @@ impl Agent {
             // Instantiate log manager actor
             let log_manager_config = LogManagerConfig::from_options(LogManagerOptions {
                 config_dir: self.config.config_dir.clone().into(),
+                tmp_dir: self.config.config_dir.clone().into(),
                 mqtt_schema,
                 mqtt_device_topic_id: self.config.mqtt_device_topic_id.clone(),
             })?;

--- a/crates/extensions/c8y_log_manager/src/actor.rs
+++ b/crates/extensions/c8y_log_manager/src/actor.rs
@@ -122,6 +122,7 @@ impl LogManagerActor {
             smartrest_request.date_from,
             smartrest_request.lines,
             &smartrest_request.search_text,
+            &self.config.tmp_dir,
         )?;
 
         let log_content = std::fs::read_to_string(&log_path)?;

--- a/crates/extensions/tedge_log_manager/src/actor.rs
+++ b/crates/extensions/tedge_log_manager/src/actor.rs
@@ -162,6 +162,7 @@ impl LogManagerActor {
             request.date_from,
             request.lines.to_owned(),
             &request.search_text,
+            &self.config.tmp_dir,
         )?;
 
         let upload_request = UploadRequest::new(

--- a/crates/extensions/tedge_log_manager/src/config.rs
+++ b/crates/extensions/tedge_log_manager/src/config.rs
@@ -16,6 +16,7 @@ pub const DEFAULT_PLUGIN_CONFIG_DIR_NAME: &str = "plugins/";
 #[derive(Clone, Debug)]
 pub struct LogManagerConfig {
     pub config_dir: PathBuf,
+    pub tmp_dir: PathBuf,
     pub plugin_config_dir: PathBuf,
     pub plugin_config_path: PathBuf,
     pub logtype_reload_topic: Topic,
@@ -24,6 +25,7 @@ pub struct LogManagerConfig {
 
 pub struct LogManagerOptions {
     pub config_dir: PathBuf,
+    pub tmp_dir: PathBuf,
     pub mqtt_schema: MqttSchema,
     pub mqtt_device_topic_id: EntityTopicId,
 }
@@ -31,6 +33,7 @@ pub struct LogManagerOptions {
 impl LogManagerConfig {
     pub fn from_options(cliopts: LogManagerOptions) -> Result<Self, ReadError> {
         let config_dir = cliopts.config_dir;
+        let tmp_dir = cliopts.tmp_dir;
         let mqtt_schema = cliopts.mqtt_schema;
         let mqtt_device_topic_id = cliopts.mqtt_device_topic_id;
 
@@ -51,6 +54,7 @@ impl LogManagerConfig {
 
         Ok(Self {
             config_dir,
+            tmp_dir,
             plugin_config_dir,
             plugin_config_path,
             logtype_reload_topic,

--- a/crates/extensions/tedge_log_manager/src/tests.rs
+++ b/crates/extensions/tedge_log_manager/src/tests.rs
@@ -89,6 +89,7 @@ async fn new_log_manager_builder(
 ) {
     let config = LogManagerConfig {
         config_dir: temp_dir.to_path_buf(),
+        tmp_dir: temp_dir.to_path_buf(),
         plugin_config_dir: temp_dir.to_path_buf(),
         plugin_config_path: temp_dir.join("tedge-log-plugin.toml"),
         logtype_reload_topic: Topic::new_unchecked("te/device/main///cmd/log_upload"),
@@ -198,7 +199,18 @@ async fn log_manager_upload_log_files_on_request() -> Result<(), anyhow::Error> 
         upload_request.url,
         "http://127.0.0.1:3000/tedge/file-transfer/main/log_upload/type_two-1234"
     );
-    assert_eq!(upload_request.file_path, tempdir.path().join("file_c.tmp"));
+    assert!(
+        upload_request.file_path.starts_with(tempdir.path()),
+        "Expected the log file to be created in tempdir"
+    );
+    assert!(
+        upload_request
+            .file_path
+            .file_name()
+            .unwrap()
+            .starts_with("type_two"),
+        "Expected a log file name with the log type as prefix"
+    );
 
     assert_eq!(upload_request.auth, None);
 

--- a/plugins/tedge_log_plugin/src/lib.rs
+++ b/plugins/tedge_log_plugin/src/lib.rs
@@ -82,6 +82,7 @@ async fn run_with(
     let runtime_events_logger = None;
     let mut runtime = Runtime::try_new(runtime_events_logger).await?;
 
+    let tmp_dir = tedge_config.tmp.path.clone().into();
     let mqtt_topic_root = cliopts
         .mqtt_topic_root
         .unwrap_or(tedge_config.mqtt.topic_root.clone().into());
@@ -124,6 +125,7 @@ async fn run_with(
     // Instantiate log manager actor
     let log_manager_config = LogManagerConfig::from_options(LogManagerOptions {
         config_dir: cliopts.config_dir,
+        tmp_dir,
         mqtt_schema: MqttSchema::with_root(mqtt_topic_root.to_string()),
         mqtt_device_topic_id: mqtt_device_topic_id.to_string().parse()?,
     })?;


### PR DESCRIPTION
## Proposed changes

The temporary aggregated log file created by the log_manager actor will be created at the temp directory instead of the target file directory, to avoid permission issues when the log manager is not running as root.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2443

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

