### PR TITLE
Fix broken test checking CSR content

### DIFF
--- a/tests/RobotFramework/tests/mqtt/custom_sub_topics_tedge-mapper-aws.robot
+++ b/tests/RobotFramework/tests/mqtt/custom_sub_topics_tedge-mapper-aws.robot
@@ -15,7 +15,7 @@ Test Tags           theme:mqtt    theme:aws
 
 Publish events to subscribed topic
     ${timestamp}=        Get Unix Timestamp
-    Execute Command    tedge mqtt pub te/device/main///e/event-type '{"text": "somone logged-in"}'   
+    Execute Command    tedge mqtt pub te/device/main///e/event-type '{"text": "someone logged-in"}'
     Should Have MQTT Messages    aws/td/device:main/e/event-type
 
 Publish measurements to unsubscribed topic   

--- a/tests/RobotFramework/tests/tedge/certificate_signing_request.robot
+++ b/tests/RobotFramework/tests/tedge/certificate_signing_request.robot
@@ -43,8 +43,8 @@ Generate CSR without an existing certificate and private key
     Execute Command    sudo tedge cert create-csr --device-id test-user
 
     ${output_csr_subject}=    Execute Command
-    ...    openssl req -noout -subject -in /etc/tedge/device-certs/tedge.csr
-    Should Contain    ${output_csr_subject}    subject=CN = test-user
+    ...    openssl req -noout -subject -in /etc/tedge/device-certs/tedge.csr | tr -d ' '
+    Should Contain    ${output_csr_subject}    subject=CN=test-user
 
     ${output_private_key_md5}=    Execute Command
     ...    openssl pkey -in /etc/tedge/device-certs/tedge-private-key.pem -pubout | openssl md5


### PR DESCRIPTION
## Proposed changes

Fix the test [Generate CSR without an existing certificate and private key](https://github.com/thin-edge/thin-edge.io/actions/runs/8566493225?pr=2813)

- Trim spaces before comparing openssl output with the expected CSR

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

