### PR TITLE
c8y-mapper sends software list to advanced software management endpoint

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/models/c8y_software_management.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/c8y_software_management.rs
@@ -1,0 +1,33 @@
+use std::str::FromStr;
+use strum::Display;
+
+/// A flag that switches legacy or advanced software management API.
+/// Can be set to auto in the future, see #2778.
+#[derive(
+    Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, doku::Document, Display,
+)]
+#[strum(serialize_all = "camelCase")]
+pub enum SoftwareManagementApiFlag {
+    Legacy,
+    Advanced,
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("Failed to parse flag: {input}. Supported values are: legacy, advanced")]
+pub struct InvalidSoftwareManagementApiFlag {
+    input: String,
+}
+
+impl FromStr for SoftwareManagementApiFlag {
+    type Err = InvalidSoftwareManagementApiFlag;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "legacy" => Ok(SoftwareManagementApiFlag::Legacy),
+            "advanced" => Ok(SoftwareManagementApiFlag::Advanced),
+            _ => Err(InvalidSoftwareManagementApiFlag {
+                input: input.to_string(),
+            }),
+        }
+    }
+}

--- a/crates/common/tedge_config/src/tedge_config_cli/models/mod.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod apt_config;
 pub mod auto;
+pub mod c8y_software_management;
 pub mod connect_url;
 pub mod flag;
 pub mod host_port;
@@ -15,6 +16,7 @@ pub const MQTT_TLS_PORT: u16 = 8883;
 
 pub use self::apt_config::*;
 pub use self::auto::*;
+pub use self::c8y_software_management::*;
 pub use self::connect_url::*;
 pub use self::flag::*;
 #[doc(inline)]

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -4,6 +4,7 @@ use crate::AutoFlag;
 use crate::ConnectUrl;
 use crate::HostPort;
 use crate::Seconds;
+use crate::SoftwareManagementApiFlag;
 use crate::TEdgeConfigLocation;
 use crate::TemplatesSet;
 use crate::HTTPS_PORT;
@@ -474,6 +475,16 @@ define_tedge_config! {
             /// On a clean start, the whole state of the device, services and child-devices is resent to the cloud
             #[tedge_config(example = "true", default(value = true))]
             clean_start: bool,
+        },
+
+        software_management: {
+            /// Switch legacy or advanced software management API to use. Value: legacy or advanced
+            #[tedge_config(example = "advanced", default(variable = "SoftwareManagementApiFlag::Legacy"))]
+            api: SoftwareManagementApiFlag,
+
+            /// Enable publishing c8y_SupportedSoftwareTypes fragment to the c8y inventory API
+            #[tedge_config(example = "true", default(value = false))]
+            with_types: bool,
         },
     },
 

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -20,6 +20,7 @@ use tedge_api::mqtt_topics::TopicIdError;
 use tedge_api::path::DataDir;
 use tedge_config::ConfigNotSet;
 use tedge_config::ReadError;
+use tedge_config::SoftwareManagementApiFlag;
 use tedge_config::TEdgeConfig;
 use tedge_config::TEdgeConfigReaderService;
 use tedge_config::TopicPrefix;
@@ -54,6 +55,8 @@ pub struct C8yMapperConfig {
     pub clean_start: bool,
     pub c8y_prefix: TopicPrefix,
     pub bridge_in_mapper: bool,
+    pub software_management_api: SoftwareManagementApiFlag,
+    pub software_management_with_types: bool,
 }
 
 impl C8yMapperConfig {
@@ -79,6 +82,8 @@ impl C8yMapperConfig {
         clean_start: bool,
         c8y_prefix: TopicPrefix,
         bridge_in_mapper: bool,
+        software_management_api: SoftwareManagementApiFlag,
+        software_management_with_types: bool,
     ) -> Self {
         let ops_dir = config_dir
             .join(SUPPORTED_OPERATIONS_DIRECTORY)
@@ -108,6 +113,8 @@ impl C8yMapperConfig {
             clean_start,
             c8y_prefix,
             bridge_in_mapper,
+            software_management_api,
+            software_management_with_types,
         }
     }
 
@@ -160,6 +167,9 @@ impl C8yMapperConfig {
         let mut topics = Self::default_internal_topic_filter(&config_dir, &c8y_prefix)?;
         let enable_auto_register = tedge_config.c8y.entity_store.auto_register;
         let clean_start = tedge_config.c8y.entity_store.clean_start;
+
+        let software_management_api = tedge_config.c8y.software_management.api.clone();
+        let software_management_with_types = tedge_config.c8y.software_management.with_types;
 
         // Add feature topic filters
         for cmd in [
@@ -220,6 +230,8 @@ impl C8yMapperConfig {
             clean_start,
             c8y_prefix,
             bridge_in_mapper,
+            software_management_api,
+            software_management_with_types,
         ))
     }
 

--- a/crates/extensions/c8y_mapper_ext/src/inventory.rs
+++ b/crates/extensions/c8y_mapper_ext/src/inventory.rs
@@ -113,11 +113,7 @@ impl CumulocityConverter {
         source: &EntityTopicId,
         fragment_value: JsonValue,
     ) -> Result<Message, ConversionError> {
-        let entity_external_id = self.entity_store.try_get(source)?.external_id.as_ref();
-        let inventory_update_topic = Topic::new_unchecked(&format!(
-            "{prefix}/{INVENTORY_MANAGED_OBJECTS_TOPIC}/{entity_external_id}",
-            prefix = self.config.c8y_prefix,
-        ));
+        let inventory_update_topic = self.get_inventory_update_topic(source)?;
 
         Ok(Message::new(
             &inventory_update_topic,
@@ -171,6 +167,18 @@ impl CumulocityConverter {
         let json: serde_json::Value = serde_json::from_str(&data)?;
         info!("Read the fragments from {file_path:?} file");
         Ok(json)
+    }
+
+    /// Returns the JSON over MQTT inventory update topic
+    pub fn get_inventory_update_topic(
+        &self,
+        source: &EntityTopicId,
+    ) -> Result<Topic, ConversionError> {
+        let entity_external_id = self.entity_store.try_get(source)?.external_id.as_ref();
+        Ok(Topic::new_unchecked(&format!(
+            "{prefix}/{INVENTORY_MANAGED_OBJECTS_TOPIC}/{entity_external_id}",
+            prefix = self.config.c8y_prefix,
+        )))
     }
 }
 

--- a/tests/RobotFramework/tests/cumulocity/software_management/software.robot
+++ b/tests/RobotFramework/tests/cumulocity/software_management/software.robot
@@ -9,11 +9,26 @@ Test Teardown    Custom Teardown
 
 *** Test Cases ***
 Supported software types should be declared during startup
-    [Documentation]    #2654 This test will be updated once advanced software management support is implemented
+    [Documentation]    c8y_SupportedSoftwareTypes should NOT be created by default #2654
     Should Have MQTT Messages    topic=te/device/main///cmd/software_list    minimum=1    maximum=1    message_contains="types":["apt"]
     Should Have MQTT Messages    topic=te/device/main///cmd/software_update    minimum=1    maximum=1    message_contains="types":["apt"]
+    Run Keyword And Expect Error    *    Device Should Have Fragment Values    c8y_SupportedSoftwareTypes\=["apt"]
+
+Supported software types and c8y_SupportedSoftwareTypes should be declared during startup
+    [Documentation]    c8y_SupportedSoftwareTypes should be created if the relevant config is set to true #2654
+    Execute Command    tedge config set c8y.software_management.with_types true
+    Restart Service    tedge-mapper-c8y
+    Device Should Have Fragment Values    c8y_SupportedSoftwareTypes\=["apt"]
 
 Software list should be populated during startup
+    [Documentation]    The list is sent via HTTP by default.
+    Device Should Have Installed Software    tedge    timeout=120
+
+Software list should be populated during startup with advanced software management
+    [Documentation]    The list is sent via SmartREST with advanced software management. See #2654
+    Execute Command    tedge config set c8y.software_management.api advanced
+    Restart Service    tedge-mapper-c8y
+    Should Have MQTT Messages    c8y/s/us    message_contains=140,    minimum=1    maximum=1
     Device Should Have Installed Software    tedge    timeout=120
 
 Install software via Cumulocity

--- a/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
+++ b/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
@@ -153,6 +153,34 @@ set/unset c8y.bridge.include.local_cleansession
     ${unset}    Execute Command    tedge config list
     Should Contain    ${unset}    c8y.bridge.include.local_cleansession=auto
 
+set/unset c8y.software_management.api
+    Execute Command    sudo tedge config set c8y.software_management.api legacy
+    ${set}    Execute Command    tedge config list
+    Should Contain    ${set}    c8y.software_management.api=legacy
+
+    Execute Command    sudo tedge config set c8y.software_management.api advanced
+    ${set}    Execute Command    tedge config list
+    Should Contain    ${set}    c8y.software_management.api=advanced
+
+    # Undo the change by using the 'unset' command, value returns to default one
+    Execute Command    sudo tedge config unset c8y.software_management.api
+    ${set}    Execute Command    tedge config list
+    Should Contain    ${set}    c8y.software_management.api=legacy
+
+set/unset c8y.software_management.with_types
+    Execute Command    sudo tedge config set c8y.software_management.with_types false
+    ${set}    Execute Command    tedge config list
+    Should Contain    ${set}    c8y.software_management.with_types=false
+
+    Execute Command    sudo tedge config set c8y.software_management.with_types true
+    ${set}    Execute Command    tedge config list
+    Should Contain    ${set}    c8y.software_management.with_types=true
+
+    # Undo the change by using the 'unset' command, value returns to default one
+    Execute Command    sudo tedge config unset c8y.software_management.with_types
+    ${set}    Execute Command    tedge config list
+    Should Contain    ${set}    c8y.software_management.with_types=false
+
 set/unset az.root_cert_path
     Execute Command    sudo tedge config set az.root_cert_path /etc/ssl/certs1    # Changing az.root_cert_path
     ${set}    Execute Command    tedge config list


### PR DESCRIPTION
## Proposed changes
Since c8y 10.14, advanced software management feature is supported together with the microservice "Advanced-software-mgmt". This PR enables users to use the feature. For more details about the feature, please read the [c8y user doc](https://cumulocity.com/docs/2024/device-integration/fragment-library/#installed-software). 

Introduced two tedge configs:
1. **c8y.software_management.api**
To switch legacy software management (= sending list via HTTP) and advanced one (= sending list via SmartREST).
By default, it is set to `legacy`. To enhance the detection, the ticket #2778 is created.
2. **c8y.software_management.with_types**
If mapper publishes `c8y_SupportedSoftwareTypes` to the inventory or not. If the type is set in its managed object, c8y stop using `c8y_SoftwareList` fragment to look up the installed software list. By default, it is set to `false` so that we can still use `c8y_SoftwareList` fragment for testing and so on.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2654 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

