### PR TITLE
Log memory usage of the agent and the mapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cap"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f125eb85b84a24c36b02ed1d22c9dd8632f53b3cde6e4d23512f94021030003"
+
+[[package]]
 name = "capture-logger"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3622,6 +3628,7 @@ dependencies = [
  "c8y-firmware-plugin",
  "c8y-remote-access-plugin",
  "camino",
+ "cap",
  "certificate",
  "clap",
  "doku",
@@ -3668,6 +3675,7 @@ dependencies = [
  "axum_tls",
  "bytes",
  "camino",
+ "cap",
  "clap",
  "flockfile",
  "futures",
@@ -3779,6 +3787,7 @@ dependencies = [
  "c8y_auth_proxy",
  "c8y_http_proxy",
  "c8y_mapper_ext",
+ "cap",
  "clap",
  "clock",
  "collectd_ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ c8y_http_proxy = { path = "crates/extensions/c8y_http_proxy" }
 c8y_log_manager = { path = "crates/extensions/c8y_log_manager" }
 c8y_mapper_ext = { path = "crates/extensions/c8y_mapper_ext" }
 camino = "1.1"
+cap = "0.1"
 capture-logger = "0.1"
 certificate = { path = "crates/common/certificate" }
 clap = { version = "4.4", features = ["cargo", "derive"] }

--- a/crates/common/tedge_config/src/lib.rs
+++ b/crates/common/tedge_config/src/lib.rs
@@ -19,3 +19,9 @@ pub fn get_new_tedge_config() -> Result<TEdgeConfig, TEdgeConfigError> {
     let tedge_config_location = TEdgeConfigLocation::default();
     TEdgeConfigRepository::new(tedge_config_location).load()
 }
+
+/// loads the tedge config from a config directory
+pub fn load_tedge_config(config_dir: &Path) -> Result<TEdgeConfig, TEdgeConfigError> {
+    let tedge_config_location = TEdgeConfigLocation::from_custom_root(config_dir);
+    TEdgeConfigRepository::new(tedge_config_location).load()
+}

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -719,6 +719,10 @@ define_tedge_config! {
         /// Whether to create a lock file or not
         #[tedge_config(example = "true", default(value = true))]
         lock_files: bool,
+
+        /// Interval at which the memory usage is logged (in seconds)
+        #[tedge_config(example = "60", default(value = 300_u64))]
+        log_memory_interval: Seconds,
     },
 
     logs: {

--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -17,6 +17,7 @@ base64 = { workspace = true }
 c8y-firmware-plugin = { workspace = true }
 c8y-remote-access-plugin = { workspace = true }
 camino = { workspace = true }
+cap = { workspace = true }
 certificate = { workspace = true }
 clap = { workspace = true, features = [
     "cargo",

--- a/crates/core/tedge_agent/Cargo.toml
+++ b/crates/core/tedge_agent/Cargo.toml
@@ -16,6 +16,7 @@ axum = { workspace = true }
 axum-server = { workspace = true }
 axum_tls = { workspace = true }
 camino = { workspace = true }
+cap = { workspace = true }
 clap = { workspace = true }
 flockfile = { workspace = true }
 futures = { workspace = true }

--- a/crates/core/tedge_agent/src/main.rs
+++ b/crates/core/tedge_agent/src/main.rs
@@ -1,7 +1,23 @@
+use cap::Cap;
 use clap::Parser;
+use std::alloc;
+
+#[global_allocator]
+static ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::MAX);
 
 #[tokio::main]
-async fn main() -> Result<(), anyhow::Error> {
+async fn main() -> anyhow::Result<()> {
     let agent_opt = tedge_agent::AgentOpt::parse();
+    let tedge_config = tedge_config::load_tedge_config(&agent_opt.config_dir)?;
+    let log_memory_interval = tedge_config.run.log_memory_interval.duration();
+    if !log_memory_interval.is_zero() {
+        tokio::spawn(async move {
+            loop {
+                log::info!("Allocated memory: {} Bytes", ALLOCATOR.allocated());
+                tokio::time::sleep(log_memory_interval).await;
+            }
+        });
+    }
+
     tedge_agent::run(agent_opt).await
 }

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -19,6 +19,7 @@ c8y_api = { workspace = true }
 c8y_auth_proxy = { workspace = true }
 c8y_http_proxy = { workspace = true }
 c8y_mapper_ext = { workspace = true }
+cap = { workspace = true }
 clap = { workspace = true }
 clock = { workspace = true }
 collectd_ext = { workspace = true }

--- a/crates/core/tedge_mapper/src/lib.rs
+++ b/crates/core/tedge_mapper/src/lib.rs
@@ -6,9 +6,9 @@ use crate::core::component::TEdgeComponent;
 use clap::Parser;
 use flockfile::check_another_instance_is_not_running;
 use std::fmt;
-use std::path::PathBuf;
 use tedge_config::system_services::get_log_level;
 use tedge_config::system_services::set_log_level;
+use tedge_config::PathBuf;
 use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 use tracing::log::warn;
 
@@ -111,6 +111,8 @@ pub async fn run(mapper_opt: MapperOpt) -> anyhow::Result<()> {
         warn!("This --clear option has been deprecated and will be removed in a future release");
         Ok(())
     } else {
-        component.start(config, &mapper_opt.config_dir).await
+        component
+            .start(config, mapper_opt.config_dir.as_ref())
+            .await
     }
 }

--- a/crates/core/tedge_mapper/src/main.rs
+++ b/crates/core/tedge_mapper/src/main.rs
@@ -1,7 +1,24 @@
+use cap::Cap;
 use clap::Parser;
+use std::alloc;
+use tracing::log;
+
+#[global_allocator]
+static ALLOCATOR: Cap<alloc::System> = Cap::new(alloc::System, usize::MAX);
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let mapper_opt = tedge_mapper::MapperOpt::parse();
+    let tedge_config = tedge_config::load_tedge_config(&mapper_opt.config_dir)?;
+    let log_memory_interval = tedge_config.run.log_memory_interval.duration();
+    if !log_memory_interval.is_zero() {
+        tokio::spawn(async move {
+            loop {
+                log::info!("Allocated memory: {} Bytes", ALLOCATOR.allocated());
+                tokio::time::sleep(log_memory_interval).await;
+            }
+        });
+    }
+
     tedge_mapper::run(mapper_opt).await
 }


### PR DESCRIPTION
## Proposed changes

Log memory usage of the agent and the mapper. 
The default interval is of 60 seconds.

This can be changed using the` --log-memory-interval` flag which sets the logging interval in seconds.

```
$ target/debug/tedge-mapper --log-memory-interval 5 c8y
$ sudo target/debug/tedge-agent --log-memory-interval 5
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2692#issuecomment-1934466228

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

