### PR TITLE
feat(logs): only enable ansi colors in logs when stderr is a terminal

### DIFF
--- a/crates/common/tedge_config/src/system_services/log_config.rs
+++ b/crates/common/tedge_config/src/system_services/log_config.rs
@@ -2,6 +2,7 @@ use camino::Utf8Path;
 
 use crate::system_services::SystemConfig;
 use crate::system_services::SystemServiceError;
+use std::io::IsTerminal;
 use std::str::FromStr;
 
 pub fn get_log_level(
@@ -27,6 +28,7 @@ pub fn get_log_level(
 pub fn set_log_level(log_level: tracing::Level) {
     let subscriber = tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
+        .with_ansi(std::io::stderr().is_terminal())
         .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339());
 
     if std::env::var("RUST_LOG").is_ok() {


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Only enable ansi colours/codes when standard error is writing to a terminal (tty).

Previously ansi colours were enabled by default leading to journald log entries being created with the ansi escape sequences (causing problems when reading from the journald using the json output):

**Example**

Previously the `.MESSAGE` field is encoded as a JSON array (of integers/chars) as the message contained non unicode characters (e.g. ansi escape codes) and journald does not try to render it as a string.

```
journalctl -fu tedge-agent -o json -n 100 -u tedge-agent
```

**Before**

```json
{"_GID":"992","PRIORITY":"6","_SYSTEMD_SLICE":"system.slice","_BOOT_ID":"d22c4e29863542fc9405091fe2b3664c","_SYSTEMD_UNIT":"tedge-agent.service","_COMM":"tedge-agent","__REALTIME_TIMESTAMP":"1708940884913851","__MONOTONIC_TIMESTAMP":"342730353966","_HOSTNAME":"rpi5-d83addab8e9f","SYSLOG_FACILITY":"3","SYSLOG_IDENTIFIER":"tedge-agent","__CURSOR":"s=6b7d33ed6e964f6b9c1f54d5f876bdac;i=950d;b=d22c4e29863542fc9405091fe2b3664c;m=4fcc522d2e;t=61245ce632ebb;x=d4ba306c00415107","_SYSTEMD_CGROUP":"/system.slice/tedge-agent.service","_TRANSPORT":"stdout","_MACHINE_ID":"78dbcdf66608d0150c6e5bfd65c60dba","_UID":"999","_RUNTIME_SCOPE":"system","_PID":"578174","_STREAM_ID":"44df7066410e42c5a611ca4750aca465","_SYSTEMD_INVOCATION_ID":"061f67e77d19442e95170650375d28e1","_EXE":"/usr/bin/tedge","MESSAGE":[27,91,50,109,50,48,50,52,45,48,50,45,50,54,84,48,57,58,52,56,58,48,52,46,57,49,51,56,50,56,48,54,90,27,91,48,109,32,27,91,51,50,109,32,73,78,70,79,27,91,48,109,32,27,91,50,109,116,101,100,103,101,95,97,103,101,110,116,58,58,116,101,100,103,101,95,111,112,101,114,97,116,105,111,110,95,99,111,110,118,101,114,116,101,114,58,58,97,99,116,111,114,27,91,48,109,27,91,50,109,58,27,91,48,109,32,87,97,105,116,105,110,103,32,115,117,99,99,101,115,115,102,117,108,32,115,111,102,116,119,97,114,101,95,108,105,115,116,32,111,112,101,114,97,116,105,111,110,32,116,111,32,98,101,32,99,108,101,97,114,101,100],"_CMDLINE":"/usr/bin/tedge-agent","_CAP_EFFECTIVE":"0"}
```

**After**

```json
{"_SYSTEMD_INVOCATION_ID":"d80adf88683c46388bdb8e6e5e315669","PRIORITY":"6","_HOSTNAME":"d6f2bd28db10","_UID":"999","SYSLOG_FACILITY":"3","_SYSTEMD_UNIT":"tedge-agent.service","MESSAGE":"2024-02-26T12:37:33.582521626Z  INFO tedge_agent::software_manager::actor: Installed binary version: 1.0.1~81+g76bb05f","_CMDLINE":"/usr/bin/tedge-agent","_SYSTEMD_SLICE":"system.slice","_STREAM_ID":"c4164a37a7644521a8e05396dcf42ece","_RUNTIME_SCOPE":"system","_TRANSPORT":"stdout","SYSLOG_IDENTIFIER":"tedge-agent","_COMM":"tedge-agent","__CURSOR":"s=b92de26806b248fc8f04a826ff9fbd6f;i=dae;b=444aeb6f111b42e6bed7c84ddf7d057c;m=9860762a9d;t=612482c7cc0d4;x=cb0774ebd64dd499","_PID":"618","_SELINUX_CONTEXT":"unconfined\n","_CAP_EFFECTIVE":"0","_GID":"997","_MACHINE_ID":"4ad61fbe472a48aa9887181877231b1a","__MONOTONIC_TIMESTAMP":"654453385885","__REALTIME_TIMESTAMP":"1708951053582548","_BOOT_ID":"444aeb6f111b42e6bed7c84ddf7d057c","_SYSTEMD_CGROUP":"/system.slice/tedge-agent.service","_EXE":"/usr/bin/tedge"}
```


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

