### PR TITLE
fix(#2749): Check sudo.enable in software and restart managers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3640,6 +3640,7 @@ dependencies = [
  "clap",
  "nix",
  "path-clean",
+ "tedge_config",
  "tempfile",
  "uzers",
  "which",
@@ -3713,6 +3714,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "which",
 ]
 
 [[package]]

--- a/crates/common/tedge_config/Cargo.toml
+++ b/crates/common/tedge_config/Cargo.toml
@@ -32,6 +32,7 @@ toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 url = { workspace = true }
+which = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/common/tedge_config/src/lib.rs
+++ b/crates/common/tedge_config/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod mqtt_config;
+mod sudo;
 pub mod system_services;
 pub mod tedge_config_cli;
+pub use sudo::SudoCommandBuilder;
 
 pub use self::tedge_config_cli::config_setting::*;
 pub use self::tedge_config_cli::error::*;

--- a/crates/common/tedge_config/src/sudo.rs
+++ b/crates/common/tedge_config/src/sudo.rs
@@ -1,0 +1,65 @@
+use std::ffi::OsStr;
+use std::process::Command;
+use std::sync::Arc;
+use tracing::warn;
+
+use crate::TEdgeConfig;
+
+const SUDO: &str = "sudo";
+
+/// A object used to spawn processes according to the user's sudo preference.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SudoCommandBuilder {
+    enabled: bool,
+    sudo_program: Arc<str>,
+}
+
+impl SudoCommandBuilder {
+    /// Configures the object to prepend `sudo` if the `sudo.enable` config
+    /// setting is enabled.
+    pub fn new(config: &TEdgeConfig) -> Self {
+        Self::enabled(config.sudo.enable)
+    }
+
+    /// Configures the object to always prepend `sudo`.
+    pub fn enabled(enabled: bool) -> Self {
+        Self {
+            enabled,
+            sudo_program: Arc::from(SUDO),
+        }
+    }
+
+    /// Instead of `sudo`, configures object to prepend other program name.
+    ///
+    /// Mainly used by tests that don't wish to actually execute the command as
+    /// `sudo` would, so they replace it with e.g. `echo`.
+    pub fn with_program(program: impl Into<Arc<str>>) -> Self {
+        Self {
+            enabled: true,
+            sudo_program: program.into(),
+        }
+    }
+
+    /// Creates a command, optionally prepended by `sudo` or other prefix.
+    ///
+    /// Checks if sudo is present in $PATH. If it's present and sudo is enabled,
+    /// prepare a [`Command`](std::process::Command) using sudo. Otherwise,
+    /// prepares a Command that starts `program` directly.
+    pub fn command<S: AsRef<OsStr>>(&self, program: S) -> Command {
+        if !self.enabled {
+            return Command::new(program);
+        }
+
+        match which::which(self.sudo_program.as_ref()) {
+            Ok(sudo) => {
+                let mut c = Command::new(sudo);
+                c.arg(program);
+                c
+            }
+            Err(_) => {
+                warn!("`sudo.enable` set to `true`, but sudo not found in $PATH");
+                Command::new(program)
+            }
+        }
+    }
+}

--- a/crates/core/plugin_sm/tests/plugin.rs
+++ b/crates/core/plugin_sm/tests/plugin.rs
@@ -11,6 +11,7 @@ mod tests {
     use std::str::FromStr;
     use tedge_api::SoftwareError;
     use tedge_api::SoftwareModule;
+    use tedge_config::SudoCommandBuilder;
     use tedge_config::TEdgeConfigLocation;
     use test_case::test_case;
 
@@ -64,7 +65,7 @@ mod tests {
         let plugin = ExternalPluginCommand::new(
             "test",
             &dummy_plugin_path,
-            None,
+            SudoCommandBuilder::enabled(false),
             config.software.plugin.max_packages,
             config.http.client.auth.identity()?,
         );
@@ -79,7 +80,13 @@ mod tests {
     fn plugin_check_module_type_both_same() {
         let dummy_plugin_path = get_dummy_plugin_path();
 
-        let plugin = ExternalPluginCommand::new("test", dummy_plugin_path, None, 100, None);
+        let plugin = ExternalPluginCommand::new(
+            "test",
+            dummy_plugin_path,
+            SudoCommandBuilder::enabled(false),
+            100,
+            None,
+        );
 
         let module = SoftwareModule {
             module_type: Some("test".into()),
@@ -103,7 +110,13 @@ mod tests {
         let dummy_plugin_path = get_dummy_plugin_path();
 
         // Create new plugin in the registry with name `test`.
-        let plugin = ExternalPluginCommand::new("test", dummy_plugin_path, None, 100, None);
+        let plugin = ExternalPluginCommand::new(
+            "test",
+            dummy_plugin_path,
+            SudoCommandBuilder::enabled(false),
+            100,
+            None,
+        );
 
         // Create test module with name `test2`.
         let module = SoftwareModule {
@@ -133,7 +146,13 @@ mod tests {
         // Create dummy plugin.
         let dummy_plugin_path = get_dummy_plugin_path();
 
-        let plugin = ExternalPluginCommand::new("test", dummy_plugin_path, None, 100, None);
+        let plugin = ExternalPluginCommand::new(
+            "test",
+            dummy_plugin_path,
+            SudoCommandBuilder::enabled(false),
+            100,
+            None,
+        );
 
         // Create software module without an explicit type.
         let module = SoftwareModule {

--- a/crates/core/plugin_sm/tests/plugin_manager.rs
+++ b/crates/core/plugin_sm/tests/plugin_manager.rs
@@ -4,6 +4,7 @@ mod tests {
     use plugin_sm::plugin_manager::ExternalPlugins;
     use plugin_sm::plugin_manager::Plugins;
     use std::fs::File;
+    use tedge_config::SudoCommandBuilder;
     use tedge_config::TEdgeConfigLocation;
     use tempfile::NamedTempFile;
 
@@ -14,8 +15,13 @@ mod tests {
         let plugin_dir = temp_dir.path().to_owned();
 
         // Call open and load to register all plugins from given directory.
-        let mut plugins =
-            ExternalPlugins::open(plugin_dir, None, None, TEdgeConfigLocation::default()).unwrap();
+        let mut plugins = ExternalPlugins::open(
+            plugin_dir,
+            None,
+            SudoCommandBuilder::enabled(false),
+            TEdgeConfigLocation::default(),
+        )
+        .unwrap();
         let _ = plugins.load();
 
         // Plugins registry should not register any plugin as no files in the directory are present.
@@ -33,8 +39,13 @@ mod tests {
         let plugin_dir = temp_dir.path().to_owned();
 
         // Call open and load to register all plugins from given directory.
-        let mut plugins =
-            ExternalPlugins::open(plugin_dir, None, None, TEdgeConfigLocation::default()).unwrap();
+        let mut plugins = ExternalPlugins::open(
+            plugin_dir,
+            None,
+            SudoCommandBuilder::enabled(false),
+            TEdgeConfigLocation::default(),
+        )
+        .unwrap();
         let _ = plugins.load();
 
         // Check if registry has loaded plugin of type `test`.
@@ -52,7 +63,7 @@ mod tests {
         let result = ExternalPlugins::open(
             plugin_dir.into_path(),
             Some("dummy".into()),
-            None,
+            SudoCommandBuilder::enabled(false),
             TEdgeConfigLocation::default(),
         )?;
         assert!(result.empty());

--- a/crates/core/tedge_agent/src/restart_manager/config.rs
+++ b/crates/core/tedge_agent/src/restart_manager/config.rs
@@ -7,6 +7,7 @@ pub struct RestartManagerConfig {
     pub tmp_dir: Utf8PathBuf,
     pub config_dir: Utf8PathBuf,
     pub state_dir: Utf8PathBuf,
+    pub is_sudo_enabled: bool,
 }
 
 impl RestartManagerConfig {
@@ -21,6 +22,7 @@ impl RestartManagerConfig {
             tmp_dir: tedge_config.tmp.path.clone(),
             config_dir: tedge_config_location.tedge_config_root_path.clone(),
             state_dir: tedge_config.agent.state.path.clone(),
+            is_sudo_enabled: tedge_config.sudo.enable,
         })
     }
 }

--- a/crates/core/tedge_agent/src/restart_manager/config.rs
+++ b/crates/core/tedge_agent/src/restart_manager/config.rs
@@ -1,5 +1,6 @@
 use camino::Utf8PathBuf;
 use tedge_api::mqtt_topics::EntityTopicId;
+use tedge_config::SudoCommandBuilder;
 
 #[derive(Debug, Clone)]
 pub struct RestartManagerConfig {
@@ -7,7 +8,7 @@ pub struct RestartManagerConfig {
     pub tmp_dir: Utf8PathBuf,
     pub config_dir: Utf8PathBuf,
     pub state_dir: Utf8PathBuf,
-    pub is_sudo_enabled: bool,
+    pub sudo: SudoCommandBuilder,
 }
 
 impl RestartManagerConfig {
@@ -22,7 +23,7 @@ impl RestartManagerConfig {
             tmp_dir: tedge_config.tmp.path.clone(),
             config_dir: tedge_config_location.tedge_config_root_path.clone(),
             state_dir: tedge_config.agent.state.path.clone(),
-            is_sudo_enabled: tedge_config.sudo.enable,
+            sudo: SudoCommandBuilder::new(&tedge_config),
         })
     }
 }

--- a/crates/core/tedge_agent/src/restart_manager/tests.rs
+++ b/crates/core/tedge_agent/src/restart_manager/tests.rs
@@ -17,6 +17,7 @@ use tedge_api::messages::CommandStatus;
 use tedge_api::messages::RestartCommandPayload;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::RestartCommand;
+use tedge_config::SudoCommandBuilder;
 use tedge_test_utils::fs::TempTedgeDir;
 
 const TEST_TIMEOUT_MS: Duration = Duration::from_millis(5000);
@@ -116,7 +117,7 @@ async fn spawn_restart_manager(
         tmp_dir: tmp_dir.utf8_path_buf(),
         config_dir: tmp_dir.utf8_path_buf(),
         state_dir: "/some/unknown/dir".into(),
-        is_sudo_enabled: true,
+        sudo: SudoCommandBuilder::enabled(true),
     };
 
     let mut restart_actor_builder = RestartManagerBuilder::new(config);

--- a/crates/core/tedge_agent/src/restart_manager/tests.rs
+++ b/crates/core/tedge_agent/src/restart_manager/tests.rs
@@ -116,6 +116,7 @@ async fn spawn_restart_manager(
         tmp_dir: tmp_dir.utf8_path_buf(),
         config_dir: tmp_dir.utf8_path_buf(),
         state_dir: "/some/unknown/dir".into(),
+        is_sudo_enabled: true,
     };
 
     let mut restart_actor_builder = RestartManagerBuilder::new(config);

--- a/crates/core/tedge_agent/src/software_manager/actor.rs
+++ b/crates/core/tedge_agent/src/software_manager/actor.rs
@@ -32,12 +32,6 @@ use tedge_config::TEdgeConfigError;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
-use which::which;
-
-#[cfg(not(test))]
-const SUDO: &str = "sudo";
-#[cfg(test)]
-const SUDO: &str = "echo";
 
 fan_in_message_type!(SoftwareCommand[SoftwareUpdateCommand, SoftwareListCommand, SoftwareCommandMetadata] : Debug, Eq, PartialEq, Deserialize, Serialize);
 
@@ -78,20 +72,10 @@ impl Actor for SoftwareManagerActor {
         let operation_logs = OperationLogs::try_new(self.config.log_dir.clone().into())
             .map_err(SoftwareManagerError::FromOperationsLogs)?;
 
-        let sudo = if self.config.is_sudo_enabled {
-            let sudo = which(SUDO).ok();
-            if sudo.is_none() {
-                warn!("`sudo.enable` is `true` but sudo wasn't found in $PATH");
-            }
-            sudo
-        } else {
-            None
-        };
-
         let mut plugins = ExternalPlugins::open(
             &self.config.sm_plugins_dir,
             self.config.default_plugin_type.clone(),
-            sudo,
+            self.config.sudo.clone(),
             self.config.config_location.clone(),
         )
         .map_err(|err| RuntimeError::ActorError(Box::new(err)))?;

--- a/crates/core/tedge_agent/src/software_manager/config.rs
+++ b/crates/core/tedge_agent/src/software_manager/config.rs
@@ -11,6 +11,7 @@ pub struct SoftwareManagerConfig {
     pub log_dir: Utf8PathBuf,
     pub default_plugin_type: Option<String>,
     pub config_location: TEdgeConfigLocation,
+    pub is_sudo_enabled: bool,
 }
 
 impl SoftwareManagerConfig {
@@ -43,6 +44,7 @@ impl SoftwareManagerConfig {
             log_dir: tedge_config.logs.path.join("agent"),
             default_plugin_type,
             config_location: tedge_config_location.clone(),
+            is_sudo_enabled: tedge_config.sudo.enable,
         })
     }
 }

--- a/crates/core/tedge_agent/src/software_manager/config.rs
+++ b/crates/core/tedge_agent/src/software_manager/config.rs
@@ -1,5 +1,6 @@
 use camino::Utf8PathBuf;
 use tedge_api::mqtt_topics::EntityTopicId;
+use tedge_config::SudoCommandBuilder;
 use tedge_config::TEdgeConfigLocation;
 #[derive(Debug, Clone)]
 pub struct SoftwareManagerConfig {
@@ -11,7 +12,7 @@ pub struct SoftwareManagerConfig {
     pub log_dir: Utf8PathBuf,
     pub default_plugin_type: Option<String>,
     pub config_location: TEdgeConfigLocation,
-    pub is_sudo_enabled: bool,
+    pub sudo: SudoCommandBuilder,
 }
 
 impl SoftwareManagerConfig {
@@ -44,7 +45,7 @@ impl SoftwareManagerConfig {
             log_dir: tedge_config.logs.path.join("agent"),
             default_plugin_type,
             config_location: tedge_config_location.clone(),
-            is_sudo_enabled: tedge_config.sudo.enable,
+            sudo: SudoCommandBuilder::new(&tedge_config),
         })
     }
 }

--- a/crates/core/tedge_agent/src/software_manager/tests.rs
+++ b/crates/core/tedge_agent/src/software_manager/tests.rs
@@ -23,10 +23,13 @@ use tedge_api::messages::SoftwareRequestResponseSoftwareList;
 use tedge_api::messages::SoftwareUpdateCommand;
 use tedge_api::messages::SoftwareUpdateCommandPayload;
 use tedge_api::mqtt_topics::EntityTopicId;
+use tedge_config::SudoCommandBuilder;
 use tedge_config::TEdgeConfigLocation;
 use tedge_test_utils::fs::TempTedgeDir;
 
 const TEST_TIMEOUT_MS: Duration = Duration::from_millis(5000);
+
+const SUDO: &str = "echo";
 
 #[tokio::test]
 async fn test_pending_software_update_operation() -> Result<(), DynError> {
@@ -185,7 +188,7 @@ async fn spawn_software_manager(
         log_dir: tmp_dir.utf8_path_buf(),
         default_plugin_type: None,
         config_location: TEdgeConfigLocation::from_custom_root(tmp_dir.utf8_path_buf()),
-        is_sudo_enabled: true,
+        sudo: SudoCommandBuilder::with_program(SUDO),
     };
 
     let mut software_actor_builder = SoftwareManagerBuilder::new(config);

--- a/crates/core/tedge_agent/src/software_manager/tests.rs
+++ b/crates/core/tedge_agent/src/software_manager/tests.rs
@@ -185,6 +185,7 @@ async fn spawn_software_manager(
         log_dir: tmp_dir.utf8_path_buf(),
         default_plugin_type: None,
         config_location: TEdgeConfigLocation::from_custom_root(tmp_dir.utf8_path_buf()),
+        is_sudo_enabled: true,
     };
 
     let mut software_actor_builder = SoftwareManagerBuilder::new(config);

--- a/crates/core/tedge_write/Cargo.toml
+++ b/crates/core/tedge_write/Cargo.toml
@@ -17,6 +17,7 @@ camino.workspace = true
 clap.workspace = true
 nix.workspace = true
 path-clean.workspace = true
+tedge_config.workspace = true
 uzers.workspace = true
 which.workspace = true
 

--- a/crates/extensions/tedge_config_manager/src/actor.rs
+++ b/crates/extensions/tedge_config_manager/src/actor.rs
@@ -386,7 +386,7 @@ impl ConfigManagerActor {
 
         let to = Utf8PathBuf::from(&file_entry.path);
 
-        match self.config.use_tedge_write {
+        match self.config.use_tedge_write.clone() {
             TedgeWriteStatus::Disabled => {
                 let src_file = std::fs::File::open(from)?;
                 tedge_utils::fs::atomically_write_file_sync(&to, src_file)?;

--- a/crates/extensions/tedge_config_manager/src/config.rs
+++ b/crates/extensions/tedge_config_manager/src/config.rs
@@ -17,6 +17,7 @@ use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
 use tedge_api::mqtt_topics::OperationType;
 use tedge_config::ReadError;
+use tedge_config::SudoCommandBuilder;
 use tedge_mqtt_ext::TopicFilter;
 use tedge_utils::file::PermissionEntry;
 
@@ -90,7 +91,7 @@ impl ConfigManagerConfig {
             config_update_topic,
             config_snapshot_topic,
             use_tedge_write: TedgeWriteStatus::Enabled {
-                sudo: cliopts.is_sudo_enabled,
+                sudo: SudoCommandBuilder::enabled(cliopts.is_sudo_enabled),
             },
             config_update_enabled: cliopts.config_update_enabled,
         })
@@ -255,8 +256,8 @@ impl PluginConfig {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TedgeWriteStatus {
-    Enabled { sudo: bool },
+    Enabled { sudo: SudoCommandBuilder },
     Disabled,
 }


### PR DESCRIPTION
## Proposed changes

Check `sudo.enable` config setting before using sudo in software and restart managers. If `sudo.enable` is `true` but isn't found in `$PATH`, a warning is emitted.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- #2749 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I'll also probably add a test, once I figure out where to put it.