### PR TITLE
feat(packaging) publish container image to ghcr

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -116,6 +116,75 @@ jobs:
 
   # Wait until all other publishing jobs are finished
   # before publishing the virtual packages (which are architecture agnostic)
+  publish-containers:
+    name: Publish Containers
+    runs-on: ubuntu-20.04
+    needs: [build]
+    env:
+      BUILDX_NO_DEFAULT_ATTESTATIONS: 1
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: extractions/setup-just@v1
+      - id: tedge
+        name: Get Version
+        run: |
+          version=$(just version container)
+          echo "Detected version: $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # Download artifacts for all targets
+      # The docker build step will select the correct target for the
+      # given container target platform
+      - name: Download release artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: containers/tedge/packages/
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            name=ghcr.io/thin-edge/tedge,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            name=ghcr.io/thin-edge/tedge-main,enable=true
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ steps.tedge.outputs.version }},enable=${{ !startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest
+      
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: containers/tedge
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+            REVISION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.revision'] }}
+
+  # Wait until all other publishing jobs are finished
+  # before publishing the virtual packages (which are architecture agnostic)
   publish-virtual-packages:
     name: Publish Virtual Packages
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ docs/src/src
 .build
 dist/
 tmp/
+containers/tedge/packages/
+containers/tedge/*.tar
 
 # Other files
 Makefile.toml

--- a/ci/build_scripts/version.sh
+++ b/ci/build_scripts/version.sh
@@ -11,6 +11,8 @@ The following environment variables are set:
 * APK_VERSION
 * DEB_VERSION
 * RPM_VERSION
+* CONTAINER_VERSION
+* TARBALL_VERSION
 
 NOTES
 
@@ -22,7 +24,7 @@ Example:
     . $0
 
 USAGE
-    $0 [apk|deb|rpm|all]
+    $0 [apk|deb|rpm|container|tarball|all]
     # Print out a version
 
     # importing values via a script
@@ -132,12 +134,15 @@ set_version_variables() {
     APK_VERSION="${GIT_SEMVER//\~/_rc}"
     DEB_VERSION="$GIT_SEMVER"
     RPM_VERSION="$GIT_SEMVER"
+    # container tags are quite limited, so replace forbidden characters with '-'
+    CONTAINER_VERSION="${GIT_SEMVER//[^a-zA-Z0-9_.-]/-}"
     TARBALL_VERSION="${GIT_SEMVER//\~/-rc}"
 
     export GIT_SEMVER
     export APK_VERSION
     export DEB_VERSION
     export RPM_VERSION
+    export CONTAINER_VERSION
     export TARBALL_VERSION
 }
 
@@ -228,11 +233,15 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         tarball)
             echo "$TARBALL_VERSION"
             ;;
+        container)
+            echo "$CONTAINER_VERSION"
+            ;;
         all)
             echo "GIT_SEMVER: $GIT_SEMVER"
             echo "APK_VERSION: $APK_VERSION"
             echo "DEB_VERSION: $DEB_VERSION"
             echo "RPM_VERSION: $RPM_VERSION"
+            echo "CONTAINER_VERSION: $CONTAINER_VERSION"
             echo "TARBALL_VERSION: $TARBALL_VERSION"
             ;;
         *)

--- a/containers/tedge/Dockerfile
+++ b/containers/tedge/Dockerfile
@@ -1,0 +1,65 @@
+FROM alpine:3.18 as build
+# Use a build layer to avoid adding binaries from every target into a layer into the output image
+ARG TARGETPLATFORM
+
+# Extract the appropriate thin-edge.io target based on the docker target platform
+COPY packages/ /packages/
+RUN case "${TARGETPLATFORM}" in \
+         "linux/amd64")  RUST_TARGET=x86_64-unknown-linux-musl  ;; \
+         "linux/arm64")  RUST_TARGET=aarch64-unknown-linux-musl ;; \
+         "linux/arm/v7") RUST_TARGET=armv7-unknown-linux-musleabihf  ;; \
+         "linux/arm/v6") RUST_TARGET=arm-unknown-linux-musleabihf  ;; \
+         *) echo "Unsupported target platform: TARGETPLATFORM=$TARGETPLATFORM"; exit 1 ;; \
+    esac \
+    && mkdir -p /build \
+    && find /packages -name "tedge_${TEDGE_VERSION:-"*"}_${RUST_TARGET}.tar.gz" -exec tar xzvf {} -C /build/ \; \
+    # Fail early if matching binaries are not found
+    && ls -l /build/tedge*
+
+#
+# Output
+#
+FROM alpine:3.18
+
+ARG BUILDTIME
+ARG REVISION
+ARG VERSION
+
+LABEL org.opencontainers.image.title="thin-edge.io"
+LABEL org.opencontainers.image.created=$BUILDTIME
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.revision=$REVISION
+LABEL org.opencontainers.image.description="thin-edge.io container with the multi-call binary"
+LABEL org.opencontainers.image.source="https://github.com/thin-edge/thin-edge.io"
+LABEL org.opencontainers.image.authors="thin-edge.io"
+LABEL org.opencontainers.image.vendor="thin-edge.io"
+LABEL org.opencontainers.image.licenses="Apache 2.0"
+LABEL org.opencontainers.image.url="https://thin-edge.io"
+LABEL org.opencontainers.image.documentation="https://thin-edge.github.io/thin-edge.io/"
+LABEL org.opencontainers.image.base.name="alpine:3.18"
+
+# Note: having ca-certificates is generally very useful as it enable trusted
+# communication with https/mqtt servers, otherwise the users would always have
+# to add their own certs into the image before they can use it
+RUN apk add --no-cache \
+    ca-certificates
+
+# install thin-edge.io
+COPY --from=build build/* /usr/bin/
+
+# setup thin-edge.io
+RUN addgroup -S tedge \
+    && adduser -g '' -H -D tedge -G tedge \
+    && /usr/bin/tedge init
+
+# Add custom config
+COPY system.toml /etc/tedge/
+
+ENV TEDGE_C8Y_PROXY_BIND_ADDRESS 0.0.0.0
+ENV TEDGE_HTTP_BIND_ADDRESS 0.0.0.0
+ENV TEDGE_MQTT_CLIENT_HOST mqtt-broker
+ENV TEDGE_HTTP_CLIENT_HOST tedge-agent
+ENV TEDGE_C8Y_PROXY_CLIENT_HOST tedge-mapper-c8y
+
+USER "tedge"
+CMD [ "/usr/bin/tedge-agent" ]

--- a/containers/tedge/system.toml
+++ b/containers/tedge/system.toml
@@ -1,0 +1,2 @@
+[system]
+reboot = ["kill", "-15", "1"]

--- a/justfile
+++ b/justfile
@@ -17,6 +17,10 @@ info:
     @echo "VERSION:        {{VERSION}}"
     @echo "DEFAULT_TARGET: {{DEFAULT_TARGET}}"
 
+# Print the current git generated version
+version TYPE="all":
+    @./ci/build_scripts/version.sh {{TYPE}} 2>/dev/null || exit 0
+
 # Default recipe
 [private]
 default:


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Publish a container image with the multi-call thin-edge.io binary to Github container registry (ghcr.io). The container image can be used to start any of the thin-edge.io binaries, e.g. tedge-agent, tedge-mapper etc.

By default, tedge-agent will be started if no command line arguments are provided when running the container.

**Additional Notes**

The PR does not include a full end-to-end user example as there still other dependencies required (e.g. a container with mosquitto setup with thin-edge.io specific configuration etc.). This end-to-end example (including documentation will be added at a later point in time)

### Examples

Once the PR is merged, then you can use the container using one of the following commands:

**Start (default) tedge-agent**

You can use the following to connect to a mosquitto instance running on your machine's host (assuming you are using Docker on Windows or MacOS)

```sh
docker run --rm -it \
    -e TEDGE_MQTT_CLIENT_HOST=host.docker.internal \
    ghcr.io/thin-edge/tedge-main
```

**Start tedge-agent as a child device**

```sh
docker run --rm -it \
    -e TEDGE_MQTT_CLIENT_HOST=host.docker.internal \
    ghcr.io/thin-edge/tedge-main \
    tedge-agent --mqtt-device-topic-id device/child01//
```


**Start tedge-mapper-c8y**

```sh
docker run --rm -it \
    -e TEDGE_MQTT_CLIENT_HOST=host.docker.internal \
    -e TEDGE_C8Y_URL=example.c8y.io \
    -v $PWD/device-certs:/etc/tedge/device-certs \
    ghcr.io/thin-edge/tedge-main tedge-mapper c8y
```


### Container images

### thin-edge/tedge - official image

Official released versions of thin-edge.io when a git tag is created.

**Published when**

* git tag is created


### thin-edge/tedge-main - main branch

Images which are built on every PR merge. This allows users to experiment/use the latest images before the official release are made public. This follows the same principle as the other thin-edge.io release artifacts on cloudsmith.io.

**Published when**

* git tag is created
* PR is merged into main

The idea behind publishing both on merging into main and git tag, is to ensure that user's will also receive the same published images as the official repo


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/1358

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

