### PR TITLE
fix(mqtt): Publish mosquitto bridge status to c8y when enabled

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -359,7 +359,8 @@ impl CumulocityConverter {
                 let ancestors_external_ids =
                     self.entity_store.ancestors_external_ids(entity_topic_id)?;
 
-                if entity_topic_id.is_bridge_health_topic() {
+                if self.config.bridge_in_mapper && entity_topic_id.is_bridge_health_topic() {
+                    // Skip service creation for the mapper-inbuilt bridge, as it is part of the mapper service itself
                     return Ok(vec![]);
                 }
 

--- a/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
+++ b/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
@@ -27,6 +27,10 @@ Test if all c8y services are up
     tedge-agent
     c8y-firmware-plugin
 
+Test bridge service status up
+    External Identity Should Exist    ${DEVICE_SN}:device:main:service:mosquitto-c8y-bridge    show_info=False
+    Cumulocity.Managed Object Should Have Fragment Values    status\=up        timeout=${TIMEOUT}
+
 Test if all c8y services are down
     [Template]     Check if a service is down
     tedge-mapper-c8y


### PR DESCRIPTION
## Proposed changes

If the mosquitto bridge is used for C8y connectivity, then the bridge service status must also be published to C8y.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2898

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

