### PR TITLE
Fix entity store file permission on mapper startup #2598

### DIFF
--- a/crates/core/tedge/src/cli/init.rs
+++ b/crates/core/tedge/src/cli/init.rs
@@ -6,6 +6,7 @@ use anyhow::Context;
 use clap::Subcommand;
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
+use tedge_utils::file::change_user_and_group;
 use tedge_utils::file::create_directory;
 use tedge_utils::file::PermissionEntry;
 
@@ -171,6 +172,23 @@ impl TEdgeInitCmd {
                 Some(0o775),
             ),
         )?;
+
+        create_directory(
+            config_dir.join(".tedge-mapper-c8y"),
+            PermissionEntry::new(
+                Some(self.user.clone()),
+                Some(self.group.clone()),
+                Some(0o775),
+            ),
+        )?;
+
+        let entity_store_file = config_dir
+            .join(".tedge-mapper-c8y")
+            .join("entity_store.jsonl");
+
+        if entity_store_file.exists() {
+            change_user_and_group(entity_store_file.as_std_path(), &self.user, &self.group)?;
+        }
 
         Ok(())
     }

--- a/crates/core/tedge_api/src/entity_store.rs
+++ b/crates/core/tedge_api/src/entity_store.rs
@@ -187,7 +187,11 @@ impl EntityStore {
             twin_data: Map::new(),
         };
 
-        let message_log = MessageLogWriter::new(log_dir.as_ref())?;
+        let message_log = MessageLogWriter::new(log_dir.as_ref()).map_err(|err| {
+            InitError::Custom(format!(
+                "Loading the entity store log for writes failed with {err}",
+            ))
+        })?;
 
         let mut entity_store = EntityStore {
             mqtt_schema: mqtt_schema.clone(),

--- a/tests/RobotFramework/tests/cumulocity/mapper_recovery/recover_and_publish_software_update_message.robot
+++ b/tests/RobotFramework/tests/cumulocity/mapper_recovery/recover_and_publish_software_update_message.robot
@@ -25,7 +25,15 @@ Mapper recovers and processes output of ongoing software update request
     ThinEdgeIO.Service Should Be Running    tedge-mapper-c8y
     Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
     Device Should Have Installed Software    rolldice
- 
+
+Recovery from corrupt entity store file
+    Stop Service    tedge-mapper-c8y
+    Execute Command    chown root:root /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl
+    Start Service    tedge-mapper-c8y
+    Service Should Be Running    tedge-mapper-c8y
+    ${owner}=    Execute Command    stat -c "%U" /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl    strip="true"
+    Should Be Equal    ${owner}    tedge
+
 *** Keywords ***
 
 Custom Setup


### PR DESCRIPTION
## Proposed changes

Fix entity store file permission using the `tedge init` command that is always executed before mapper startup.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2598

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

