### PR TITLE
feat: add user warning when an invalid custom operation filename is used

### DIFF
--- a/crates/core/c8y_api/src/smartrest/operations.rs
+++ b/crates/core/c8y_api/src/smartrest/operations.rs
@@ -8,6 +8,7 @@ use crate::smartrest::error::OperationsError;
 use crate::smartrest::smartrest_serializer::declare_supported_operations;
 use serde::Deserialize;
 use serde::Deserializer;
+use tracing::warn;
 
 use std::time::Duration;
 
@@ -194,6 +195,9 @@ pub fn get_operations(dir: impl AsRef<Path>) -> Result<Operations, OperationsErr
     for path in dir_entries {
         if let Some(file_name) = path.file_name().and_then(|file_name| file_name.to_str()) {
             if !is_valid_operation_name(file_name) {
+                // Warn user about invalid operation names, otherwise the
+                // user does not know that the operation is being ignored
+                warn!("Ignoring custom operation definition as the filename uses an invalid character. Only [A-Za-z0-9_] characters are accepted. file={}", path.display());
                 continue;
             }
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Add a warning log message when an invalid custom operation filename is encountered to warn the user that the file will be ignored.

This helps users understand why their custom operation definition is not being used. Previously the user would not receive any indication that thin-edge.io was actively ignoring the file.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

