### PR TITLE
feat(watcher): use canonical path when watching a directory

### DIFF
--- a/crates/common/tedge_utils/src/notify.rs
+++ b/crates/common/tedge_utils/src/notify.rs
@@ -144,9 +144,11 @@ impl NotifyStream {
 
     /// Will return an error if you try to watch a file/directory which doesn't exist
     pub fn add_watcher(&mut self, dir_path: &Path) -> Result<(), NotifyStreamError> {
+        // Try to use canonical paths to avoid false negatives when dealing with symlinks
+        let dir_path = dir_path.canonicalize()?;
         self.debouncer
             .watcher()
-            .watch(dir_path, RecursiveMode::Recursive)?;
+            .watch(&dir_path, RecursiveMode::Recursive)?;
 
         Ok(())
     }

--- a/crates/extensions/tedge_file_system_ext/src/lib.rs
+++ b/crates/extensions/tedge_file_system_ext/src/lib.rs
@@ -84,8 +84,9 @@ impl Default for FsWatchActorBuilder {
 }
 
 impl MessageSource<FsWatchEvent, PathBuf> for FsWatchActorBuilder {
-    fn register_peer(&mut self, config: PathBuf, sender: DynSender<FsWatchEvent>) {
-        self.watch_dirs.push((config, sender));
+    fn register_peer(&mut self, path: PathBuf, sender: DynSender<FsWatchEvent>) {
+        let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        self.watch_dirs.push((path, sender));
     }
 }
 
@@ -173,12 +174,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_fs_events() -> Result<(), DynError> {
-        let ttd = TempTedgeDir::new();
+        let temp = TempTedgeDir::new();
+        let ttd = temp.dir("watched-dir");
+        let ttd_link = temp.link_dir(&ttd, "watched-symlink");
+        let ttd_full = ttd.to_path_buf().canonicalize().unwrap().to_path_buf();
         let mut fs_actor_builder = FsWatchActorBuilder::new();
         let client_builder: SimpleMessageBoxBuilder<FsWatchEvent, NoMessage> =
             SimpleMessageBoxBuilder::new("FS Client", 5);
 
-        fs_actor_builder.register_peer(ttd.to_path_buf(), client_builder.get_sender());
+        fs_actor_builder.register_peer(ttd_link.to_path_buf(), client_builder.get_sender());
 
         let actor = fs_actor_builder.build();
         let client_box = client_builder.build();
@@ -195,9 +199,9 @@ mod tests {
         client_box
             .with_timeout(TEST_TIMEOUT)
             .assert_received_unordered([
-                FsWatchEvent::Modified(ttd.to_path_buf().join("file_a")),
-                FsWatchEvent::DirectoryCreated(ttd.to_path_buf().join("dir_b")),
-                FsWatchEvent::Modified(ttd.to_path_buf().join("dir_b").join("file_b")),
+                FsWatchEvent::Modified(ttd_full.to_path_buf().join("file_a")),
+                FsWatchEvent::DirectoryCreated(ttd_full.to_path_buf().join("dir_b")),
+                FsWatchEvent::Modified(ttd_full.to_path_buf().join("dir_b").join("file_b")),
             ])
             .await;
 

--- a/crates/tests/tedge_test_utils/src/fs.rs
+++ b/crates/tests/tedge_test_utils/src/fs.rs
@@ -60,6 +60,22 @@ impl TempTedgeDir {
         TempTedgeFile { file_path: path }
     }
 
+    pub fn link_dir(&self, original: &TempTedgeDir, link_name: &str) -> TempTedgeDir {
+        let root = Utf8Path::from_path(self.temp_dir.path()).unwrap();
+        let path = root.join(&self.current_file_path).join(link_name);
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(original.path(), &path).unwrap();
+
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_dir(original.path(), &path).unwrap();
+
+        TempTedgeDir {
+            temp_dir: self.temp_dir.clone(),
+            current_file_path: path,
+        }
+    }
+
     pub fn path(&self) -> &Path {
         self.current_file_path.as_std_path()
     }


### PR DESCRIPTION
## Proposed changes

Use canonical path (e.g. resolving symlinks etc.) when watching a directory.

On some platforms like MacOS, the watcher path and the paths in the notify messages can differ if the watcher path is a symlink. Most notably this occurs during testing as the default tmp directory is a symlink under MacOS (e.g. the temp folder is given as`/var/folders`, however this is actually a symlink to `/private/var/folders`).


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

