### PR TITLE
refactor: use generic RecommendedWatcher type over platform specific type

### DIFF
--- a/crates/common/tedge_utils/src/notify.rs
+++ b/crates/common/tedge_utils/src/notify.rs
@@ -4,7 +4,7 @@ use notify::event::AccessMode;
 use notify::event::CreateKind;
 use notify::event::RemoveKind;
 use notify::EventKind;
-use notify::INotifyWatcher;
+use notify::RecommendedWatcher;
 use notify::RecursiveMode;
 use notify::Watcher;
 use notify_debouncer_full as debouncer;
@@ -65,7 +65,7 @@ pub enum NotifyStreamError {
 }
 
 pub struct NotifyStream {
-    debouncer: debouncer::Debouncer<INotifyWatcher, debouncer::NoCache>,
+    debouncer: debouncer::Debouncer<RecommendedWatcher, debouncer::NoCache>,
     pub rx: Receiver<(PathBuf, FsEvent)>,
 }
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Use the generic [RecommendedWatcher](https://docs.rs/notify/latest/notify/) notify type to remove OS specific types, as `INotifyWatcher` is generally only supported on linux targets.

There should be no functional difference.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

