### PR TITLE
Fix broken mosquitto config generation for Azure

### DIFF
--- a/crates/core/tedge/src/cli/connect/bridge_config_azure.rs
+++ b/crates/core/tedge/src/cli/connect/bridge_config_azure.rs
@@ -65,8 +65,8 @@ impl From<BridgeConfigAzureParams> for BridgeConfig {
                 pub_msg_topic,
                 sub_msg_topic,
                 // Direct methods (request/response)
-                r##"topic methods/POST/# in 1 az/ $iothub/"##.into(),
-                r##"topic methods/res/# out 1 az/ $iothub/"##.into(),
+                r##"methods/POST/# in 1 az/ $iothub/"##.into(),
+                r##"methods/res/# out 1 az/ $iothub/"##.into(),
                 // Digital twin
                 r##"twin/res/# in 1 az/ $iothub/"##.into(),
                 r##"twin/GET/# out 1 az/ $iothub/"##.into(),
@@ -108,8 +108,8 @@ fn test_bridge_config_from_azure_params() -> anyhow::Result<()> {
         topics: vec![
             r#"messages/events/# out 1 az/ devices/alpha/"#.into(),
             r##"messages/devicebound/# in 1 az/ devices/alpha/"##.into(),
-            r##"topic methods/POST/# in 1 az/ $iothub/"##.into(),
-            r##"topic methods/res/# out 1 az/ $iothub/"##.into(),
+            r##"methods/POST/# in 1 az/ $iothub/"##.into(),
+            r##"methods/res/# out 1 az/ $iothub/"##.into(),
             r##"twin/res/# in 1 az/ $iothub/"##.into(),
             r##"twin/GET/# out 1 az/ $iothub/"##.into(),
             r##"twin/PATCH/# out 1 az/ $iothub/"##.into(),


### PR DESCRIPTION
## Proposed changes
This fixes broken mosquitto configuration generation for Azure when running `tedge connect az`. The generated configuration looked like

```
topic mesages/devicebound/# in 1 az/ devices/alpha/
topic topic methods/POST/# in 1 az/ $iothub/
//      ^^^ extra topic keyword here
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #2514

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
The unit tests for this should probably generate the configuration and do some checking of the actual output, that would have made the error here more obvious. I haven't spent any real time creating this PR beyond just fixing the bug, and my time is probably better spent elsewhere, but it seems like there's definitely a gap here.
