### PR TITLE
Simplify the operation handling code by replacing fragmented control flow with regular async/await

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,6 +709,7 @@ dependencies = [
  "json-writer",
  "logged_command",
  "mime",
+ "mockito",
  "plugin_sm",
  "proptest",
  "rand",

--- a/crates/common/download/src/download.rs
+++ b/crates/common/download/src/download.rs
@@ -10,7 +10,6 @@ use log::warn;
 use nix::sys::statvfs;
 pub use partial_response::InvalidResponseError;
 use reqwest::header;
-use reqwest::Identity;
 use serde::Deserialize;
 use serde::Serialize;
 use std::fs;
@@ -26,6 +25,8 @@ use std::time::Duration;
 use tedge_utils::file::move_file;
 use tedge_utils::file::FileError;
 use tedge_utils::file::PermissionEntry;
+
+pub type Identity = reqwest::Identity;
 
 #[cfg(target_os = "linux")]
 use nix::fcntl::fallocate;

--- a/crates/common/download/src/lib.rs
+++ b/crates/common/download/src/lib.rs
@@ -48,4 +48,5 @@ mod error;
 pub use crate::download::Auth;
 pub use crate::download::DownloadInfo;
 pub use crate::download::Downloader;
+pub use crate::download::Identity;
 pub use crate::error::DownloadError;

--- a/crates/core/tedge_api/src/lib.rs
+++ b/crates/core/tedge_api/src/lib.rs
@@ -17,6 +17,7 @@ pub use commands::OperationStatus;
 pub use commands::RestartCommand;
 pub use commands::SoftwareListCommand;
 pub use commands::SoftwareUpdateCommand;
+pub use download;
 pub use download::*;
 pub use entity_store::EntityStore;
 pub use error::*;

--- a/crates/extensions/c8y_mapper_ext/Cargo.toml
+++ b/crates/extensions/c8y_mapper_ext/Cargo.toml
@@ -51,6 +51,7 @@ url = { workspace = true }
 assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
 capture-logger = { workspace = true }
+mockito = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 tedge_actors = { workspace = true, features = ["test-helpers"] }

--- a/crates/extensions/c8y_mapper_ext/src/actor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/actor.rs
@@ -329,11 +329,12 @@ impl C8yMapperWorker {
             let cmd_id = cmd_id.clone();
             match fts_download.download_type {
                 FtsDownloadOperationType::ConfigDownload => {
-                    self.converter
-                        .lock()
-                        .await
-                        .handle_fts_config_download_result(cmd_id, result, fts_download)
-                        .await
+                    // self.converter
+                    //     .lock()
+                    //     .await
+                    //     .handle_fts_config_download_result(cmd_id, result, fts_download)
+                    //     .await
+                    Ok(vec![])
                 }
                 FtsDownloadOperationType::LogDownload => {
                     self.converter

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -51,6 +51,7 @@ pub struct C8yMapperConfig {
     pub software_management_api: SoftwareManagementApiFlag,
     pub software_management_with_types: bool,
     pub auto_log_upload: AutoLogUpload,
+    pub identity: Option<tedge_api::download::Identity>,
 
     pub data_dir: DataDir,
     pub config_dir: Arc<Utf8Path>,
@@ -87,6 +88,7 @@ impl C8yMapperConfig {
         software_management_api: SoftwareManagementApiFlag,
         software_management_with_types: bool,
         auto_log_upload: AutoLogUpload,
+        identity: Option<tedge_api::download::Identity>,
     ) -> Self {
         let ops_dir = config_dir
             .join(SUPPORTED_OPERATIONS_DIRECTORY)
@@ -115,6 +117,7 @@ impl C8yMapperConfig {
             software_management_api,
             software_management_with_types,
             auto_log_upload,
+            identity,
 
             config_dir,
             logs_path,
@@ -178,6 +181,7 @@ impl C8yMapperConfig {
         let software_management_with_types = tedge_config.c8y.software_management.with_types;
 
         let auto_log_upload = tedge_config.c8y.operations.auto_log_upload.clone();
+        let identity = tedge_config.http.client.auth.identity()?;
 
         // Add feature topic filters
         for cmd in [
@@ -241,6 +245,7 @@ impl C8yMapperConfig {
             software_management_api,
             software_management_with_types,
             auto_log_upload,
+            identity,
         ))
     }
 
@@ -298,6 +303,9 @@ pub enum C8yMapperConfigBuildError {
 
     #[error(transparent)]
     FromTopicIdError(#[from] TopicIdError),
+
+    #[error(transparent)]
+    OtherError(#[from] anyhow::Error),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -1127,8 +1127,11 @@ impl CumulocityConverter {
                             .await
                     }
                     OperationType::ConfigSnapshot => {
-                        self.handle_config_snapshot_state_change(&source, cmd_id, message)
-                            .await
+                        dbg!("calling config snapshot handler");
+                        dbg!(
+                            self.handle_config_snapshot_state_change(&source, cmd_id, message)
+                                .await
+                        )
                     }
                     OperationType::ConfigUpdate => {
                         self.handle_config_update_state_change(&source, cmd_id, message)

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -3416,6 +3416,7 @@ pub(crate) mod tests {
             SoftwareManagementApiFlag::Advanced,
             true,
             AutoLogUpload::Never,
+            None,
         )
     }
 

--- a/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
@@ -242,14 +242,6 @@ impl CumulocityConverter {
             .with_retain()
             .with_qos(QoS::AtLeastOnce);
 
-        self.upload_operation_log(
-            &topic_id,
-            &cmd_id,
-            &CumulocitySupportedOperations::C8yLogFileRequest.into(),
-            fts_download.command,
-        )
-        .await?;
-
         Ok(vec![c8y_notification, clear_local_cmd])
     }
 

--- a/crates/extensions/c8y_mapper_ext/src/operations/mod.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/mod.rs
@@ -85,6 +85,23 @@ impl CumulocityConverter {
     }
 }
 
+fn get_smartrest_response_for_upload_result(
+    upload_result: tedge_uploader_ext::UploadResult,
+    binary_url: &str,
+    operation: c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations,
+) -> c8y_api::smartrest::smartrest_serializer::SmartRest {
+    match upload_result {
+        Ok(_) => c8y_api::smartrest::smartrest_serializer::succeed_static_operation(
+            operation,
+            Some(binary_url),
+        ),
+        Err(err) => c8y_api::smartrest::smartrest_serializer::fail_operation(
+            operation,
+            &format!("Upload failed with {err}"),
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::tests::skip_init_messages;

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -2418,6 +2418,50 @@ async fn c8y_mapper_nested_child_service_event_mapping_to_smartrest() {
     .await;
 }
 
+#[tokio::test]
+async fn mapper_processes_operations_concurrently() {
+    let num_operations = 100;
+
+    let mut fts_server = mockito::Server::new();
+    let mock = fts_server
+        .mock(
+            "GET",
+            "/tedge/file-transfer/test-device/config_snapshot/c8y-mapper-1234",
+        )
+        // make each download block so it doesn't complete before we submit all operations
+        .with_chunked_body(|_w| {
+            std::thread::sleep(Duration::from_secs(5));
+            Ok(())
+        })
+        .expect(num_operations)
+        .create_async()
+        .await;
+    let host_port = fts_server.host_with_port();
+
+    let cfg_dir = TempTedgeDir::new();
+    let (mqtt, http, _fs, _timer, _ul, _dl) = spawn_c8y_mapper_actor(&cfg_dir, true).await;
+    spawn_dummy_c8y_http_proxy(http);
+
+    let mut mqtt = mqtt.with_timeout(TEST_TIMEOUT_MS);
+    skip_init_messages(&mut mqtt).await;
+
+    // simulate many successful operations that needs to be handled by the mapper
+    for i in 0..num_operations {
+        mqtt.send(MqttMessage::new(
+            &Topic::new_unchecked(&format!("te/device/main///cmd/config_snapshot/c8y-mapper-{i}")),
+            json!({
+            "status": "successful",
+            "tedgeUrl": format!("http://{host_port}/tedge/file-transfer/test-device/config_snapshot/c8y-mapper-1234"),
+            "type": "path/type/A",
+        })
+                .to_string(),
+        ))
+            .await.unwrap();
+    }
+
+    mock.assert();
+}
+
 fn assert_command_exec_log_content(cfg_dir: TempTedgeDir, expected_contents: &str) {
     let paths = fs::read_dir(cfg_dir.to_path_buf().join("agent")).unwrap();
     for path in paths {

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -2623,6 +2623,7 @@ pub(crate) fn test_mapper_config(tmp_dir: &TempTedgeDir) -> C8yMapperConfig {
         SoftwareManagementApiFlag::Advanced,
         true,
         AutoLogUpload::Never,
+        None,
     )
 }
 


### PR DESCRIPTION
## Proposed changes

This PR should make the operation handle simpler to reason about and change, by allowing operation handlers to use `.await` without blocking. The scope of the PR is to show the idea working on the `config_snapshot` and `config_update` operations.

Below i describe the current state, which is subject to change.

1. In 6b90d51e4420dbfe5cd7906bcf57e48494e9ae4e, the main C8y mapper actor is prepared for its messages to be handled concurrently in separate tasks. For now, we use `Mutex`es to guard the `MqttPublisher` and `CumulocityConverter`:
   - using wrapper `struct MqttPublisher(Arc<Mutex<LoggingSender<MqttMessage>>>)` with `fn send(&self)` is ok, as we lock the mutex to use the sender, and unlock it immediately after we finished sending, so it shouldn't block. The alternative would be to clone the sender for each worker, and I will explore it later.
   - with `Mutex<CumulocityConverter>`, it ensures that only a single worker can use `CumulocityConverter` at any given time, which can lead to deadlocks if we're not careful, and currently results in the same behaviour as before, i.e. blocking in the operation handling code will block processing of other messages, because the lock will be open across await points.
      This is temporary, and will have to be fixed, but is used right now so I could show how the full operation handling function would look like, without the current fragmentation. Also, the test demonstrating that the converter doesn't block should be made.
2. In 72dc9d09bb644758c4684253ee8f276d53168666, I export `Identity` type from the `download` crate, so I can use it in the next commit.
3. In 0e8656851b2fb1d9be90021ef0feab33d9d7d818, `Downloader` is used directly in the operation handler, to show how we can use it directly without going through the actor: if we only want to download a file via HTTP, and this download shouldn't influence anything else, we can use it directly.
4.  In 892ecbec71a21a9e9bc93252f27abdac4057390d we use `UploaderActor` via `ClientMessageBox`, where we receive the response directly in the same place where we `send()`, instead of going to the top-level receiver in the top-level actor, which then needs to decide to call an operation handling function again. This way we still use an uploader actor, and have messages sent between them, but don't need to fragment our control flow. This was done to show that we can still send and receive messages from other actors from within the proposed new operation handlers.

### Next steps

- [x] rebase newest changes
- [x] ~~replace lock on mqtt sender with cloned senders~~ (can be done, but will require `&mut self`)
- [ ] add more tests to see which operations are blocked/executed concurrently
- [ ] make necessary changes to `CumulocityConverter` so operation handling doesn't block
- [ ] clean up operation handling code

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #2880 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

