### PR TITLE
fix: flaky custom_sub_topics_tedge-mapper-az test

### DIFF
--- a/tests/RobotFramework/tests/mqtt/custom_sub_topics_tedge-mapper-az.robot
+++ b/tests/RobotFramework/tests/mqtt/custom_sub_topics_tedge-mapper-az.robot
@@ -18,7 +18,7 @@ Publish events to subscribed topic
 Publish measurements to unsubscribed topic
     Execute Command    tedge mqtt pub te/device/main///m/ '{"temperature": 10}'
     Sleep    5s    reason=If a message is not published in 5s, it will never be published.
-    Should Have MQTT Messages    az/messages/events/#   minimum=0    maximum=0
+    Should Have MQTT Messages    az/messages/events/#   minimum=0    maximum=0    message_contains=temperature
 
 
 *** Keywords ***

--- a/tests/RobotFramework/tests/tedge_to_te_converter/convert_tedge_topics_to_te_topics.robot
+++ b/tests/RobotFramework/tests/tedge_to_te_converter/convert_tedge_topics_to_te_topics.robot
@@ -18,48 +18,48 @@ Convert main device measurement topic
     Should Be Equal    ${messages_tedge}  ${messages_te}    
 
 Convert main device empty measurement topic
-    Execute Command    tedge mqtt pub tedge/measurements '{"temperature":25}'
-    ${messages_tedge}=    Should Have MQTT Messages    tedge/measurements    minimum=1    maximum=1
-    ${messages_te}=    Should Have MQTT Messages    te/device/main///m/    minimum=1    maximum=1
+    Execute Command    tedge mqtt pub tedge/measurements '{"temperature":20}'
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/measurements    minimum=1    maximum=1    message_contains=20
+    ${messages_te}=    Should Have MQTT Messages    te/device/main///m/    minimum=1    maximum=1   message_contains=20
     Should Be Equal    ${messages_tedge}  ${messages_te}
-    Should Have MQTT Messages    te/device/main///m/    message_pattern={"temperature":25}
+    Should Have MQTT Messages    te/device/main///m/    message_pattern={"temperature":20}
    
 Convert child device measurement topic
     Execute Command    tedge mqtt pub tedge/measurements/child '{"temperature":25}'
-    ${messages_tedge}=    Should Have MQTT Messages    tedge/measurements/child   minimum=1    maximum=1
-    ${messages_te}=    Should Have MQTT Messages    te/device/child///m/    minimum=1    maximum=1
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/measurements/child   minimum=1    maximum=1    message_contains=25
+    ${messages_te}=    Should Have MQTT Messages    te/device/child///m/    minimum=1    maximum=1    message_contains=25
     Should Be Equal    ${messages_tedge}  ${messages_te}
     Should Have MQTT Messages    te/device/child///m/    message_pattern={"temperature":25}
 
 Convert main device event topic
-    Execute Command    tedge mqtt pub tedge/events/login_event '{"text":"someone logedin"}'
-    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event   minimum=1    maximum=1
-    ${messages_te}=    Should Have MQTT Messages    te/device/main///e/login_event    minimum=1    maximum=1
+    Execute Command    tedge mqtt pub tedge/events/login_event '{"text":"someone loggedin"}'
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event   minimum=1    maximum=1    message_contains=someone loggedin
+    ${messages_te}=    Should Have MQTT Messages    te/device/main///e/login_event    minimum=1    maximum=1    message_contains=someone loggedin
     Should Be Equal    ${messages_tedge}  ${messages_te}
-    Should Have MQTT Messages    te/device/main///e/login_event    message_pattern={"text":"someone logedin"}
+    Should Have MQTT Messages    te/device/main///e/login_event    message_pattern={"text":"someone loggedin"}
 
 Convert main device empty event topic
-    Execute Command    tedge mqtt pub tedge/events/login_event ''
-    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event   minimum=1    maximum=1
-    ${messages_te}=    Should Have MQTT Messages    te/device/main///e/login_event    minimum=1    maximum=1
+    Execute Command    tedge mqtt pub tedge/events/login_event2 ''
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event2   minimum=1    maximum=1
+    ${messages_te}=    Should Have MQTT Messages    te/device/main///e/login_event2    minimum=1    maximum=1
     Should Be Equal    ${messages_tedge}  ${messages_te}      
 
 Convert child device event topic
-    Execute Command    tedge mqtt pub tedge/events/login_event/child '{"text":"someone logedin"}'
-    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event/child   minimum=1    maximum=1
-    ${messages_te}=    Should Have MQTT Messages    te/device/child///e/login_event    minimum=1    maximum=1
+    Execute Command    tedge mqtt pub tedge/events/login_event/child '{"text":"someone loggedin 2"}'
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event/child   minimum=1    maximum=1    message_contains="someone loggedin 2"
+    ${messages_te}=    Should Have MQTT Messages    te/device/child///e/login_event    minimum=1    maximum=1    message_contains="someone loggedin 2"
     Should Be Equal    ${messages_tedge}  ${messages_te}
-    Should Have MQTT Messages    te/device/child///e/login_event    message_pattern={"text":"someone logedin"}
+    Should Have MQTT Messages    te/device/child///e/login_event    message_pattern={"text":"someone loggedin 2"}
 
 Convert main device alarm topic
-    Execute Command    tedge mqtt pub tedge/alarms/minor/test_alarm '{"text":"test alarm"}' -q 2 -r
-    ${messages}=    Should Have MQTT Messages    te/device/main///a/test_alarm    minimum=1    maximum=1
+    Execute Command    tedge mqtt pub tedge/alarms/minor/test_alarm '{"text":"test alarm 1"}' -q 2 -r
+    ${messages}=    Should Have MQTT Messages    te/device/main///a/test_alarm    minimum=1    maximum=1    message_contains="test alarm 1"
     ${message}=    Convert String To Json    ${messages[0]}
     Should Be Equal    ${message["severity"]}    minor
 
 Convert main device alarm topic and retain
-    Execute Command    tedge mqtt pub tedge/alarms/minor/test_alarm '{"text":"test alarm"}' -q 2 -r
-    ${messages}=    Should Have MQTT Messages    te/device/main///a/test_alarm    minimum=1     maximum=1
+    Execute Command    tedge mqtt pub tedge/alarms/minor/test_alarm '{"text":"test alarm 2"}' -q 2 -r
+    ${messages}=    Should Have MQTT Messages    te/device/main///a/test_alarm    minimum=1     maximum=1    message_contains="test alarm 2"
     ${message}=    Convert String To Json    ${messages[0]}
     Should Be Equal    ${message["severity"]}    minor
     # Check if the retained message received with new client or not
@@ -67,21 +67,21 @@ Convert main device alarm topic and retain
     Should Contain    ${result}    "severity":"minor"
 
 Convert child device alarm topic
-    Execute Command    tedge mqtt pub tedge/alarms/major/test_alarm/child '{"text":"test alarm"}' -q 2 -r
-    ${messages}=    Should Have MQTT Messages    te/device/child///a/test_alarm    minimum=1     maximum=1
+    Execute Command    tedge mqtt pub tedge/alarms/major/test_alarm/child1 '{"text":"test alarm 3"}' -q 2 -r
+    ${messages}=    Should Have MQTT Messages    te/device/child1///a/test_alarm    minimum=1     maximum=1    message_contains="test alarm 3"
     ${message}=    Convert String To Json    ${messages[0]}
     Should Be Equal    ${message["severity"]}    major
 
 
 Convert clear alarm topic
-    Execute Command    tedge mqtt pub tedge/alarms/major/test_alarm/child '' -q 2 -r
-    ${messages_tedge}=    Should Have MQTT Messages    tedge/alarms/major/test_alarm/child    minimum=1    maximum=1
-    ${messages_te}=    Should Have MQTT Messages    te/device/child///a/test_alarm    minimum=1    maximum=1
+    Execute Command    tedge mqtt pub tedge/alarms/major/test_alarm/child2 '' -q 2 -r
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/alarms/major/test_alarm/child2    minimum=1    maximum=1
+    ${messages_te}=    Should Have MQTT Messages    te/device/child2///a/test_alarm    minimum=1    maximum=1
     Should Be Equal    ${messages_tedge}  ${messages_te}
     
 Convert empty alarm message
-    Execute Command    tedge mqtt pub tedge/alarms/major/test_alarm/child {} -q 2 -r
-    ${messages}=    Should Have MQTT Messages    te/device/child///a/test_alarm    minimum=1     maximum=1
+    Execute Command    tedge mqtt pub tedge/alarms/major/test_alarm/child3 {} -q 2 -r
+    ${messages}=    Should Have MQTT Messages    te/device/child3///a/test_alarm    minimum=1     maximum=1
     ${message}=    Convert String To Json    ${messages[0]}
     Should Be Equal    ${message["severity"]}    major
 


### PR DESCRIPTION


## Proposed changes

The cause of the flake was `Should Have MQTT Messages` keyword finding a message from the previous test case, because of the default 1s precision in the `messages_from` timestamp, so the proper timestamp had to be rounded down, which leads to issues when test cases are short and execute in less than 1 second.

Closes #2799

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- #2799 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

