### PR TITLE
fix: add delay on BadSignature error mqtt connect

### DIFF
--- a/crates/common/mqtt_channel/src/connection.rs
+++ b/crates/common/mqtt_channel/src/connection.rs
@@ -17,7 +17,6 @@ use rumqttc::EventLoop;
 use rumqttc::Incoming;
 use rumqttc::Outgoing;
 use rumqttc::Packet;
-use rumqttc::StateError;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -308,9 +307,7 @@ impl Connection {
     pub(crate) fn pause_on_error(err: &ConnectionError) -> bool {
         matches!(
             err,
-            rumqttc::ConnectionError::Io(_)
-                | rumqttc::ConnectionError::MqttState(StateError::Io(_))
-                | rumqttc::ConnectionError::MqttState(_)
+            ConnectionError::Io(_) | ConnectionError::MqttState(_) | ConnectionError::Tls(_)
         )
     }
 


### PR DESCRIPTION
## Proposed changes

Add 1s delay to connection retry when MQTT broker server certificate verification fails.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- #2728 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

~~I realized that it would be a bit of a pain to keep testing Yocto without this fix, so I decided to make a PR anyway.~~ Nevermind, I found a way to avoid this issue in Yocto, so it's not crucial to merge this, and we can discuss a more permanent solution. 

I'm open to discussing whether or not delay should be added to any other error cases or we should just do a delay for all possible errors, since spinning like this is usually bad and we're not gaining that much by being 1s quicker when the error is very transient and disappears on next connection attempt.