### PR TITLE
Don't restart tedge-agent on (re)connect

### DIFF
--- a/configuration/contrib/system/bsd/system.toml
+++ b/configuration/contrib/system/bsd/system.toml
@@ -2,6 +2,7 @@
 name = "service(8)"
 is_available = ["/usr/sbin/service", "-l"]
 restart = ["/usr/sbin/service", "{}", "restart"]
+start = ["/usr/sbin/service", "{}", "start"]
 stop =  ["/usr/sbin/service", "{}", "stop"]
 enable =  ["/usr/sbin/service", "{}", "enable"]
 disable =  ["/usr/sbin/service", "{}", "forcedisable"]

--- a/configuration/contrib/system/openrc/system.toml
+++ b/configuration/contrib/system/openrc/system.toml
@@ -2,6 +2,7 @@
 name = "OpenRC"
 is_available = ["/sbin/rc-service", "-l"]
 restart = ["/sbin/rc-service", "{}", "restart"]
+start = ["/sbin/rc-service", "{}", "start"]
 stop =  ["/sbin/rc-service", "{}", "stop"]
 enable =  ["/sbin/rc-update", "add", "{}"]
 disable =  ["/sbin/rc-update", "delete", "{}"]

--- a/configuration/contrib/system/systemd/system.toml
+++ b/configuration/contrib/system/systemd/system.toml
@@ -2,6 +2,7 @@
 name = "systemd"
 is_available = ["/bin/systemctl", "--version"]
 restart = ["/bin/systemctl", "restart", "{}"]
+start = ["/bin/systemctl", "start", "{}"]
 stop =  ["/bin/systemctl", "stop", "{}"]
 enable =  ["/bin/systemctl", "enable", "{}"]
 disable =  ["/bin/systemctl", "disable", "{}"]

--- a/crates/common/tedge_config/src/system_services/manager.rs
+++ b/crates/common/tedge_config/src/system_services/manager.rs
@@ -16,6 +16,9 @@ pub trait SystemServiceManager: Debug {
     /// Stops the specified system service.
     fn stop_service(&self, service: SystemService) -> Result<(), SystemServiceError>;
 
+    /// Starts the specified system service.
+    fn start_service(&self, service: SystemService) -> Result<(), SystemServiceError>;
+
     /// Restarts the specified system service.
     fn restart_service(&self, service: SystemService) -> Result<(), SystemServiceError>;
 

--- a/crates/common/tedge_config/src/system_services/manager_ext.rs
+++ b/crates/common/tedge_config/src/system_services/manager_ext.rs
@@ -12,7 +12,7 @@ impl SystemServiceManagerExt for &dyn SystemServiceManager {
         let mut failed = false;
 
         let _ = writeln!(&mut wr, "Starting {} service.\n", service);
-        if let Err(err) = self.restart_service(service) {
+        if let Err(err) = self.start_service(service) {
             let _ = writeln!(&mut wr, "Failed to stop {} service: {:?}", service, err);
             failed = true;
         }

--- a/crates/common/tedge_config/src/system_services/managers/config.rs
+++ b/crates/common/tedge_config/src/system_services/managers/config.rs
@@ -25,6 +25,7 @@ pub struct InitConfig {
     pub is_available: Vec<String>,
     pub restart: Vec<String>,
     pub stop: Vec<String>,
+    pub start: Vec<String>,
     pub enable: Vec<String>,
     pub disable: Vec<String>,
     pub is_active: Vec<String>,
@@ -71,6 +72,7 @@ impl Default for InitConfig {
             is_available: vec!["/bin/systemctl".into(), "--version".into()],
             restart: vec!["/bin/systemctl".into(), "restart".into(), "{}".into()],
             stop: vec!["/bin/systemctl".into(), "stop".into(), "{}".into()],
+            start: vec!["/bin/systemctl".into(), "start".into(), "{}".into()],
             enable: vec!["/bin/systemctl".into(), "enable".into(), "{}".into()],
             disable: vec!["/bin/systemctl".into(), "disable".into(), "{}".into()],
             is_active: vec!["/bin/systemctl".into(), "is-active".into(), "{}".into()],
@@ -116,6 +118,7 @@ mod tests {
             is_available = ["/bin/systemctl", "--version"]
             restart = ["/bin/systemctl", "restart", "{}"]
             stop =  ["/bin/systemctl", "stop", "{}"]
+            start =  ["/bin/systemctl", "start", "{}"]
             enable =  ["/bin/systemctl", "enable", "{}"]
             disable =  ["/bin/systemctl", "disable", "{}"]
             is_active = ["/bin/systemctl", "is-active", "{}"]
@@ -140,6 +143,7 @@ mod tests {
         );
         assert_eq!(config.init.restart, vec!["/bin/systemctl", "restart", "{}"]);
         assert_eq!(config.init.stop, vec!["/bin/systemctl", "stop", "{}"]);
+        assert_eq!(config.init.start, vec!["/bin/systemctl", "start", "{}"]);
         assert_eq!(config.init.enable, vec!["/bin/systemctl", "enable", "{}"]);
         assert_eq!(config.init.disable, vec!["/bin/systemctl", "disable", "{}"]);
         assert_eq!(

--- a/crates/core/tedge/src/cli/disconnect/disconnect_bridge.rs
+++ b/crates/core/tedge/src/cli/disconnect/disconnect_bridge.rs
@@ -61,12 +61,6 @@ impl DisconnectBridgeCommand {
                 .stop_and_disable_service(self.cloud.mapper_service(), std::io::stdout());
         }
 
-        if self.use_agent && which("tedge-agent").is_ok() {
-            failed = self
-                .service_manager()
-                .stop_and_disable_service(SystemService::TEdgeSMAgent, std::io::stdout());
-        }
-
         match failed {
             false => Ok(()),
             true => Err(DisconnectBridgeError::ServiceFailed),

--- a/docs/src/references/init-system-config.md
+++ b/docs/src/references/init-system-config.md
@@ -17,6 +17,7 @@ name = "systemd"
 is_available = ["/bin/systemctl", "--version"]
 restart = ["/bin/systemctl", "restart", "{}"]
 stop =  ["/bin/systemctl", "stop", "{}"]
+start =  ["/bin/systemctl", "start", "{}"]
 enable =  ["/bin/systemctl", "enable", "{}"]
 disable =  ["/bin/systemctl", "disable", "{}"]
 is_active = ["/bin/systemctl", "is-active", "{}"]
@@ -47,15 +48,16 @@ will be interpreted as
 
 ## Keys
 
-|Property|Description|
-|--------|-----------|
-|`name`|An identifier of the init system. It is used in the output of `tedge connect` and `tedge disconnect`|
-|`is_available`|The command to check if the init is available on your system|
-|`restart`|The command to restart a service by the init system|
-|`stop`|The command to stop a service by the init system|
-|`enable`|The command to enable a service by the init system|
-|`disable`|The command to disable a service by the init system|
-|`is_active`|The command to check if the service is running by the init system|
+| Property       | Description                                                                                          |
+|----------------|------------------------------------------------------------------------------------------------------|
+| `name`         | An identifier of the init system. It is used in the output of `tedge connect` and `tedge disconnect` |
+| `is_available` | The command to check if the init is available on your system                                         |
+| `restart`      | The command to restart a service by the init system                                                  |
+| `stop`         | The command to stop a service by the init system                                                     |
+| `start`        | The command to start a service by the init system                                                    |
+| `enable`       | The command to enable a service by the init system                                                   |
+| `disable`      | The command to disable a service by the init system                                                  |
+| `is_active`    | The command to check if the service is running by the init system                                    |
 
 ## Default settings
 

--- a/tests/PySys/misc_features/custom_init_system/system.toml
+++ b/tests/PySys/misc_features/custom_init_system/system.toml
@@ -2,6 +2,7 @@
 name = "test"
 is_available = ["/tmp/dummy_init/dummy_init.sh", "is_available"]
 restart = ["/tmp/dummy_init/dummy_init.sh", "restart", "{}"]
+start = ["/tmp/dummy_init/dummy_init.sh", "start", "{}"]
 stop =  ["/tmp/dummy_init/dummy_init.sh", "stop", "{}"]
 enable =  ["/tmp/dummy_init/dummy_init.sh", "enable", "{}"]
 disable =  ["/tmp/dummy_init/dummy_init.sh", "disable", "{}"]

--- a/tests/RobotFramework/tests/config_management/child_conf_mgmt_plugin.robot
+++ b/tests/RobotFramework/tests/config_management/child_conf_mgmt_plugin.robot
@@ -46,6 +46,7 @@ Prerequisite Parent
     Check for child related content    #Checks if folders that will trigger child device creation are existing
     Set external MQTT bind address    #Setting external MQTT bind address which child will use for communication
     Set external MQTT port    #Setting external MQTT port which child will use for communication Default:1883
+    Restart agent
 
     Sleep    3s
     Execute Command    sudo tedge connect c8y
@@ -80,6 +81,10 @@ Set external MQTT port
     Set Device Context    ${PARENT_SN}
     Execute Command    sudo tedge config set mqtt.external.bind.port 1883
 
+Restart agent
+    Set Device Context    ${PARENT_SN}
+    Restart Service     tedge-agent
+
 Check for child related content
     Set Device Context    ${CHILD_SN}
     Directory Should Not Have Sub Directories    /etc/tedge/operations/c8y
@@ -95,10 +100,6 @@ Delete child related content
 Check parent child relationship
     Cumulocity.Set Device    ${PARENT_SN}
     Cumulocity.Device Should Have A Child Devices    ${CHILD_SN}
-
-Reconnect c8y
-    Execute Command    sudo tedge disconnect c8y
-    Execute Command    sudo tedge connect c8y
 
 Restart Configuration plugin
     Restart Service    c8y-configuration-plugin.service

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -258,6 +258,7 @@ Suite Setup
     Execute Command    sudo tedge config set mqtt.external.bind.address ${parent_ip}
     Execute Command    sudo tedge config set mqtt.external.bind.port 1883
     Execute Command    sudo tedge config set http.client.host ${parent_ip}
+    Restart Service    tedge-agent
 
     ThinEdgeIO.Disconnect Then Connect Mapper    c8y
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-c8y

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -141,6 +141,7 @@ Suite Setup
     ${client_certificate}=    Execute Command    cat /etc/tedge/device-local-certs/tedge-client.crt
     ${client_key}=    Execute Command    cat /etc/tedge/device-local-certs/tedge-client.key
 
+    Restart Service    tedge-agent
     ThinEdgeIO.Disconnect Then Connect Mapper    c8y
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-c8y
 

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
@@ -36,6 +36,7 @@ Prerequisite Parent
     Set external MQTT port    #Setting external MQTT port which child will use for communication Default:1883
 
     Sleep    3s
+    Restart Service    tedge-agent
     Execute Command    sudo tedge connect c8y
     Restart Firmware plugin    #Stop and Start c8y-firmware-plugin
     Cumulocity.Log Device Info

--- a/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
+++ b/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
@@ -37,7 +37,7 @@ tedge_connect_test_sm_services
 tedge_disconnect_test_sm_services
     ${output}=    Execute Command    sudo tedge disconnect c8y
     Should Contain    ${output}    Cumulocity Bridge successfully disconnected!
-    Should Contain    ${output}    tedge-agent service successfully stopped and disabled!
+    Should Not Contain    ${output}    tedge-agent service successfully stopped and disabled!
     Should Contain    ${output}    tedge-mapper-c8y service successfully stopped and disabled!
 
 *** Keywords ***

--- a/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
+++ b/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
@@ -40,6 +40,18 @@ tedge_disconnect_test_sm_services
     Should Not Contain    ${output}    tedge-agent service successfully stopped and disabled!
     Should Contain    ${output}    tedge-mapper-c8y service successfully stopped and disabled!
 
+tedge reconnect does not restart agent
+    ${pid_before}=  Execute Command    sudo systemctl show --property MainPID tedge-agent
+    ${output}=    Execute Command    sudo tedge reconnect c8y
+    ${pid_after}=  Execute Command    sudo systemctl show --property MainPID tedge-agent
+    Should Be Equal    ${pid_before}    ${pid_after}
+
+tedge reconnect restarts mapper
+    ${pid_before}=  Execute Command    sudo systemctl show --property MainPID tedge-mapper-c8y
+    ${output}=    Execute Command    sudo tedge reconnect c8y
+    ${pid_after}=  Execute Command    sudo systemctl show --property MainPID tedge-mapper-c8y
+    Should Not Be Equal    ${pid_before}    ${pid_after}
+
 *** Keywords ***
 
 Should Have File Permissions

--- a/tests/images/debian-systemd/files/system.toml
+++ b/tests/images/debian-systemd/files/system.toml
@@ -4,6 +4,7 @@ name = "systemd"
 is_available = ["/bin/systemctl", "--version"]
 restart = ["/bin/systemctl", "restart", "{}"]
 stop =  ["/bin/systemctl", "stop", "{}"]
+start = ["/bin/systemctl", "start", "{}"]
 enable =  ["/bin/systemctl", "enable", "{}"]
 disable =  ["/bin/systemctl", "disable", "{}"]
 is_active = ["/bin/systemctl", "is-active", "{}"]


### PR DESCRIPTION
## Proposed changes
This changes `tedge connect` and `tedge reconnect` to merely start `tedge-agent`, and prevents `tedge disconnect c8y` from stopping `tedge-agent` since there is no longer any cloud-specific functionality in tedge-agent.

~In order to make the feature work, a new `start` field in `system.toml`'s `init` section is required, hence this is a breaking change.~ The new `start` field is now optional as per @didier-wenzek's suggestion, so this is no longer a breaking change.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2494 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

