### PR TITLE
Mark fail-fast false to matrix jobs

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -79,6 +79,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build]
     strategy:
+      fail-fast: false
       matrix:
         job:
           - { target: x86_64-unknown-linux-musl,      repo: tedge-main,          component: main }

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -84,6 +84,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
+        fail-fast: false
         # Add only arm targets here as we use a custom strip binary!
         target:
           [
@@ -141,6 +142,7 @@ jobs:
 
   clean-up-rpi-matrix:
     strategy:
+      fail-fast: false
       matrix:
         rpi: [ m32sd10a, m32sd10b, m32sd10c, m32sd10d ]
     runs-on:
@@ -162,6 +164,7 @@ jobs:
 
   install-and-use-rpi-matrix:
     strategy:
+      fail-fast: false
       matrix:
         rpi: [ m32sd10a, m32sd10b, m32sd10c, m32sd10d ]
     runs-on:


### PR DESCRIPTION
## Proposed changes
`fail-fast` can cause the half successful state, which cause another issue in the next attempt.  
See this attempt. https://github.com/thin-edge/thin-edge.io/actions/runs/7251106688/attempts/1

This PR adds `fail-fast false` to matrix jobs. This option is `true` by default.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

