### PR TITLE
Limit the length of the message for failed operation

### DIFF
--- a/crates/core/c8y_api/src/smartrest/smartrest_serializer.rs
+++ b/crates/core/c8y_api/src/smartrest/smartrest_serializer.rs
@@ -7,6 +7,7 @@ use serde::ser::SerializeSeq;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::Serializer;
+use tracing::warn;
 
 pub type SmartRest = String;
 
@@ -21,7 +22,13 @@ pub fn set_operation_executing(operation: impl C8yOperation) -> String {
 
 /// Generates a SmartREST message to set the provided operation to failed with the provided reason
 pub fn fail_operation(operation: impl C8yOperation, reason: &str) -> String {
-    fields_to_csv_string(&["502", operation.name(), reason])
+    // If the failure reason exceeds 500 bytes, trancuate it
+    if reason.len() <= 500 {
+        fields_to_csv_string(&["502", operation.name(), reason])
+    } else {
+        warn!("Failure reason too long, message trancuated to 500 bytes");
+        fields_to_csv_string(&["502", operation.name(), &reason[..500]])
+    }
 }
 
 /// Generates a SmartREST message to set the provided operation to successful without a payload


### PR DESCRIPTION
## Proposed changes
This PR introduces a limit to the size of the message that is sent when the operation fails. If the failure reason is longer than 200 characters, it is truncated from the end, and the user gets a warning message about truncation. 
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #2567
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

