### PR TITLE
Retry internal id lookup when not found #2533

### DIFF
--- a/crates/core/c8y_api/src/http_proxy.rs
+++ b/crates/core/c8y_api/src/http_proxy.rs
@@ -66,10 +66,10 @@ impl C8yEndPoint {
         url_update_swlist
     }
 
-    pub fn get_url_for_internal_id(&self, device_id: String) -> String {
+    pub fn get_url_for_internal_id(&self, device_id: &str) -> String {
         let mut url_get_id = self.get_base_url();
         url_get_id.push_str("/identity/externalIds/c8y_Serial/");
-        url_get_id.push_str(device_id.as_str());
+        url_get_id.push_str(device_id);
 
         url_get_id
     }
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn get_url_for_get_id_returns_correct_address() {
         let c8y = C8yEndPoint::new("test_host", "test_device");
-        let res = c8y.get_url_for_internal_id("test_device".into());
+        let res = c8y.get_url_for_internal_id("test_device");
 
         assert_eq!(
             res,

--- a/crates/extensions/c8y_http_proxy/src/lib.rs
+++ b/crates/extensions/c8y_http_proxy/src/lib.rs
@@ -7,6 +7,7 @@ use crate::messages::C8YRestResult;
 use reqwest::Identity;
 use std::convert::Infallible;
 use std::path::PathBuf;
+use std::time::Duration;
 use tedge_actors::Builder;
 use tedge_actors::ClientMessageBox;
 use tedge_actors::DynSender;
@@ -30,12 +31,13 @@ pub mod messages;
 mod tests;
 
 /// Configuration of C8Y REST API
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct C8YHttpConfig {
     pub c8y_host: String,
     pub device_id: String,
     pub tmp_dir: PathBuf,
     identity: Option<Identity>,
+    retry_interval: Duration,
 }
 
 impl TryFrom<&NewTEdgeConfig> for C8YHttpConfig {
@@ -46,12 +48,14 @@ impl TryFrom<&NewTEdgeConfig> for C8YHttpConfig {
         let device_id = tedge_config.device.id.try_read(tedge_config)?.to_string();
         let tmp_dir = tedge_config.tmp.path.as_std_path().to_path_buf();
         let identity = tedge_config.http.client.auth.identity()?;
+        let retry_interval = Duration::from_secs(5);
 
         Ok(Self {
             c8y_host,
             device_id,
             tmp_dir,
             identity,
+            retry_interval,
         })
     }
 }


### PR DESCRIPTION
## Proposed changes

Even if the internal ID lookup fails on the initial attempt (presumably because of delays in the creation of the device), retry a few more times before failing.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

