### PR TITLE
Support quotes in Cumulocity failureReason field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,6 @@ dependencies = [
  "futures",
  "maplit",
  "mqtt_channel",
- "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/core/c8y_api/Cargo.toml
+++ b/crates/core/c8y_api/Cargo.toml
@@ -31,7 +31,6 @@ anyhow = { workspace = true }
 assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
 maplit = { workspace = true }
-regex = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 time = { workspace = true, features = ["macros"] }

--- a/crates/core/c8y_api/src/smartrest/alarm.rs
+++ b/crates/core/c8y_api/src/smartrest/alarm.rs
@@ -1,5 +1,6 @@
 use crate::json_c8y::AlarmSeverity;
 use crate::json_c8y::C8yAlarm;
+use crate::smartrest::csv::fields_to_csv_string;
 use time::format_description::well_known::Rfc3339;
 
 /// Serialize C8yAlarm to SmartREST message
@@ -20,7 +21,7 @@ pub fn serialize_alarm(c8y_alarm: &C8yAlarm) -> Result<String, time::error::Form
                 alarm.time.format(&Rfc3339)?
             )
         }
-        C8yAlarm::Clear(alarm) => format!("306,{}", alarm.alarm_type),
+        C8yAlarm::Clear(alarm) => fields_to_csv_string(&["306", &alarm.alarm_type]),
     };
     Ok(smartrest)
 }

--- a/crates/core/c8y_api/src/smartrest/csv.rs
+++ b/crates/core/c8y_api/src/smartrest/csv.rs
@@ -1,0 +1,25 @@
+pub fn fields_to_csv_string(record: &[&str]) -> String {
+    let mut writer = csv::Writer::from_writer(vec![]);
+    writer
+        .write_record(record)
+        .expect("write to vec never fails");
+    let mut output = writer.into_inner().expect("write to vec never fails");
+    output.pop();
+    String::from_utf8(output).expect("all input is utf-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::smartrest::csv::fields_to_csv_string;
+
+    #[test]
+    fn normal_fields_containing_commas_are_quoted() {
+        assert_eq!(fields_to_csv_string(&["503", "test,me"]), "503,\"test,me\"");
+    }
+
+    #[test]
+    fn normal_fields_containing_quotes_are_quoted() {
+        let rcd = fields_to_csv_string(&["503", r#"A value"with" quotes"#, "field"]);
+        assert_eq!(rcd, r#"503,"A value""with"" quotes",field"#);
+    }
+}

--- a/crates/core/c8y_api/src/smartrest/mod.rs
+++ b/crates/core/c8y_api/src/smartrest/mod.rs
@@ -1,4 +1,5 @@
 pub mod alarm;
+pub mod csv;
 pub mod error;
 pub mod inventory;
 pub mod message;

--- a/crates/core/c8y_api/src/smartrest/operations.rs
+++ b/crates/core/c8y_api/src/smartrest/operations.rs
@@ -5,12 +5,10 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use crate::smartrest::error::OperationsError;
-use crate::smartrest::smartrest_serializer::SmartRestSerializer;
-use crate::smartrest::smartrest_serializer::SmartRestSetSupportedOperations;
+use crate::smartrest::smartrest_serializer::declare_supported_operations;
 use serde::Deserialize;
 use serde::Deserializer;
 
-use super::error::SmartRestSerializerError;
 use std::time::Duration;
 
 const DEFAULT_GRACEFUL_TIMEOUT: Duration = Duration::from_secs(3600);
@@ -173,11 +171,11 @@ impl Operations {
             .collect::<HashSet<String>>()
     }
 
-    pub fn create_smartrest_ops_message(&self) -> Result<String, SmartRestSerializerError> {
+    pub fn create_smartrest_ops_message(&self) -> String {
         let mut ops = self.get_operations_list();
         ops.sort();
-        let ops = ops.iter().map(|op| op as &str).collect::<Vec<&str>>();
-        SmartRestSetSupportedOperations::new(&ops).to_smartrest()
+        let ops = ops.iter().map(|op| op.as_str()).collect::<Vec<_>>();
+        declare_supported_operations(&ops)
     }
 }
 

--- a/crates/core/c8y_api/src/smartrest/smartrest_serializer.rs
+++ b/crates/core/c8y_api/src/smartrest/smartrest_serializer.rs
@@ -1,13 +1,76 @@
+use crate::smartrest::csv::fields_to_csv_string;
 use crate::smartrest::error::SmartRestSerializerError;
 use crate::smartrest::topic::C8yTopic;
-use csv::WriterBuilder;
+use csv::StringRecord;
 use mqtt_channel::Message;
+use serde::ser::SerializeSeq;
 use serde::Deserialize;
 use serde::Serialize;
+use serde::Serializer;
 
 pub type SmartRest = String;
 
-#[derive(Debug)]
+pub fn request_pending_operations() -> &'static str {
+    "500"
+}
+
+/// Generates a SmartREST message to set the provided operation to executing
+pub fn set_operation_executing(operation: impl C8yOperation) -> String {
+    fields_to_csv_string(&["501", operation.name()])
+}
+
+/// Generates a SmartREST message to set the provided operation to failed with the provided reason
+pub fn fail_operation(operation: impl C8yOperation, reason: &str) -> String {
+    fields_to_csv_string(&["502", operation.name(), reason])
+}
+
+/// Generates a SmartREST message to set the provided operation to successful without a payload
+pub fn succeed_operation_no_payload(operation: CumulocitySupportedOperations) -> String {
+    succeed_static_operation(operation, None::<&str>)
+}
+
+/// Generates a SmartREST message to set the provided operation to successful with an optional payload
+pub fn succeed_static_operation(
+    operation: CumulocitySupportedOperations,
+    payload: Option<impl AsRef<str>>,
+) -> String {
+    let mut wtr = csv::Writer::from_writer(vec![]);
+    // Serialization will never fail for text
+    match payload {
+        Some(payload) => wtr.serialize(("503", operation.name(), payload.as_ref())),
+        None => wtr.serialize(("503", operation.name())),
+    }
+    .unwrap();
+    let mut output = wtr.into_inner().unwrap();
+    output.pop();
+    String::from_utf8(output).unwrap()
+}
+
+/// Generates a SmartREST message to set the provided custom operation to successful with a text or csv payload
+///
+/// - If the payload is "text", then a single payload field will be created
+/// - If the payload is "csv", then the provided CSV record will be appended to the SmartREST message
+///
+/// # CSV
+/// If the provided CSV does not match the standard Cumulocity format, the standard CSV escaping
+/// rules will be applied. For example, `a,field "with" quotes` will be converted to
+/// `a,"field ""with"" quotes"` before being appended to the output of this function.
+///
+/// # Errors
+/// This will return an error if the payload is a CSV with multiple records, or an empty CSV.
+pub fn succeed_operation(
+    operation: &str,
+    reason: impl Into<TextOrCsv>,
+) -> Result<String, SmartRestSerializerError> {
+    let mut wtr = csv::Writer::from_writer(vec![]);
+    // Serialization can fail for CSV, but not for text
+    wtr.serialize(("503", operation, reason.into()))?;
+    let mut output = wtr.into_inner().unwrap();
+    output.pop();
+    Ok(String::from_utf8(output)?)
+}
+
+#[derive(Debug, Copy, Clone)]
 pub enum CumulocitySupportedOperations {
     C8ySoftwareUpdate,
     C8yLogFileRequest,
@@ -30,52 +93,9 @@ impl From<CumulocitySupportedOperations> for &'static str {
     }
 }
 
-pub trait SmartRestSerializer<'a>
-where
-    Self: Serialize,
-{
-    fn to_smartrest(&self) -> Result<SmartRest, SmartRestSerializerError> {
-        serialize_smartrest(self)
-    }
+pub fn declare_supported_operations(ops: &[&str]) -> String {
+    format!("114,{}", fields_to_csv_string(ops))
 }
-
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
-pub struct SmartRestSetSupportedLogType {
-    pub message_id: &'static str,
-    pub supported_operations: Vec<String>,
-}
-
-impl From<Vec<String>> for SmartRestSetSupportedLogType {
-    fn from(operation_types: Vec<String>) -> Self {
-        Self {
-            message_id: "118",
-            supported_operations: operation_types,
-        }
-    }
-}
-
-impl<'a> SmartRestSerializer<'a> for SmartRestSetSupportedLogType {}
-
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
-pub struct SmartRestSetSupportedOperations<'a> {
-    pub message_id: &'static str,
-    pub supported_operations: Vec<&'a str>,
-}
-
-impl<'a> SmartRestSetSupportedOperations<'a> {
-    pub fn new(supported_operations: &[&'a str]) -> Self {
-        Self {
-            message_id: "114",
-            supported_operations: supported_operations.into(),
-        }
-    }
-
-    pub fn add_operation(&mut self, operation: &'a str) {
-        self.supported_operations.push(operation);
-    }
-}
-
-impl<'a> SmartRestSerializer<'a> for SmartRestSetSupportedOperations<'a> {}
 
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct SmartRestSoftwareModuleItem {
@@ -84,108 +104,103 @@ pub struct SmartRestSoftwareModuleItem {
     pub url: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
-pub struct SmartRestGetPendingOperations {
-    pub id: &'static str,
+/// A supported operation of the thin-edge device, used in status updates via SmartREST
+///
+/// This has two implementations, `&str` for custom operations, and [CumolocitySupportedOperations]
+/// for statically supported operations.
+pub trait C8yOperation {
+    fn name(&self) -> &str;
 }
 
-impl Default for SmartRestGetPendingOperations {
-    fn default() -> Self {
-        Self { id: "500" }
+impl C8yOperation for CumulocitySupportedOperations {
+    fn name(&self) -> &str {
+        (*self).into()
     }
 }
 
-impl<'a> SmartRestSerializer<'a> for SmartRestGetPendingOperations {}
-
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
-pub struct SmartRestSetOperationToExecuting {
-    pub message_id: &'static str,
-    pub operation: &'static str,
+impl<'a> C8yOperation for &'a str {
+    fn name(&self) -> &str {
+        self
+    }
 }
 
-impl SmartRestSetOperationToExecuting {
-    pub fn new(operation: CumulocitySupportedOperations) -> Self {
-        Self {
-            message_id: "501",
-            operation: operation.into(),
+#[derive(Debug, Serialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum TextOrCsv {
+    Text(String),
+    Csv(EmbeddedCsv),
+}
+
+impl From<EmbeddedCsv> for TextOrCsv {
+    fn from(value: EmbeddedCsv) -> Self {
+        Self::Csv(value)
+    }
+}
+
+impl From<String> for TextOrCsv {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct EmbeddedCsv(String);
+
+impl EmbeddedCsv {
+    pub fn new(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl Serialize for EmbeddedCsv {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        S::Error: serde::ser::Error,
+    {
+        let record = dbg!(parse_single_record(&self.0)?);
+        let mut seq = serializer.serialize_seq(Some(record.len()))?;
+        for field in record.iter() {
+            seq.serialize_element(field)?;
         }
+        seq.end()
     }
 }
 
-impl<'a> SmartRestSerializer<'a> for SmartRestSetOperationToExecuting {}
+fn parse_single_record<E>(csv: &str) -> Result<StringRecord, E>
+where
+    E: serde::ser::Error,
+{
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .from_reader(csv.as_bytes());
 
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
-pub struct SmartRestSetOperationToSuccessful {
-    pub message_id: &'static str,
-    pub operation: &'static str,
-    pub operation_parameter: Option<String>,
-}
-
-impl SmartRestSetOperationToSuccessful {
-    pub fn new(operation: CumulocitySupportedOperations) -> Self {
-        Self {
-            message_id: "503",
-            operation: operation.into(),
-            operation_parameter: None,
-        }
+    let mut record = StringRecord::new();
+    match rdr.read_record(&mut record) {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(E::custom("No data in embedded csv")),
+        Err(e) => Err(E::custom(format!(
+            "Failed to read record from embedded csv: {e}"
+        ))),
+    }?;
+    match rdr.read_record(&mut StringRecord::new()) {
+        Ok(false) => Ok(record),
+        Ok(true) | Err(_) => Err(E::custom(format!("Multiple CSV records found (did you forget to quote a field containing a newline?) in {csv:?}"))),
     }
-
-    pub fn with_response_parameter(self, response_parameter: &str) -> Self {
-        Self {
-            operation_parameter: Some(response_parameter.into()),
-            ..self
-        }
-    }
-}
-
-impl<'a> SmartRestSerializer<'a> for SmartRestSetOperationToSuccessful {}
-
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
-pub struct SmartRestSetOperationToFailed {
-    pub message_id: &'static str,
-    pub operation: &'static str,
-    pub reason: String,
-}
-
-impl SmartRestSetOperationToFailed {
-    pub fn new(operation: CumulocitySupportedOperations, reason: String) -> Self {
-        Self {
-            message_id: "502",
-            operation: operation.into(),
-            reason,
-        }
-    }
-}
-
-impl<'a> SmartRestSerializer<'a> for SmartRestSetOperationToFailed {}
-
-fn serialize_smartrest<S: Serialize>(record: S) -> Result<String, SmartRestSerializerError> {
-    let mut wtr = WriterBuilder::new().has_headers(false).from_writer(vec![]);
-    wtr.serialize(record)?;
-
-    // csv::IntoInnerError still contains the writer and we can use it to
-    // recover, but if we don't and only report the error, we should report the
-    // inner io::Error
-    let csv = wtr.into_inner().map_err(|e| e.into_error())?;
-    let csv = String::from_utf8(csv)?;
-    Ok(csv)
 }
 
 /// Helper to generate a SmartREST operation status message
-pub trait TryIntoOperationStatusMessage {
-    fn executing() -> Result<Message, SmartRestSerializerError> {
-        let status = Self::status_executing()?;
-        Ok(Self::create_message(status))
+pub trait OperationStatusMessage {
+    fn executing() -> Message {
+        Self::create_message(Self::status_executing())
     }
 
-    fn successful(parameter: Option<String>) -> Result<Message, SmartRestSerializerError> {
-        let status = Self::status_successful(parameter)?;
-        Ok(Self::create_message(status))
+    fn successful(parameter: Option<&str>) -> Message {
+        Self::create_message(Self::status_successful(parameter))
     }
 
-    fn failed(failure_reason: String) -> Result<Message, SmartRestSerializerError> {
-        let status = Self::status_failed(failure_reason)?;
-        Ok(Self::create_message(status))
+    fn failed(failure_reason: &str) -> Message {
+        Self::create_message(Self::status_failed(failure_reason))
     }
 
     fn create_message(payload: SmartRest) -> Message {
@@ -193,9 +208,9 @@ pub trait TryIntoOperationStatusMessage {
         Message::new(&topic, payload)
     }
 
-    fn status_executing() -> Result<SmartRest, SmartRestSerializerError>;
-    fn status_successful(parameter: Option<String>) -> Result<SmartRest, SmartRestSerializerError>;
-    fn status_failed(failure_reason: String) -> Result<SmartRest, SmartRestSerializerError>;
+    fn status_executing() -> SmartRest;
+    fn status_successful(parameter: Option<&str>) -> SmartRest;
+    fn status_failed(failure_reason: &str) -> SmartRest;
 }
 
 #[cfg(test)]
@@ -204,90 +219,122 @@ mod tests {
 
     #[test]
     fn serialize_smartrest_supported_operations() {
-        let smartrest =
-            SmartRestSetSupportedOperations::new(&["c8y_SoftwareUpdate", "c8y_LogfileRequest"])
-                .to_smartrest()
-                .unwrap();
-        assert_eq!(smartrest, "114,c8y_SoftwareUpdate,c8y_LogfileRequest\n");
+        let smartrest = declare_supported_operations(&["c8y_SoftwareUpdate", "c8y_LogfileRequest"]);
+        assert_eq!(smartrest, "114,c8y_SoftwareUpdate,c8y_LogfileRequest");
     }
 
     #[test]
     fn serialize_smartrest_get_pending_operations() {
-        let smartrest = SmartRestGetPendingOperations::default()
-            .to_smartrest()
-            .unwrap();
-        assert_eq!(smartrest, "500\n");
+        let smartrest = request_pending_operations();
+        assert_eq!(smartrest, "500");
     }
 
     #[test]
     fn serialize_smartrest_set_operation_to_executing() {
-        let smartrest =
-            SmartRestSetOperationToExecuting::new(CumulocitySupportedOperations::C8ySoftwareUpdate)
-                .to_smartrest()
-                .unwrap();
-        assert_eq!(smartrest, "501,c8y_SoftwareUpdate\n");
+        let smartrest = set_operation_executing(CumulocitySupportedOperations::C8ySoftwareUpdate);
+        assert_eq!(smartrest, "501,c8y_SoftwareUpdate");
     }
 
     #[test]
     fn serialize_smartrest_set_operation_to_successful() {
-        let smartrest = SmartRestSetOperationToSuccessful::new(
+        let smartrest =
+            succeed_operation_no_payload(CumulocitySupportedOperations::C8ySoftwareUpdate);
+        assert_eq!(smartrest, "503,c8y_SoftwareUpdate");
+    }
+
+    #[test]
+    fn serialize_smartrest_set_operation_to_successful_with_payload() {
+        let smartrest = succeed_static_operation(
             CumulocitySupportedOperations::C8ySoftwareUpdate,
+            Some("a payload"),
+        );
+        assert_eq!(smartrest, "503,c8y_SoftwareUpdate,a payload");
+    }
+
+    #[test]
+    fn serialize_smartrest_set_custom_operation_to_successful_with_text_payload() {
+        let smartrest = succeed_operation(
+            "c8y_RelayArray",
+            TextOrCsv::Text("true,false,true".to_owned()),
         )
-        .to_smartrest()
         .unwrap();
-        assert_eq!(smartrest, "503,c8y_SoftwareUpdate,\n");
+        assert_eq!(smartrest, "503,c8y_RelayArray,\"true,false,true\"");
+    }
+
+    #[test]
+    fn serialize_smartrest_set_custom_operation_to_successful_with_csv_payload() {
+        let smartrest = succeed_operation(
+            "c8y_RelayArray",
+            TextOrCsv::Csv(EmbeddedCsv("true,false,true".to_owned())),
+        )
+        .unwrap();
+        assert_eq!(smartrest, "503,c8y_RelayArray,true,false,true");
+    }
+
+    #[test]
+    fn serialize_smartrest_set_custom_operation_to_successful_with_multi_record_csv_payload() {
+        succeed_operation(
+            "c8y_RelayArray",
+            TextOrCsv::Csv(EmbeddedCsv("true\n1,2,3".to_owned())),
+        )
+        .unwrap_err();
+    }
+
+    #[test]
+    fn serialize_smartrest_set_custom_operation_to_successful_requotes_csv_payload() {
+        let smartrest = succeed_operation(
+            "c8y_RelayArray",
+            TextOrCsv::Csv(EmbeddedCsv("true,random\"quote".to_owned())),
+        )
+        .unwrap();
+        assert_eq!(smartrest, "503,c8y_RelayArray,true,\"random\"\"quote\"");
     }
 
     #[test]
     fn serialize_smartrest_set_operation_to_failed() {
-        let smartrest = SmartRestSetOperationToFailed::new(
+        let smartrest = fail_operation(
             CumulocitySupportedOperations::C8ySoftwareUpdate,
-            "Failed due to permission.".into(),
-        )
-        .to_smartrest()
-        .unwrap();
+            "Failed due to permission.",
+        );
         assert_eq!(
             smartrest,
-            "502,c8y_SoftwareUpdate,Failed due to permission.\n"
+            "502,c8y_SoftwareUpdate,Failed due to permission."
         );
     }
 
     #[test]
+    fn serialize_smartrest_set_custom_operation_to_failed() {
+        let smartrest = fail_operation("c8y_Custom", "Something went wrong");
+        assert_eq!(smartrest, "502,c8y_Custom,Something went wrong");
+    }
+
+    #[test]
     fn serialize_smartrest_set_operation_to_failed_with_quotes() {
-        let smartrest = SmartRestSetOperationToFailed::new(
+        let smartrest = fail_operation(
             CumulocitySupportedOperations::C8ySoftwareUpdate,
-            "Failed due to permi\"ssion.".into(),
-        )
-        .to_smartrest()
-        .unwrap();
+            "Failed due to permi\"ssion.",
+        );
         assert_eq!(
             smartrest,
-            "502,c8y_SoftwareUpdate,\"Failed due to permi\"\"ssion.\"\n"
+            "502,c8y_SoftwareUpdate,\"Failed due to permi\"\"ssion.\""
         );
     }
 
     #[test]
     fn serialize_smartrest_set_operation_to_failed_with_comma_reason() {
-        let smartrest = SmartRestSetOperationToFailed::new(
+        let smartrest = fail_operation(
             CumulocitySupportedOperations::C8ySoftwareUpdate,
-            "Failed to install collectd, modbus, and golang.".into(),
-        )
-        .to_smartrest()
-        .unwrap();
+            "Failed to install collectd, modbus, and golang.",
+        );
         assert_eq!(
             smartrest,
-            "502,c8y_SoftwareUpdate,\"Failed to install collectd, modbus, and golang.\"\n"
+            "502,c8y_SoftwareUpdate,\"Failed to install collectd, modbus, and golang.\""
         );
     }
 
     #[test]
     fn serialize_smartrest_set_operation_to_failed_with_empty_reason() {
-        let smartrest = SmartRestSetOperationToFailed::new(
-            CumulocitySupportedOperations::C8ySoftwareUpdate,
-            "".into(),
-        )
-        .to_smartrest()
-        .unwrap();
-        assert_eq!(smartrest, "502,c8y_SoftwareUpdate,\n");
+        let smartrest = fail_operation(CumulocitySupportedOperations::C8ySoftwareUpdate, "");
+        assert_eq!(smartrest, "502,c8y_SoftwareUpdate,");
     }
 }

--- a/crates/core/c8y_api/src/smartrest/smartrest_serializer.rs
+++ b/crates/core/c8y_api/src/smartrest/smartrest_serializer.rs
@@ -158,7 +158,7 @@ impl Serialize for EmbeddedCsv {
         S: Serializer,
         S::Error: serde::ser::Error,
     {
-        let record = dbg!(parse_single_record(&self.0)?);
+        let record = parse_single_record(&self.0)?;
         let mut seq = serializer.serialize_seq(Some(record.len()))?;
         for field in record.iter() {
             seq.serialize_element(field)?;

--- a/crates/core/c8y_api/src/smartrest/topic.rs
+++ b/crates/core/c8y_api/src/smartrest/topic.rs
@@ -93,12 +93,12 @@ impl From<&C8yAlarm> for C8yTopic {
 /// - `["main"]` -> `c8y/s/us`
 /// - `["child1", "main"]` -> `c8y/s/us/child1`
 /// - `["child2", "child1", "main"]` -> `c8y/s/us/child1/child2`
-pub fn publish_topic_from_ancestors(ancestors: &[String]) -> Topic {
+pub fn publish_topic_from_ancestors(ancestors: &[impl AsRef<str>]) -> Topic {
     let mut target_topic = SMARTREST_PUBLISH_TOPIC.to_string();
     for ancestor in ancestors.iter().rev().skip(1) {
         // Skipping the last ancestor as it is the main device represented by the root topic itself
         target_topic.push('/');
-        target_topic.push_str(ancestor);
+        target_topic.push_str(ancestor.as_ref());
     }
 
     Topic::new_unchecked(&target_topic)
@@ -124,8 +124,7 @@ mod tests {
     #[test_case(&["child1", "main"], "c8y/s/us/child1")]
     #[test_case(&["child3", "child2", "child1", "main"], "c8y/s/us/child1/child2/child3")]
     fn topic_from_ancestors(ancestors: &[&str], topic: &str) {
-        let ancestors: Vec<String> = ancestors.iter().map(|v| v.to_string()).collect();
-        let nested_child_topic = publish_topic_from_ancestors(&ancestors);
+        let nested_child_topic = publish_topic_from_ancestors(ancestors);
         assert_eq!(nested_child_topic, Topic::new_unchecked(topic));
     }
 }

--- a/crates/extensions/c8y_config_manager/src/tests.rs
+++ b/crates/extensions/c8y_config_manager/src/tests.rs
@@ -96,7 +96,7 @@ async fn test_config_upload_tedge_device() -> Result<(), DynError> {
     mqtt_message_box
         .assert_received([MqttMessage::new(
             &C8yTopic::SmartRestResponse.to_topic()?,
-            "501,c8y_UploadConfigFile\n",
+            "501,c8y_UploadConfigFile",
         )])
         .await;
 
@@ -118,7 +118,7 @@ async fn test_config_upload_tedge_device() -> Result<(), DynError> {
     mqtt_message_box
         .assert_received([MqttMessage::new(
             &C8yTopic::SmartRestResponse.to_topic()?,
-            "503,c8y_UploadConfigFile,test-url\n",
+            "503,c8y_UploadConfigFile,test-url",
         )])
         .await;
 
@@ -160,7 +160,7 @@ async fn test_config_download_tedge_device() -> Result<(), DynError> {
     mqtt_message_box
         .assert_received([MqttMessage::new(
             &C8yTopic::SmartRestResponse.to_topic()?,
-            "501,c8y_DownloadConfigFile\n",
+            "501,c8y_DownloadConfigFile",
         )])
         .await;
 
@@ -182,7 +182,7 @@ async fn test_config_download_tedge_device() -> Result<(), DynError> {
     mqtt_message_box
         .assert_received([MqttMessage::new(
             &C8yTopic::SmartRestResponse.to_topic()?,
-            "503,c8y_DownloadConfigFile,\n",
+            "503,c8y_DownloadConfigFile",
         )])
         .await;
 
@@ -283,7 +283,7 @@ async fn test_child_device_config_upload_executing_response_mapping() -> Result<
         .with_timeout(TEST_TIMEOUT)
         .assert_received([MqttMessage::new(
             &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-            "501,c8y_UploadConfigFile\n",
+            "501,c8y_UploadConfigFile",
         )])
         .await;
 
@@ -334,11 +334,11 @@ async fn test_child_device_config_upload_failed_response_mapping() -> Result<(),
         .assert_received([
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "501,c8y_UploadConfigFile\n",
+                "501,c8y_UploadConfigFile",
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_UploadConfigFile,upload failed\n",
+                "502,c8y_UploadConfigFile,upload failed",
             ),
         ])
         .await;
@@ -386,11 +386,11 @@ async fn test_invalid_config_snapshot_response_child_device() -> Result<(), DynE
         [
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "501,c8y_UploadConfigFile\n",
+                "501,c8y_UploadConfigFile",
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_UploadConfigFile,Failed to parse response from child device with: expected value at line 1 column 1\n",
+                "502,c8y_UploadConfigFile,Failed to parse response from child device with: expected value at line 1 column 1",
             ),
         ],
     )
@@ -451,11 +451,11 @@ async fn test_timeout_on_no_config_snapshot_response_child_device() -> Result<()
         .assert_received([
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "501,c8y_UploadConfigFile\n",
+                "501,c8y_UploadConfigFile",
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_UploadConfigFile,Timeout due to lack of response from child device: child-aa for config type: file_a\n",
+                "502,c8y_UploadConfigFile,Timeout due to lack of response from child device: child-aa for config type: file_a",
             ),
         ],
     )
@@ -525,11 +525,11 @@ async fn test_child_device_successful_config_snapshot_response_mapping() -> Resu
         .assert_received([
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "501,c8y_UploadConfigFile\n",
+                "501,c8y_UploadConfigFile",
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "503,c8y_UploadConfigFile,test-url\n",
+                "503,c8y_UploadConfigFile,test-url",
             ),
         ])
         .await;
@@ -599,11 +599,11 @@ async fn test_child_config_snapshot_successful_response_without_uploaded_file_ma
         .assert_received([
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "501,c8y_UploadConfigFile\n",
+                "501,c8y_UploadConfigFile",
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_UploadConfigFile,Failed with file not found\n",
+                "502,c8y_UploadConfigFile,Failed with file not found",
             ),
         ])
         .await;
@@ -722,7 +722,7 @@ async fn test_child_device_config_update_executing_response_mapping() -> Result<
         .with_timeout(TEST_TIMEOUT)
         .assert_received([MqttMessage::new(
             &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-            "501,c8y_DownloadConfigFile\n",
+            "501,c8y_DownloadConfigFile",
         )])
         .await;
 
@@ -772,11 +772,11 @@ async fn test_child_device_config_update_successful_response_mapping() -> Result
         .assert_received([
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "501,c8y_DownloadConfigFile\n",
+                "501,c8y_DownloadConfigFile",
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "503,c8y_DownloadConfigFile,\n",
+                "503,c8y_DownloadConfigFile",
             ),
         ])
         .await;
@@ -828,11 +828,11 @@ async fn test_child_device_config_update_failed_response_mapping() -> Result<(),
         .assert_received([
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "501,c8y_DownloadConfigFile\n",
+                "501,c8y_DownloadConfigFile",
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_DownloadConfigFile,download failed\n",
+                "502,c8y_DownloadConfigFile,download failed",
             ),
         ])
         .await;
@@ -895,11 +895,11 @@ async fn test_child_device_config_download_fail_with_broken_url() -> Result<(), 
         .with_timeout(TEST_TIMEOUT)
         .assert_received([MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "501,c8y_DownloadConfigFile\n",
+                "501,c8y_DownloadConfigFile",
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_DownloadConfigFile,Downloading the config file update from bad-url failed with Failed with file not found\n",
+                "502,c8y_DownloadConfigFile,Downloading the config file update from bad-url failed with Failed with file not found",
             ),
         ],
     )
@@ -954,11 +954,11 @@ async fn test_multiline_smartrest_requests() -> Result<(), DynError> {
         .assert_received([
             MqttMessage::new(
                 &C8yTopic::SmartRestResponse.to_topic()?,
-                "501,c8y_UploadConfigFile\n",
+                "501,c8y_UploadConfigFile",
             ),
             MqttMessage::new(
                 &C8yTopic::SmartRestResponse.to_topic()?,
-                "503,c8y_UploadConfigFile,test-url\n",
+                "503,c8y_UploadConfigFile,test-url",
             ),
         ])
         .await;

--- a/crates/extensions/c8y_config_manager/src/tests.rs
+++ b/crates/extensions/c8y_config_manager/src/tests.rs
@@ -338,7 +338,7 @@ async fn test_child_device_config_upload_failed_response_mapping() -> Result<(),
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_UploadConfigFile,\"upload failed\"\n",
+                "502,c8y_UploadConfigFile,upload failed\n",
             ),
         ])
         .await;
@@ -390,7 +390,7 @@ async fn test_invalid_config_snapshot_response_child_device() -> Result<(), DynE
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_UploadConfigFile,\"Failed to parse response from child device with: expected value at line 1 column 1\"\n",
+                "502,c8y_UploadConfigFile,Failed to parse response from child device with: expected value at line 1 column 1\n",
             ),
         ],
     )
@@ -455,7 +455,7 @@ async fn test_timeout_on_no_config_snapshot_response_child_device() -> Result<()
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_UploadConfigFile,\"Timeout due to lack of response from child device: child-aa for config type: file_a\"\n",
+                "502,c8y_UploadConfigFile,Timeout due to lack of response from child device: child-aa for config type: file_a\n",
             ),
         ],
     )
@@ -603,7 +603,7 @@ async fn test_child_config_snapshot_successful_response_without_uploaded_file_ma
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_UploadConfigFile,\"Failed with file not found\"\n",
+                "502,c8y_UploadConfigFile,Failed with file not found\n",
             ),
         ])
         .await;
@@ -832,7 +832,7 @@ async fn test_child_device_config_update_failed_response_mapping() -> Result<(),
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_DownloadConfigFile,\"download failed\"\n",
+                "502,c8y_DownloadConfigFile,download failed\n",
             ),
         ])
         .await;
@@ -899,7 +899,7 @@ async fn test_child_device_config_download_fail_with_broken_url() -> Result<(), 
             ),
             MqttMessage::new(
                 &C8yTopic::ChildSmartRestResponse(child_device_id.into()).to_topic()?,
-                "502,c8y_DownloadConfigFile,\"Downloading the config file update from bad-url failed with Failed with file not found\"\n",
+                "502,c8y_DownloadConfigFile,Downloading the config file update from bad-url failed with Failed with file not found\n",
             ),
         ],
     )

--- a/crates/extensions/c8y_firmware_manager/src/actor.rs
+++ b/crates/extensions/c8y_firmware_manager/src/actor.rs
@@ -3,7 +3,7 @@ use c8y_api::smartrest::message::collect_smartrest_messages;
 use c8y_api::smartrest::message::get_smartrest_template_id;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestFirmwareRequest;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestRequestGeneric;
-use c8y_api::smartrest::smartrest_serializer::TryIntoOperationStatusMessage;
+use c8y_api::smartrest::smartrest_serializer::OperationStatusMessage;
 use c8y_api::smartrest::topic::C8yTopic;
 use c8y_http_proxy::credentials::JwtRetriever;
 use camino::Utf8PathBuf;
@@ -641,7 +641,7 @@ impl FirmwareManagerActor {
         );
         let executing_msg = MqttMessage::new(
             &c8y_child_topic,
-            DownloadFirmwareStatusMessage::status_executing()?,
+            DownloadFirmwareStatusMessage::status_executing(),
         );
         self.message_box.mqtt_publisher.send(executing_msg).await?;
         Ok(())
@@ -656,7 +656,7 @@ impl FirmwareManagerActor {
         );
         let successful_msg = MqttMessage::new(
             &c8y_child_topic,
-            DownloadFirmwareStatusMessage::status_successful(None)?,
+            DownloadFirmwareStatusMessage::status_successful(None),
         );
         self.message_box.mqtt_publisher.send(successful_msg).await?;
         Ok(())
@@ -672,7 +672,7 @@ impl FirmwareManagerActor {
         );
         let failed_msg = MqttMessage::new(
             &c8y_child_topic,
-            DownloadFirmwareStatusMessage::status_failed(failure_reason.to_string())?,
+            DownloadFirmwareStatusMessage::status_failed(failure_reason),
         );
         self.message_box.mqtt_publisher.send(failed_msg).await?;
         Ok(())

--- a/crates/extensions/c8y_firmware_manager/src/tests.rs
+++ b/crates/extensions/c8y_firmware_manager/src/tests.rs
@@ -278,7 +278,7 @@ async fn handle_request_child_device_with_failed_download() -> Result<(), DynErr
             ),
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-                format!("502,c8y_Firmware,\"Download from {DOWNLOAD_URL} failed with fail\"\n"),
+                format!("502,c8y_Firmware,Download from {DOWNLOAD_URL} failed with fail\n"),
             ),
         ])
         .await;
@@ -415,7 +415,7 @@ async fn handle_response_executing_and_failed_child_device() -> Result<(), DynEr
     mqtt_message_box
         .assert_received([MqttMessage::new(
             &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-            "502,c8y_Firmware,\"No failure reason provided by child device.\"\n",
+            "502,c8y_Firmware,No failure reason provided by child device.\n",
         )])
         .await;
 
@@ -528,7 +528,7 @@ async fn handle_request_timeout_child_device() -> Result<(), DynError> {
             ),
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-                format!("502,c8y_Firmware,\"{expected_failure_text}\"\n"),
+                format!("502,c8y_Firmware,{expected_failure_text}\n"),
             ),
         ])
         .await;

--- a/crates/extensions/c8y_firmware_manager/src/tests.rs
+++ b/crates/extensions/c8y_firmware_manager/src/tests.rs
@@ -274,11 +274,11 @@ async fn handle_request_child_device_with_failed_download() -> Result<(), DynErr
         .assert_received([
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-                "501,c8y_Firmware\n",
+                "501,c8y_Firmware",
             ),
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-                format!("502,c8y_Firmware,Download from {DOWNLOAD_URL} failed with fail\n"),
+                format!("502,c8y_Firmware,Download from {DOWNLOAD_URL} failed with fail"),
             ),
         ])
         .await;
@@ -360,7 +360,7 @@ async fn handle_response_successful_child_device() -> Result<(), DynError> {
         .assert_received([
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-                "501,c8y_Firmware\n",
+                "501,c8y_Firmware",
             ),
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
@@ -368,7 +368,7 @@ async fn handle_response_successful_child_device() -> Result<(), DynError> {
             ),
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-                "503,c8y_Firmware,\n",
+                "503,c8y_Firmware",
             ),
         ])
         .await;
@@ -404,7 +404,7 @@ async fn handle_response_executing_and_failed_child_device() -> Result<(), DynEr
     mqtt_message_box
         .assert_received([MqttMessage::new(
             &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-            "501,c8y_Firmware\n",
+            "501,c8y_Firmware",
         )])
         .await;
 
@@ -415,7 +415,7 @@ async fn handle_response_executing_and_failed_child_device() -> Result<(), DynEr
     mqtt_message_box
         .assert_received([MqttMessage::new(
             &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-            "502,c8y_Firmware,No failure reason provided by child device.\n",
+            "502,c8y_Firmware,No failure reason provided by child device.",
         )])
         .await;
 
@@ -524,11 +524,11 @@ async fn handle_request_timeout_child_device() -> Result<(), DynError> {
         .assert_received([
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-                "501,c8y_Firmware\n",
+                "501,c8y_Firmware",
             ),
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-                format!("502,c8y_Firmware,{expected_failure_text}\n"),
+                format!("502,c8y_Firmware,{expected_failure_text}"),
             ),
         ])
         .await;
@@ -572,7 +572,7 @@ async fn handle_child_response_while_busy_downloading() -> Result<(), DynError> 
         .assert_received([
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-                "501,c8y_Firmware\n",
+                "501,c8y_Firmware",
             ),
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
@@ -580,7 +580,7 @@ async fn handle_child_response_while_busy_downloading() -> Result<(), DynError> 
             ),
             MqttMessage::new(
                 &Topic::new_unchecked(C8Y_CHILD_PUBLISH_TOPIC_NAME),
-                "503,c8y_Firmware,\n",
+                "503,c8y_Firmware",
             ),
         ])
         .await;

--- a/crates/extensions/c8y_mapper_ext/src/config_operations.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config_operations.rs
@@ -869,10 +869,7 @@ mod tests {
         // Expect `502` smartrest message on `c8y/s/us`.
         assert_received_contains_str(
             &mut mqtt,
-            [(
-                "c8y/s/us",
-                "502,c8y_UploadConfigFile,\"Something went wrong\"",
-            )],
+            [("c8y/s/us", "502,c8y_UploadConfigFile,Something went wrong")],
         )
         .await;
     }
@@ -931,7 +928,7 @@ mod tests {
             &mut mqtt,
             [(
                 "c8y/s/us/child1",
-                "502,c8y_UploadConfigFile,\"Something went wrong\"",
+                "502,c8y_UploadConfigFile,Something went wrong",
             )],
         )
         .await;
@@ -1280,7 +1277,7 @@ mod tests {
             &mut mqtt,
             [(
                 "c8y/s/us",
-                "502,c8y_DownloadConfigFile,\"Something went wrong\"",
+                "502,c8y_DownloadConfigFile,Something went wrong",
             )],
         )
         .await;
@@ -1351,7 +1348,7 @@ mod tests {
             &mut mqtt,
             [(
                 "c8y/s/us/child1",
-                "502,c8y_DownloadConfigFile,\"Something went wrong\"",
+                "502,c8y_DownloadConfigFile,Something went wrong",
             )],
         )
         .await;

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -22,7 +22,7 @@ use c8y_api::smartrest::message::collect_smartrest_messages;
 use c8y_api::smartrest::message::get_failure_reason_for_smartrest;
 use c8y_api::smartrest::message::get_smartrest_device_id;
 use c8y_api::smartrest::message::get_smartrest_template_id;
-use c8y_api::smartrest::message::sanitize_for_smartrest;
+use c8y_api::smartrest::message::sanitize_bytes_for_smartrest;
 use c8y_api::smartrest::message::MAX_PAYLOAD_LIMIT_IN_BYTES;
 use c8y_api::smartrest::operations::get_child_ops;
 use c8y_api::smartrest::operations::get_operations;
@@ -33,12 +33,14 @@ use c8y_api::smartrest::smartrest_deserializer::SmartRestOperationVariant;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestRequestGeneric;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestRestartRequest;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestUpdateSoftware;
+use c8y_api::smartrest::smartrest_serializer::fail_operation;
+use c8y_api::smartrest::smartrest_serializer::request_pending_operations;
+use c8y_api::smartrest::smartrest_serializer::set_operation_executing;
+use c8y_api::smartrest::smartrest_serializer::succeed_operation;
+use c8y_api::smartrest::smartrest_serializer::succeed_operation_no_payload;
 use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations;
-use c8y_api::smartrest::smartrest_serializer::SmartRestGetPendingOperations;
-use c8y_api::smartrest::smartrest_serializer::SmartRestSerializer;
-use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToExecuting;
-use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToFailed;
-use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToSuccessful;
+use c8y_api::smartrest::smartrest_serializer::EmbeddedCsv;
+use c8y_api::smartrest::smartrest_serializer::TextOrCsv;
 use c8y_api::smartrest::topic::publish_topic_from_ancestors;
 use c8y_api::smartrest::topic::C8yTopic;
 use c8y_api::smartrest::topic::SMARTREST_PUBLISH_TOPIC;
@@ -710,10 +712,10 @@ impl CumulocityConverter {
                 self.execute_operation(
                     payload,
                     command.as_str(),
-                    &operation.name,
                     operation.result_format(),
                     operation.graceful_timeout(),
                     operation.forceful_timeout(),
+                    operation.name,
                 )
                 .await?;
             }
@@ -726,10 +728,10 @@ impl CumulocityConverter {
         &self,
         payload: &str,
         command: &str,
-        operation_name: &str,
         result_format: ResultFormat,
         graceful_timeout: Duration,
         forceful_timeout: Duration,
+        operation_name: String,
     ) -> Result<(), CumulocityMapperError> {
         let command = command.to_owned();
         let payload = payload.to_string();
@@ -755,15 +757,16 @@ impl CumulocityConverter {
 
         match maybe_child_process {
             Ok(child_process) => {
-                let op_name = operation_name.to_string();
+                let op_name = operation_name.to_owned();
                 let mut mqtt_publisher = self.mqtt_publisher.clone();
 
                 tokio::spawn(async move {
+                    let op_name = op_name.as_str();
                     let logger = log_file.buffer();
 
                     // mqtt client publishes executing
                     let topic = C8yTopic::SmartRestResponse.to_topic().unwrap();
-                    let executing_str = format!("501,{op_name}");
+                    let executing_str = set_operation_executing(op_name);
                     mqtt_publisher
                         .send(Message::new(&topic, executing_str.as_str()))
                         .await
@@ -779,36 +782,44 @@ impl CumulocityConverter {
                     {
                         match output.status.code() {
                             Some(0) => {
-                                let sanitized_stdout = sanitize_for_smartrest(
-                                    output.stdout,
+                                let sanitized_stdout = sanitize_bytes_for_smartrest(
+                                    &output.stdout,
                                     MAX_PAYLOAD_LIMIT_IN_BYTES,
                                 );
-                                let successful_str = match result_format {
-                                    ResultFormat::Text => {
-                                        format!("503,{op_name},\"{sanitized_stdout}\"")
-                                    }
-                                    ResultFormat::Csv => {
-                                        format!("503,{op_name},{sanitized_stdout}")
-                                    }
+                                let result = match result_format {
+                                    ResultFormat::Text => TextOrCsv::Text(sanitized_stdout),
+                                    ResultFormat::Csv => EmbeddedCsv::new(sanitized_stdout).into(),
                                 };
-                                mqtt_publisher.send(Message::new(&topic, successful_str.as_str())).await
-                                    .unwrap_or_else(|err| {
-                                        error!("Failed to publish a message: {successful_str}. Error: {err}")
-                                    })
+                                let success_message = succeed_operation(op_name, result);
+                                match success_message {
+                                    Ok(message) => mqtt_publisher.send(Message::new(&topic, message.as_str())).await
+                                        .unwrap_or_else(|err| {
+                                            error!("Failed to publish a message: {message}. Error: {err}")
+                                        }),
+                                    Err(e) => {
+                                        let fail_message = fail_operation(
+                                            op_name,
+                                            &format!("{:?}", anyhow::Error::from(e).context("Custom operation process exited successfully, but couldn't convert output to valid SmartREST message")));
+                                        mqtt_publisher.send(Message::new(&topic, fail_message.as_str())).await.unwrap_or_else(|err| {
+                                            error!("Failed to publish a message: {fail_message}. Error: {err}")
+                                        })
+                                    }
+                                }
                             }
                             _ => {
                                 let failure_reason = get_failure_reason_for_smartrest(
-                                    output.stderr,
+                                    &output.stderr,
                                     MAX_PAYLOAD_LIMIT_IN_BYTES,
                                 );
-                                let failed_str = format!("502,{op_name},\"{failure_reason}\"");
+                                let payload = fail_operation(op_name, &failure_reason);
+
                                 mqtt_publisher
-                                    .send(Message::new(&topic, failed_str.as_str()))
+                                    .send(Message::new(&topic, payload.as_bytes()))
                                     .await
                                     .unwrap_or_else(|err| {
                                         error!(
-                                        "Failed to publish a message: {failed_str}. Error: {err}"
-                                    )
+                                            "Failed to publish a message: {payload}. Error: {err}"
+                                        )
                                     })
                             }
                         }
@@ -897,7 +908,7 @@ impl CumulocityConverter {
             let ops = Operations::try_new(path_to_child_devices.join(&child_id))?;
             self.children
                 .insert(child_external_id.clone().into(), ops.clone());
-            let ops_msg = ops.create_smartrest_ops_message()?;
+            let ops_msg = ops.create_smartrest_ops_message();
             let topic = C8yTopic::ChildSmartRestResponse(child_external_id.into()).to_topic()?;
             messages_vec.push(Message::new(&topic, ops_msg));
         }
@@ -1241,13 +1252,13 @@ impl CumulocityConverter {
             let topic = C8yTopic::ChildSmartRestResponse(child_external_id.into()).to_topic()?;
             Ok(Message::new(
                 &topic,
-                Operations::try_new(path)?.create_smartrest_ops_message()?,
+                Operations::try_new(path)?.create_smartrest_ops_message(),
             ))
         } else {
             // operations for parent
             Ok(Message::new(
                 &Topic::new_unchecked(SMARTREST_PUBLISH_TOPIC),
-                Operations::try_new(path)?.create_smartrest_ops_message()?,
+                Operations::try_new(path)?.create_smartrest_ops_message(),
             ))
         }
     }
@@ -1305,10 +1316,8 @@ fn get_child_id(dir_path: &PathBuf) -> Result<String, ConversionError> {
 }
 
 fn create_get_pending_operations_message() -> Result<Message, ConversionError> {
-    let data = SmartRestGetPendingOperations::default();
     let topic = C8yTopic::SmartRestResponse.to_topic()?;
-    let payload = data.to_smartrest()?;
-    Ok(Message::new(&topic, payload))
+    Ok(Message::new(&topic, request_pending_operations()))
 }
 
 fn is_child_operation_path(path: &Path) -> bool {
@@ -1393,18 +1402,13 @@ impl CumulocityConverter {
 
         match command.status() {
             CommandStatus::Executing => {
-                let smartrest_set_operation = SmartRestSetOperationToExecuting::new(
-                    CumulocitySupportedOperations::C8yRestartRequest,
-                )
-                .to_smartrest()?;
-
+                let smartrest_set_operation =
+                    set_operation_executing(CumulocitySupportedOperations::C8yRestartRequest);
                 Ok(vec![Message::new(&topic, smartrest_set_operation)])
             }
             CommandStatus::Successful => {
-                let smartrest_set_operation = SmartRestSetOperationToSuccessful::new(
-                    CumulocitySupportedOperations::C8yRestartRequest,
-                )
-                .to_smartrest()?;
+                let smartrest_set_operation =
+                    succeed_operation_no_payload(CumulocitySupportedOperations::C8yRestartRequest);
 
                 Ok(vec![
                     command.clearing_message(&self.mqtt_schema),
@@ -1412,11 +1416,11 @@ impl CumulocityConverter {
                 ])
             }
             CommandStatus::Failed { ref reason } => {
-                let smartrest_set_operation = SmartRestSetOperationToFailed::new(
+                let smartrest_set_operation = fail_operation(
                     CumulocitySupportedOperations::C8yRestartRequest,
-                    format!("Restart Failed: {}", reason),
-                )
-                .to_smartrest()?;
+                    &format!("Restart Failed: {reason}"),
+                );
+
                 Ok(vec![
                     command.clearing_message(&self.mqtt_schema),
                     Message::new(&topic, smartrest_set_operation),
@@ -1484,17 +1488,13 @@ impl CumulocityConverter {
                 Ok(vec![])
             }
             CommandStatus::Executing => {
-                let smartrest_set_operation_status = SmartRestSetOperationToExecuting::new(
-                    CumulocitySupportedOperations::C8ySoftwareUpdate,
-                )
-                .to_smartrest()?;
+                let smartrest_set_operation_status =
+                    set_operation_executing(CumulocitySupportedOperations::C8ySoftwareUpdate);
                 Ok(vec![Message::new(&topic, smartrest_set_operation_status)])
             }
             CommandStatus::Successful => {
-                let smartrest_set_operation = SmartRestSetOperationToSuccessful::new(
-                    CumulocitySupportedOperations::C8ySoftwareUpdate,
-                )
-                .to_smartrest()?;
+                let smartrest_set_operation =
+                    succeed_operation_no_payload(CumulocitySupportedOperations::C8ySoftwareUpdate);
 
                 Ok(vec![
                     Message::new(&topic, smartrest_set_operation),
@@ -1503,11 +1503,9 @@ impl CumulocityConverter {
                 ])
             }
             CommandStatus::Failed { reason } => {
-                let smartrest_set_operation = SmartRestSetOperationToFailed::new(
-                    CumulocitySupportedOperations::C8ySoftwareUpdate,
-                    reason,
-                )
-                .to_smartrest()?;
+                let smartrest_set_operation =
+                    fail_operation(CumulocitySupportedOperations::C8ySoftwareUpdate, &reason);
+
                 Ok(vec![
                     Message::new(&topic, smartrest_set_operation),
                     response.clearing_message(&self.mqtt_schema),
@@ -2651,10 +2649,10 @@ pub(crate) mod tests {
             .execute_operation(
                 "5",
                 "sleep",
-                "sleep_ten",
                 ResultFormat::Text,
                 tokio::time::Duration::from_secs(10),
                 tokio::time::Duration::from_secs(1),
+                "sleep_ten".to_owned(),
             )
             .await
             .unwrap();
@@ -2662,10 +2660,10 @@ pub(crate) mod tests {
             .execute_operation(
                 "5",
                 "sleep",
-                "sleep_twenty",
                 ResultFormat::Text,
                 tokio::time::Duration::from_secs(20),
                 tokio::time::Duration::from_secs(1),
+                "sleep_twenty".to_owned(),
             )
             .await
             .unwrap();

--- a/crates/extensions/c8y_mapper_ext/src/firmware_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/firmware_update.rs
@@ -399,7 +399,7 @@ mod tests {
         // Expect `502` smartrest message on `c8y/s/us`.
         assert_received_contains_str(
             &mut mqtt,
-            [("c8y/s/us", "502,c8y_Firmware,\"Something went wrong\"")],
+            [("c8y/s/us", "502,c8y_Firmware,Something went wrong")],
         )
         .await;
     }
@@ -455,7 +455,7 @@ mod tests {
             &mut mqtt,
             [(
                 "c8y/s/us/test-device:device:child1",
-                "502,c8y_Firmware,\"Something went wrong\"",
+                "502,c8y_Firmware,Something went wrong",
             )],
         )
         .await;

--- a/crates/extensions/c8y_mapper_ext/src/firmware_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/firmware_update.rs
@@ -3,11 +3,10 @@ use crate::error::ConversionError;
 use crate::error::CumulocityMapperError;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestFirmwareRequest;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestRequestGeneric;
+use c8y_api::smartrest::smartrest_serializer::fail_operation;
+use c8y_api::smartrest::smartrest_serializer::set_operation_executing;
+use c8y_api::smartrest::smartrest_serializer::succeed_operation_no_payload;
 use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations;
-use c8y_api::smartrest::smartrest_serializer::SmartRestSerializer;
-use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToExecuting;
-use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToFailed;
-use c8y_api::smartrest::smartrest_serializer::SmartRestSetOperationToSuccessful;
 use tedge_api::entity_store::EntityType;
 use tedge_api::messages::FirmwareMetadata;
 use tedge_api::messages::FirmwareUpdateCmdPayload;
@@ -89,20 +88,16 @@ impl CumulocityConverter {
         let payload = message.payload_str()?;
         let response = &FirmwareUpdateCmdPayload::from_json(payload)?;
 
-        let messages = match response.status {
+        let messages = match &response.status {
             CommandStatus::Executing => {
-                let smartrest_operation_status = SmartRestSetOperationToExecuting::new(
-                    CumulocitySupportedOperations::C8yFirmware,
-                )
-                .to_smartrest()?;
+                let smartrest_operation_status =
+                    set_operation_executing(CumulocitySupportedOperations::C8yFirmware);
 
                 vec![Message::new(&sm_topic, smartrest_operation_status)]
             }
             CommandStatus::Successful => {
-                let smartrest_operation_status = SmartRestSetOperationToSuccessful::new(
-                    CumulocitySupportedOperations::C8yFirmware,
-                )
-                .to_smartrest()?;
+                let smartrest_operation_status =
+                    succeed_operation_no_payload(CumulocitySupportedOperations::C8yFirmware);
                 let c8y_notification = Message::new(&sm_topic, smartrest_operation_status);
 
                 let clear_local_cmd = Message::new(&message.topic, "")
@@ -126,12 +121,9 @@ impl CumulocityConverter {
 
                 vec![c8y_notification, clear_local_cmd, update_metadata]
             }
-            CommandStatus::Failed { ref reason } => {
-                let smartrest_operation_status = SmartRestSetOperationToFailed::new(
-                    CumulocitySupportedOperations::C8yFirmware,
-                    reason.clone(),
-                )
-                .to_smartrest()?;
+            CommandStatus::Failed { reason } => {
+                let smartrest_operation_status =
+                    fail_operation(CumulocitySupportedOperations::C8yFirmware, reason);
                 let c8y_notification = Message::new(&sm_topic, smartrest_operation_status);
                 let clear_local_cmd = Message::new(&message.topic, "")
                     .with_retain()

--- a/crates/extensions/c8y_mapper_ext/src/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/log_upload.rs
@@ -568,7 +568,7 @@ mod tests {
         // Expect `502` smartrest message on `c8y/s/us`.
         assert_received_contains_str(
             &mut mqtt,
-            [("c8y/s/us", "502,c8y_LogfileRequest,\"Unknown reason\"")],
+            [("c8y/s/us", "502,c8y_LogfileRequest,Unknown reason")],
         )
         .await;
     }
@@ -650,7 +650,7 @@ mod tests {
             &mut mqtt,
             [(
                 "c8y/s/us/test-device:device:child1",
-                "502,c8y_LogfileRequest,\"Something went wrong\"",
+                "502,c8y_LogfileRequest,Something went wrong",
             )],
         )
         .await;

--- a/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
@@ -68,7 +68,7 @@ mod tests {
         r#"{"pid":"1234","status":"up"}"#,
         "c8y/s/us/test_device:device:main:service:tedge-mapper-c8y",
         r#"104,up"#;
-        "service-monitoring-thin-edge-device"
+        "service monitoring thin-edge device"
     )]
     #[test_case(
         "test_device",
@@ -76,7 +76,7 @@ mod tests {
         r#"{"pid":"1234","status":"up"}"#,
         "c8y/s/us/test_device:device:child/test_device:device:child:service:tedge-mapper-c8y",
         r#"104,up"#;
-        "service-monitoring-thin-edge-child-device"
+        "service monitoring thin-edge child device"
     )]
     #[test_case(
         "test_device",
@@ -84,7 +84,7 @@ mod tests {
         r#"{"pid":"123456"}"#,
         "c8y/s/us/test_device:device:main:service:tedge-mapper-c8y",
         r#"104,unknown"#;
-        "service-monitoring-thin-edge-no-status"
+        "service monitoring thin-edge no status"
     )]
     #[test_case(
         "test_device",
@@ -92,7 +92,7 @@ mod tests {
         r#"{"status":""}"#,
         "c8y/s/us/test_device:device:main:service:tedge-mapper-c8y",
         r#"104,unknown"#;
-        "service-monitoring-empty-status"
+        "service monitoring empty status"
     )]
     #[test_case(
         "test_device",
@@ -100,7 +100,7 @@ mod tests {
         "{}",
         "c8y/s/us/test_device:device:main:service:tedge-mapper-c8y",
         r#"104,unknown"#;
-        "service-monitoring-empty-health-message"
+        "service monitoring empty health message"
     )]
     #[test_case(
         "test_device",
@@ -108,15 +108,15 @@ mod tests {
         r#"{"status":"up,down"}"#,
         "c8y/s/us/test_device:device:main:service:tedge-mapper-c8y",
         r#"104,"up,down""#;
-        "service-monitoring-type-with-comma-health-message"
+        "service monitoring type with comma health message"
     )]
     #[test_case(
         "test_device",
         "te/device/main/service/tedge-mapper-c8y/status/health",
         r#"{"status":"up\"down"}"#,
         "c8y/s/us/test_device:device:main:service:tedge-mapper-c8y",
-        r#"104,up""down"#;
-        "service-monitoring-double-quotes-health-message"
+        r#"104,"up""down""#;
+        "service monitoring double quotes health message"
     )]
     fn translate_health_status_to_c8y_service_monitoring_message(
         device_name: &str,

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -397,7 +397,7 @@ async fn mapper_publishes_software_update_failed_status_onto_c8y_topic() {
         &mut mqtt,
         [(
             "c8y/s/us",
-            "502,c8y_SoftwareUpdate,Partial failure: Couldn't install collectd and nginx\n",
+            "502,c8y_SoftwareUpdate,Partial failure: Couldn't install collectd and nginx",
         )],
     )
     .await;
@@ -1459,7 +1459,7 @@ async fn mapper_publishes_supported_operations_for_child_device() {
         &mut mqtt,
         [
             ("c8y/s/us", "101,child1,child1,thin-edge.io-child"),
-            ("c8y/s/us/child1", "114,c8y_ChildTestOp1,c8y_ChildTestOp2\n"),
+            ("c8y/s/us/child1", "114,c8y_ChildTestOp1,c8y_ChildTestOp2"),
         ],
     )
     .await;
@@ -1500,7 +1500,7 @@ async fn mapping_child_device_dirs_with_forbidden_characters() {
                 "c8y/s/us",
                 "101,simple_child,simple_child,thin-edge.io-child",
             ),
-            ("c8y/s/us/simple_child", "114,c8y_ChildTestOp2\n"),
+            ("c8y/s/us/simple_child", "114,c8y_ChildTestOp2"),
         ],
     )
     .await;
@@ -2068,7 +2068,7 @@ async fn custom_operation_timeout_sigterm() {
         &mut mqtt,
         [(
             "c8y/s/us",
-            "502,c8y_Command,\"operation failed due to timeout: duration=1s\"",
+            "502,c8y_Command,operation failed due to timeout: duration=1s",
         )],
     )
     .await;
@@ -2141,7 +2141,7 @@ async fn custom_operation_timeout_sigkill() {
         &mut mqtt,
         [(
             "c8y/s/us",
-            "502,c8y_Command,\"operation failed due to timeout: duration=1s\"",
+            "502,c8y_Command,operation failed due to timeout: duration=1s",
         )],
     )
     .await;

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -397,7 +397,7 @@ async fn mapper_publishes_software_update_failed_status_onto_c8y_topic() {
         &mut mqtt,
         [(
             "c8y/s/us",
-            "502,c8y_SoftwareUpdate,\"Partial failure: Couldn\'t install collectd and nginx\"\n",
+            "502,c8y_SoftwareUpdate,Partial failure: Couldn't install collectd and nginx\n",
         )],
     )
     .await;

--- a/crates/extensions/tedge_config_manager/src/actor.rs
+++ b/crates/extensions/tedge_config_manager/src/actor.rs
@@ -238,7 +238,7 @@ impl ConfigManagerActor {
                 }
                 Err(err) => {
                     let error_message = format!(
-                        "tedge-configuration-plugin failed uploading configuration snapshot: {}",
+                        "config-manager failed uploading configuration snapshot: {}",
                         err
                     );
                     request.failed(&error_message);
@@ -264,7 +264,7 @@ impl ConfigManagerActor {
             }
             Err(error) => {
                 let error_message = format!(
-                    "tedge-configuration-plugin failed to start downloading configuration: {}",
+                    "config-manager failed to start downloading configuration: {}",
                     error
                 );
                 request.failed(&error_message);
@@ -319,8 +319,7 @@ impl ConfigManagerActor {
                         .await?;
                 }
                 Err(err) => {
-                    let error_message =
-                        format!("tedge-configuration-plugin failed downloading a file: {err}",);
+                    let error_message = format!("config-manager failed downloading a file: {err}",);
                     request.failed(&error_message);
                     error!("{}", error_message);
                     self.publish_command_status(&topic, &ConfigOperation::Update(request))

--- a/crates/extensions/tedge_mqtt_ext/src/test_helpers.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/test_helpers.rs
@@ -47,9 +47,7 @@ pub fn assert_message_contains_str(message: &Message, expected: (&str, &str)) {
     let payload = message.payload_str().expect("non UTF-8 payload");
     assert!(
         payload.contains(expected_payload),
-        "Payload assertion failed.\n Actual: {} \n Expected: {}",
-        payload,
-        expected_payload
+        "Payload assertion failed.\n Actual: {payload:?} \n Expected: {expected_payload:?}",
     )
 }
 

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -157,7 +157,7 @@ Get Unknown Configuration Type From Device
     [Arguments]    ${test_desc}    ${external_id}    ${config_type}
     Cumulocity.Set Device    ${external_id}
     ${operation}=    Cumulocity.Get Configuration    ${config_type}
-    Operation Should Be FAILED    ${operation}    failure_reason=.*requested config_type ${config_type} is not defined in the plugin configuration file.*
+    Operation Should Be FAILED    ${operation}    failure_reason=.*requested config_type "${config_type}" is not defined in the plugin configuration file.*
 
 Get non existent configuration file From Device
     [Arguments]    ${test_desc}    ${device}    ${external_id}    ${config_type}    ${device_file}

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -47,11 +47,11 @@ Configuration operation fails when configuration-plugin does not supply client c
     Disable HTTP Client Certificate for Child Device
     Get Configuration Should Fail
     ...  device=${CHILD_SN}
-    ...  failure_reason=tedge-configuration-plugin failed uploading configuration snapshot:.+https://${parent_ip}:8000/tedge/file-transfer/.+received fatal alert: CertificateRequired
+    ...  failure_reason=config-manager failed uploading configuration snapshot:.+https://${parent_ip}:8000/tedge/file-transfer/.+received fatal alert: CertificateRequired
     ...  external_id=${PARENT_SN}:device:${CHILD_SN}
     Update Configuration Should Fail
     ...  device=${CHILD_SN}
-    ...  failure_reason=tedge-configuration-plugin failed downloading a file:.+https://${parent_ip}:8000/tedge/file-transfer/.+received fatal alert: CertificateRequired
+    ...  failure_reason=config-manager failed downloading a file:.+https://${parent_ip}:8000/tedge/file-transfer/.+received fatal alert: CertificateRequired
     ...  external_id=${PARENT_SN}:device:${CHILD_SN}
 
 Configuration snapshot fails when mapper does not supply client certificate

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
@@ -30,7 +30,7 @@ Request with non-existing log type
     ...    fragments={"c8y_LogfileRequest":{"dateFrom":"${start_timestamp}","dateTo":"${end_timestamp}","logFile":"example1","searchText":"first","maximumLines":10}}
     Operation Should Be FAILED
     ...    ${operation}
-    ...    failure_reason=.*No logs found for log type example1
+    ...    failure_reason=.*No logs found for log type "example1"
     ...    timeout=120
 
 Manual log_upload operation request


### PR DESCRIPTION
## Proposed changes
This PR simplifies the CSV serialization logic for `SmartRestSetOperationToFailed`, allowing quotes inside the `failure_reason` field to be preserved.

It also makes a small tweak to an error message modified as part of #2474 to make it more generic, referring to `config-manager` instead of `tedge-configuration-plugin` as suggested by @albinsuresh. 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2487 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

