### PR TITLE
Bypass duplicate message filtering on mapper startup with config flag

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -450,6 +450,10 @@ define_tedge_config! {
             /// Enable auto registration feature
             #[tedge_config(example = "true", default(value = true))]
             auto_register: bool,
+
+            /// On a clean start, the whole state of the device, services and child-devices is resent to the cloud
+            #[tedge_config(example = "true", default(value = true))]
+            clean_start: bool,
         },
     },
 

--- a/crates/core/c8y_api/src/json_c8y.rs
+++ b/crates/core/c8y_api/src/json_c8y.rs
@@ -719,6 +719,7 @@ mod tests {
             dummy_external_id_validator,
             5,
             &temp_dir,
+            true,
         )
         .unwrap();
 
@@ -756,6 +757,7 @@ mod tests {
             dummy_external_id_validator,
             5,
             &temp_dir,
+            true,
         )
         .unwrap();
 

--- a/crates/core/tedge_api/src/message_log.rs
+++ b/crates/core/tedge_api/src/message_log.rs
@@ -91,6 +91,19 @@ impl MessageLogWriter {
         Ok(MessageLogWriter { writer })
     }
 
+    pub fn new_truncated<P>(log_dir: P) -> Result<MessageLogWriter, std::io::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let _ = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(log_dir.as_ref().join(LOG_FILE_NAME))?;
+
+        MessageLogWriter::new(log_dir)
+    }
+
     /// Append the JSON representation of the given message to the log.
     /// Each message is appended on a new line.
     pub fn append_message(&mut self, message: &MqttMessage) -> Result<(), std::io::Error> {

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -50,6 +50,7 @@ pub struct C8yMapperConfig {
     pub auth_proxy_protocol: Protocol,
     pub mqtt_schema: MqttSchema,
     pub enable_auto_register: bool,
+    pub clean_start: bool,
 }
 
 impl C8yMapperConfig {
@@ -72,6 +73,7 @@ impl C8yMapperConfig {
         auth_proxy_protocol: Protocol,
         mqtt_schema: MqttSchema,
         enable_auto_register: bool,
+        clean_start: bool,
     ) -> Self {
         let ops_dir = config_dir
             .join(SUPPORTED_OPERATIONS_DIRECTORY)
@@ -98,6 +100,7 @@ impl C8yMapperConfig {
             auth_proxy_protocol,
             mqtt_schema,
             enable_auto_register,
+            clean_start,
         }
     }
 
@@ -139,6 +142,7 @@ impl C8yMapperConfig {
 
         let mut topics = Self::default_internal_topic_filter(&config_dir)?;
         let enable_auto_register = tedge_config.c8y.entity_store.auto_register;
+        let clean_start = tedge_config.c8y.entity_store.clean_start;
 
         // Add feature topic filters
         for cmd in [
@@ -194,6 +198,7 @@ impl C8yMapperConfig {
             auth_proxy_protocol,
             mqtt_schema,
             enable_auto_register,
+            clean_start,
         ))
     }
 

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -262,6 +262,7 @@ impl CumulocityConverter {
             Self::validate_external_id,
             EARLY_MESSAGE_BUFFER_SIZE,
             config.state_dir.clone(),
+            config.clean_start,
         )
         .unwrap();
 
@@ -3161,6 +3162,7 @@ pub(crate) mod tests {
             auth_proxy_port,
             auth_proxy_protocol,
             MqttSchema::default(),
+            true,
             true,
         )
     }

--- a/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
@@ -157,6 +157,7 @@ mod tests {
             crate::converter::CumulocityConverter::validate_external_id,
             5,
             &temp_dir,
+            true,
         )
         .unwrap();
 

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -2414,6 +2414,7 @@ pub(crate) async fn spawn_c8y_mapper_actor(
         Protocol::Http,
         MqttSchema::default(),
         true,
+        true,
     );
 
     let mut mqtt_builder: SimpleMessageBoxBuilder<MqttMessage, MqttMessage> =


### PR DESCRIPTION
## Proposed changes
TODO:

- [x] fix tests
- [x] add test
- [x] replace `sync_on_startup` with better name

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2605 
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

