### PR TITLE
Uploader supports multipart/form-data and attaches filename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,6 +2013,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,6 +2804,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4430,6 +4441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4485,6 +4505,8 @@ dependencies = [
  "camino",
  "futures",
  "log",
+ "mime",
+ "mime_guess",
  "mockito",
  "reqwest",
  "tedge_test_utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ log_manager = { path = "crates/common/log_manager" }
 logged_command = { path = "crates/common/logged_command" }
 maplit = "1.0"
 miette = { version = "5.5.0", features = ["fancy"] }
+mime = "0.3.17"
+mime_guess = "2.0.4"
 mockall = "0.11"
 mockito = "1.1.0"
 mqtt_channel = { path = "crates/common/mqtt_channel" }

--- a/crates/common/upload/Cargo.toml
+++ b/crates/common/upload/Cargo.toml
@@ -14,7 +14,13 @@ axum_tls = { workspace = true, features = ["error-matching"] }
 backoff = { workspace = true }
 camino = { workspace = true }
 log = { workspace = true }
-reqwest = { workspace = true, features = ["stream", "rustls-tls-native-roots"] }
+mime = { workspace = true }
+mime_guess = { workspace = true }
+reqwest = { workspace = true, features = [
+    "stream",
+    "rustls-tls-native-roots",
+    "multipart",
+] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tokio-util = { workspace = true, features = ["codec"] }

--- a/crates/common/upload/src/lib.rs
+++ b/crates/common/upload/src/lib.rs
@@ -41,5 +41,8 @@ mod upload;
 pub use crate::error::UploadError;
 pub use crate::upload::Auth;
 pub use crate::upload::ContentType;
+pub use crate::upload::FormData;
 pub use crate::upload::UploadInfo;
+pub use crate::upload::UploadMethod;
 pub use crate::upload::Uploader;
+pub use mime::Mime;

--- a/crates/extensions/tedge_uploader_ext/src/lib.rs
+++ b/crates/extensions/tedge_uploader_ext/src/lib.rs
@@ -5,3 +5,5 @@ mod tests;
 
 pub use actor::*;
 pub use upload::ContentType;
+pub use upload::FormData;
+pub use upload::Mime;

--- a/tests/RobotFramework/requirements/requirements.txt
+++ b/tests/RobotFramework/requirements/requirements.txt
@@ -2,7 +2,7 @@ dateparser~=1.2.0
 paho-mqtt~=1.6.1
 python-dotenv~=1.0.0
 robotframework~=6.1.1
-robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.31.3
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.32.1
 robotframework-debuglibrary~=2.3.0
 robotframework-jsonlibrary~=0.5
 robotframework-pabot~=2.17.0

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -232,6 +232,9 @@ Get Configuration from Device
     ${contents}=    Cumulocity.Event Should Have An Attachment
     ...    ${events[0]["id"]}
     ...    expected_md5=${expected_checksum}
+
+    ${event}=    Cumulocity.Event Attachment Should Have File Info    ${events[0]["id"]}    name=^${external_id}_[\\w\\W]+-c8y-mapper-\\d+$
+
     RETURN    ${contents}
 
 #

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
@@ -152,13 +152,14 @@ Publish and Verify Local Command
     [Teardown]    Execute Command    tedge mqtt pub --retain '${topic}' ''
 
 Log File Contents Should Be Equal
-    [Arguments]    ${operation}    ${expected_contents}    ${encoding}=utf-8
+    [Arguments]    ${operation}    ${expected_contents}    ${encoding}=utf-8    ${expected_filename}=^${DEVICE_SN}_[\\w\\W]+-c8y-mapper-\\d+$    ${expected_mime_type}=text/plain
     ${event_url_parts}=    Split String    ${operation["c8y_LogfileRequest"]["file"]}    separator=/
     ${event_id}=    Set Variable    ${event_url_parts}[-2]
     ${contents}=    Cumulocity.Event Should Have An Attachment
     ...    ${event_id}
     ...    expected_contents=${expected_contents}
     ...    encoding=${encoding}
+    ${event}=    Cumulocity.Event Attachment Should Have File Info    ${event_id}    name=${expected_filename}    mime_type=${expected_mime_type}
     RETURN    ${contents}
 
 Disable log upload capability of tedge-agent


### PR DESCRIPTION
## Proposed changes

With this change, now you can download log files with file name such as `rina0005_software-management-c8y-mapper-5369.txt`.

Technical changes:
- Use async client to support multipart/form-data
- Expand Uploader to support both PUT and POST method
- Add MIME auto-detection based on file extension

### Takeaways

I added a half working content-type auto detection mechanism to this PR. Stories behind:
* It is nice to have auto-detection of `Content-Type` header. 
* The `reqwest` feature `multipart` adds a dependency on the `mime_guess` crate. So, using `mime_guess` crate shouldn't give any new dependency to thin-edge.
* However, their function gives a guess based on a file extension without file access. Read [this](https://docs.rs/mime_guess/latest/mime_guess/struct.MimeGuess.html#method.from_path).

For example, in our real scenario, uploading `tedge.toml` to the configuration snapshot,
1. `PUT` to the file transfer service with content-type `text/x-toml` since the target file has `.toml` extension.
2. `GET` the file from the file transfer service, but at this point, we lose the file extension since it is stored as `tedge-configuration-plugin-c8y-mapper-5375`.
3. `POST` the file to the c8y-proxy endpoint. However, content-type is now set to `applications/octet-stream` since the file is missing the extension.

This is the log. 
![Screenshot from 2024-04-03 19-45-58](https://github.com/thin-edge/thin-edge.io/assets/18257209/bdd5ead3-779d-4393-81b9-01f749b25b5d)

So probably as the next step, we can choose either 1) reading the file content and guess the mime or 2) giving a file extension when we store the file in the file transfer service.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2763 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

