### PR TITLE
Restart tedge-agent after self update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_amd64.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_amd64.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_amd64.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_amd64.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_amd64.deb filter=lfs diff=lfs merge=lfs -text
+
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_arm64.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_arm64.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_arm64.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_arm64.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_arm64.deb filter=lfs diff=lfs merge=lfs -text
+
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_armv6.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_armv6.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_armv6.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_armv6.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_armv6.deb filter=lfs diff=lfs merge=lfs -text
+
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_armhf.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_armhf.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_armhf.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_armhf.deb filter=lfs diff=lfs merge=lfs -text
+tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_armhf.deb filter=lfs diff=lfs merge=lfs -text

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ zeroize = "1.5"
 codegen-units = 1
 lto = true
 opt-level = "z"
-panic = "abort"
+panic = "unwind"
 strip = "symbols"
 overflow-checks = true
 

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -59,7 +59,7 @@ use tracing::info;
 use tracing::instrument;
 use tracing::warn;
 
-const TEDGE_AGENT: &str = "tedge-agent";
+pub const TEDGE_AGENT: &str = "tedge-agent";
 
 #[derive(Debug, Clone)]
 pub(crate) struct AgentConfig {
@@ -219,7 +219,8 @@ impl Agent {
 
     #[instrument(skip(self), name = "sm-agent")]
     pub async fn start(self) -> Result<(), anyhow::Error> {
-        info!("Starting tedge agent");
+        let version = env!("CARGO_PKG_VERSION");
+        info!("Starting tedge-agent v{}", version);
         self.init()?;
 
         // Runtime

--- a/crates/core/tedge_agent/src/software_manager/error.rs
+++ b/crates/core/tedge_agent/src/software_manager/error.rs
@@ -22,6 +22,9 @@ pub enum SoftwareManagerError {
     #[error(transparent)]
     FromTedgeConfig(#[from] tedge_config::TEdgeConfigError),
 
+    #[error("Tedge-agent is not running the latest version")]
+    NotRunningLatestVersion,
+
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/tests/RobotFramework/bin/setup.sh
+++ b/tests/RobotFramework/bin/setup.sh
@@ -13,6 +13,12 @@ pushd "$SCRIPT_DIR/.." >/dev/null || exit 1
 # Required to prevent dbus errors on raspberry pi
 export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
 
+# Use git lfs for test artefacts
+curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash
+sudo apt install -y git-lfs
+git lfs install
+git lfs pull
+
 #
 # Setup python virtual environment and install dependencies
 #

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_amd64.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01bd9f63f5cb8f5ff094ca20946bdb0346fd3c61522bbb5f0e84ebcaf7e2773d
+size 2042

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_arm64.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_arm64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9f3b316a068741a8f226d7e8e5f2e70af057a529f66da1f78df20cb8106091f
+size 2044

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_armhf.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_armhf.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8af24344714c4f9ddb5865cfb9d1195603ab066093ef14acffded4d66ad86891
+size 2042

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_armv6.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-agent_0.0.1_armv6.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2199508f48fdf0ec8fd3039caddc416494d8fa09eb356216657727b0ad19964c
+size 2044

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_amd64.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62b58730e3985e057865393a2954e3de0319f0e2bfc0997ae70d621a900515dd
+size 840

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_arm64.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_arm64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d78581ed5dc4b708d01d7e2d31ff48ea914fc2bba5d442d8c9fc0d0c84eaf09
+size 840

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_armhf.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_armhf.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15f665bbbf4700ef4b2fa04fbcef09264d5bae2d63cea7f0ac97237845f522c3
+size 842

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_armv6.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-apt-plugin_0.0.1_armv6.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c803f15f446bf6a9e3f4a1569135c05178f46e4cf5a58d478397d70ddfbad4d
+size 844

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_amd64.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce618a7f2eea03c971a5fb80ade907c74abf54083d7e68fece40037b8f4fcc60
+size 6988

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_arm64.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_arm64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5222dab2fa749336de9b0460b55a953d61bdad6fb55036c89906eb3ab5898095
+size 6984

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_armhf.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_armhf.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ee8c21ee2a233b3815e6703f11489412a73b626d1dc1f49b0ecdc1d09c9c1c3
+size 6984

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_armv6.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-mapper_0.0.1_armv6.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:712730b769192de21c1124d812a2837cf732bc2a9894e21634bbfc75a61bf0b1
+size 6988

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_amd64.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23ef503f52bb36cfcb876d2cc2d169a13dc838eaf790cf1eacac1668d1c7080f
+size 1830

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_arm64.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_arm64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e6ba7b80c6c31d4c61dbc34ec3e4d9bff96f114b1feb36b2ab6b07af7933fa9
+size 1830

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_armhf.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_armhf.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74d06141eb7bfe5571ee88215f4b2698d9562aed9a963d8544523f7217a87c18
+size 1828

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_armv6.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge-watchdog_0.0.1_armv6.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ef6e442383f9e4199424901d8a8296c6f21e818d077f88dac55d5b15cfb4cd6
+size 1830

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_amd64.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:deefb6b4df143283f79e2e16817d699524a9018e4fec83c0714af36854ce557f
+size 5045978

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_arm64.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_arm64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:176d9ea0f315b3aae36e1a2f82960c72c0492ba6bbf32789cdd0f38b2e94018c
+size 4782014

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_armhf.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_armhf.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fdec76167998611eb048215ff6e7068c5e13f726af1cffdba1e3088df9c129b
+size 4236146

--- a/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_armv6.deb
+++ b/tests/RobotFramework/tests/cumulocity/self-update/base-version/tedge_0.0.1_armv6.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f2d49356603466a9e7051b771c833a2233ee7e0dcc24f243592784ccc9925e11
+size 4284860


### PR DESCRIPTION
## Proposed changes

When tedge-agent detects that the `tedge` binary itself is updated, exit with a non-zero exit code, so that the process manger like systemd restarts the upgraded agent.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2501

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

