### PR TITLE
Switch to env::args for establishing the executable name

### DIFF
--- a/plugins/c8y_remote_access_plugin/src/lib.rs
+++ b/plugins/c8y_remote_access_plugin/src/lib.rs
@@ -93,9 +93,9 @@ static SUCCESS_MESSAGE: &str = "CONNECTED";
 struct Unreachable<E: std::error::Error + 'static>(#[source] E, &'static str);
 
 async fn spawn_child(command: String, config_dir: &Utf8Path) -> miette::Result<()> {
-    let exec_path = std::env::current_exe()
-        .into_diagnostic()
-        .with_context(|| "Could not get current process executable")?;
+    let exec_path = std::env::args()
+        .next()
+        .ok_or(miette!("Could not get current process executable"))?;
 
     let mut command = tokio::process::Command::new(exec_path)
         .args(["--config-dir", config_dir.as_str()])


### PR DESCRIPTION
## Proposed changes
This switches from `current_exe()` to `env::args()` as `current_exe` resolves the symlink on Linux (so the plugin was calling `tedge` rather than `c8y-remote-access-plugin` when calling itself).

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #2890

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

