### PR TITLE
Test no unexpected child devices

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/bootstrap.robot
+++ b/tests/RobotFramework/tests/cumulocity/bootstrap.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Resource    ../../resources/common.resource
+
+Library    Cumulocity
+Library    ThinEdgeIO
+Library    DateTime
+
+Test Teardown    Get Logs
+
+*** Test Cases ***
+
+No unexpected child devices created with service autostart
+    [Tags]    \#2584
+    ${DEVICE_SN}=    Setup    skip_bootstrap=True
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
+    Execute Command    systemctl start mosquitto
+    Execute Command    systemctl start tedge-agent
+    Execute Command    systemctl start tedge-mapper-c8y
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-install --no-secure || true
+    Device Should Exist    ${DEVICE_SN}
+
+    # wait for messages to be processed
+    Sleep    15s
+
+    # Assert that there are no child devices present.
+    Cumulocity.Device Should Not Have Any Child Devices
+
+No unexpected child devices created without service autostart
+    [Tags]    \#2606
+    ${DEVICE_SN}=    Setup
+    Device Should Exist    ${DEVICE_SN}
+
+    # Touching the operations directories should not create child devices
+    Execute Command    touch /etc/tedge/operations
+    Execute Command    touch /etc/tedge/operations/c8y
+
+    # wait for fs event to be detected
+    Sleep    5s
+
+    # Assert that there are no child devices present.
+    Cumulocity.Device Should Not Have Any Child Devices


### PR DESCRIPTION
## Proposed changes

A draft PR to make sure [the tests of this PR properly test the fix](https://github.com/thin-edge/thin-edge.io/pull/2620) .

I expect 2 test failures!.
- No unexpected child devices created with service autostart
- No unexpected child devices created without service autostart

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

