### PR TITLE
Support different clouds in built-in bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,6 +3893,7 @@ dependencies = [
  "tedge_actors",
  "tedge_api",
  "tedge_config",
+ "thiserror",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3606,6 +3606,7 @@ dependencies = [
  "flockfile",
  "mqtt_channel",
  "reqwest",
+ "rumqttc",
  "tedge_actors",
  "tedge_api",
  "tedge_config",
@@ -3885,14 +3886,20 @@ dependencies = [
 name = "tedge_mqtt_bridge"
 version = "1.0.1"
 dependencies = [
+ "anyhow",
  "async-trait",
  "certificate",
+ "env_logger",
  "futures",
+ "mockall",
  "mqtt_channel",
  "rumqttc",
+ "rumqttd",
+ "serde_json",
  "tedge_actors",
  "tedge_api",
  "tedge_config",
+ "tedge_test_utils",
  "thiserror",
  "tokio",
  "tracing",
@@ -4156,9 +4163,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2129,6 +2129,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutants"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
+
+[[package]]
 name = "nanoid"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3892,6 +3898,8 @@ dependencies = [
  "futures",
  "mockall",
  "mqtt_channel",
+ "mutants",
+ "rcgen",
  "rumqttc",
  "rumqttd",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3606,7 +3606,6 @@ dependencies = [
  "flockfile",
  "mqtt_channel",
  "reqwest",
- "rumqttc",
  "tedge_actors",
  "tedge_api",
  "tedge_config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ tempfile = "3.9"
 test-case = "3.2"
 thiserror = "1.0"
 time = "0.3"
-tokio = { version = "1.23", default-features = false }
+tokio = { version = "1.37", default-features = false }
 tokio-rustls = "0.24.1"
 tokio-tungstenite = { version = "0.20.0" }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ mockall = "0.11"
 mockito = "1.1.0"
 mqtt_channel = { path = "crates/common/mqtt_channel" }
 mqtt_tests = { path = "crates/tests/mqtt_tests" }
+mutants = "0.0.3"
 nanoid = "0.4"
 nix = "0.26"
 notify = { version = "6.1.1", default-features = false }

--- a/crates/core/c8y_api/src/smartrest/topic.rs
+++ b/crates/core/c8y_api/src/smartrest/topic.rs
@@ -109,15 +109,16 @@ mod tests {
     #[test]
     fn convert_c8y_topic_to_str() {
         assert_eq!(
-            &C8yTopic::SmartRestRequest.with_prefix(&"c8y".into()),
+            &C8yTopic::SmartRestRequest.with_prefix(&"c8y".try_into().unwrap()),
             "c8y/s/ds"
         );
         assert_eq!(
-            &C8yTopic::SmartRestResponse.with_prefix(&"c8y".into()),
+            &C8yTopic::SmartRestResponse.with_prefix(&"c8y".try_into().unwrap()),
             "c8y/s/us"
         );
         assert_eq!(
-            &C8yTopic::ChildSmartRestResponse("child-id".into()).with_prefix(&"custom".into()),
+            &C8yTopic::ChildSmartRestResponse("child-id".into())
+                .with_prefix(&"custom".try_into().unwrap()),
             "custom/s/us/child-id"
         );
     }
@@ -125,11 +126,11 @@ mod tests {
     #[test]
     fn topic_methods() {
         assert_eq!(
-            C8yTopic::upstream_topic(&"c8y-local".into()),
+            C8yTopic::upstream_topic(&"c8y-local".try_into().unwrap()),
             Topic::new_unchecked("c8y-local/s/us")
         );
         assert_eq!(
-            C8yTopic::downstream_topic(&"custom-topic".into()),
+            C8yTopic::downstream_topic(&"custom-topic".try_into().unwrap()),
             Topic::new_unchecked("custom-topic/s/ds")
         )
     }
@@ -139,7 +140,8 @@ mod tests {
     #[test_case(& ["child1", "main"], "c8y2/s/us/child1")]
     #[test_case(& ["child3", "child2", "child1", "main"], "c8y2/s/us/child1/child2/child3")]
     fn topic_from_ancestors(ancestors: &[&str], topic: &str) {
-        let nested_child_topic = publish_topic_from_ancestors(ancestors, &"c8y2".into());
+        let nested_child_topic =
+            publish_topic_from_ancestors(ancestors, &"c8y2".try_into().unwrap());
         assert_eq!(nested_child_topic, Topic::new_unchecked(topic));
     }
 }

--- a/crates/core/tedge/src/bridge/aws.rs
+++ b/crates/core/tedge/src/bridge/aws.rs
@@ -14,6 +14,7 @@ pub struct BridgeConfigAwsParams {
     pub bridge_root_cert_path: Utf8PathBuf,
     pub bridge_certfile: Utf8PathBuf,
     pub bridge_keyfile: Utf8PathBuf,
+    pub bridge_location: BridgeLocation,
 }
 
 impl From<BridgeConfigAwsParams> for BridgeConfig {
@@ -25,6 +26,7 @@ impl From<BridgeConfigAwsParams> for BridgeConfig {
             remote_clientid,
             bridge_certfile,
             bridge_keyfile,
+            bridge_location,
         } = params;
 
         let user_name = remote_clientid.to_string();
@@ -73,8 +75,7 @@ impl From<BridgeConfigAwsParams> for BridgeConfig {
                 connection_check_pub_msg_topic,
                 connection_check_sub_msg_topic,
             ],
-            // TODO support configurability
-            bridge_location: BridgeLocation::Mosquitto,
+            bridge_location,
         }
     }
 }
@@ -90,6 +91,7 @@ fn test_bridge_config_from_aws_params() -> anyhow::Result<()> {
         bridge_root_cert_path: "./test_root.pem".into(),
         bridge_certfile: "./test-certificate.pem".into(),
         bridge_keyfile: "./test-private-key.pem".into(),
+        bridge_location: BridgeLocation::Mosquitto,
     };
 
     let bridge = BridgeConfig::from(params);

--- a/crates/core/tedge/src/bridge/azure.rs
+++ b/crates/core/tedge/src/bridge/azure.rs
@@ -14,6 +14,7 @@ pub struct BridgeConfigAzureParams {
     pub bridge_root_cert_path: Utf8PathBuf,
     pub bridge_certfile: Utf8PathBuf,
     pub bridge_keyfile: Utf8PathBuf,
+    pub bridge_location: BridgeLocation,
 }
 
 impl From<BridgeConfigAzureParams> for BridgeConfig {
@@ -25,6 +26,7 @@ impl From<BridgeConfigAzureParams> for BridgeConfig {
             remote_clientid,
             bridge_certfile,
             bridge_keyfile,
+            bridge_location,
         } = params;
 
         let address = mqtt_host.clone();
@@ -66,15 +68,14 @@ impl From<BridgeConfigAzureParams> for BridgeConfig {
                 pub_msg_topic,
                 sub_msg_topic,
                 // Direct methods (request/response)
-                r##"methods/POST/# in 1 az/ $iothub/"##.into(),
-                r##"methods/res/# out 1 az/ $iothub/"##.into(),
+                "methods/POST/# in 1 az/ $iothub/".into(),
+                "methods/res/# out 1 az/ $iothub/".into(),
                 // Digital twin
-                r##"twin/res/# in 1 az/ $iothub/"##.into(),
-                r##"twin/GET/# out 1 az/ $iothub/"##.into(),
-                r##"twin/PATCH/# out 1 az/ $iothub/"##.into(),
+                "twin/res/# in 1 az/ $iothub/".into(),
+                "twin/GET/# out 1 az/ $iothub/".into(),
+                "twin/PATCH/# out 1 az/ $iothub/".into(),
             ],
-            // TODO support configurability
-            bridge_location: BridgeLocation::Mosquitto,
+            bridge_location,
         }
     }
 }
@@ -90,6 +91,7 @@ fn test_bridge_config_from_azure_params() -> anyhow::Result<()> {
         bridge_root_cert_path: "./test_root.pem".into(),
         bridge_certfile: "./test-certificate.pem".into(),
         bridge_keyfile: "./test-private-key.pem".into(),
+        bridge_location: BridgeLocation::Mosquitto,
     };
 
     let bridge = BridgeConfig::from(params);
@@ -108,13 +110,13 @@ fn test_bridge_config_from_azure_params() -> anyhow::Result<()> {
         use_mapper: true,
         use_agent: false,
         topics: vec![
-            r#"messages/events/# out 1 az/ devices/alpha/"#.into(),
-            r##"messages/devicebound/# in 1 az/ devices/alpha/"##.into(),
-            r##"methods/POST/# in 1 az/ $iothub/"##.into(),
-            r##"methods/res/# out 1 az/ $iothub/"##.into(),
-            r##"twin/res/# in 1 az/ $iothub/"##.into(),
-            r##"twin/GET/# out 1 az/ $iothub/"##.into(),
-            r##"twin/PATCH/# out 1 az/ $iothub/"##.into(),
+            "messages/events/# out 1 az/ devices/alpha/".into(),
+            "messages/devicebound/# in 1 az/ devices/alpha/".into(),
+            "methods/POST/# in 1 az/ $iothub/".into(),
+            "methods/res/# out 1 az/ $iothub/".into(),
+            "twin/res/# in 1 az/ $iothub/".into(),
+            "twin/GET/# out 1 az/ $iothub/".into(),
+            "twin/PATCH/# out 1 az/ $iothub/".into(),
         ],
         try_private: false,
         start_type: "automatic".into(),

--- a/crates/core/tedge/src/cli/common.rs
+++ b/crates/core/tedge/src/cli/common.rs
@@ -17,10 +17,6 @@ impl Cloud {
         }
     }
 
-    pub fn as_str(self) -> &'static str {
-        self.into()
-    }
-
     pub fn bridge_config_filename(&self) -> &str {
         match self {
             Self::C8y => crate::bridge::C8Y_CONFIG_FILENAME,

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -54,9 +54,9 @@ pub enum DeviceStatus {
 impl Command for ConnectCommand {
     fn description(&self) -> String {
         if self.is_test_connection {
-            format!("test connection to {} cloud.", self.cloud.as_str())
+            format!("test connection to {} cloud.", self.cloud)
         } else {
-            format!("connect {} cloud.", self.cloud.as_str())
+            format!("connect to {} cloud.", self.cloud)
         }
     }
 
@@ -68,8 +68,8 @@ impl Command for ConnectCommand {
         if self.is_test_connection {
             // If the bridge is part of the mapper, the bridge config file won't exist
             // TODO tidy me up once mosquitto is no longer required for bridge
-            if self.check_if_bridge_exists(&bridge_config) {
-                return match self.check_connection(config) {
+            return if self.check_if_bridge_exists(&bridge_config) {
+                match self.check_connection(config) {
                     Ok(DeviceStatus::AlreadyExists) => {
                         let cloud = bridge_config.cloud_name;
                         println!("Connection check to {} cloud is successful.\n", cloud);
@@ -77,13 +77,13 @@ impl Command for ConnectCommand {
                     }
                     Ok(DeviceStatus::Unknown) => Err(ConnectError::UnknownDeviceStatus.into()),
                     Err(err) => Err(err.into()),
-                };
+                }
             } else {
-                return Err((ConnectError::DeviceNotConnected {
-                    cloud: self.cloud.as_str().into(),
+                Err((ConnectError::DeviceNotConnected {
+                    cloud: self.cloud.to_string(),
                 })
-                .into());
-            }
+                .into())
+            };
         }
 
         let device_type = &config.device.ty;
@@ -119,7 +119,7 @@ impl Command for ConnectCommand {
                 _ => {
                     println!(
                         "Warning: Bridge has been configured, but {} connection check failed.\n",
-                        self.cloud.as_str()
+                        self.cloud
                     );
                 }
             }
@@ -139,7 +139,6 @@ impl Command for ConnectCommand {
                         .c8y
                         .mqtt
                         .or_none()
-                        .cloned()
                         .map(|u| u.to_string())
                         .unwrap_or_default(),
                 );

--- a/crates/core/tedge/src/cli/disconnect/cli.rs
+++ b/crates/core/tedge/src/cli/disconnect/cli.rs
@@ -19,6 +19,7 @@ pub enum TEdgeDisconnectBridgeCli {
 
 impl BuildCommand for TEdgeDisconnectBridgeCli {
     fn build_command(self, context: BuildContext) -> Result<Box<dyn Command>, crate::ConfigError> {
+        let tedge_config = context.load_config()?;
         let cmd = match self {
             TEdgeDisconnectBridgeCli::C8y => DisconnectBridgeCommand {
                 config_location: context.config_location.clone(),
@@ -27,6 +28,7 @@ impl BuildCommand for TEdgeDisconnectBridgeCli {
                 use_mapper: true,
                 use_agent: true,
                 service_manager: service_manager(&context.config_location.tedge_config_root_path)?,
+                built_in_bridge: tedge_config.mqtt.bridge.built_in,
             },
             TEdgeDisconnectBridgeCli::Az => DisconnectBridgeCommand {
                 config_location: context.config_location.clone(),
@@ -35,6 +37,7 @@ impl BuildCommand for TEdgeDisconnectBridgeCli {
                 use_mapper: true,
                 use_agent: false,
                 service_manager: service_manager(&context.config_location.tedge_config_root_path)?,
+                built_in_bridge: tedge_config.mqtt.bridge.built_in,
             },
             TEdgeDisconnectBridgeCli::Aws => DisconnectBridgeCommand {
                 config_location: context.config_location.clone(),
@@ -43,6 +46,7 @@ impl BuildCommand for TEdgeDisconnectBridgeCli {
                 use_mapper: true,
                 use_agent: false,
                 service_manager: service_manager(&context.config_location.tedge_config_root_path)?,
+                built_in_bridge: tedge_config.mqtt.bridge.built_in,
             },
         };
         Ok(cmd.into_boxed())

--- a/crates/core/tedge/src/cli/disconnect/disconnect_bridge.rs
+++ b/crates/core/tedge/src/cli/disconnect/disconnect_bridge.rs
@@ -16,6 +16,7 @@ pub struct DisconnectBridgeCommand {
     pub use_mapper: bool,
     pub use_agent: bool,
     pub service_manager: Arc<dyn SystemServiceManager>,
+    pub built_in_bridge: bool,
 }
 
 impl Command for DisconnectBridgeCommand {
@@ -84,8 +85,12 @@ impl DisconnectBridgeCommand {
             // If bridge config file was not found we assume that the bridge doesn't exist,
             // We finish early returning exit code 0.
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                println!("Bridge doesn't exist. Operation finished!");
-                Err(DisconnectBridgeError::BridgeFileDoesNotExist)
+                if self.built_in_bridge {
+                    Ok(())
+                } else {
+                    println!("Bridge doesn't exist. Operation finished!");
+                    Err(DisconnectBridgeError::BridgeFileDoesNotExist)
+                }
             }
 
             Err(e) => Err(DisconnectBridgeError::FileOperationFailed(

--- a/crates/core/tedge/src/cli/reconnect/command.rs
+++ b/crates/core/tedge/src/cli/reconnect/command.rs
@@ -45,6 +45,7 @@ impl From<&ReconnectBridgeCommand> for DisconnectBridgeCommand {
             use_mapper: reconnect_cmd.use_mapper,
             use_agent: reconnect_cmd.use_agent,
             service_manager: reconnect_cmd.service_manager.clone(),
+            built_in_bridge: reconnect_cmd.config.mqtt.bridge.built_in,
         }
     }
 }

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -25,7 +25,6 @@ collectd_ext = { workspace = true }
 flockfile = { workspace = true }
 mqtt_channel = { workspace = true }
 reqwest = { workspace = true }
-rumqttc = { workspace = true }
 tedge_actors = { workspace = true }
 tedge_api = { workspace = true }
 tedge_config = { workspace = true }

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -25,6 +25,7 @@ collectd_ext = { workspace = true }
 flockfile = { workspace = true }
 mqtt_channel = { workspace = true }
 reqwest = { workspace = true }
+rumqttc = { workspace = true }
 tedge_actors = { workspace = true }
 tedge_api = { workspace = true }
 tedge_config = { workspace = true }

--- a/crates/core/tedge_mapper/src/aws/mapper.rs
+++ b/crates/core/tedge_mapper/src/aws/mapper.rs
@@ -36,7 +36,7 @@ impl TEdgeComponent for AwsMapper {
             let device_id = tedge_config.device.id.try_read(&tedge_config)?;
             let rules = built_in_bridge_rules(device_id)?;
 
-            let mut cloud_config = rumqttc::MqttOptions::new(
+            let mut cloud_config = tedge_mqtt_bridge::MqttOptions::new(
                 tedge_config.device.id.try_read(&tedge_config)?,
                 tedge_config.aws.url.or_config_not_set()?.to_string(),
                 8883,

--- a/crates/core/tedge_mapper/src/aws/mapper.rs
+++ b/crates/core/tedge_mapper/src/aws/mapper.rs
@@ -10,6 +10,8 @@ use tedge_actors::MessageSource;
 use tedge_actors::NoConfig;
 use tedge_api::mqtt_topics::MqttSchema;
 use tedge_config::TEdgeConfig;
+use tedge_mqtt_bridge::BridgeConfig;
+use tedge_mqtt_bridge::MqttBridgeActorBuilder;
 use tracing::warn;
 
 const AWS_MAPPER_NAME: &str = "tedge-mapper-aws";
@@ -29,6 +31,18 @@ impl TEdgeComponent for AwsMapper {
     ) -> Result<(), anyhow::Error> {
         let (mut runtime, mut mqtt_actor) =
             start_basic_actors(self.session_name(), &tedge_config).await?;
+        if tedge_config.mqtt.bridge.built_in {
+            let device_id = tedge_config.device.id.try_read(&tedge_config)?;
+            let rules = built_in_bridge_rules(device_id)?;
+            let bridge_actor = MqttBridgeActorBuilder::new(
+                &tedge_config,
+                "tedge-mapper-bridge-az".to_owned(),
+                rules,
+                &tedge_config.az.root_cert_path,
+            )
+            .await;
+            runtime.spawn(bridge_actor).await?;
+        }
         let clock = Box::new(WallClock);
         let mqtt_schema = MqttSchema::with_root(tedge_config.mqtt.topic_root.clone());
         let aws_converter = AwsConverter::new(
@@ -57,4 +71,31 @@ fn get_topic_filter(tedge_config: &TEdgeConfig) -> TopicFilter {
         }
     }
     topics
+}
+
+fn built_in_bridge_rules(remote_client_id: &str) -> Result<BridgeConfig, anyhow::Error> {
+    let local_prefix = "aws/";
+    let device_id_prefix = format!("thinedge/{remote_client_id}/");
+    let things_prefix = format!("$aws/things/{remote_client_id}/");
+    let conn_check = format!("thinedge/devices/{remote_client_id}/test-connection");
+    let mut bridge = BridgeConfig::new();
+
+    // telemetry/command topics for use by the user
+    bridge.forward_from_local("td/#", local_prefix, device_id_prefix.clone())?;
+    bridge.forward_from_remote("cmd/#", local_prefix, device_id_prefix)?;
+
+    // topic to interact with the shadow of the device
+    bridge.forward_from_local("shadow/#", local_prefix, things_prefix.clone())?;
+    bridge.forward_from_remote("shadow/#", local_prefix, things_prefix)?;
+
+    // echo topic mapping to check the connection
+    bridge.forward_from_local("", "aws/test-connection", conn_check.clone())?;
+    bridge.forward_from_remote("", "aws/connection-success", conn_check)?;
+
+    Ok(bridge)
+}
+
+#[test]
+fn bridge_rules_are_valid() {
+    built_in_bridge_rules("test-device-id").unwrap();
 }

--- a/crates/core/tedge_mapper/src/az/mapper.rs
+++ b/crates/core/tedge_mapper/src/az/mapper.rs
@@ -10,6 +10,8 @@ use tedge_actors::MessageSource;
 use tedge_actors::NoConfig;
 use tedge_api::mqtt_topics::MqttSchema;
 use tedge_config::TEdgeConfig;
+use tedge_mqtt_bridge::BridgeConfig;
+use tedge_mqtt_bridge::MqttBridgeActorBuilder;
 use tracing::warn;
 
 const AZURE_MAPPER_NAME: &str = "tedge-mapper-az";
@@ -29,6 +31,19 @@ impl TEdgeComponent for AzureMapper {
     ) -> Result<(), anyhow::Error> {
         let (mut runtime, mut mqtt_actor) =
             start_basic_actors(self.session_name(), &tedge_config).await?;
+        if tedge_config.mqtt.bridge.built_in {
+            let remote_clientid = tedge_config.device.id.try_read(&tedge_config)?;
+            let rules = built_in_bridge_rules(remote_clientid)?;
+
+            let bridge_actor = MqttBridgeActorBuilder::new(
+                &tedge_config,
+                "tedge-mapper-bridge-az".to_owned(),
+                rules,
+                &tedge_config.az.root_cert_path,
+            )
+            .await;
+            runtime.spawn(bridge_actor).await?;
+        }
         let mqtt_schema = MqttSchema::with_root(tedge_config.mqtt.topic_root.clone());
         let az_converter = AzureConverter::new(
             tedge_config.az.mapper.timestamp,
@@ -55,4 +70,28 @@ fn get_topic_filter(tedge_config: &TEdgeConfig) -> TopicFilter {
         }
     }
     topics
+}
+
+fn built_in_bridge_rules(remote_clientid: &str) -> anyhow::Result<BridgeConfig> {
+    let local_prefix = "az/";
+    let iothub_prefix = "$iothub/";
+    let device_id_prefix = format!("devices/{remote_clientid}/");
+    let mut bridge = BridgeConfig::new();
+    bridge.forward_from_local("messages/events/#", local_prefix, device_id_prefix.clone())?;
+    bridge.forward_from_remote("messages/devicebound/#", local_prefix, device_id_prefix)?;
+    // Direct methods (request/response)
+    bridge.forward_from_local("methods/res/#", local_prefix, iothub_prefix)?;
+    bridge.forward_from_remote("methods/POST/#", local_prefix, iothub_prefix)?;
+
+    // Digital twin
+    bridge.forward_from_local("twin/GET/#", local_prefix, iothub_prefix)?;
+    bridge.forward_from_local("twin/PATCH/#", local_prefix, iothub_prefix)?;
+    bridge.forward_from_remote("twin/res/#", local_prefix, iothub_prefix)?;
+
+    Ok(bridge)
+}
+
+#[test]
+fn bridge_rules_are_valid() {
+    built_in_bridge_rules("test-device-id").unwrap();
 }

--- a/crates/core/tedge_mapper/src/az/mapper.rs
+++ b/crates/core/tedge_mapper/src/az/mapper.rs
@@ -36,7 +36,7 @@ impl TEdgeComponent for AzureMapper {
             let remote_clientid = tedge_config.device.id.try_read(&tedge_config)?;
             let rules = built_in_bridge_rules(remote_clientid)?;
 
-            let mut cloud_config = rumqttc::MqttOptions::new(
+            let mut cloud_config = tedge_mqtt_bridge::MqttOptions::new(
                 remote_clientid,
                 tedge_config.az.url.or_config_not_set()?.to_string(),
                 8883,

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -74,15 +74,11 @@ impl TEdgeComponent for CumulocityMapper {
 
             tc.forward_from_local("#", local_prefix, "")?;
 
-            let mut cloud_config = rumqttc::MqttOptions::new(
+            let c8y = tedge_config.c8y.mqtt.or_config_not_set()?;
+            let mut cloud_config = tedge_mqtt_bridge::MqttOptions::new(
                 tedge_config.device.id.try_read(&tedge_config)?,
-                tedge_config
-                    .c8y
-                    .mqtt
-                    .or_config_not_set()?
-                    .host()
-                    .to_string(),
-                8883,
+                c8y.host().to_string(),
+                c8y.port().into(),
             );
             // Cumulocity tells us not to not set clean session to false, so don't
             // https://cumulocity.com/docs/device-integration/mqtt/#mqtt-clean-session

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -10,12 +10,14 @@ use c8y_mapper_ext::compatibility_adapter::OldAgentAdapter;
 use c8y_mapper_ext::config::C8yMapperConfig;
 use c8y_mapper_ext::converter::CumulocityConverter;
 use mqtt_channel::Config;
+use std::borrow::Cow;
 use tedge_api::entity_store::EntityExternalId;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_config::TEdgeConfig;
 use tedge_downloader_ext::DownloaderActor;
 use tedge_file_system_ext::FsWatchActorBuilder;
 use tedge_http_ext::HttpActor;
+use tedge_mqtt_bridge::BridgeConfig;
 use tedge_mqtt_bridge::MqttBridgeActorBuilder;
 use tedge_mqtt_ext::MqttActorBuilder;
 use tedge_timer_ext::TimerActor;
@@ -48,24 +50,34 @@ impl TEdgeComponent for CumulocityMapper {
                 .templates
                 .0
                 .iter()
-                .map(|id| format!("s/dc/{id}"));
-            let smartrest_topics: Vec<String> = [
+                .map(|id| Cow::Owned(format!("s/dc/{id}")));
+
+            let cloud_topics = [
                 "s/dt",
                 "s/dat",
                 "s/ds",
                 "s/e",
-                "s/dc/#",
                 "devicecontrol/notifications",
                 "error",
             ]
             .into_iter()
-            .map(<_>::to_owned)
-            .chain(custom_topics)
-            .collect();
+            .map(Cow::Borrowed)
+            .chain(custom_topics);
+
+            let mut tc = BridgeConfig::new();
+            let local_prefix = format!("{}/", tedge_config.c8y.bridge.topic_prefix.as_str());
+
+            for topic in cloud_topics {
+                tc.forward_from_remote(topic, local_prefix.clone(), "")?;
+            }
+
+            tc.forward_from_local("#", local_prefix, "")?;
+
             let bridge_actor = MqttBridgeActorBuilder::new(
                 &tedge_config,
                 c8y_mapper_config.bridge_service_name(),
-                &smartrest_topics,
+                tc,
+                &tedge_config.c8y.root_cert_path,
             )
             .await;
             runtime.spawn(bridge_actor).await?;

--- a/crates/extensions/c8y_firmware_manager/src/tests.rs
+++ b/crates/extensions/c8y_firmware_manager/src/tests.rs
@@ -530,7 +530,7 @@ async fn required_init_state_recreated_on_startup() -> Result<(), DynError> {
     // Assert that the startup succeeds and the plugin requests for pending operations
     mqtt_message_box
         .assert_received([MqttMessage::new(
-            &C8yTopic::upstream_topic(&"c8y".into()),
+            &C8yTopic::upstream_topic(&"c8y".try_into().unwrap()),
             "500",
         )])
         .await;
@@ -555,7 +555,7 @@ async fn required_init_state_recreated_on_startup() -> Result<(), DynError> {
     // Assert that the startup succeeds again and the mapper requests for pending operations
     mqtt_message_box
         .assert_received([MqttMessage::new(
-            &C8yTopic::upstream_topic(&"c8y".into()),
+            &C8yTopic::upstream_topic(&"c8y".try_into().unwrap()),
             "500",
         )])
         .await;
@@ -643,7 +643,7 @@ async fn spawn_firmware_manager(
         tmp_dir.utf8_path_buf().into(),
         timeout_sec,
         C8Y_HOST.into(),
-        "c8y".into(),
+        "c8y".try_into().unwrap(),
     );
 
     let mut mqtt_builder: SimpleMessageBoxBuilder<MqttMessage, MqttMessage> =

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -120,7 +120,6 @@ impl C8yMapperConfig {
         }
     }
 
-    // TODO don't allocate string
     pub fn bridge_service_name(&self) -> String {
         if self.bridge_in_mapper {
             format!("tedge-mapper-bridge-{}", self.c8y_prefix)

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -2445,7 +2445,7 @@ pub(crate) mod tests {
         let mut config = c8y_converter_config(&tmp_dir);
         let tedge_config = TEdgeConfig::load_toml_str("service.ty = \"\"");
         config.service = tedge_config.service.clone();
-        config.c8y_prefix = "custom-topic".into();
+        config.c8y_prefix = "custom-topic".try_into().unwrap();
 
         let (mut converter, _) = create_c8y_converter_from_config(config);
         let event_topic = "te/device/main///e/click_event";
@@ -2788,7 +2788,7 @@ pub(crate) mod tests {
             ChannelFilter::Command(OperationType::SoftwareUpdate),
         );
         let mqtt_message = MqttMessage::new(
-            &C8yDeviceControlTopic::topic(&"c8y".into()),
+            &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
             json!({
                 "id": "123456",
                 "c8y_SoftwareUpdate": [
@@ -2932,7 +2932,7 @@ pub(crate) mod tests {
         let output = converter.convert(&service_health_message).await;
         let service_creation_message = output
             .into_iter()
-            .find(|m| m.topic == C8yTopic::upstream_topic(&"c8y".into()))
+            .find(|m| m.topic == C8yTopic::upstream_topic(&"c8y".try_into().unwrap()))
             .expect("service creation message should be present");
 
         let mut smartrest_fields = service_creation_message.payload_str().unwrap().split(',');
@@ -3057,7 +3057,7 @@ pub(crate) mod tests {
         let tmp_dir = TempTedgeDir::new();
         let mut config = c8y_converter_config(&tmp_dir);
         config.enable_auto_register = false;
-        config.c8y_prefix = "custom-c8y-prefix".into();
+        config.c8y_prefix = "custom-c8y-prefix".try_into().unwrap();
 
         let (mut converter, _http_proxy) = create_c8y_converter_from_config(config);
 
@@ -3240,9 +3240,11 @@ pub(crate) mod tests {
         let auth_proxy_addr = "127.0.0.1".into();
         let auth_proxy_port = 8001;
         let auth_proxy_protocol = Protocol::Http;
-        let topics =
-            C8yMapperConfig::default_internal_topic_filter(&tmp_dir.to_path_buf(), &"c8y".into())
-                .unwrap();
+        let topics = C8yMapperConfig::default_internal_topic_filter(
+            &tmp_dir.to_path_buf(),
+            &"c8y".try_into().unwrap(),
+        )
+        .unwrap();
 
         C8yMapperConfig::new(
             tmp_dir.utf8_path().into(),
@@ -3263,7 +3265,7 @@ pub(crate) mod tests {
             MqttSchema::default(),
             true,
             true,
-            "c8y".into(),
+            "c8y".try_into().unwrap(),
             false,
             SoftwareManagementApiFlag::Advanced,
             true,

--- a/crates/extensions/c8y_mapper_ext/src/operations/config_snapshot.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/config_snapshot.rs
@@ -305,7 +305,7 @@ mod tests {
 
         // Simulate c8y_UploadConfigFile operation delivered via JSON over MQTT
         mqtt.send(MqttMessage::new(
-            &C8yDeviceControlTopic::topic(&"c8y".into()),
+            &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
             json!({
                 "id": "123456",
                 "c8y_UploadConfigFile": {
@@ -355,7 +355,7 @@ mod tests {
 
         // Simulate c8y_UploadConfigFile operation delivered via JSON over MQTT
         mqtt.send(MqttMessage::new(
-            &C8yDeviceControlTopic::topic(&"c8y".into()),
+            &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
             json!({
                 "id": "123456",
                 "c8y_UploadConfigFile": {

--- a/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
@@ -184,7 +184,7 @@ mod tests {
 
         // Simulate c8y_DownloadConfigFile operation delivered via JSON over MQTT
         mqtt.send(MqttMessage::new(
-            &C8yDeviceControlTopic::topic(&"c8y".into()),
+            &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
             json!({
                 "id": "123456",
                 "c8y_DownloadConfigFile": {
@@ -235,7 +235,7 @@ mod tests {
 
         // Simulate c8y_DownloadConfigFile operation delivered via JSON over MQTT
         mqtt.send(MqttMessage::new(
-            &C8yDeviceControlTopic::topic(&"c8y".into()),
+            &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
             json!({
                 "id": "123456",
                 "c8y_DownloadConfigFile": {

--- a/crates/extensions/c8y_mapper_ext/src/operations/firmware_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/firmware_update.rs
@@ -272,7 +272,7 @@ mod tests {
 
         // Simulate c8y_Firmware operation delivered via JSON over MQTT
         mqtt.send(MqttMessage::new(
-            &C8yDeviceControlTopic::topic(&"c8y".into()),
+            &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
             json!({
                 "id": "123456",
                 "c8y_Firmware": {
@@ -316,7 +316,7 @@ mod tests {
 
         // Simulate c8y_Firmware operation delivered via JSON over MQTT
         mqtt.send(MqttMessage::new(
-            &C8yDeviceControlTopic::topic(&"c8y".into()),
+            &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
             json!({
                 "id": "123456",
                 "c8y_Firmware": {
@@ -370,7 +370,7 @@ mod tests {
 
         // Simulate c8y_Firmware operation delivered via JSON over MQTT
         mqtt.send(MqttMessage::new(
-            &C8yDeviceControlTopic::topic(&"c8y".into()),
+            &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
             json!({
                 "id": "123456",
                 "c8y_Firmware": {

--- a/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
@@ -325,7 +325,7 @@ mod tests {
 
         // Simulate c8y_LogfileRequest JSON over MQTT request
         mqtt.send(MqttMessage::new(
-            &C8yDeviceControlTopic::topic(&"c8y".into()),
+            &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
             json!({
                 "id": "123456",
                 "c8y_LogfileRequest": {
@@ -382,7 +382,7 @@ mod tests {
 
         // Simulate c8y_LogfileRequest JSON over MQTT request
         mqtt.send(MqttMessage::new(
-            &C8yDeviceControlTopic::topic(&"c8y".into()),
+            &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
             json!({
                 "id": "123456",
                 "c8y_LogfileRequest": {

--- a/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
@@ -183,7 +183,7 @@ mod tests {
             entity,
             &ancestors_external_ids,
             &health_message,
-            &"c8y".into(),
+            &"c8y".try_into().unwrap(),
         );
         assert_eq!(msg[0], expected_message);
     }

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -374,7 +374,7 @@ async fn mapper_publishes_software_update_request() {
 
     // Simulate c8y_SoftwareUpdate JSON over MQTT request
     mqtt.send(MqttMessage::new(
-        &C8yDeviceControlTopic::topic(&"c8y".into()),
+        &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
         json!({
             "id": "123456",
             "c8y_SoftwareUpdate": [
@@ -533,7 +533,7 @@ async fn mapper_publishes_software_update_request_with_wrong_action() {
 
     // Publish a c8y_SoftwareUpdate via JSON over MQTT that contains a wrong action `remove`, that is not known by c8y.
     mqtt.send(MqttMessage::new(
-        &C8yDeviceControlTopic::topic(&"c8y".into()),
+        &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
         json!({
             "id": "123456",
             "c8y_SoftwareUpdate": [
@@ -1429,7 +1429,7 @@ async fn mapper_handles_multiple_modules_in_update_list_sm_requests() {
 
     // Publish multiple modules software update via JSON over MQTT.
     mqtt.send(MqttMessage::new(
-        &C8yDeviceControlTopic::topic(&"c8y".into()),
+        &C8yDeviceControlTopic::topic(&"c8y".try_into().unwrap()),
         json!({
             "id": "123456",
             "c8y_SoftwareUpdate": [
@@ -1877,7 +1877,7 @@ async fn custom_operation_without_timeout_successful() {
 
     // Simulate c8y_Command SmartREST request
     mqtt.send(MqttMessage::new(
-        &C8yTopic::downstream_topic(&"c8y".into()),
+        &C8yTopic::downstream_topic(&"c8y".try_into().unwrap()),
         "511,test-device,c8y_Command",
     ))
     .await
@@ -1938,7 +1938,7 @@ async fn custom_operation_with_timeout_successful() {
 
     // Simulate c8y_Command SmartREST request
     mqtt.send(MqttMessage::new(
-        &C8yTopic::downstream_topic(&"c8y".into()),
+        &C8yTopic::downstream_topic(&"c8y".try_into().unwrap()),
         "511,test-device,c8y_Command",
     ))
     .await
@@ -1998,7 +1998,7 @@ async fn custom_operation_timeout_sigterm() {
 
     // Simulate c8y_Command SmartREST request
     mqtt.send(MqttMessage::new(
-        &C8yTopic::downstream_topic(&"c8y".into()),
+        &C8yTopic::downstream_topic(&"c8y".try_into().unwrap()),
         "511,test-device,c8y_Command",
     ))
     .await
@@ -2064,7 +2064,7 @@ async fn custom_operation_timeout_sigkill() {
 
     // Simulate c8y_Command SmartREST request
     mqtt.send(MqttMessage::new(
-        &C8yTopic::downstream_topic(&"c8y".into()),
+        &C8yTopic::downstream_topic(&"c8y".try_into().unwrap()),
         "511,test-device,c8y_Command",
     ))
     .await
@@ -2512,8 +2512,11 @@ pub(crate) async fn spawn_c8y_mapper_actor(
     let mqtt_schema = MqttSchema::default();
     let auth_proxy_addr = "127.0.0.1".into();
     let auth_proxy_port = 8001;
-    let mut topics =
-        C8yMapperConfig::default_internal_topic_filter(config_dir.path(), &"c8y".into()).unwrap();
+    let mut topics = C8yMapperConfig::default_internal_topic_filter(
+        config_dir.path(),
+        &"c8y".try_into().unwrap(),
+    )
+    .unwrap();
     topics.add_all(crate::operations::log_upload::log_upload_topic_filter(
         &mqtt_schema,
     ));
@@ -2542,7 +2545,7 @@ pub(crate) async fn spawn_c8y_mapper_actor(
         MqttSchema::default(),
         true,
         true,
-        "c8y".into(),
+        "c8y".try_into().unwrap(),
         false,
         SoftwareManagementApiFlag::Advanced,
         true,

--- a/crates/extensions/tedge_mqtt_bridge/Cargo.toml
+++ b/crates/extensions/tedge_mqtt_bridge/Cargo.toml
@@ -22,6 +22,7 @@ rumqttc = { workspace = true }
 tedge_actors = { workspace = true }
 tedge_api = { workspace = true }
 tedge_config = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, default_features = false, features = ["macros"] }
 tracing = { workspace = true }
 

--- a/crates/extensions/tedge_mqtt_bridge/Cargo.toml
+++ b/crates/extensions/tedge_mqtt_bridge/Cargo.toml
@@ -14,6 +14,7 @@ repository = { workspace = true }
 default = []
 
 [dependencies]
+anyhow = { workspace = true }
 async-trait = { workspace = true }
 certificate = { workspace = true }
 futures = { workspace = true }
@@ -25,6 +26,13 @@ tedge_config = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, default_features = false, features = ["macros"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+env_logger = { workspace = true }
+mockall = { workspace = true }
+rumqttd = { workspace = true }
+serde_json = { workspace = true }
+tedge_test_utils = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/extensions/tedge_mqtt_bridge/Cargo.toml
+++ b/crates/extensions/tedge_mqtt_bridge/Cargo.toml
@@ -19,6 +19,7 @@ async-trait = { workspace = true }
 certificate = { workspace = true }
 futures = { workspace = true }
 mqtt_channel = { workspace = true }
+mutants = { workspace = true }
 rumqttc = { workspace = true }
 tedge_actors = { workspace = true }
 tedge_api = { workspace = true }
@@ -30,6 +31,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 env_logger = { workspace = true }
 mockall = { workspace = true }
+rcgen = { workspace = true }
 rumqttd = { workspace = true }
 serde_json = { workspace = true }
 tedge_test_utils = { workspace = true }

--- a/crates/extensions/tedge_mqtt_bridge/src/config.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/config.rs
@@ -1,0 +1,361 @@
+use crate::topics::matches_ignore_dollar_prefix;
+use crate::topics::prepend;
+use crate::topics::TopicConverter;
+use certificate::parse_root_certificate::create_tls_config;
+use rumqttc::valid_filter;
+use rumqttc::valid_topic;
+use rumqttc::MqttOptions;
+use rumqttc::Transport;
+use std::borrow::Cow;
+use std::path::Path;
+use tedge_config::TEdgeConfig;
+
+pub fn use_key_and_cert(
+    config: &mut MqttOptions,
+    root_cert_path: impl AsRef<Path>,
+    tedge_config: &TEdgeConfig,
+) -> anyhow::Result<()> {
+    let tls_config = create_tls_config(
+        root_cert_path,
+        &tedge_config.device.key_path,
+        &tedge_config.device.cert_path,
+    )?;
+    config.set_transport(Transport::tls_with_config(tls_config.into()));
+    Ok(())
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct BridgeConfig {
+    local_to_remote: Vec<BridgeRule>,
+    remote_to_local: Vec<BridgeRule>,
+    bidirectional_topics: Vec<(Cow<'static, str>, Cow<'static, str>)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BridgeRule {
+    topic_filter: Cow<'static, str>,
+    prefix_to_remove: Cow<'static, str>,
+    prefix_to_add: Cow<'static, str>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidBridgeRule {
+    #[error("{0:?} is not a valid MQTT bridge topic prefix as is missing a trailing slash")]
+    MissingTrailingSlash(Cow<'static, str>),
+
+    #[error(
+    "{0:?} is not a valid rule, at least one of the topic filter or both prefixes must be non-empty"
+    )]
+    Empty(BridgeRule),
+
+    #[error("{0:?} is not a valid MQTT bridge topic prefix because it contains '+' or '#'")]
+    InvalidTopicPrefix(String),
+
+    #[error("{0:?} is not a valid MQTT bridge topic filter")]
+    InvalidTopicFilter(String),
+}
+
+fn validate_topic(topic: &str) -> Result<(), InvalidBridgeRule> {
+    match valid_topic(topic) {
+        true => Ok(()),
+        false => Err(InvalidBridgeRule::InvalidTopicPrefix(topic.to_owned())),
+    }
+}
+
+fn validate_filter(topic: &str) -> Result<(), InvalidBridgeRule> {
+    match valid_filter(topic) {
+        true => Ok(()),
+        false => Err(InvalidBridgeRule::InvalidTopicFilter(topic.to_owned())),
+    }
+}
+
+impl BridgeRule {
+    fn try_new(
+        base_topic_filter: Cow<'static, str>,
+        prefix_to_remove: Cow<'static, str>,
+        prefix_to_add: Cow<'static, str>,
+    ) -> Result<Self, InvalidBridgeRule> {
+        let filter_is_empty = base_topic_filter.is_empty();
+        let mut r = Self {
+            topic_filter: prepend(base_topic_filter.clone(), &prefix_to_remove),
+            prefix_to_remove,
+            prefix_to_add,
+        };
+
+        validate_topic(&r.prefix_to_add)?;
+        validate_topic(&r.prefix_to_remove)?;
+        if filter_is_empty {
+            if r.prefix_to_add.is_empty() || r.prefix_to_remove.is_empty() {
+                r.topic_filter = base_topic_filter;
+                Err(InvalidBridgeRule::Empty(r))
+            } else {
+                Ok(r)
+            }
+        } else if !(r.prefix_to_remove.ends_with('/') || r.prefix_to_remove.is_empty()) {
+            Err(InvalidBridgeRule::MissingTrailingSlash(r.prefix_to_remove))
+        } else if !(r.prefix_to_add.ends_with('/') || r.prefix_to_add.is_empty()) {
+            Err(InvalidBridgeRule::MissingTrailingSlash(r.prefix_to_add))
+        } else {
+            validate_filter(&base_topic_filter)?;
+            Ok(r)
+        }
+    }
+
+    pub fn apply<'a>(&self, topic: &'a str) -> Option<Cow<'a, str>> {
+        matches_ignore_dollar_prefix(topic, &self.topic_filter).then(|| {
+            prepend(
+                topic.strip_prefix(&*self.prefix_to_remove).unwrap().into(),
+                &self.prefix_to_add,
+            )
+        })
+    }
+}
+
+impl BridgeConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn forward_from_local(
+        &mut self,
+        topic: impl Into<Cow<'static, str>>,
+        local_prefix: impl Into<Cow<'static, str>>,
+        remote_prefix: impl Into<Cow<'static, str>>,
+    ) -> Result<(), InvalidBridgeRule> {
+        self.local_to_remote.push(BridgeRule::try_new(
+            topic.into(),
+            local_prefix.into(),
+            remote_prefix.into(),
+        )?);
+        Ok(())
+    }
+
+    pub fn forward_from_remote(
+        &mut self,
+        topic: impl Into<Cow<'static, str>>,
+        local_prefix: impl Into<Cow<'static, str>>,
+        remote_prefix: impl Into<Cow<'static, str>>,
+    ) -> Result<(), InvalidBridgeRule> {
+        self.remote_to_local.push(BridgeRule::try_new(
+            topic.into(),
+            remote_prefix.into(),
+            local_prefix.into(),
+        )?);
+        Ok(())
+    }
+
+    /// Forwards the message in both directions, ensuring that an infinite loop is avoided
+    ///
+    /// Because this method keeps track of the topic so we don't create an infinite loop of messages
+    /// this is not equivalent to calling [forward_from_local] and [forward_from_remote] in sequence.
+    pub fn forward_bidirectionally(
+        &mut self,
+        topic: impl Into<Cow<'static, str>>,
+        local_prefix: impl Into<Cow<'static, str>>,
+        remote_prefix: impl Into<Cow<'static, str>>,
+    ) -> Result<(), InvalidBridgeRule> {
+        let topic = topic.into();
+        let local_prefix = local_prefix.into();
+        let remote_prefix = remote_prefix.into();
+        self.bidirectional_topics.push((
+            prepend(topic.clone(), &local_prefix),
+            prepend(topic.clone(), &remote_prefix),
+        ));
+        self.forward_from_local(topic.clone(), local_prefix.clone(), remote_prefix.clone())?;
+        self.forward_from_remote(topic, local_prefix, remote_prefix)?;
+        Ok(())
+    }
+
+    pub fn local_subscriptions(&self) -> impl Iterator<Item = &str> {
+        self.local_to_remote
+            .iter()
+            .map(|rule| rule.topic_filter.as_ref())
+    }
+
+    pub fn remote_subscriptions(&self) -> impl Iterator<Item = &str> {
+        self.remote_to_local.iter().map(|rule| &*rule.topic_filter)
+    }
+
+    pub(super) fn converters_and_bidirectional_topic_filters(
+        self,
+    ) -> [(TopicConverter, Vec<Cow<'static, str>>); 2] {
+        let Self {
+            local_to_remote,
+            remote_to_local,
+            bidirectional_topics,
+        } = self;
+
+        let (bidir_local_topics, bidir_remote_topics) = bidirectional_topics.into_iter().unzip();
+        [
+            (TopicConverter(local_to_remote), bidir_local_topics),
+            (TopicConverter(remote_to_local), bidir_remote_topics),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod bridge_rule {
+        use super::*;
+
+        #[test]
+        fn forward_topics_without_any_prefixes() {
+            let rule = BridgeRule::try_new("a/topic".into(), "".into(), "".into()).unwrap();
+            assert_eq!(rule.apply("a/topic"), Some("a/topic".into()))
+        }
+
+        #[test]
+        fn forwards_wildcard_topics() {
+            let rule = BridgeRule::try_new("a/#".into(), "".into(), "".into()).unwrap();
+            assert_eq!(rule.apply("a/topic"), Some("a/topic".into()));
+        }
+
+        #[test]
+        fn does_not_forward_non_matching_topics() {
+            let rule = BridgeRule::try_new("a/topic".into(), "".into(), "".into()).unwrap();
+            assert_eq!(rule.apply("different/topic"), None)
+        }
+
+        #[test]
+        fn removes_local_prefix() {
+            let rule = BridgeRule::try_new("topic".into(), "a/".into(), "".into()).unwrap();
+            assert_eq!(rule.apply("a/topic"), Some("topic".into()));
+        }
+
+        #[test]
+        fn prepends_remote_prefix() {
+            // TODO maybe debug warn if topic filter begins with prefix to remove
+            let rule = BridgeRule::try_new("topic".into(), "a/".into(), "b/".into()).unwrap();
+            assert_eq!(rule.apply("a/topic"), Some("b/topic".into()));
+        }
+
+        #[test]
+        fn does_not_clone_if_topic_is_unchanged() {
+            let rule = BridgeRule::try_new("a/topic".into(), "".into(), "".into()).unwrap();
+            assert!(matches!(rule.apply("a/topic"), Some(Cow::Borrowed(_))))
+        }
+
+        #[test]
+        fn does_not_clone_if_prefix_is_removed_but_not_added() {
+            let rule = BridgeRule::try_new("topic".into(), "a/".into(), "".into()).unwrap();
+            assert!(matches!(rule.apply("a/topic"), Some(Cow::Borrowed(_))))
+        }
+
+        #[test]
+        fn matches_topics_with_dollar_prefix() {
+            let rule =
+                BridgeRule::try_new("twin/res/#".into(), "$iothub/".into(), "az/".into()).unwrap();
+            assert_eq!(
+                rule.apply("$iothub/twin/res/200/?$rid=1"),
+                Some("az/twin/res/200/?$rid=1".into())
+            )
+        }
+
+        #[test]
+        fn forwards_unfiltered_topic() {
+            let cloud_topic = "thinedge/devices/my-device/test-connection";
+            let rule =
+                BridgeRule::try_new("".into(), "aws/test-connection".into(), cloud_topic.into())
+                    .unwrap();
+            assert_eq!(rule.apply("aws/test-connection"), Some(cloud_topic.into()))
+        }
+
+        #[test]
+        fn allows_empty_input_prefix() {
+            let rule = BridgeRule::try_new("test/#".into(), "".into(), "output/".into()).unwrap();
+            assert_eq!(rule.apply("test/me"), Some("output/test/me".into()));
+        }
+
+        #[test]
+        fn allows_empty_output_prefix() {
+            let rule = BridgeRule::try_new("test/#".into(), "input/".into(), "".into()).unwrap();
+            assert_eq!(rule.apply("input/test/me"), Some("test/me".into()));
+        }
+
+        #[test]
+        fn rejects_invalid_input_topic() {
+            let err = BridgeRule::try_new("test/#".into(), "wildcard/#".into(), "output/".into())
+                .unwrap_err();
+            assert_eq!(err.to_string(), "\"wildcard/#\" is not a valid MQTT bridge topic prefix because it contains '+' or '#'");
+        }
+
+        #[test]
+        fn rejects_invalid_output_topic() {
+            let err = BridgeRule::try_new("test/#".into(), "input/".into(), "wildcard/+".into())
+                .unwrap_err();
+            assert_eq!(err.to_string(), "\"wildcard/+\" is not a valid MQTT bridge topic prefix because it contains '+' or '#'");
+        }
+
+        #[test]
+        fn rejects_input_prefix_missing_trailing_slash() {
+            let err =
+                BridgeRule::try_new("test/#".into(), "input".into(), "output/".into()).unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "\"input\" is not a valid MQTT bridge topic prefix as is missing a trailing slash"
+            );
+        }
+
+        #[test]
+        fn rejects_output_prefix_missing_trailing_slash() {
+            let err =
+                BridgeRule::try_new("test/#".into(), "input/".into(), "output".into()).unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "\"output\" is not a valid MQTT bridge topic prefix as is missing a trailing slash"
+            );
+        }
+
+        #[test]
+        fn rejects_empty_input_topic_with_empty_filter() {
+            let err = BridgeRule::try_new("".into(), "".into(), "a/".into()).unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                r#"BridgeRule { topic_filter: "", prefix_to_remove: "", prefix_to_add: "a/" } is not a valid rule, at least one of the topic filter or both prefixes must be non-empty"#
+            )
+        }
+
+        #[test]
+        fn rejects_empty_output_topic_with_empty_filter() {
+            let err = BridgeRule::try_new("".into(), "a/".into(), "".into()).unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                r#"BridgeRule { topic_filter: "", prefix_to_remove: "a/", prefix_to_add: "" } is not a valid rule, at least one of the topic filter or both prefixes must be non-empty"#
+            )
+        }
+    }
+
+    mod single_converter {
+        use super::*;
+        #[test]
+        fn applies_matching_topic() {
+            let converter = TopicConverter(vec![BridgeRule::try_new(
+                "topic".into(),
+                "a/".into(),
+                "b/".into(),
+            )
+            .unwrap()]);
+            assert_eq!(converter.convert_topic("a/topic"), "b/topic")
+        }
+
+        #[test]
+        fn applies_first_matching_topic_if_multiple_are_provided() {
+            let converter = TopicConverter(vec![
+                BridgeRule::try_new("topic".into(), "a/".into(), "b/".into()).unwrap(),
+                BridgeRule::try_new("#".into(), "a/".into(), "c/".into()).unwrap(),
+            ]);
+            assert_eq!(converter.convert_topic("a/topic"), "b/topic");
+        }
+
+        #[test]
+        fn does_not_apply_non_matching_topics() {
+            let converter = TopicConverter(vec![
+                BridgeRule::try_new("topic".into(), "x/".into(), "b/".into()).unwrap(),
+                BridgeRule::try_new("#".into(), "a/".into(), "c/".into()).unwrap(),
+            ]);
+            assert_eq!(converter.convert_topic("a/topic"), "c/topic");
+        }
+    }
+}

--- a/crates/extensions/tedge_mqtt_bridge/src/health.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/health.rs
@@ -1,0 +1,108 @@
+use crate::overall_status;
+use crate::BidirectionalChannelHalf;
+use crate::Status;
+use futures::channel::mpsc;
+use futures::SinkExt;
+use futures::StreamExt;
+use rumqttc::AsyncClient;
+use rumqttc::ConnectionError;
+use rumqttc::Event;
+use rumqttc::Incoming;
+use rumqttc::QoS;
+use std::collections::HashMap;
+use tracing::error;
+use tracing::log::info;
+
+/// A tool for monitoring and publishing the health of the two bridge halves
+///
+/// When [Self::monitor] runs, this will watch the status of the bridge halves, and notify the
+/// relevant MQTT topic about the overall health.
+pub struct BridgeHealthMonitor<T> {
+    target: AsyncClient,
+    topic: String,
+    rx_status: mpsc::Receiver<(&'static str, Status)>,
+    companion_bridge_half: mpsc::Sender<Option<T>>,
+}
+
+impl<T> BridgeHealthMonitor<T> {
+    pub(crate) fn new(
+        target: AsyncClient,
+        topic: String,
+        bridge_half: &BidirectionalChannelHalf<Option<T>>,
+    ) -> (mpsc::Sender<(&'static str, Status)>, Self) {
+        let (tx, rx_status) = mpsc::channel(10);
+        (
+            tx,
+            BridgeHealthMonitor {
+                target,
+                topic,
+                rx_status,
+                companion_bridge_half: bridge_half.clone_sender(),
+            },
+        )
+    }
+
+    pub async fn monitor(mut self) -> ! {
+        let mut statuses = HashMap::from([("local", None), ("cloud", None)]);
+        let mut last_status = None;
+        loop {
+            let (name, status) = self.rx_status.next().await.unwrap();
+            *statuses.entry(name).or_insert(Some(status)) = Some(status);
+
+            let status = statuses.values().fold(Some(Status::Up), overall_status);
+            if last_status != status {
+                last_status = status;
+                self.target
+                    .publish(&self.topic, QoS::AtLeastOnce, true, status.unwrap().json())
+                    .await
+                    .unwrap();
+                // Send a note that a message has been published to maintain synchronisation
+                // between the two bridge halves
+                self.companion_bridge_half.send(None).await.unwrap();
+            }
+        }
+    }
+}
+
+type NotificationRes = Result<Event, ConnectionError>;
+
+/// A client for [BridgeHealthMonitor]
+///
+/// This is used by each bridge half to log and notify the monitor of health status updates
+pub struct BridgeHealth {
+    name: &'static str,
+    tx_health: mpsc::Sender<(&'static str, Status)>,
+    last_err: Option<String>,
+}
+
+impl BridgeHealth {
+    pub(crate) fn new(name: &'static str, tx_health: mpsc::Sender<(&'static str, Status)>) -> Self {
+        Self {
+            name,
+            tx_health,
+            last_err: Some("dummy error".into()),
+        }
+    }
+
+    pub async fn update(&mut self, result: &NotificationRes) {
+        let name = self.name;
+        let err = match result {
+            Ok(event) => {
+                if let Event::Incoming(Incoming::ConnAck(_)) = event {
+                    info!("MQTT bridge connected to {name} broker")
+                }
+                None
+            }
+            Err(err) => Some(err.to_string()),
+        };
+
+        if self.last_err != err {
+            if let Some(err) = &err {
+                error!("MQTT bridge failed to connect to {name} broker: {err}")
+            }
+            self.last_err = err;
+            let status = self.last_err.as_ref().map_or(Status::Up, |_| Status::Down);
+            self.tx_health.send((name, status)).await.unwrap()
+        }
+    }
+}

--- a/crates/extensions/tedge_mqtt_bridge/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/lib.rs
@@ -410,7 +410,7 @@ trait MqttAck {
 }
 
 #[async_trait::async_trait]
-#[mutants::skip]
+#[mutants::skip] // missed: replace <impl MqttAck for AsyncClient>::ack -> Result<(), ClientError> with Ok(())
 impl MqttAck for AsyncClient {
     async fn ack(&self, publish: &Publish) -> Result<(), ClientError> {
         AsyncClient::ack(self, publish).await
@@ -505,8 +505,8 @@ impl RuntimeRequestSink for MqttBridgeActorBuilder {
 pub struct MqttBridgeActor {}
 
 #[async_trait]
-#[mutants::skip]
 impl Actor for MqttBridgeActor {
+    #[mutants::skip]
     fn name(&self) -> &str {
         "MQTT-Bridge"
     }

--- a/crates/extensions/tedge_mqtt_bridge/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/lib.rs
@@ -12,7 +12,7 @@ use rumqttc::Event;
 use rumqttc::EventLoop;
 use rumqttc::Incoming;
 use rumqttc::LastWill;
-use rumqttc::MqttOptions;
+pub use rumqttc::MqttOptions;
 use rumqttc::Outgoing;
 use rumqttc::PubAck;
 use rumqttc::PubRec;
@@ -691,29 +691,6 @@ mod tests {
                 tc.remote_subscriptions().collect::<Vec<_>>(),
                 ["s/ds", "s/dat"]
             );
-        }
-    }
-
-    mod prepend {
-        use super::*;
-        use crate::topics::prepend;
-
-        #[test]
-        fn applies_nonempty_prefix_to_start_of_value() {
-            assert_eq!(prepend("tested".into(), &"being ".into()), "being tested");
-        }
-
-        #[test]
-        fn does_not_clone_if_prefix_is_empty() {
-            assert!(matches!(
-                prepend("test".into(), &"".into()),
-                Cow::Borrowed(_)
-            ));
-        }
-
-        #[test]
-        fn leaves_value_unchanged_if_prefix_is_empty() {
-            assert_eq!(prepend("test".into(), &"".into()), "test");
         }
     }
 }

--- a/crates/extensions/tedge_mqtt_bridge/src/topics.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/topics.rs
@@ -1,0 +1,34 @@
+use crate::BridgeRule;
+use rumqttc::matches;
+use std::borrow::Cow;
+
+pub fn prepend<'a>(target: Cow<'a, str>, prefix: &Cow<'a, str>) -> Cow<'a, str> {
+    match (prefix, target) {
+        (prefix, target) if prefix.is_empty() => target,
+        (prefix, target) if target.is_empty() => prefix.clone(),
+        (prefix, Cow::Borrowed(target)) => format!("{prefix}{target}").into(),
+        (prefix, Cow::Owned(mut target)) => {
+            target.insert_str(0, prefix.as_ref());
+            Cow::Owned(target)
+        }
+    }
+}
+
+pub fn matches_ignore_dollar_prefix(topic: &str, filter: &str) -> bool {
+    match (&topic[..1], &filter[..1]) {
+        ("$", "$") => matches(&topic[1..], &filter[1..]),
+        _ => matches(topic, filter),
+    }
+}
+
+pub struct TopicConverter(pub Vec<BridgeRule>);
+
+impl TopicConverter {
+    pub fn convert_topic<'a>(&'a self, topic: &'a str) -> Cow<'a, str> {
+        self.0
+            .iter()
+            .find_map(|rule| rule.apply(topic))
+            // TODO should this be an error
+            .unwrap_or_else(|| panic!("Failed to convert {topic:?} with {:?}", self.0))
+    }
+}

--- a/crates/extensions/tedge_mqtt_bridge/src/topics.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/topics.rs
@@ -2,18 +2,6 @@ use crate::BridgeRule;
 use rumqttc::matches;
 use std::borrow::Cow;
 
-pub fn prepend<'a>(target: Cow<'a, str>, prefix: &Cow<'a, str>) -> Cow<'a, str> {
-    match (prefix, target) {
-        (prefix, target) if prefix.is_empty() => target,
-        (prefix, target) if target.is_empty() => prefix.clone(),
-        (prefix, Cow::Borrowed(target)) => format!("{prefix}{target}").into(),
-        (prefix, Cow::Owned(mut target)) => {
-            target.insert_str(0, prefix.as_ref());
-            Cow::Owned(target)
-        }
-    }
-}
-
 pub fn matches_ignore_dollar_prefix(topic: &str, filter: &str) -> bool {
     match (&topic[..1], &filter[..1]) {
         ("$", "$") => matches(&topic[1..], &filter[1..]),

--- a/crates/extensions/tedge_mqtt_bridge/tests/bridge.rs
+++ b/crates/extensions/tedge_mqtt_bridge/tests/bridge.rs
@@ -1,0 +1,484 @@
+use anyhow::anyhow;
+use anyhow::Context;
+use rumqttc::AsyncClient;
+use rumqttc::Event;
+use rumqttc::EventLoop;
+use rumqttc::Incoming;
+use rumqttc::MqttOptions;
+use rumqttc::Outgoing;
+use rumqttc::Publish;
+use rumqttc::QoS;
+use rumqttd::Broker;
+use rumqttd::Config;
+use rumqttd::ConnectionSettings;
+use rumqttd::ConsoleSettings;
+use rumqttd::ServerSettings;
+use std::collections::HashMap;
+use std::str::from_utf8;
+use std::time::Duration;
+use tedge_config::TEdgeConfig;
+use tedge_config::TEdgeConfigLocation;
+use tedge_mqtt_bridge::BridgeConfig;
+use tedge_mqtt_bridge::MqttBridgeActorBuilder;
+use tedge_test_utils::fs::TempTedgeDir;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+use tracing::info;
+use tracing::warn;
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn new_broker_and_client(name: &str, port: u16) -> (AsyncClient, EventLoop) {
+    let mut broker = Broker::new(get_rumqttd_config(port));
+    std::thread::Builder::new()
+        .name(format!("{name} broker"))
+        .spawn(move || broker.start().unwrap())
+        .unwrap();
+    AsyncClient::new(
+        MqttOptions::new(format!("{name}-test-client"), "localhost", port),
+        10,
+    )
+}
+
+async fn start_mqtt_bridge(local_port: u16, cloud_port: u16, rules: BridgeConfig) {
+    let cloud_config = MqttOptions::new("a-device-id", "localhost", cloud_port);
+    MqttBridgeActorBuilder::new(
+        &tedge_mqtt_config(local_port),
+        "tedge-mapper-test".into(),
+        rules,
+        cloud_config,
+    )
+    .await;
+}
+
+const HEALTH: &str = "te/device/main/#";
+
+// TODO acknowledgement with lost connection bridge, check we acknowledge the correct message
+#[tokio::test]
+async fn bridge_reconnects_successfully_after_cloud_connection_interrupted() {
+    std::env::set_var("RUST_LOG", "tedge_mqtt_bridge=info");
+    let _ = env_logger::try_init();
+    let local_broker_port = free_port().await;
+    let cloud_broker_port = free_port().await;
+    let (local, mut ev_local) = new_broker_and_client("local", local_broker_port);
+    let (cloud, mut ev_cloud) = new_broker_and_client("cloud", cloud_broker_port);
+
+    // We can't easily restart rumqttd, so instead, we'll connect via a proxy
+    // that we can interrupt the connection of
+    let cloud_proxy = Proxy::start(cloud_broker_port).await;
+
+    let mut rules = BridgeConfig::new();
+    rules.forward_from_local("s/us", "c8y/", "").unwrap();
+    rules.forward_from_remote("s/ds", "c8y/", "").unwrap();
+    start_mqtt_bridge(local_broker_port, cloud_proxy.port, rules).await;
+
+    local.subscribe(HEALTH, QoS::AtLeastOnce).await.unwrap();
+    cloud.subscribe("s/us", QoS::AtLeastOnce).await.unwrap();
+
+    wait_until_health_status_is("up", &mut ev_local)
+        .await
+        .unwrap();
+    cloud_proxy.interrupt_connections();
+    wait_until_health_status_is("down", &mut ev_local)
+        .await
+        .unwrap();
+    wait_until_health_status_is("up", &mut ev_local)
+        .await
+        .unwrap();
+
+    local.unsubscribe(HEALTH).await.unwrap();
+    local.subscribe("c8y/s/ds", QoS::AtLeastOnce).await.unwrap();
+
+    await_subscription(&mut ev_local).await;
+    await_subscription(&mut ev_cloud).await;
+
+    let poll_cloud = EventPoller::run_in_bg(ev_cloud);
+
+    // Verify messages are forwarded from cloud to local
+    cloud
+        .publish("s/ds", QoS::AtLeastOnce, false, "a,fake,smartrest,message")
+        .await
+        .unwrap();
+
+    let msg = next_received_message(&mut ev_local).await.unwrap();
+    assert_eq!(msg.topic, "c8y/s/ds");
+    assert_eq!(from_utf8(&msg.payload).unwrap(), "a,fake,smartrest,message");
+
+    let mut ev_cloud = poll_cloud.stop_polling().await;
+    EventPoller::run_in_bg(ev_local);
+
+    // Verify messages are forwarded from local to cloud
+    local
+        .publish("c8y/s/us", QoS::AtLeastOnce, false, "a,different,message")
+        .await
+        .unwrap();
+
+    let msg = next_received_message(&mut ev_cloud).await.unwrap();
+    assert_eq!(msg.topic, "s/us");
+    assert_eq!(from_utf8(&msg.payload).unwrap(), "a,different,message");
+}
+
+async fn wait_until_health_status_is(
+    status: &str,
+    event_loop: &mut EventLoop,
+) -> anyhow::Result<()> {
+    loop {
+        let health = next_received_message(event_loop).await.with_context(|| {
+            format!("expecting health message waiting for status to be {status:?}")
+        })?;
+        if !(health.topic.starts_with("te/device/main/service")
+            && health.topic.ends_with("status/health"))
+        {
+            warn!(
+                "Unexpected message on topic {} when looking for health status messages",
+                health.topic
+            );
+        }
+        let payload = from_utf8(&health.payload).context("decoding health payload")?;
+        let json: serde_json::Value = serde_json::from_str(payload)?;
+        match (status, json["status"].as_str()) {
+            ("up", Some("up")) | ("down", Some("down")) => break Ok(()),
+            (_, Some("up" | "down")) => continue,
+            (_, Some(status)) => {
+                break Err(anyhow!(
+                    "Unknown health status {status:?} in tedge-json: {payload}"
+                ))
+            }
+            (_, None) => break Err(anyhow!("Health status missing from payload: {payload}")),
+        }
+    }
+}
+
+#[tokio::test]
+async fn bridge_reconnects_successfully_after_local_connection_interrupted() {
+    std::env::set_var("RUST_LOG", "tedge_mqtt_bridge=info");
+    let _ = env_logger::try_init();
+    let local_broker_port = free_port().await;
+    let cloud_broker_port = free_port().await;
+    let (local, mut ev_local) = new_broker_and_client("local", local_broker_port);
+    let (cloud, mut ev_cloud) = new_broker_and_client("cloud", cloud_broker_port);
+
+    // We can't easily restart rumqttd, so instead, we'll connect via a proxy
+    // that we can interrupt the connection of
+    let local_proxy = Proxy::start(local_broker_port).await;
+
+    let mut rules = BridgeConfig::new();
+    rules.forward_from_local("s/us", "c8y/", "").unwrap();
+    rules.forward_from_remote("s/ds", "c8y/", "").unwrap();
+    start_mqtt_bridge(local_proxy.port, cloud_broker_port, rules).await;
+
+    local.subscribe(HEALTH, QoS::AtLeastOnce).await.unwrap();
+    cloud.subscribe("s/us", QoS::AtLeastOnce).await.unwrap();
+
+    wait_until_health_status_is("up", &mut ev_local)
+        .await
+        .unwrap();
+    local_proxy.interrupt_connections();
+    wait_until_health_status_is("up", &mut ev_local)
+        .await
+        .unwrap();
+
+    local.unsubscribe(HEALTH).await.unwrap();
+    local.subscribe("c8y/s/ds", QoS::AtLeastOnce).await.unwrap();
+
+    await_subscription(&mut ev_local).await;
+    await_subscription(&mut ev_cloud).await;
+
+    let poll_cloud = EventPoller::run_in_bg(ev_cloud);
+
+    // Verify messages are forwarded from cloud to local
+    cloud
+        .publish("s/ds", QoS::AtLeastOnce, false, "a,fake,smartrest,message")
+        .await
+        .unwrap();
+
+    let msg = next_received_message(&mut ev_local).await.unwrap();
+    assert_eq!(msg.topic, "c8y/s/ds");
+    assert_eq!(from_utf8(&msg.payload).unwrap(), "a,fake,smartrest,message");
+
+    let mut ev_cloud = poll_cloud.stop_polling().await;
+    EventPoller::run_in_bg(ev_local);
+
+    // Verify messages are forwarded from local to cloud
+    local
+        .publish("c8y/s/us", QoS::AtLeastOnce, false, "a,different,message")
+        .await
+        .unwrap();
+
+    let msg = next_received_message(&mut ev_cloud).await.unwrap();
+    assert_eq!(msg.topic, "s/us");
+    assert_eq!(from_utf8(&msg.payload).unwrap(), "a,different,message");
+}
+
+#[tokio::test]
+async fn bidirectional_forwarding_avoids_infinite_loop() {
+    let local_port = free_port().await;
+    let cloud_port = free_port().await;
+    new_broker_and_client("local", local_port);
+    new_broker_and_client("cloud", cloud_port);
+    let mut rules = BridgeConfig::new();
+    rules
+        // The cloud prefix in practice is `$aws/things/<device-id>`, but rumqttd doesn't
+        // support $aws as it's not the aws broker
+        .forward_bidirectionally("shadow/#", "aws/", "aws/things/my-device/")
+        .unwrap();
+
+    start_mqtt_bridge(local_port, cloud_port, rules).await;
+
+    let (local_client, mut local_ev_loop) = AsyncClient::new(
+        MqttOptions::new("test-client-local", "localhost", local_port),
+        10,
+    );
+    local_client
+        .subscribe("aws/#", QoS::AtLeastOnce)
+        .await
+        .unwrap();
+    loop {
+        if let Ok(Event::Incoming(Incoming::SubAck(_))) = local_ev_loop.poll().await {
+            break;
+        }
+    }
+
+    let (client, mut ev_loop) = AsyncClient::new(
+        MqttOptions::new("test-client-cloud", "localhost", cloud_port),
+        10,
+    );
+    client
+        .subscribe("aws/things/my-device/shadow/#", QoS::AtLeastOnce)
+        .await
+        .unwrap();
+    client
+        .publish(
+            "aws/things/my-device/shadow/request",
+            QoS::AtMostOnce,
+            false,
+            "test message",
+        )
+        .await
+        .unwrap();
+
+    let cloud = tokio::spawn(async move {
+        loop {
+            match ev_loop.poll().await.unwrap() {
+                // Ignore the initial request message
+                Event::Incoming(Incoming::Publish(Publish { pkid: 1, .. })) => (),
+                Event::Incoming(Incoming::Publish(publish)) => {
+                    assert_eq!(
+                        publish.topic, "aws/things/my-device/shadow/response",
+                        "We should receive the response, the request should not be forwarded back"
+                    );
+                    assert_eq!(from_utf8(&publish.payload).unwrap(), "test response");
+                    break;
+                }
+                Event::Outgoing(Outgoing::Publish(_)) => {}
+                _ => (),
+            }
+        }
+    });
+
+    loop {
+        match local_ev_loop.poll().await.unwrap() {
+            Event::Incoming(Incoming::Publish(publish)) => {
+                assert_eq!(publish.topic, "aws/shadow/request");
+                assert_eq!(from_utf8(&publish.payload).unwrap(), "test message");
+                local_client
+                    .publish(
+                        "aws/shadow/response",
+                        QoS::AtLeastOnce,
+                        false,
+                        "test response",
+                    )
+                    .await
+                    .unwrap();
+            }
+            Event::Outgoing(Outgoing::Publish(_)) => break,
+            _ => (),
+        }
+    }
+
+    timeout(DEFAULT_TIMEOUT, cloud).await.unwrap().unwrap();
+}
+
+/// A TCP proxy that allows the connection to be dropped upon request
+///
+/// This is used to simulate a dropped connection between the client and MQTT broker
+struct Proxy {
+    port: u16,
+    stop_tx: tokio::sync::watch::Sender<()>,
+}
+
+impl Proxy {
+    async fn start(target_port: u16) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (stop_tx, stop_rx) = tokio::sync::watch::channel(());
+        tokio::spawn(async move {
+            let target = format!("127.0.0.1:{target_port}");
+            loop {
+                let mut stop = stop_rx.clone();
+                stop.mark_unchanged();
+                if let Ok((mut socket, _)) = listener.accept().await {
+                    let mut conn = tokio::net::TcpStream::connect(&target).await.unwrap();
+                    tokio::spawn(async move {
+                        let (mut read_socket, mut write_socket) = socket.split();
+                        let (mut read_conn, mut write_conn) = conn.split();
+
+                        tokio::select! {
+                            res = tokio::io::copy(&mut read_socket, &mut write_conn) => { res.unwrap(); },
+                            res = tokio::io::copy(&mut read_conn, &mut write_socket) => { res.unwrap(); },
+                            _ = stop.changed() => info!("shutting down proxy"),
+                        };
+
+                        write_socket.shutdown().await.unwrap();
+                        write_conn.shutdown().await.unwrap();
+                    });
+                }
+            }
+        });
+
+        Self { port, stop_tx }
+    }
+
+    /// Sends a signal to drop all active connections to the proxy
+    fn interrupt_connections(&self) {
+        self.stop_tx.send(()).unwrap()
+    }
+}
+
+async fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .await
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// A wrapper around an event loop that allows temporary polling
+struct EventPoller {
+    tx: oneshot::Sender<()>,
+    rx: oneshot::Receiver<EventLoop>,
+}
+
+impl EventPoller {
+    /// Executes the event loop in a spawned task
+    pub fn run_in_bg(mut event_loop: EventLoop) -> Self {
+        let (tx_stop_polling, mut rx_stop_polling) = oneshot::channel();
+        let (tx_ev_loop, rx_ev_loop) = oneshot::channel();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    // Not quite sure why I need
+                    biased;
+                    _ = event_loop.poll() => (),
+                    res = &mut rx_stop_polling => {
+                        if res.is_err() {
+                            return
+                        } else {
+                            break
+                        }
+                    },
+                }
+            }
+            tx_ev_loop
+                .send(event_loop)
+                .ok()
+                .expect("Channel should still be open");
+        });
+
+        Self {
+            tx: tx_stop_polling,
+            rx: rx_ev_loop,
+        }
+    }
+
+    /// Stops the spawned task from polling the loop, and returns the loop for re-use
+    pub async fn stop_polling(self) -> EventLoop {
+        self.tx.send(()).unwrap();
+        self.rx.await.unwrap()
+    }
+}
+
+async fn await_subscription(event_loop: &mut EventLoop) {
+    loop {
+        if let Ok(Event::Incoming(Incoming::SubAck(_))) =
+            timeout(DEFAULT_TIMEOUT, event_loop.poll())
+                .await
+                .context("timed-out waiting for subscription")
+                .unwrap()
+        {
+            break;
+        }
+    }
+}
+
+async fn next_received_message(event_loop: &mut EventLoop) -> anyhow::Result<Publish> {
+    loop {
+        if let Ok(Event::Incoming(Incoming::Publish(publish))) =
+            timeout(DEFAULT_TIMEOUT, event_loop.poll())
+                .await
+                .context("timed-out waiting for received message")?
+        {
+            break Ok(publish);
+        }
+    }
+}
+
+fn tedge_mqtt_config(mqtt_port: u16) -> TEdgeConfig {
+    let ttd = TempTedgeDir::new();
+    let config_loc = TEdgeConfigLocation::from_custom_root(ttd.path());
+    config_loc
+        .update_toml(&|dto| {
+            dto.mqtt.client.port = Some(mqtt_port.try_into().unwrap());
+            Ok(())
+        })
+        .unwrap();
+    TEdgeConfig::try_new(config_loc).unwrap()
+}
+
+fn get_rumqttd_config(port: u16) -> Config {
+    let router_config = rumqttd::RouterConfig {
+        max_segment_size: 10240,
+        max_segment_count: 10,
+        max_connections: 10,
+        initialized_filters: None,
+        ..Default::default()
+    };
+
+    let connections_settings = ConnectionSettings {
+        connection_timeout_ms: 1000,
+        max_payload_size: 268435455,
+        max_inflight_count: 200,
+        auth: None,
+        dynamic_filters: false,
+    };
+
+    let server_config = ServerSettings {
+        name: port.to_string(),
+        listen: ([0, 0, 0, 0], port).into(),
+        tls: None,
+        next_connection_delay_ms: 1,
+        connections: connections_settings,
+    };
+
+    let mut console_settings = ConsoleSettings::default();
+    console_settings.listen = format!("localhost:{}", port + 6);
+
+    let mut servers = HashMap::new();
+    servers.insert("1".to_string(), server_config);
+
+    rumqttd::Config {
+        id: 0,
+        router: router_config,
+        cluster: None,
+        console: console_settings,
+        v4: servers,
+        ws: None,
+        v5: None,
+        bridge: None,
+        prometheus: None,
+        metrics: None,
+    }
+}

--- a/crates/extensions/tedge_mqtt_bridge/tests/bridge.rs
+++ b/crates/extensions/tedge_mqtt_bridge/tests/bridge.rs
@@ -63,7 +63,7 @@ async fn bridge_many_messages() {
     let local_broker_port = free_port().await;
     let cloud_broker_port = free_port().await;
     let (local, mut ev_local) = new_broker_and_client("local", local_broker_port);
-    let (cloud, mut ev_cloud) = new_broker_and_client("cloud", cloud_broker_port);
+    let (cloud, ev_cloud) = new_broker_and_client("cloud", cloud_broker_port);
 
     // We can't easily restart rumqttd, so instead, we'll connect via a proxy
     // that we can interrupt the connection of
@@ -425,7 +425,8 @@ impl EventPoller {
         tokio::spawn(async move {
             loop {
                 tokio::select! {
-                    // Not quite sure why I need
+                    // Not quite sure why I need to use biased here,
+                    // but it doesn't poll the event loop if we don't
                     biased;
                     _ = event_loop.poll() => (),
                     res = &mut rx_stop_polling => {


### PR DESCRIPTION
## Proposed changes
This adds support for AWS and Azure to the built-in bridge, as well as some clean session configuration to ensure we don't lose messages.

Previously the rules were Cumulocity rules, where all we needed to do was remove and add local prefixes, so a large section of the changes are around supporting more complex mapping logic, so a `BridgeRule` struct has been added to support the same configurations as mosquitto.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

