### PR TITLE
fixed services shown as child devices #2584

### DIFF
--- a/crates/core/tedge_api/src/entity_store.rs
+++ b/crates/core/tedge_api/src/entity_store.rs
@@ -714,13 +714,19 @@ pub enum EntityType {
     Service,
 }
 
+impl EntityType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            EntityType::MainDevice => "device",
+            EntityType::ChildDevice => "child-device",
+            EntityType::Service => "service",
+        }
+    }
+}
+
 impl Display for EntityType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            EntityType::MainDevice => write!(f, "device"),
-            EntityType::ChildDevice => write!(f, "child-device"),
-            EntityType::Service => write!(f, "service"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/crates/extensions/c8y_mapper_ext/src/actor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/actor.rs
@@ -201,7 +201,7 @@ impl C8yMapperActor {
             | FsWatchEvent::FileDeleted(path)
             | FsWatchEvent::Modified(path)
             | FsWatchEvent::DirectoryDeleted(path) => {
-                match process_inotify_events(&path, file_event) {
+                match process_inotify_events(&self.converter.ops_dir, &path, file_event) {
                     Ok(Some(discovered_ops)) => {
                         self.mqtt_publisher
                             .send(

--- a/crates/extensions/c8y_mapper_ext/src/dynamic_discovery.rs
+++ b/crates/extensions/c8y_mapper_ext/src/dynamic_discovery.rs
@@ -28,6 +28,7 @@ pub enum DynamicDiscoverOpsError {
 }
 
 pub fn process_inotify_events(
+    c8y_operations_dir: &Path,
     path: &Path,
     mask: FsWatchEvent,
 ) -> Result<Option<DiscoverOp>, DynamicDiscoverOpsError> {
@@ -39,6 +40,11 @@ pub fn process_inotify_events(
     let parent_dir = path
         .parent()
         .ok_or_else(|| DynamicDiscoverOpsError::NotAnOperation(path.to_path_buf()))?;
+
+    // only files inside `/etc/tedge/operations/c8y` directory are valid c8y operations
+    if !parent_dir.starts_with(c8y_operations_dir) {
+        return Ok(None);
+    }
 
     if is_valid_operation_name(operation_name) {
         match mask {

--- a/tests/RobotFramework/tests/cumulocity/bootstrap.robot
+++ b/tests/RobotFramework/tests/cumulocity/bootstrap.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Resource    ../../resources/common.resource
+
+Library    Cumulocity
+Library    ThinEdgeIO
+Library    DateTime
+
+Test Teardown    Get Logs
+
+*** Test Cases ***
+
+No unexpected child devices created with service autostart
+    [Tags]    \#2584
+    ${DEVICE_SN}=    Setup    skip_bootstrap=True
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
+    Execute Command    systemctl start mosquitto
+    Execute Command    systemctl start tedge-agent
+    Execute Command    systemctl start tedge-mapper-c8y
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-install --no-secure || true
+    Device Should Exist    ${DEVICE_SN}
+
+    # wait for messages to be processed
+    Sleep    15s
+
+    # Assert that there are no child devices present.
+    Cumulocity.Device Should Not Have Any Child Devices
+
+No unexpected child devices created without service autostart
+    [Tags]    \#2606
+    ${DEVICE_SN}=    Setup
+    Device Should Exist    ${DEVICE_SN}
+
+    # Touching the operations directories should not create child devices
+    Execute Command    touch /etc/tedge/operations
+    Execute Command    touch /etc/tedge/operations/c8y
+
+    # wait for fs event to be detected
+    Sleep    5s
+
+    # Assert that there are no child devices present.
+    Cumulocity.Device Should Not Have Any Child Devices


### PR DESCRIPTION
## TODO

- [x] add tests

## Proposed changes

Added a workaround for #2584 by changing status update smartrest message to 102.

Also fixed #2606 by properly checking in the fs event handler if the path of the event is actually inside the c8y operations path.

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #2584

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Note that changing `104` to `102` in this case is only a workaround, because, fundamentally, Cumulocity maintains a certain state, and depending on this state, we either can or can't send certain messages, e.g. `104` can't be sent before a `102` or it will create a child device, but I assume this is only a single example and there are many more. To be able to use certain messages, we need to actually maintain the state for entities in cumulocity - if they're registered, if they're child devices or services, etc. So ultimately we may need to change our model a bit from "map every local MQTT message to a C8y message" to "every local MQTT message may modify entity store state and if this state is different we need to sync it with C8y".
