### PR TITLE
Move `config_update` file download from tedge-mapper-c8y to tedge-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,6 +3658,7 @@ dependencies = [
  "rustls-pemfile",
  "serde",
  "serde_json",
+ "sha256",
  "tedge_actors",
  "tedge_api",
  "tedge_config",

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -645,7 +645,7 @@ define_tedge_config! {
         #[doku(as = "PathBuf")]
         key_path: Utf8PathBuf,
 
-        /// Path to a file containing the PEM encoded CA certificates that are
+        /// Path to a directory containing the PEM encoded CA certificates that are
         /// trusted when checking incoming client certificates for the File Transfer Service
         #[tedge_config(example = "/etc/ssl/certs")]
         #[doku(as = "PathBuf")]

--- a/crates/core/c8y_api/src/http_proxy.rs
+++ b/crates/core/c8y_api/src/http_proxy.rs
@@ -20,7 +20,7 @@ pub enum C8yEndPointError {
 }
 
 /// Define a C8y endpoint
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct C8yEndPoint {
     c8y_host: String,
     pub device_id: String,

--- a/crates/core/tedge_agent/Cargo.toml
+++ b/crates/core/tedge_agent/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha256 = { workspace = true }
 tedge_actors = { workspace = true }
 tedge_api = { workspace = true }
 tedge_config = { workspace = true }

--- a/crates/core/tedge_agent/src/lib.rs
+++ b/crates/core/tedge_agent/src/lib.rs
@@ -22,6 +22,7 @@ use tracing::log::warn;
 
 mod agent;
 mod file_transfer_server;
+mod operation_file_cache;
 mod restart_manager;
 mod software_manager;
 mod state_repository;

--- a/crates/core/tedge_agent/src/operation_file_cache/mod.rs
+++ b/crates/core/tedge_agent/src/operation_file_cache/mod.rs
@@ -1,0 +1,360 @@
+//! Inspects incoming operation requests for URLs to files and downloads them into the File Transfer
+//! Service, so that they can be downloaded more quickly by the child devices.
+//!
+//! Payloads of some operations contain `remoteUrl` property which contains a URL from which we
+//! need to download a file. However, child devices may have reduced speed or even may not be able
+//! to reach the remote URL at all. Additionally, multiple child devices may require the same file,
+//! so it makes sense to download it once and place it inside the File Transfer Service, so that
+//! child devices may download the files quickly on the local network.
+//!
+//! This actor, for all child devices, for operations that have `remoteUrl` property, tries to
+//! download the file from this URL, places it in the File Transfer Service, and inserts the URL to
+//! download the file from the FTS in the `tedgeUrl` property.
+
+use async_trait::async_trait;
+use camino::Utf8PathBuf;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use tedge_actors::adapt;
+use tedge_actors::fan_in_message_type;
+use tedge_actors::Actor;
+use tedge_actors::Builder;
+use tedge_actors::DynSender;
+use tedge_actors::LinkError;
+use tedge_actors::LoggingReceiver;
+use tedge_actors::MessageReceiver;
+use tedge_actors::MessageSink;
+use tedge_actors::NoConfig;
+use tedge_actors::RuntimeError;
+use tedge_actors::RuntimeRequest;
+use tedge_actors::RuntimeRequestSink;
+use tedge_actors::Sender;
+use tedge_actors::ServiceProvider;
+use tedge_actors::SimpleMessageBoxBuilder;
+use tedge_api::messages::ConfigUpdateCmdPayload;
+use tedge_api::mqtt_topics::Channel;
+use tedge_api::mqtt_topics::ChannelFilter;
+use tedge_api::mqtt_topics::EntityFilter;
+use tedge_api::mqtt_topics::EntityTopicId;
+use tedge_api::mqtt_topics::MqttSchema;
+use tedge_api::mqtt_topics::OperationType;
+use tedge_api::path::DataDir;
+use tedge_api::CommandStatus;
+use tedge_downloader_ext::DownloadRequest;
+use tedge_downloader_ext::DownloadResult;
+use tedge_mqtt_ext::MqttMessage;
+use tedge_mqtt_ext::Topic;
+use tedge_mqtt_ext::TopicFilter;
+use tracing::error;
+use tracing::info;
+use tracing::warn;
+
+type IdDownloadRequest = (String, DownloadRequest);
+type IdDownloadResult = (String, DownloadResult);
+
+fan_in_message_type!(FileCacheInput[MqttMessage, IdDownloadResult]: Debug);
+
+pub struct FileCacheActor {
+    input_receiver: LoggingReceiver<FileCacheInput>,
+    mqtt_sender: DynSender<MqttMessage>,
+    downloader_sender: DynSender<IdDownloadRequest>,
+
+    tedge_http_host: Arc<str>,
+    mqtt_schema: MqttSchema,
+    data_dir: DataDir,
+
+    pending_operations: HashMap<String, ConfigUpdateCmdPayload>,
+}
+
+#[async_trait]
+impl Actor for FileCacheActor {
+    fn name(&self) -> &str {
+        "FileCacheActor"
+    }
+
+    async fn run(mut self) -> Result<(), RuntimeError> {
+        while let Some(message) = self.input_receiver.recv().await {
+            match message {
+                FileCacheInput::MqttMessage(message) => self.process_mqtt_message(message).await?,
+                FileCacheInput::IdDownloadResult(message) => self.process_download(message).await?,
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl FileCacheActor {
+    async fn process_mqtt_message(
+        &mut self,
+        mqtt_message: MqttMessage,
+    ) -> Result<(), RuntimeError> {
+        let Ok((entity, channel)) = self.mqtt_schema.entity_channel_of(&mqtt_message.topic) else {
+            return Ok(());
+        };
+
+        let Channel::Command {
+            operation: OperationType::ConfigUpdate,
+            cmd_id,
+        } = channel
+        else {
+            return Ok(());
+        };
+
+        let update_payload =
+            match serde_json::from_slice::<ConfigUpdateCmdPayload>(mqtt_message.payload.as_bytes())
+            {
+                Ok(payload) => payload,
+                Err(err) => {
+                    warn!("Received config update, but payload is malformed: {err}");
+                    return Ok(());
+                }
+            };
+
+        if update_payload.remote_url.is_empty() || update_payload.tedge_url.is_some() {
+            return Ok(());
+        }
+
+        match &update_payload.status {
+            CommandStatus::Executing => {
+                self.download_config_file_to_cache(&mqtt_message.topic, &update_payload)
+                    .await?;
+            }
+            CommandStatus::Successful => self.delete_symlink_for_config_update(
+                &entity,
+                &update_payload.config_type,
+                &cmd_id,
+            )?,
+            CommandStatus::Failed { .. } => self.delete_symlink_for_config_update(
+                &entity,
+                &update_payload.config_type,
+                &cmd_id,
+            )?,
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    async fn process_download(&mut self, download: IdDownloadResult) -> Result<(), RuntimeError> {
+        let (topic, result) = download;
+
+        let Some(mut operation) = self.pending_operations.remove(&topic) else {
+            return Ok(());
+        };
+
+        let (entity, Channel::Command { cmd_id, .. }) = self
+            .mqtt_schema
+            .entity_channel_of(&Topic::new(&topic).unwrap())
+            .expect("only topics targeting config update command should be inserted")
+        else {
+            return Ok(());
+        };
+
+        let download = match result {
+            // if cant download file, operation failed
+            Err(err) => {
+                let error_message = format!("tedge-agent failed downloading a file: {err}");
+                operation.failed(&error_message);
+                error!("{}", error_message);
+                let message = MqttMessage::new(
+                    &Topic::new_unchecked(&topic),
+                    serde_json::to_string(&operation).unwrap(),
+                );
+                self.mqtt_sender.send(message).await?;
+                return Ok(());
+            }
+            Ok(download) => download,
+        };
+
+        self.create_symlink_for_config_update(
+            &entity,
+            &operation.config_type,
+            &cmd_id,
+            download.file_path,
+        )?;
+
+        let url_symlink_path = symlink_path(&entity, &operation.config_type, &cmd_id);
+
+        let tedge_url = format!(
+            "http://{}/tedge/file-transfer/{}",
+            &self.tedge_http_host, url_symlink_path
+        );
+
+        operation.tedge_url = Some(tedge_url);
+
+        let mqtt_message = MqttMessage::new(
+            &Topic::new(&topic).unwrap(),
+            serde_json::to_string(&operation).unwrap(),
+        );
+        self.mqtt_sender.send(mqtt_message).await.unwrap();
+
+        Ok(())
+    }
+
+    async fn download_config_file_to_cache(
+        &mut self,
+        config_update_topic: &Topic,
+        config_update_payload: &ConfigUpdateCmdPayload,
+    ) -> Result<(), RuntimeError> {
+        let remote_url = &config_update_payload.remote_url;
+
+        let file_cache_key = sha256::digest(remote_url);
+        let dest_path = self.data_dir.cache_dir().join(file_cache_key);
+        let topic = config_update_topic.name.clone();
+
+        info!("Downloading config file from `{remote_url}` to cache");
+
+        let download_request = DownloadRequest::new(remote_url, dest_path.as_std_path());
+
+        self.pending_operations.insert(
+            config_update_topic.name.clone(),
+            config_update_payload.clone(),
+        );
+
+        self.downloader_sender
+            .send((topic, download_request))
+            .await?;
+
+        Ok(())
+    }
+
+    fn create_symlink_for_config_update(
+        &self,
+        entity_topic_id: &EntityTopicId,
+        config_type: &str,
+        cmd_id: &str,
+        original: impl AsRef<Path>,
+    ) -> Result<(), RuntimeError> {
+        let symlink_path = self.fs_file_transfer_symlink_path(entity_topic_id, config_type, cmd_id);
+
+        if !symlink_path.is_symlink() {
+            std::fs::create_dir_all(symlink_path.parent().unwrap())
+                .and_then(|_| std::os::unix::fs::symlink(original, &symlink_path))
+                .map_err(|e| RuntimeError::ActorError(e.into()))?;
+        }
+
+        Ok(())
+    }
+
+    fn delete_symlink_for_config_update(
+        &self,
+        entity_topic_id: &EntityTopicId,
+        config_type: &str,
+        cmd_id: &str,
+    ) -> Result<(), RuntimeError> {
+        let symlink_path = self.fs_file_transfer_symlink_path(entity_topic_id, config_type, cmd_id);
+
+        if let Err(e) = std::fs::remove_file(symlink_path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                // we're missing permissions or trying to delete a directory
+                return Err(RuntimeError::ActorError(e.into()))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn fs_file_transfer_symlink_path(
+        &self,
+        entity_topic_id: &EntityTopicId,
+        config_type: &str,
+        cmd_id: &str,
+    ) -> Utf8PathBuf {
+        let symlink_dir_path = self.data_dir.file_transfer_dir();
+
+        symlink_dir_path.join(symlink_path(entity_topic_id, config_type, cmd_id))
+    }
+}
+
+fn symlink_path(entity_topic_id: &EntityTopicId, config_type: &str, cmd_id: &str) -> Utf8PathBuf {
+    Utf8PathBuf::from(entity_topic_id.as_str().replace('/', "_"))
+        .join("config_update")
+        .join(format!("{}-{cmd_id}", config_type.replace('/', ":")))
+}
+
+pub struct FileCacheActorBuilder {
+    message_box: SimpleMessageBoxBuilder<FileCacheInput, MqttMessage>,
+    mqtt_sender: DynSender<MqttMessage>,
+    download_sender: DynSender<IdDownloadRequest>,
+
+    mqtt_schema: MqttSchema,
+    tedge_http_host: Arc<str>,
+    data_dir: DataDir,
+}
+
+impl FileCacheActorBuilder {
+    pub fn new(
+        mqtt_schema: MqttSchema,
+        tedge_http_host: Arc<str>,
+        data_dir: DataDir,
+        downloader_actor: &mut impl ServiceProvider<IdDownloadRequest, IdDownloadResult, NoConfig>,
+        mqtt_actor: &mut impl ServiceProvider<MqttMessage, MqttMessage, TopicFilter>,
+    ) -> Self {
+        let message_box = SimpleMessageBoxBuilder::new("RestartManager", 10);
+
+        let download_sender =
+            downloader_actor.connect_consumer(NoConfig, adapt(&message_box.get_sender()));
+
+        let mqtt_sender = mqtt_actor.connect_consumer(
+            Self::subscriptions(&mqtt_schema),
+            adapt(&message_box.get_sender()),
+        );
+
+        Self {
+            message_box,
+            mqtt_sender,
+            download_sender,
+            mqtt_schema,
+            tedge_http_host,
+            data_dir,
+        }
+    }
+
+    fn subscriptions(mqtt_schema: &MqttSchema) -> TopicFilter {
+        mqtt_schema.topics(
+            EntityFilter::AnyEntity,
+            ChannelFilter::Command(OperationType::ConfigUpdate),
+        )
+    }
+}
+
+impl MessageSink<FileCacheInput, NoConfig> for FileCacheActorBuilder {
+    fn get_config(&self) -> NoConfig {
+        NoConfig
+    }
+
+    fn get_sender(&self) -> DynSender<FileCacheInput> {
+        self.message_box.get_sender()
+    }
+}
+
+impl RuntimeRequestSink for FileCacheActorBuilder {
+    fn get_signal_sender(&self) -> DynSender<RuntimeRequest> {
+        self.message_box.get_signal_sender()
+    }
+}
+
+impl Builder<FileCacheActor> for FileCacheActorBuilder {
+    type Error = LinkError;
+
+    fn try_build(self) -> Result<FileCacheActor, Self::Error> {
+        Ok(self.build())
+    }
+
+    fn build(self) -> FileCacheActor {
+        let (_, rx) = self.message_box.build().into_split();
+        FileCacheActor {
+            mqtt_sender: self.mqtt_sender,
+            downloader_sender: self.download_sender,
+            input_receiver: rx,
+
+            tedge_http_host: self.tedge_http_host,
+            mqtt_schema: self.mqtt_schema,
+            data_dir: self.data_dir,
+
+            pending_operations: HashMap::new(),
+        }
+    }
+}

--- a/crates/core/tedge_api/src/messages.rs
+++ b/crates/core/tedge_api/src/messages.rs
@@ -680,7 +680,8 @@ impl ConfigSnapshotCmdPayload {
 pub struct ConfigUpdateCmdPayload {
     #[serde(flatten)]
     pub status: CommandStatus,
-    pub tedge_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tedge_url: Option<String>,
     pub remote_url: String,
     #[serde(rename = "type")]
     pub config_type: String,

--- a/crates/extensions/c8y_auth_proxy/src/url.rs
+++ b/crates/extensions/c8y_auth_proxy/src/url.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use tedge_config::TEdgeConfig;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProxyUrlGenerator {
     host: Arc<str>,
     port: u16,

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -30,7 +30,6 @@ use c8y_api::smartrest::operations::get_operations;
 use c8y_api::smartrest::operations::Operations;
 use c8y_api::smartrest::operations::ResultFormat;
 use c8y_api::smartrest::smartrest_deserializer::AvailableChildDevices;
-use c8y_api::smartrest::smartrest_deserializer::SmartRestOperationVariant;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestRequestGeneric;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestRestartRequest;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestUpdateSoftware;
@@ -202,7 +201,6 @@ pub struct CumulocityConverter {
     pub uploader_sender: LoggingSender<IdUploadRequest>,
     pub downloader_sender: LoggingSender<IdDownloadRequest>,
     pub pending_upload_operations: HashMap<CmdId, UploadOperationData>,
-    pub pending_download_operations: HashMap<CmdId, SmartRestOperationVariant>,
 
     /// Used to store pending downloads from the FTS.
     // Using a separate field to not mix downloads from FTS and HTTP proxy
@@ -293,7 +291,6 @@ impl CumulocityConverter {
             uploader_sender,
             downloader_sender,
             pending_upload_operations: HashMap::new(),
-            pending_download_operations: HashMap::new(),
             pending_fts_download_operations: HashMap::new(),
             command_id,
         })
@@ -3293,16 +3290,11 @@ pub(crate) mod tests {
         let service_type = "service".into();
         let c8y_host = "test.c8y.io".into();
         let tedge_http_host = "localhost".into();
-        let mqtt_schema = MqttSchema::default();
         let auth_proxy_addr = "127.0.0.1".into();
         let auth_proxy_port = 8001;
         let auth_proxy_protocol = Protocol::Http;
-        let mut topics =
+        let topics =
             C8yMapperConfig::default_internal_topic_filter(&tmp_dir.to_path_buf()).unwrap();
-        topics.add_all(crate::operations::log_upload::log_upload_topic_filter(
-            &mqtt_schema,
-        ));
-        topics.add_all(C8yMapperConfig::default_external_topic_filter());
 
         C8yMapperConfig::new(
             tmp_dir.to_path_buf(),

--- a/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
@@ -2,18 +2,12 @@ use crate::converter::CumulocityConverter;
 use crate::error::ConversionError;
 use crate::error::CumulocityMapperError;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestConfigDownloadRequest;
-use c8y_api::smartrest::smartrest_deserializer::SmartRestOperationVariant;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestRequestGeneric;
 use c8y_api::smartrest::smartrest_serializer::fail_operation;
 use c8y_api::smartrest::smartrest_serializer::set_operation_executing;
 use c8y_api::smartrest::smartrest_serializer::succeed_operation_no_payload;
 use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations;
-use std::fs;
-use std::io;
-use std::os::unix::fs as unix_fs;
-use std::path::Path;
 use std::sync::Arc;
-use tedge_actors::Sender;
 use tedge_api::entity_store::EntityMetadata;
 use tedge_api::messages::CommandStatus;
 use tedge_api::messages::ConfigUpdateCmdPayload;
@@ -24,12 +18,9 @@ use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
 use tedge_api::mqtt_topics::OperationType;
 use tedge_api::Jsonify;
-use tedge_downloader_ext::DownloadRequest;
-use tedge_downloader_ext::DownloadResult;
 use tedge_mqtt_ext::Message;
 use tedge_mqtt_ext::QoS;
 use tedge_mqtt_ext::TopicFilter;
-use tracing::info;
 use tracing::log::warn;
 
 pub fn topic_filter(mqtt_schema: &MqttSchema) -> TopicFilter {
@@ -48,60 +39,14 @@ pub fn topic_filter(mqtt_schema: &MqttSchema) -> TopicFilter {
 }
 
 impl CumulocityConverter {
-    /// This function is called after DownloaderActor returns the result.
-    /// If the result is
-    /// - Ok, create a new config_update command.
-    /// - Err, create SmartREST Executing and Failed messages to move the operation to end state.
-    pub async fn process_download_result_for_config_update(
-        &mut self,
-        cmd_id: Arc<str>,
-        smartrest: &SmartRestConfigDownloadRequest,
-        download_result: DownloadResult,
-    ) -> Result<Vec<Message>, ConversionError> {
-        let target = self
-            .entity_store
-            .try_get_by_external_id(&smartrest.device.clone().into())?;
-
-        match download_result {
-            Ok(download_response) => {
-                self.create_symlink_for_config_update(
-                    target,
-                    &smartrest.config_type,
-                    &cmd_id,
-                    download_response.file_path,
-                )?;
-                let message = self.create_config_update_cmd(cmd_id, smartrest, target);
-                Ok(message)
-            }
-            Err(download_err) => {
-                let sm_topic = self.smartrest_publish_topic_for_entity(&target.topic_id)?;
-                let smartrest_executing =
-                    set_operation_executing(CumulocitySupportedOperations::C8yDownloadConfigFile);
-                let smartrest_failed = fail_operation(
-                    CumulocitySupportedOperations::C8yDownloadConfigFile,
-                    &format!(
-                        "Download from {} failed with {}",
-                        smartrest.url, download_err
-                    ),
-                );
-
-                Ok(vec![
-                    Message::new(&sm_topic, smartrest_executing),
-                    Message::new(&sm_topic, smartrest_failed),
-                ])
-            }
-        }
-    }
-
     /// Address a received ThinEdge config_update command. If its status is
     /// - "executing", it converts the message to SmartREST "Executing".
     /// - "successful", it converts the message to SmartREST "Successful".
     /// - "failed", it converts the message to SmartREST "Failed".
-    /// Remove the symlink when the status is either successful or failed.
     pub async fn handle_config_update_state_change(
         &mut self,
         topic_id: &EntityTopicId,
-        cmd_id: &str,
+        _cmd_id: &str,
         message: &Message,
     ) -> Result<Vec<Message>, ConversionError> {
         if !self.config.capabilities.config_update {
@@ -109,7 +54,6 @@ impl CumulocityConverter {
             return Ok(vec![]);
         }
 
-        let target = self.entity_store.try_get(topic_id)?;
         let sm_topic = self.smartrest_publish_topic_for_entity(topic_id)?;
         let payload = message.payload_str()?;
         let response = &ConfigUpdateCmdPayload::from_json(payload)?;
@@ -130,8 +74,6 @@ impl CumulocityConverter {
                     .with_retain()
                     .with_qos(QoS::AtLeastOnce);
 
-                self.delete_symlink_for_config_update(target, &response.config_type, cmd_id)?;
-
                 vec![c8y_notification, clear_local_cmd]
             }
             CommandStatus::Failed { reason } => {
@@ -141,8 +83,6 @@ impl CumulocityConverter {
                 let clear_local_cmd = Message::new(&message.topic, "")
                     .with_retain()
                     .with_qos(QoS::AtLeastOnce);
-
-                self.delete_symlink_for_config_update(target, &response.config_type, cmd_id)?;
 
                 vec![c8y_notification, clear_local_cmd]
             }
@@ -154,10 +94,8 @@ impl CumulocityConverter {
         Ok(messages)
     }
 
-    /// Upon receiving a SmartREST c8y_DownloadConfigFile request,
-    /// - Create a download request if the target file is not available in cache.
-    /// - If the file is already available, proceed to create a new ThinEdge config_update command.
-    /// Command ID is generated here, but it should be replaced by c8y's operation ID in the future.
+    /// Upon receiving a SmartREST c8y_DownloadConfigFile request, convert it to a message on the
+    /// command channel.
     pub async fn convert_config_update_request(
         &mut self,
         smartrest: &str,
@@ -168,47 +106,9 @@ impl CumulocityConverter {
             .try_get_by_external_id(&smartrest.device.clone().into())?;
 
         let cmd_id = self.command_id.new_id();
-        let remote_url = smartrest.url.as_str();
-        let file_cache_key = sha256::digest(remote_url);
-        let file_cache_path = self.config.data_dir.cache_dir().join(file_cache_key);
 
-        if file_cache_path.is_file() {
-            // No download. Create a symlink and config_update command.
-            info!("Hit the file cache={file_cache_path}. Create a symlink to the file");
-            self.create_symlink_for_config_update(
-                target,
-                &smartrest.config_type,
-                &cmd_id,
-                file_cache_path,
-            )?;
-
-            let message = self.create_config_update_cmd(cmd_id.into(), &smartrest, target);
-            Ok(message)
-        } else {
-            // Require file download
-            // Send a request to the Downloader to download the file asynchronously.
-            let download_request =
-                if let Some(cumulocity_url) = self.c8y_endpoint.maybe_tenant_url(remote_url) {
-                    DownloadRequest::new(
-                        self.auth_proxy.proxy_url(cumulocity_url).as_ref(),
-                        file_cache_path.as_std_path(),
-                    )
-                } else {
-                    DownloadRequest::new(remote_url, file_cache_path.as_std_path())
-                };
-
-            self.downloader_sender
-                .send((cmd_id.clone(), download_request))
-                .await?;
-            info!("Awaiting config download for cmd_id: {cmd_id} from url: {remote_url}");
-
-            self.pending_download_operations.insert(
-                cmd_id,
-                SmartRestOperationVariant::DownloadConfigFile(smartrest),
-            );
-
-            Ok(vec![])
-        }
+        let message = self.create_config_update_cmd(cmd_id.into(), &smartrest, target);
+        Ok(message)
     }
 
     /// Converts a config_update metadata message to
@@ -237,21 +137,18 @@ impl CumulocityConverter {
             cmd_id: cmd_id.to_string(),
         };
         let topic = self.mqtt_schema.topic_for(&target.topic_id, &channel);
-        let external_id: String = target.external_id.clone().into();
 
-        // Replace '/' with ':' to avoid creating unexpected directories in file transfer repo
-        let tedge_url = format!(
-            "http://{}/tedge/file-transfer/{}/config_update/{}-{}",
-            &self.config.tedge_http_host,
-            external_id,
-            smartrest.config_type.replace('/', ":"),
-            cmd_id
-        );
+        let proxy_url = self
+            .c8y_endpoint
+            .maybe_tenant_url(&smartrest.url)
+            .map(|cumulocity_url| self.auth_proxy.proxy_url(cumulocity_url).into());
+
+        let remote_url = proxy_url.unwrap_or(smartrest.url.to_string());
 
         let request = ConfigUpdateCmdPayload {
             status: CommandStatus::Init,
-            tedge_url,
-            remote_url: smartrest.url.clone(),
+            tedge_url: None,
+            remote_url,
             config_type: smartrest.config_type.clone(),
             path: None,
         };
@@ -259,70 +156,22 @@ impl CumulocityConverter {
         // Command messages must be retained
         vec![Message::new(&topic, request.to_json()).with_retain()]
     }
-
-    fn create_symlink_for_config_update(
-        &self,
-        target: &EntityMetadata,
-        config_type: &str,
-        cmd_id: &str,
-        original: impl AsRef<Path>,
-    ) -> Result<(), io::Error> {
-        let symlink_dir_path = self
-            .config
-            .data_dir
-            .file_transfer_dir()
-            .join(target.external_id.as_ref())
-            .join("config_update");
-        let symlink_path =
-            symlink_dir_path.join(format!("{}-{cmd_id}", config_type.replace('/', ":")));
-
-        if !symlink_path.is_symlink() {
-            fs::create_dir_all(symlink_dir_path)?;
-            unix_fs::symlink(original, &symlink_path)?;
-        }
-
-        Ok(())
-    }
-
-    fn delete_symlink_for_config_update(
-        &self,
-        target: &EntityMetadata,
-        config_type: &str,
-        cmd_id: &str,
-    ) -> Result<(), io::Error> {
-        let symlink_dir_path = self
-            .config
-            .data_dir
-            .file_transfer_dir()
-            .join(target.external_id.as_ref())
-            .join("config_update");
-        let symlink_path =
-            symlink_dir_path.join(format!("{}-{cmd_id}", config_type.replace('/', ":")));
-
-        if symlink_path.exists() {
-            fs::remove_file(symlink_path)?
-        }
-
-        Ok(())
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use crate::tests::skip_init_messages;
     use crate::tests::spawn_c8y_mapper_actor;
     use c8y_api::smartrest::topic::C8yTopic;
     use serde_json::json;
     use sha256::digest;
+    use std::time::Duration;
     use tedge_actors::test_helpers::MessageReceiverExt;
     use tedge_actors::MessageReceiver;
     use tedge_actors::Sender;
     use tedge_api::mqtt_topics::Channel;
     use tedge_api::mqtt_topics::MqttSchema;
     use tedge_api::mqtt_topics::OperationType;
-    use tedge_downloader_ext::DownloadResponse;
     use tedge_mqtt_ext::test_helpers::assert_received_contains_str;
     use tedge_mqtt_ext::MqttMessage;
     use tedge_mqtt_ext::Topic;
@@ -331,80 +180,6 @@ mod tests {
     const TEST_TIMEOUT_MS: Duration = Duration::from_millis(5000);
 
     #[tokio::test]
-    #[ignore]
-    async fn mapper_converts_smartrest_config_download_req_with_new_download_for_main_device() {
-        let ttd = TempTedgeDir::new();
-        let (mqtt, _http, _fs, _timer, _ul, mut dl) = spawn_c8y_mapper_actor(&ttd, true).await;
-        let mut mqtt = mqtt.with_timeout(TEST_TIMEOUT_MS);
-
-        skip_init_messages(&mut mqtt).await;
-
-        // Simulate c8y_DownloadConfigFile SmartREST request
-        mqtt.send(MqttMessage::new(
-            &C8yTopic::downstream_topic(),
-            "524,test-device,http://www.my.url,path/config/A",
-        ))
-        .await
-        .expect("Send failed");
-
-        // Assert download request
-        let download_path = ttd.path().join("cache").join(digest("http://www.my.url"));
-        let (cmd_id, download_request) = dl.recv().await.unwrap();
-        assert_eq!(download_request.url, "http://www.my.url");
-        assert_eq!(download_request.file_path, download_path);
-        assert_eq!(download_request.auth, None);
-
-        // Simulate downloading a file is completed
-        ttd.dir("cache").file(&digest("http://www.my.url"));
-        let download_response = DownloadResponse::new("http://www.my.url", &download_path);
-        dl.send((cmd_id.clone(), Ok(download_response)))
-            .await
-            .unwrap();
-
-        // New config_update command should be published
-        let (topic, received_json) = mqtt
-            .recv()
-            .await
-            .map(|msg| {
-                (
-                    msg.topic,
-                    serde_json::from_str::<serde_json::Value>(msg.payload.as_str().expect("UTF8"))
-                        .expect("JSON"),
-                )
-            })
-            .unwrap();
-
-        let mqtt_schema = MqttSchema::default();
-        let (entity, channel) = mqtt_schema.entity_channel_of(&topic).unwrap();
-        assert_eq!(entity, "device/main//");
-
-        if let Channel::Command {
-            operation: OperationType::ConfigUpdate,
-            cmd_id,
-        } = channel
-        {
-            // Assert symlink is created
-            assert!(ttd
-                .path()
-                .join(format!(
-                    "file-transfer/test-device/config_update/path:config:A-{cmd_id}"
-                ))
-                .is_symlink());
-
-            // Validate the payload JSON
-            let expected_json = json!({
-                "status": "init",
-                "tedgeUrl": format!("http://localhost:8888/tedge/file-transfer/test-device/config_update/path:config:A-{cmd_id}"),
-                "type": "path/config/A",
-            });
-            assert_json_diff::assert_json_include!(actual: received_json, expected: expected_json);
-        } else {
-            panic!("Unexpected response on channel: {:?}", topic)
-        }
-    }
-
-    #[tokio::test]
-    #[ignore]
     async fn mapper_converts_smartrest_config_download_req_without_new_download_for_child_device() {
         let ttd = TempTedgeDir::new();
         let (mqtt, _http, _fs, _timer, _ul, _dl) = spawn_c8y_mapper_actor(&ttd, true).await;
@@ -450,29 +225,21 @@ mod tests {
         let (entity, channel) = mqtt_schema.entity_channel_of(&topic).unwrap();
         assert_eq!(entity, "device/child1//");
 
-        if let Channel::Command {
+        let Channel::Command {
             operation: OperationType::ConfigUpdate,
-            cmd_id,
+            ..
         } = channel
-        {
-            // Assert symlink is created
-            assert!(ttd
-                .path()
-                .join(format!(
-                    "file-transfer/child1/config_update/configA-{cmd_id}"
-                ))
-                .is_symlink());
-
-            // Validate the payload JSON
-            let expected_json = json!({
-                "status": "init",
-                "tedgeUrl": format!("http://localhost:8888/tedge/file-transfer/child1/config_update/configA-{cmd_id}"),
-                "type": "configA",
-            });
-            assert_json_diff::assert_json_include!(actual: received_json, expected: expected_json);
-        } else {
+        else {
             panic!("Unexpected response on channel: {:?}", topic)
-        }
+        };
+
+        // Validate the payload JSON
+        let expected_json = json!({
+            "status": "init",
+            "remoteUrl": "http://www.my.url",
+            "type": "configA",
+        });
+        assert_json_diff::assert_json_include!(actual: received_json, expected: expected_json);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## TODO

- [x] addressing feedback for unit tests

## Proposed changes

### Motivation

This PR moves file download from cloud - which needs to happen when handling `config_update` operation - from the mapper to the tedge-agent, in order to simplify the mapper. However, the complexity is not eliminated and is merely moved into tedge-agent, which now needs to have special handling for Cumulocity. However, this is accepted for now, because it enables tedge-agent and tedge-mapper-c8y to be run on different containers, and eliminates the implicit dependency on File Transfer Service (a part of tedge-agent) in tedge-mapper-c8y.

### Summary

The updated operation works like this:

1. The [`Download configuration type with type`](https://cumulocity.com/guides/reference/smartrest-two/#download-configuration-file-with-type-524) Smartrest message is received by the mapper
2. tedge-mapper-c8y converts the smartrest message into the following MQTT message:
    ```
    topic: te/device/device01///cmd/config_update/1234
    payload: {"status": "init", "remoteUrl": "https://example.org/file", "configType": "type"}
    ```
    i.e. `tedgeUrl` property was made optional and in the initial message it isn't set.

3. tedge-configuration-manager (part of tedge-agent) of the given entity, if the config type is supported, marks the operation as executing and waits for the operation to be updated with `tedgeUrl`
4. tedge-agent on the main device, upon seing that `config_update` operation is being executed, but does not have `tedgeUrl`, downloads the file in `remoteUrl`, saves it into FTS, and updates the operation with a valid `tedgeUrl` pointing into FTS
5. tedge-configuration-manager of the given entity, upon seeing that `tedgeUrl` is now present, downloads the file from it and continues processing the operation
6. The workflow continues unchanged from this point.

### Test changes

To test the changes, `configuration_with_file_transfer_https.robot` was modified to start `tedge-agent` on a child device, and `tedge-agent` was removed from the main device.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- https://github.com/thin-edge/thin-edge.io/issues/2477

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

The current implementation of caching files which are further needed by child devices, is very ad-hoc and as said in https://github.com/thin-edge/thin-edge.io/pull/2071#discussion_r1392990394, can be improved by custom workflow. This is something we'll need to think more about, but for now, it's enough to remove the implicit dependency on the FTS in tedge-mapper-c8y.