### PR TITLE
Add support for commands with multiple arguments in custom operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,6 +1944,7 @@ dependencies = [
  "anyhow",
  "log",
  "nix",
+ "shell-words",
  "tedge_test_utils",
  "tokio",
 ]

--- a/crates/common/logged_command/Cargo.toml
+++ b/crates/common/logged_command/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 [dependencies]
 log = { workspace = true }
 nix = { workspace = true }
+shell-words = { workspace = true }
 tokio = { workspace = true, features = [
     "fs",
     "io-util",
@@ -22,6 +23,7 @@ tokio = { workspace = true, features = [
 [dev-dependencies]
 anyhow = { workspace = true }
 tedge_test_utils = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 
 [lints]
 workspace = true

--- a/crates/core/plugin_sm/src/plugin.rs
+++ b/crates/core/plugin_sm/src/plugin.rs
@@ -263,11 +263,14 @@ impl ExternalPluginCommand {
         maybe_module: Option<&SoftwareModule>,
     ) -> Result<LoggedCommand, SoftwareError> {
         let mut command = if let Some(sudo) = &self.sudo {
-            let mut command = LoggedCommand::new(sudo);
+            // Safe unwrap
+            let mut command = LoggedCommand::new(sudo).unwrap();
             command.arg(&self.path);
             command
         } else {
-            LoggedCommand::new(&self.path)
+            LoggedCommand::new(&self.path).map_err(|err| SoftwareError::ParseError {
+                reason: err.to_string(),
+            })?
         };
         command.arg(action);
 

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -793,7 +793,13 @@ impl CumulocityConverter {
         let command = command.to_owned();
         let payload = payload.to_string();
 
-        let mut logged = LoggedCommand::new(&command);
+        let mut logged =
+            LoggedCommand::new(&command).map_err(|e| CumulocityMapperError::ExecuteFailed {
+                error_message: e.to_string(),
+                command: command.to_string(),
+                operation_name: operation_name.to_string(),
+            })?;
+
         logged.arg(&payload);
 
         let maybe_child_process =

--- a/docs/src/operate/c8y/supported_operations.md
+++ b/docs/src/operate/c8y/supported_operations.md
@@ -237,3 +237,25 @@ The command will be executed with tedge-mapper permission level so most of the s
 * `on_message` - The SmartRest template on which the operation will be executed.
 * `command` - The command to execute.
 * `result_format` - The expected command output format: `"text"` or `"csv"`, `"text"` being the default.
+
+:::info
+The `command` parameter accepts command arguments when provided as a one string, e.g.
+
+```toml title="file: /etc/tedge/operations/c8y/c8y_Command"
+[exec]
+  topic = "c8y/s/ds"
+  on_message = "511"
+  command = "python /etc/tedge/operations/command.py"
+  timeout = 10
+``` 
+
+Arguments will be parsed correctly as long as following features are not included in input: operators, variable assignments, tilde expansion, parameter expansion, command substitution, arithmetic expansion and pathname expansion. 
+
+In case those unsupported shell features are present, the syntax that introduce them is interpreted literally.
+
+Be aware that SmartREST payload is always added as the last argument. The command presented above will actually lead to following code execution
+
+```bash
+python /etc/tedge/operations/command.py $SMART_REST_PAYLOAD
+```
+:::

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_multiple_args/c8y_Command_1
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_multiple_args/c8y_Command_1
@@ -1,0 +1,4 @@
+[exec]
+topic = "c8y/s/ds"
+on_message = "511"
+command = "sh /etc/tedge/operations/command_1.sh"

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_multiple_args/command_1.sh
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_multiple_args/command_1.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "command 1"

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_multiple_args/operation_multiple_arguments_in_command.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_multiple_args/operation_multiple_arguments_in_command.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+Resource            ../../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:operation    theme:custom
+
+
+*** Test Cases ***
+Run the custom operation with multiple arguments
+    ${operation}=    Cumulocity.Create Operation    description=do something    fragments={"c8y_Command":{"text":""}}
+    Operation Should Be SUCCESSFUL    ${operation}
+    Should Be Equal    ${operation.to_json()["c8y_Command"]["result"]}    command 1\n
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Device Should Exist    ${DEVICE_SN}
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/command_1.sh    /etc/tedge/operations/
+    Execute Command    chmod a+x /etc/tedge/operations/command_1.sh
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command_1    /etc/tedge/operations/c8y/c8y_Command


### PR DESCRIPTION
## Proposed changes
This PR adds support for arguments/subcommands when running command in custom operation. Command accepts string with arguments separated by whitespaces, e.g:
```
command = "python /etc/tedge/operations/command.py"
```
More in #2568.
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #2568

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

