### PR TITLE
fix(riscv): building using Rust 1.73 to avoid segmentation fault in release mode

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -54,7 +54,6 @@ jobs:
           - armv5te-unknown-linux-musleabi
           - x86_64-unknown-linux-musl
           - i686-unknown-linux-musl
-          - riscv64gc-unknown-linux-gnu
           - x86_64-apple-darwin
         mode:
           - --release
@@ -91,6 +90,13 @@ jobs:
             cargo_options: --no-run
 
           - target: riscv64gc-unknown-linux-gnu
+            mode: '--release'
+            # Using < 1.73 causes a segmentation fault when running a binary built with the --release flag
+            # Rust 1.73 includes both an updated llvm version and updated binutils which is like to have improved compatibility
+            # See: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1730-2023-10-05
+            # There is a comment in the https://github.com/rust-lang/rust/pull/114048/ which refers to riscv64 support:
+            # * "Updated dist-riscv64-linux to use binutils 2.36 in order to recognize the zicsr feature, which is no longer part of the base ISA."
+            rust_channel: "1.73" 
             host_os: ubuntu-22.04
             cargo_options: --no-run
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Build `riscv64gc-unknown-linux-gnu` target using minimum Rust 1.73, otherwise the produced binary crashes with a "segmentation fault".

Rust 1.73 upgraded the internal use of llvm to version 17 (which includes some other improvements) which 

* [PR Upgrade to llvm 17](https://github.com/rust-lang/rust/pull/114048/) is mentioned in the [Rust 1.73 release notes](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1730-2023-10-05)


Rust versions 1.70 through to 1.76 were tested on a Star Vision2 device (with a riscv processor) - where "Segmentation fault" is observed whilst initialising the c8y-remote-access-plugin (though it is not limited to this command):

```sh
user@starfive:~$ uname -a
Linux starfive 5.15.0-starfive #1 SMP Fri Nov 24 07:22:28 UTC 2023 riscv64 GNU/Linux
user@starfive:~$ sudo -u tedge ./tedge-1.70 c8y-remote-access-plugin --init
Segmentation fault
user@starfive:~$ sudo -u tedge ./tedge-1.71 c8y-remote-access-plugin --init
Segmentation fault
user@starfive:~$ sudo -u tedge ./tedge-1.72 c8y-remote-access-plugin --init
Segmentation fault
user@starfive:~$ sudo -u tedge ./tedge-1.73 c8y-remote-access-plugin --init
user@starfive:~$ sudo -u tedge ./tedge-1.74 c8y-remote-access-plugin --init
user@starfive:~$ sudo -u tedge ./tedge-1.75 c8y-remote-access-plugin --init
user@starfive:~$ sudo -u tedge ./tedge-1.76 c8y-remote-access-plugin --init
user@starfive:~$ sudo -u tedge ./tedge-1.7 c8y-remote-access-plugin --init
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

