### PR TITLE
docs: correct note about certificate chain order

### DIFF
--- a/docs/src/operate/security/device-certificate.md
+++ b/docs/src/operate/security/device-certificate.md
@@ -36,12 +36,12 @@ Note that *only* the MQTT broker should be able to read or write the private key
 Then thin-edge must be told where the certificate is stored.
 Note that the device certificate file must contain not only the device certificate itself
 but also the signing certificate
-(so the cloud endpoint can check the chain, starting from a trusted root upto the device certificate).
+(so the cloud endpoint can check the chain, starting from the device certificate up to the trusted root).
 
 ```sh
-# Create a new cert chain, which contains both the signing and device public cert
-cat signing-cert.pem > demo-device-007.chain.pem
-cat demo-device-007.pem >> demo-device-007.chain.pem
+# Create a new cert chain, which contains both the device public cert and the signing (in that order)
+cat demo-device-007.pem > demo-device-007.chain.pem
+cat signing-cert.pem >> demo-device-007.chain.pem
 
 # Configure the cert chain file as the main cert to be used by thin-edge.io
 tedge config set device.cert_path /etc/mosquitto/certs/demo-device-007.chain.pem


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix documentation about the order of certificates in the cert chain (when using a signing cert). The first cert in the chain must be the device cert.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

