### PR TITLE
Give the default failure "reason" when commands failed

### DIFF
--- a/crates/core/tedge_api/src/messages.rs
+++ b/crates/core/tedge_api/src/messages.rs
@@ -489,8 +489,13 @@ pub enum CommandStatus {
     Executing,
     Successful,
     Failed {
+        #[serde(default = "default_failure_reason")]
         reason: String,
     },
+}
+
+fn default_failure_reason() -> String {
+    "Unknown reason".to_string()
 }
 
 /// TODO: Deprecate OperationStatus

--- a/crates/extensions/c8y_mapper_ext/src/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/log_upload.rs
@@ -563,8 +563,7 @@ mod tests {
             "dateFrom": "2013-06-22T17:03:14.123+02:00",
             "dateTo": "2013-06-23T18:03:14.123+02:00",
             "searchText": "ERROR",
-            "lines": 1000,
-            "reason": "Something went wrong"
+            "lines": 1000
         })
                 .to_string(),
         ))
@@ -574,10 +573,7 @@ mod tests {
         // Expect `502` smartrest message on `c8y/s/us`.
         assert_received_contains_str(
             &mut mqtt,
-            [(
-                "c8y/s/us",
-                "502,c8y_LogfileRequest,\"Something went wrong\"",
-            )],
+            [("c8y/s/us", "502,c8y_LogfileRequest,\"Unknown reason\"")],
         )
         .await;
     }


### PR DESCRIPTION
## Proposed changes
Without giving the default reason, mappers will parse an error when command status is failed but no "reason" is given. However, "reason" filed should be optional in command payloads.

This bug was found during writing a unit test for firmware_update support.  
```
[te/device/main///cmd/firmware_update/c8y-mapper-2023-11-16T14:02:31.419901262Z] {
   "status":"failed",
   "remoteUrl":"https://speed.hetzner.de/10GB.bin",
   "name":"10GB",
   "version":"2.0.0"
}
[te/errors] missing field `reason` at line 6 column 1
```

The bahaviour is covered by the unit test `handle_log_upload_executing_and_failed_cmd_for_main_device()`.

Maybe worth adding a robot test?

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

