### PR TITLE
Add tedge config agent.state.path setting

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -652,6 +652,17 @@ define_tedge_config! {
         ca_path: Utf8PathBuf,
     },
 
+    agent: {
+        state: {
+            /// The directory where the tedge-agent persists its state across restarts
+            #[tedge_config(note = "If the given directory doesn't exists, `/etc/tedge/.agent` is used as a fallback irrespective of the current setting.")]
+            #[tedge_config(default(value = "/data/tedge/agent"))]
+            #[tedge_config(example = "/data/tedge/agent")]
+            #[doku(as = "PathBuf")]
+            path: Utf8PathBuf,
+        },
+    },
+
     software: {
         plugin: {
             /// The default software plugin to be used for software management on the device

--- a/crates/core/tedge_agent/src/restart_manager/actor.rs
+++ b/crates/core/tedge_agent/src/restart_manager/actor.rs
@@ -108,8 +108,11 @@ impl RestartManagerActor {
         config: RestartManagerConfig,
         message_box: SimpleMessageBox<RestartCommand, RestartCommand>,
     ) -> Self {
-        let state_repository =
-            AgentStateRepository::new(config.config_dir.clone(), "restart-current-operation");
+        let state_repository = AgentStateRepository::new(
+            config.state_dir.clone(),
+            config.config_dir.clone(),
+            "restart-current-operation",
+        );
         Self {
             config,
             state_repository,

--- a/crates/core/tedge_agent/src/restart_manager/config.rs
+++ b/crates/core/tedge_agent/src/restart_manager/config.rs
@@ -6,21 +6,10 @@ pub struct RestartManagerConfig {
     pub device_topic_id: EntityTopicId,
     pub tmp_dir: Utf8PathBuf,
     pub config_dir: Utf8PathBuf,
+    pub state_dir: Utf8PathBuf,
 }
 
 impl RestartManagerConfig {
-    pub fn new(
-        device_topic_id: &EntityTopicId,
-        tmp_dir: &Utf8PathBuf,
-        config_dir: &Utf8PathBuf,
-    ) -> Self {
-        Self {
-            device_topic_id: device_topic_id.clone(),
-            tmp_dir: tmp_dir.clone(),
-            config_dir: config_dir.clone(),
-        }
-    }
-
     pub fn from_tedge_config(
         device_topic_id: &EntityTopicId,
         tedge_config_location: &tedge_config::TEdgeConfigLocation,
@@ -29,9 +18,11 @@ impl RestartManagerConfig {
             tedge_config::TEdgeConfigRepository::new(tedge_config_location.clone());
         let tedge_config = config_repository.load()?;
 
-        let tmp_dir = tedge_config.tmp.path.clone();
-        let config_dir = tedge_config_location.tedge_config_root_path.clone();
-
-        Ok(Self::new(device_topic_id, &tmp_dir, &config_dir))
+        Ok(RestartManagerConfig {
+            device_topic_id: device_topic_id.clone(),
+            tmp_dir: tedge_config.tmp.path.clone(),
+            config_dir: tedge_config_location.tedge_config_root_path.clone(),
+            state_dir: tedge_config.agent.state.path.clone(),
+        })
     }
 }

--- a/crates/core/tedge_agent/src/restart_manager/tests.rs
+++ b/crates/core/tedge_agent/src/restart_manager/tests.rs
@@ -110,11 +110,12 @@ async fn spawn_restart_manager(
     let mut converter_builder: SimpleMessageBoxBuilder<RestartCommand, RestartCommand> =
         SimpleMessageBoxBuilder::new("Converter", 5);
 
-    let config = RestartManagerConfig::new(
-        &EntityTopicId::default_main_device(),
-        &tmp_dir.utf8_path_buf(),
-        &tmp_dir.utf8_path_buf(),
-    );
+    let config = RestartManagerConfig {
+        device_topic_id: EntityTopicId::default_main_device(),
+        tmp_dir: tmp_dir.utf8_path_buf(),
+        config_dir: tmp_dir.utf8_path_buf(),
+        state_dir: "/some/unknown/dir".into(),
+    };
 
     let mut restart_actor_builder = RestartManagerBuilder::new(config);
     converter_builder.set_connection(&mut restart_actor_builder);

--- a/crates/core/tedge_agent/src/software_manager/actor.rs
+++ b/crates/core/tedge_agent/src/software_manager/actor.rs
@@ -124,9 +124,11 @@ impl SoftwareManagerActor {
         config: SoftwareManagerConfig,
         message_box: SimpleMessageBox<SoftwareCommand, SoftwareCommand>,
     ) -> Self {
-        let state_repository =
-            AgentStateRepository::new(config.config_dir.clone(), "software-current-operation");
-
+        let state_repository = AgentStateRepository::new(
+            config.state_dir.clone(),
+            config.config_dir.clone(),
+            "software-current-operation",
+        );
         let (output_sender, input_receiver) = message_box.into_split();
 
         Self {

--- a/crates/core/tedge_agent/src/software_manager/tests.rs
+++ b/crates/core/tedge_agent/src/software_manager/tests.rs
@@ -160,15 +160,16 @@ async fn spawn_software_manager(
     let mut converter_builder: SimpleMessageBoxBuilder<SoftwareCommand, SoftwareCommand> =
         SimpleMessageBoxBuilder::new("Converter", 5);
 
-    let config = SoftwareManagerConfig::new(
-        &EntityTopicId::default_main_device(),
-        &tmp_dir.utf8_path_buf(),
-        &tmp_dir.utf8_path_buf(),
-        &tmp_dir.utf8_path_buf(),
-        &tmp_dir.utf8_path_buf(),
-        None,
-        &TEdgeConfigLocation::from_custom_root(tmp_dir.utf8_path_buf()),
-    );
+    let config = SoftwareManagerConfig {
+        device: EntityTopicId::default_main_device(),
+        tmp_dir: tmp_dir.utf8_path_buf(),
+        config_dir: tmp_dir.utf8_path_buf(),
+        state_dir: "/some/unknown/dir".into(),
+        sm_plugins_dir: tmp_dir.utf8_path_buf(),
+        log_dir: tmp_dir.utf8_path_buf(),
+        default_plugin_type: None,
+        config_location: TEdgeConfigLocation::from_custom_root(tmp_dir.utf8_path_buf()),
+    };
 
     let mut software_actor_builder = SoftwareManagerBuilder::new(config);
     converter_builder.set_connection(&mut software_actor_builder);


### PR DESCRIPTION
## Proposed changes

- A new tedge-config setting has been added: `agent.state.path`
- This path is used to store the __tedge-agent__ state across restarts.
- If for some reasons this directory cannot be used (doesn't exist or is not writable),
  then  the __tedge-agent__ use `/etc/tedge/.agent` as a fallback.
- The default value for `agent.state.path` is `/data/tedge/agent`.

```
agent.state.path
   The directory where the tedge-agent persists its state across restarts. 
   Note: If the given directory doesn't exists, `/etc/tedge/.agent` is used as a fallback irrespective of the current setting.
   Example: /data/tedge/agent
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2488

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

