### PR TITLE
tedge cert upload c8y: ambiguous file/folder not found error - missing path in error message

### DIFF
--- a/crates/core/tedge/src/cli/certificate/error.rs
+++ b/crates/core/tedge/src/cli/certificate/error.rs
@@ -78,6 +78,9 @@ pub enum CertError {
 
     #[error(transparent)]
     TedgeConfigSettingError(#[from] ConfigSettingError),
+
+    #[error("Root certificate path {0} does not exist")]
+    RootCertificatePathDoesNotExist(String),
 }
 
 impl CertError {

--- a/tests/RobotFramework/tests/tedge/tedge_upload_cert.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_upload_cert.robot
@@ -1,0 +1,19 @@
+*** Settings ***
+Documentation    Run certificate upload test and fails to upload the cert because there is no root certificate directory,
+...              Then check the negative response in stderr              
+
+Resource    ../../resources/common.resource
+Library    ThinEdgeIO
+
+Test Tags    theme:cli    theme:mqtt    theme:c8y
+Suite Setup            Setup
+Suite Teardown         Get Logs
+
+*** Test Cases ***
+
+tedge cert upload c8y command fails
+    Execute Command    tedge config set c8y.root_cert_path /etc/ssl/certs_test    
+    ${output}=    Execute Command    sudo env C8YPASS\='password' tedge cert upload c8y --user testuser    ignore_exit_code=${True}    stdout=${False}    stderr=${True}
+    Execute Command    tedge config unset c8y.root_cert_path
+    Should Contain    ${output}    Root certificate path /etc/ssl/certs_test does not exist  
+    


### PR DESCRIPTION
## Proposed changes

While uploading the certificate, if the `root` certificate path does not exist, the error message must be more verbose, providing the info about which `path` or `directory` does not exist. The error must be as below.

```
Error: failed to upload root certificate

Caused by:
    Root certificate path /etc/ssl/certssaa does not exist

```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/2419
## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

