### PR TITLE
Fix fs event deduplication for vi

### DIFF
--- a/crates/common/tedge_utils/src/notify.rs
+++ b/crates/common/tedge_utils/src/notify.rs
@@ -85,8 +85,9 @@ impl NotifyStream {
                     };
 
                     // simplify event type
-                    let debounced_events =
-                        debounced_events.into_iter().filter_map(|notify_event| {
+                    let mut debounced_events: Vec<_> = debounced_events
+                        .into_iter()
+                        .filter_map(|notify_event| {
                             let event = match notify_event.kind {
                                 EventKind::Access(access_kind) => match access_kind {
                                     AccessKind::Close(access_mode) => match access_mode {
@@ -114,7 +115,9 @@ impl NotifyStream {
                                 EventKind::Any | EventKind::Other => Some(FsEvent::Modified),
                             };
                             event.map(|event| (notify_event.event.paths, event))
-                        });
+                        })
+                        .collect();
+                    debounced_events.dedup();
 
                     for (paths, event) in debounced_events {
                         for path in paths {


### PR DESCRIPTION


## Proposed changes

vi doesn't use a temporary file, but just modifies the file directly. In vim, modification was handled by changing Access(Close(Write)) event to Modify. Vi created both Modify and then Access(Close(Write)), which were duplicates. The missed case was added.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2451

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- x ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

