### PR TITLE
test: use local ca to generate device certificates

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -146,6 +146,7 @@ jobs:
           touch .env
           echo 'C8Y_BASEURL="${{ secrets.C8Y_BASEURL }}"' >> .env
           echo 'C8Y_USER="${{ secrets.C8Y_USER }}"' >> .env
+          echo 'C8Y_TENANT="${{ secrets.C8Y_TENANT }}"' >> .env
           echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
 
       - uses: actions/setup-python@v5

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -148,6 +148,8 @@ jobs:
           echo 'C8Y_USER="${{ secrets.C8Y_USER }}"' >> .env
           echo 'C8Y_TENANT="${{ secrets.C8Y_TENANT }}"' >> .env
           echo 'C8Y_PASSWORD="${{ secrets.C8Y_PASSWORD }}"' >> .env
+          echo 'CA_KEY="${{ secrets.CA_KEY || '' }}"' >> .env
+          echo 'CA_PUB="${{ secrets.CA_PUB || '' }}"' >> .env
 
       - uses: actions/setup-python@v5
         with:

--- a/tests/RobotFramework/devdata/env.template
+++ b/tests/RobotFramework/devdata/env.template
@@ -20,6 +20,15 @@ C8Y_BASEURL=
 C8Y_USER=
 C8Y_PASSWORD=
 
+
+# CA Certificate (key/cert) to use to create device certificates
+# These values will be picked up by the bootstrap.sh and used if present
+# The following environment variables expect the key/cert contents to be
+# base64 encoded, so you can just run `cat ca.key | base64` on the key/cert
+# and set the following env variables with the output:
+# CA_KEY="{base64_encoded_key}"
+# CA_PUB="{base64_encoded_public_certificate}"
+
 #
 # GitHub Settings - Required if using some GitHub related API (though requires the `gh` command to be installed)
 # E.g. "Download From GitHub"

--- a/tests/RobotFramework/requirements/requirements.txt
+++ b/tests/RobotFramework/requirements/requirements.txt
@@ -2,7 +2,7 @@ dateparser~=1.2.0
 paho-mqtt~=1.6.1
 python-dotenv~=1.0.0
 robotframework~=6.1.1
-robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.30.0
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.30.1
 robotframework-debuglibrary~=2.3.0
 robotframework-jsonlibrary~=0.5
 robotframework-pabot~=2.16.0

--- a/tests/RobotFramework/requirements/requirements.txt
+++ b/tests/RobotFramework/requirements/requirements.txt
@@ -2,7 +2,7 @@ dateparser~=1.2.0
 paho-mqtt~=1.6.1
 python-dotenv~=1.0.0
 robotframework~=6.1.1
-robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.27.0
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.30.0
 robotframework-debuglibrary~=2.3.0
 robotframework-jsonlibrary~=0.5
 robotframework-pabot~=2.16.0

--- a/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
+++ b/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
@@ -97,7 +97,7 @@ Update tedge version from base to current using Cumulocity
     Create Local Repository
     ${OPERATION}=    Install Software    tedge,${NEW_VERSION}    tedge-mapper,${NEW_VERSION}    tedge-agent,${NEW_VERSION}    tedge-watchdog,${NEW_VERSION}    tedge-apt-plugin,${NEW_VERSION}
 
-    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
+    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=300
     Device Should Have Installed Software    tedge,${NEW_VERSION_ESCAPED}::apt    tedge-mapper,${NEW_VERSION_ESCAPED}::apt    tedge-agent,${NEW_VERSION_ESCAPED}::apt    tedge-watchdog,${NEW_VERSION_ESCAPED}::apt    tedge-apt-plugin,${NEW_VERSION_ESCAPED}::apt
 
     ${pid_after}=    Execute Command    pgrep tedge-agent    strip=${True}

--- a/tests/images/debian-systemd/files/bootstrap.sh
+++ b/tests/images/debian-systemd/files/bootstrap.sh
@@ -756,7 +756,10 @@ sign_local_ca() {
     # Use a local-ca file (to minimize dependencies)
     CN="$1"
     LEAF_EXPIRE_DAYS="${2:-7}"
-    DEVICE_KEY_PATH=$(tedge config get device.key_path)
+    # Note: older thin-edge.io versions the device certificate key/path
+    # config names changed. Support the newer name but still fallback to the previous
+    # name as some tests use the older agent version
+    DEVICE_KEY_PATH=$(tedge config get device.key_path 2>/dev/null || tedge config get device.key.path)
 
     sudo openssl genrsa -out "$DEVICE_KEY_PATH" 2048
 
@@ -775,7 +778,7 @@ subjectAltName=DNS:${CN},DNS:localhost
 EOF
     )
 
-    DEVICE_CERT_PATH=$(tedge config get device.cert_path)
+    DEVICE_CERT_PATH=$(tedge config get device.cert_path 2>/dev/null || tedge config get device.cert.path)
     openssl x509 -req \
         -in <(echo "$DEVICE_CSR") \
         -out "$DEVICE_CERT_PATH" \

--- a/tests/images/debian-systemd/files/bootstrap.sh
+++ b/tests/images/debian-systemd/files/bootstrap.sh
@@ -878,7 +878,7 @@ display_banner_c8y() {
     echo ""
     echo "tedge.version:   $(tedge --version 2>/dev/null | tail -1 | cut -d' ' -f2)"
     echo "device.id:       ${DEVICE_ID}"
-    DEVICE_SEARCH=$(echo "$DEVICE_ID" | sed 's/-/*/g')
+    DEVICE_SEARCH="${DEVICE_ID//-/*}"
     echo "Cumulocity IoT:  https://${C8Y_BASEURL}/apps/devicemanagement/index.html#/assetsearch?filter=*${DEVICE_SEARCH}*"
     echo ""
     echo "----------------------------------------------------------"    


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Use a local CA to generate the device certificates used in each test. This should improve overall performance, and avoid creating large amounts of device certificates in Cumulocity IoT

* Generate device certificate during bootstrap.sh script using a local CA provided  via environment variables (if `CA_KEY` and `CA_PUB` are present, which are base64 encoded values), otherwise continue using self signed certificate
* Only run "delete cert" logic in the cleanup of tests if a self-signed device certificate is detected
* Decouple the certificate deletion and the device deletion to avoid problems where the device is not cleaned up if the cert deletion fails

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

