### PR TITLE
Do not panic changing ownership of device cert to unknown user

### DIFF
--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -24,6 +24,7 @@ use tedge_config::*;
 use tedge_utils::paths::create_directories;
 use tedge_utils::paths::ok_if_not_found;
 use tedge_utils::paths::DraftFile;
+use tracing::warn;
 use which::which;
 
 use crate::bridge::AWS_CONFIG_FILENAME;
@@ -564,8 +565,9 @@ fn restart_mosquitto(
         &bridge_config.bridge_certfile,
         &bridge_config.bridge_keyfile,
     ] {
-        // TODO maybe ignore errors here
-        tedge_utils::file::change_user_and_group(path.as_ref(), user, group).unwrap();
+        if let Err(err) = tedge_utils::file::change_user_and_group(path.as_ref(), user, group) {
+            warn!("Failed to change ownership of {path} to {user}:{group}: {err}");
+        }
     }
 
     if let Err(err) = service_manager.restart_service(SystemService::Mosquitto) {


### PR DESCRIPTION
## Proposed changes

Avoid to panic when running `tedge connect c8y` on a device where there is no `mosquitto` user.

https://github.com/thin-edge/thin-edge.io/issues/2867

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2867

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

