### PR TITLE
tedge cert renew uses the existing key to create a new certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3627,6 +3627,7 @@ dependencies = [
  "tracing",
  "url",
  "which",
+ "x509-parser 0.14.0",
  "yansi 0.5.1",
 ]
 

--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -64,6 +64,8 @@ predicates = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true }
+x509-parser = { workspace = true }
+
 
 [features]
 integration-test = []


### PR DESCRIPTION
## Proposed changes
This PR changes the behaviour of `tedge cert renew`. The work on #2502 defines that `renew` = `remove` + `create`, however, as #2512 is created, `renew` should reuse the private key and create only a new certificate.

At first, I thought I should have changed the robot tests regarding `tedge cert renew`, but I changed my mind. Indeed, the tests pass and they test the validity of the new certificate. So, I decided not to change them.

tests/RobotFramework/tests/tedge/tedge_upload_cert.robot
- Renew the certificate
- Renew certificate fails

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2512 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

