### PR TITLE
Fix tedge-agent stuck on too many pending operations

### DIFF
--- a/crates/core/tedge_agent/src/tedge_operation_converter/actor.rs
+++ b/crates/core/tedge_agent/src/tedge_operation_converter/actor.rs
@@ -10,11 +10,11 @@ use tedge_actors::fan_in_message_type;
 use tedge_actors::Actor;
 use tedge_actors::ClientMessageBox;
 use tedge_actors::DynSender;
-use tedge_actors::LoggingReceiver;
 use tedge_actors::LoggingSender;
 use tedge_actors::MessageReceiver;
 use tedge_actors::RuntimeError;
 use tedge_actors::Sender;
+use tedge_actors::UnboundedLoggingReceiver;
 use tedge_api::messages::RestartCommand;
 use tedge_api::messages::SoftwareListCommand;
 use tedge_api::messages::SoftwareUpdateCommand;
@@ -43,7 +43,7 @@ pub struct TedgeOperationConverterActor {
     pub(crate) workflows: WorkflowSupervisor,
     pub(crate) state_repository: AgentStateRepository<CommandBoard>,
     pub(crate) log_dir: Utf8PathBuf,
-    pub(crate) input_receiver: LoggingReceiver<AgentInput>,
+    pub(crate) input_receiver: UnboundedLoggingReceiver<AgentInput>,
     pub(crate) software_sender: LoggingSender<SoftwareCommand>,
     pub(crate) restart_sender: LoggingSender<RestartCommand>,
     pub(crate) command_sender: DynSender<GenericCommandState>,

--- a/crates/core/tedge_agent/src/tedge_operation_converter/builder.rs
+++ b/crates/core/tedge_agent/src/tedge_operation_converter/builder.rs
@@ -10,12 +10,12 @@ use tedge_actors::Builder;
 use tedge_actors::ClientMessageBox;
 use tedge_actors::DynSender;
 use tedge_actors::LinkError;
-use tedge_actors::LoggingReceiver;
 use tedge_actors::LoggingSender;
 use tedge_actors::NoConfig;
 use tedge_actors::RuntimeRequest;
 use tedge_actors::RuntimeRequestSink;
 use tedge_actors::ServiceProvider;
+use tedge_actors::UnboundedLoggingReceiver;
 use tedge_api::mqtt_topics::ChannelFilter::AnyCommand;
 use tedge_api::mqtt_topics::EntityFilter;
 use tedge_api::mqtt_topics::EntityTopicId;
@@ -31,7 +31,7 @@ use tedge_script_ext::Execute;
 pub struct TedgeOperationConverterBuilder {
     config: OperationConfig,
     workflows: WorkflowSupervisor,
-    input_receiver: LoggingReceiver<AgentInput>,
+    input_receiver: UnboundedLoggingReceiver<AgentInput>,
     software_sender: LoggingSender<SoftwareCommand>,
     restart_sender: LoggingSender<RestartCommand>,
     command_sender: DynSender<GenericCommandState>,
@@ -49,10 +49,10 @@ impl TedgeOperationConverterBuilder {
         mqtt_actor: &mut impl ServiceProvider<MqttMessage, MqttMessage, TopicFilter>,
         script_runner: &mut impl ServiceProvider<Execute, std::io::Result<Output>, NoConfig>,
     ) -> Self {
-        let (input_sender, input_receiver) = mpsc::channel(10);
+        let (input_sender, input_receiver) = mpsc::unbounded();
         let (signal_sender, signal_receiver) = mpsc::channel(10);
 
-        let input_receiver = LoggingReceiver::new(
+        let input_receiver = UnboundedLoggingReceiver::new(
             "Mqtt-Request-Converter".into(),
             input_receiver,
             signal_receiver,

--- a/crates/core/tedge_api/src/message_log.rs
+++ b/crates/core/tedge_api/src/message_log.rs
@@ -84,7 +84,7 @@ impl MessageLogWriter {
         let mut writer = BufWriter::new(file);
 
         if file_is_empty {
-            let version_info = json!({"version": LOG_FORMAT_VERSION}).to_string();
+            let version_info = json!({ "version": LOG_FORMAT_VERSION }).to_string();
             writeln!(writer, "{}", version_info)?;
         }
 

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -2969,7 +2969,7 @@ pub(crate) mod tests {
         for i in 0..3 {
             let measurement_message = Message::new(
                 &Topic::new_unchecked("te/custom/child1///m/environment"),
-                json!({"temperature": i}).to_string(),
+                json!({ "temperature": i }).to_string(),
             );
             let mapped_messages = converter.convert(&measurement_message).await;
             assert!(

--- a/crates/extensions/tedge_mqtt_ext/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/lib.rs
@@ -135,7 +135,9 @@ impl FromPeers {
         outgoing_mqtt: &mut mpsc::UnboundedSender<MqttMessage>,
     ) -> Result<(), RuntimeError> {
         while let Ok(Some(message)) = self.try_recv().await {
-            outgoing_mqtt.send(message).await.map_err(Box::new)?;
+            SinkExt::send(outgoing_mqtt, message)
+                .await
+                .map_err(Box::new)?;
         }
 
         // On shutdown, first close input so no new messages can be pushed
@@ -143,7 +145,9 @@ impl FromPeers {
 
         // Then, publish all the messages awaiting to be sent over MQTT
         while let Some(message) = self.recv().await {
-            outgoing_mqtt.send(message).await.map_err(Box::new)?;
+            SinkExt::send(outgoing_mqtt, message)
+                .await
+                .map_err(Box::new)?;
         }
         Ok(())
     }

--- a/tests/RobotFramework/tests/tedge_agent/main_tedge_agent.robot
+++ b/tests/RobotFramework/tests/tedge_agent/main_tedge_agent.robot
@@ -1,0 +1,28 @@
+*** Settings ***
+Resource            ../../resources/common.resource
+Library    ThinEdgeIO
+
+Test Tags           theme:tedge_agent
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+*** Test Cases ***
+
+On start process all the pending operations
+    [Tags]    \#2369
+    Stop Service    tedge-agent
+    FOR  ${id}   IN RANGE    0   10
+         Execute Command    tedge mqtt pub --retain te/device/main///cmd/software_list/test-${id} '{"status":"init"}'
+    END
+    Start Service    tedge-agent
+    Sleep    5s
+    FOR  ${id}   IN RANGE    0   10
+         Should Have MQTT Messages    te/device/main///cmd/software_list/test-${id}    message_pattern=.*successful.*    minimum=1
+         Execute Command    tedge mqtt pub --retain te/device/main///cmd/software_list/test-${id} ''
+    END
+
+*** Keywords ***
+
+Custom Setup
+    ${DEVICE_SN}=    Setup    skip_bootstrap=False
+    Set Suite Variable    $DEVICE_SN


### PR DESCRIPTION
## Proposed changes

Introduce unbounded receivers. Given a cycle of actors (say A sending messages to B, B to C and C to A), at least one of these actors must use such an unbounded receiver.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2639

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

