### PR TITLE
test: use a more reliable service pid detection

### DIFF
--- a/tests/RobotFramework/requirements/requirements.adapter-docker.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-docker.txt
@@ -1,1 +1,1 @@
-robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.12.1
+robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.13.0

--- a/tests/RobotFramework/requirements/requirements.adapter-local.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-local.txt
@@ -1,1 +1,1 @@
-robotframework-devicelibrary[local] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.12.1
+robotframework-devicelibrary[local] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.13.0

--- a/tests/RobotFramework/requirements/requirements.adapter-ssh.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-ssh.txt
@@ -1,2 +1,2 @@
-robotframework-devicelibrary[ssh] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.12.1
+robotframework-devicelibrary[ssh] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.13.0
 robotframework-sshlibrary~=3.8.0

--- a/tests/RobotFramework/tests/MQTT_health_check/MQTT_health_endpoints.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/MQTT_health_endpoints.robot
@@ -12,7 +12,7 @@ Suite Teardown    Get Logs
 *** Test Cases ***
 
 tedge-agent health status
-    ${pid}=    Execute Command    pgrep -f '^/usr/bin/tedge-agent'    strip=${True}
+    ${pid}=    Service Should Be Running    tedge-agent
     Execute Command    sudo tedge mqtt pub 'te/device/main/service/tedge-agent/cmd/health/check' ''
     ${messages}=    Should Have MQTT Messages    te/device/main/service/tedge-agent/status/health    minimum=1    maximum=2
     Should Contain    ${messages[0]}    "pid":${pid}

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-agent.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-agent.robot
@@ -28,14 +28,14 @@ Start watchdog service
     Sleep    10s
 
 Check PID of tedge-mapper
-    ${pid}=    Execute Command    pgrep -f '^/usr/bin/tedge-agent'    strip=${True}
+    ${pid}=    Service Should Be Running    tedge-agent
     Set Suite Variable    ${pid}
 
 Kill the PID
     Kill Process    ${pid}
 
 Recheck PID of tedge-agent
-    ${pid1}=    Execute Command    pgrep -f '^/usr/bin/tedge-agent'    strip=${True}
+    ${pid1}=    Service Should Be Running    tedge-agent
     Set Suite Variable    ${pid1}
 
 Compare PID change

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-aws.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-aws.robot
@@ -18,10 +18,10 @@ Watchdog does not kill mapper if it responds
     Execute Command    sudo systemctl start tedge-mapper-aws.service
     Execute Command    sudo systemctl start tedge-watchdog.service
 
-    ${pid_before_healthcheck}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper aws'    strip=${True}
+    ${pid_before_healthcheck}=    Service Should Be Running    tedge-mapper-aws
     # The watchdog should send a health check command while we wait
     Sleep    10s
-    ${pid_after_healthcheck}=     Execute Command    pgrep -f '^/usr/bin/tedge-mapper aws'    strip=${True}
+    ${pid_after_healthcheck}=    Service Should Be Running    tedge-mapper-aws
 
     Should Have MQTT Messages     topic=te/device/main/service/tedge-mapper-aws/cmd/health/check    minimum=1
     Should Be Equal               ${pid_before_healthcheck}    ${pid_after_healthcheck}

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-az.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-az.robot
@@ -28,14 +28,14 @@ Start watchdog service
 
     Sleep    10s
 Check PID of tedge-mapper-az
-    ${pid}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper az'    strip=${True}
+    ${pid}=    Service Should Be Running    tedge-mapper-az
     Set Suite Variable    ${pid}
 
 Kill the PID
     Kill Process    ${pid}
 
 Recheck PID of tedge-mapper-az
-    ${pid1}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper az'    strip=${True}
+    ${pid1}=    Service Should Be Running    tedge-mapper-az
     Set Suite Variable    ${pid1}
 
 Compare PID change
@@ -56,10 +56,10 @@ Watchdog does not kill mapper if it responds
     Execute Command    sudo systemctl start tedge-mapper-az.service
     Execute Command    sudo systemctl start tedge-watchdog.service
 
-    ${pid_before_healthcheck}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper az'    strip=${True}
+    ${pid_before_healthcheck}=    Service Should Be Running    tedge-mapper-az
     # The watchdog should send a health check command while we wait
     Sleep    10s
-    ${pid_after_healthcheck}=     Execute Command    pgrep -f '^/usr/bin/tedge-mapper az'    strip=${True}
+    ${pid_after_healthcheck}=    Service Should Be Running    tedge-mapper-az
 
     Should Have MQTT Messages     topic=te/device/main/service/tedge-mapper-az/cmd/health/check    minimum=1
     Should Be Equal               ${pid_before_healthcheck}    ${pid_after_healthcheck}

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-collectd.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-collectd.robot
@@ -28,14 +28,14 @@ Start watchdog service
     Sleep    10s
 
 Check PID of tedge-mapper-collectd
-    ${pid}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper collectd'    strip=${True}
+    ${pid}=    Service Should Be Running    tedge-mapper-collectd
     Set Suite Variable    ${pid}
 
 Kill the PID
     Kill Process    ${pid}
 
 Recheck PID of tedge-mapper-collectd
-    ${pid1}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper collectd'    strip=${True}
+    ${pid1}=    Service Should Be Running    tedge-mapper-collectd
     Set Suite Variable    ${pid1}
 
 Compare PID change
@@ -52,7 +52,7 @@ tedge-collectd-mapper health status
     Execute Command    sudo systemctl start tedge-mapper-collectd.service
 
     Sleep    5s     reason=It fails without this! It needs a better way of queuing requests
-    ${pid}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper collectd'    strip=${True}
+    ${pid}=    Service Should Be Running    tedge-mapper-collectd
     Execute Command    sudo tedge mqtt pub 'te/device/main/service/tedge-mapper-collectd/cmd/health/check' ''
     ${messages}=    Should Have MQTT Messages    te/device/main/service/tedge-mapper-collectd/status/health    minimum=1    maximum=2
     Should Contain    ${messages[0]}    "pid":${pid}

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge_mapper_c8y.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge_mapper_c8y.robot
@@ -28,14 +28,14 @@ Start watchdog service
 
     Sleep    10s
 Check PID of tedge-mapper
-    ${pid}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper c8y'    strip=${True}
+    ${pid}=    Service Should Be Running    tedge-mapper-c8y
     Set Suite Variable    ${pid}
 
 Kill the PID
     Kill Process    ${pid}
 
 Recheck PID of tedge-mapper
-    ${pid1}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper c8y'    strip=${True}
+    ${pid1}=    Service Should Be Running    tedge-mapper-c8y
     Set Suite Variable    ${pid1}
 
 Compare PID change
@@ -56,10 +56,10 @@ Watchdog does not kill mapper if it responds
     Execute Command    sudo systemctl start tedge-mapper-c8y.service
     Execute Command    sudo systemctl start tedge-watchdog.service
 
-    ${pid_before_healthcheck}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper c8y'    strip=${True}
+    ${pid_before_healthcheck}=    Service Should Be Running    tedge-mapper-c8y
     # The watchdog should send a health check command while we wait
     Sleep    10s
-    ${pid_after_healthcheck}=     Execute Command    pgrep -f '^/usr/bin/tedge-mapper c8y'    strip=${True}
+    ${pid_after_healthcheck}=    Service Should Be Running    tedge-mapper-c8y
 
     Should Have MQTT Messages     topic=te/device/main/service/tedge-mapper-c8y/cmd/health/check    minimum=1
     Should Be Equal               ${pid_before_healthcheck}    ${pid_after_healthcheck}

--- a/tests/RobotFramework/tests/configuration/lock_file.robot
+++ b/tests/RobotFramework/tests/configuration/lock_file.robot
@@ -22,8 +22,8 @@ Check PID number in lock file
     ${pid_mapper1}=    Service Should Be Running    tedge-mapper-c8y
     ${pid_agent_lock1}=    Execute Command    cat /run/lock/tedge-agent.lock
     ${pid_mapper_lock1}=    Execute Command    cat /run/lock/tedge-mapper-c8y.lock
-    Should Be Equal    ${pid_agent1}    ${pid_agent_lock1}
-    Should Be Equal    ${pid_mapper1}    ${pid_mapper_lock1}
+    Should Be Equal As Integers    ${pid_agent1}    ${pid_agent_lock1}
+    Should Be Equal As Integers    ${pid_mapper1}    ${pid_mapper_lock1}
 
 Check PID number in lock file after restarting the services
     [Documentation]    Include the new pid generated after service restart 
@@ -34,8 +34,8 @@ Check PID number in lock file after restarting the services
     ${pid_mapper2}=    Service Should Be Running    tedge-mapper-c8y
     ${pid_agent_lock2}=    Execute Command    cat /run/lock/tedge-agent.lock
     ${pid_mapper_lock2}=    Execute Command    cat /run/lock/tedge-mapper-c8y.lock
-    Should Be Equal    ${pid_agent2}    ${pid_agent_lock2}
-    Should Be Equal    ${pid_mapper2}    ${pid_mapper_lock2}
+    Should Be Equal As Integers    ${pid_agent2}    ${pid_agent_lock2}
+    Should Be Equal As Integers    ${pid_mapper2}    ${pid_mapper_lock2}
 
 Check starting same service twice
     [Documentation]    This step is checking if same service can be started twice, 

--- a/tests/RobotFramework/tests/configuration/lock_file.robot
+++ b/tests/RobotFramework/tests/configuration/lock_file.robot
@@ -18,8 +18,8 @@ Check lock file existence in default folder
 
 Check PID number in lock file
     [Documentation]    Include the pid inside the existing lock files under /run/lock/
-    ${pid_agent1}=    Execute Command    pgrep -f '^/usr/bin/tedge-agent'    strip=${True}
-    ${pid_mapper1}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper c8y'   strip=${True}
+    ${pid_agent1}=    Service Should Be Running    tedge-agent
+    ${pid_mapper1}=    Service Should Be Running    tedge-mapper-c8y
     ${pid_agent_lock1}=    Execute Command    cat /run/lock/tedge-agent.lock
     ${pid_mapper_lock1}=    Execute Command    cat /run/lock/tedge-mapper-c8y.lock
     Should Be Equal    ${pid_agent1}    ${pid_agent_lock1}
@@ -30,8 +30,8 @@ Check PID number in lock file after restarting the services
     ...  inside the existing lock files under /run/lock/
     Stop/Start Service    tedge-agent
     Stop/Start Service    tedge-mapper-c8y
-    ${pid_agent2}=    Execute Command    pgrep -f '^/usr/bin/tedge-agent'    strip=True
-    ${pid_mapper2}=    Execute Command    pgrep -f '^/usr/bin/tedge-mapper c8y'    strip=${True}
+    ${pid_agent2}=    Service Should Be Running    tedge-agent
+    ${pid_mapper2}=    Service Should Be Running    tedge-mapper-c8y
     ${pid_agent_lock2}=    Execute Command    cat /run/lock/tedge-agent.lock
     ${pid_mapper_lock2}=    Execute Command    cat /run/lock/tedge-mapper-c8y.lock
     Should Be Equal    ${pid_agent2}    ${pid_agent_lock2}

--- a/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
+++ b/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
@@ -103,7 +103,7 @@ Update tedge version from base to current using Cumulocity
     Install Packages    /setup/base-version
     Execute Command    cd /setup && test -f ./bootstrap.sh && ./bootstrap.sh --no-install --no-secure
     Device Should Exist                      ${DEVICE_SN}
-    ${pid_before}=    Execute Command    pgrep tedge-agent    strip=${True}
+    ${pid_before}=    Service Should Be Running    tedge-agent
 
     # Upgrade to current version
     Create Local Repository
@@ -117,7 +117,7 @@ Update tedge version from base to current using Cumulocity
     ...    {"name": "tedge-watchdog", "softwareType": "apt", "version": "${NEW_VERSION_ESCAPED}"}
     ...    {"name": "tedge-apt-plugin", "softwareType": "apt", "version": "${NEW_VERSION_ESCAPED}"}
 
-    ${pid_after}=    Execute Command    pgrep tedge-agent    strip=${True}
+    ${pid_after}=    Service Should Be Running    tedge-agent
     Should Not Be Equal    ${pid_before}    ${pid_after}
 
 *** Keywords ***


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Due to some flake-finder runs, it was found that the assertions which rely on getting a service's main PID can suffer from race conditions if there is a delay between starting a service and getting the pid via `pgrep`. Instead the `Service Should Be Running` keyword also returns the PID of the running service, so it does not assume that the service is running "now", but will wait if necessary if the service is not already running.

<img width="1548" alt="image" src="https://github.com/thin-edge/thin-edge.io/assets/3029781/7bd59835-4a3c-4097-b196-1815e1fce5d9">


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

