### PR TITLE
Simplify the operation handling code by replacing fragmented control flow with regular async/await - attempt #2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "clock",
  "json-writer",
  "mime",
+ "mockito",
  "plugin_sm",
  "proptest",
  "rand",

--- a/crates/common/tedge_config/src/tedge_config_cli/models/c8y_software_management.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/c8y_software_management.rs
@@ -4,7 +4,7 @@ use strum::Display;
 /// A flag that switches legacy or advanced software management API.
 /// Can be set to auto in the future, see #2778.
 #[derive(
-    Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, doku::Document, Display,
+    Debug, Clone, Copy, serde::Serialize, serde::Deserialize, Eq, PartialEq, doku::Document, Display,
 )]
 #[strum(serialize_all = "camelCase")]
 pub enum SoftwareManagementApiFlag {

--- a/crates/common/tedge_config/src/tedge_config_cli/models/mod.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/mod.rs
@@ -29,7 +29,7 @@ pub use self::templates_set::*;
 pub use tedge_utils::timestamp;
 
 #[derive(
-    Debug, Display, Clone, Eq, PartialEq, doku::Document, serde::Serialize, serde::Deserialize,
+    Debug, Display, Clone, Copy, Eq, PartialEq, doku::Document, serde::Serialize, serde::Deserialize,
 )]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]

--- a/crates/core/tedge_api/src/mqtt_topics.rs
+++ b/crates/core/tedge_api/src/mqtt_topics.rs
@@ -771,6 +771,7 @@ impl From<&Channel> for ChannelFilter {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct IdGenerator {
     prefix: String,
 }

--- a/crates/extensions/c8y_auth_proxy/src/url.rs
+++ b/crates/extensions/c8y_auth_proxy/src/url.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use tedge_config::TEdgeConfig;
 
+#[derive(Clone, Debug)]
 pub struct ProxyUrlGenerator {
     host: Arc<str>,
     port: u16,

--- a/crates/extensions/c8y_http_proxy/src/handle.rs
+++ b/crates/extensions/c8y_http_proxy/src/handle.rs
@@ -18,6 +18,7 @@ use tedge_utils::file::PermissionEntry;
 use super::messages::DownloadFile;
 
 /// Handle to the C8YHttpProxy
+#[derive(Clone)]
 pub struct C8YHttpProxy {
     c8y: ClientMessageBox<C8YRestRequest, C8YRestResult>,
 }

--- a/crates/extensions/c8y_mapper_ext/Cargo.toml
+++ b/crates/extensions/c8y_mapper_ext/Cargo.toml
@@ -49,6 +49,7 @@ url = { workspace = true }
 [dev-dependencies]
 assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
+mockito = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 tedge_actors = { workspace = true, features = ["test-helpers"] }

--- a/crates/extensions/c8y_mapper_ext/src/actor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/actor.rs
@@ -70,6 +70,7 @@ impl From<PublishMessage> for MqttMessage {
 }
 
 fan_in_message_type!(C8yMapperInput[MqttMessage, FsWatchEvent, SyncComplete, PublishMessage] : Debug);
+
 type C8yMapperOutput = MqttMessage;
 
 pub struct C8yMapperActor {
@@ -331,7 +332,7 @@ pub struct C8yMapperBuilder {
     http_proxy: C8YHttpProxy,
     timer_sender: DynSender<SyncStart>,
     downloader: ClientMessageBox<IdDownloadRequest, IdDownloadResult>,
-    uploader: ClientMessageBox<(String, UploadRequest), (String, UploadResult)>,
+    uploader: ClientMessageBox<IdUploadRequest, IdUploadResult>,
     auth_proxy: ProxyUrlGenerator,
     bridge_monitor_builder: SimpleMessageBoxBuilder<MqttMessage, MqttMessage>,
     message_handlers: HashMap<ChannelFilter, Vec<LoggingSender<MqttMessage>>>,

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -180,7 +180,7 @@ impl C8yMapperConfig {
         let enable_auto_register = tedge_config.c8y.entity_store.auto_register;
         let clean_start = tedge_config.c8y.entity_store.clean_start;
 
-        let software_management_api = tedge_config.c8y.software_management.api.clone();
+        let software_management_api = tedge_config.c8y.software_management.api;
         let software_management_with_types = tedge_config.c8y.software_management.with_types;
 
         let auto_log_upload = tedge_config.c8y.operations.auto_log_upload;

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -304,6 +304,9 @@ pub enum C8yMapperConfigBuildError {
 
     #[error(transparent)]
     FromTopicIdError(#[from] TopicIdError),
+
+    #[error(transparent)]
+    OtherError(#[from] anyhow::Error),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -304,9 +304,6 @@ pub enum C8yMapperConfigBuildError {
 
     #[error(transparent)]
     FromTopicIdError(#[from] TopicIdError),
-
-    #[error(transparent)]
-    OtherError(#[from] anyhow::Error),
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -183,7 +183,7 @@ impl C8yMapperConfig {
         let software_management_api = tedge_config.c8y.software_management.api.clone();
         let software_management_with_types = tedge_config.c8y.software_management.with_types;
 
-        let auto_log_upload = tedge_config.c8y.operations.auto_log_upload.clone();
+        let auto_log_upload = tedge_config.c8y.operations.auto_log_upload;
 
         // Add feature topic filters
         for cmd in [

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -104,7 +104,7 @@ const TEDGE_AGENT_LOG_DIR: &str = "agent";
 const CREATE_EVENT_SMARTREST_CODE: u16 = 400;
 const DEFAULT_EVENT_TYPE: &str = "ThinEdgeEvent";
 const FORBIDDEN_ID_CHARS: [char; 3] = ['/', '+', '#'];
-const REQUESTER_NAME: &str = "c8y-mapper";
+pub const REQUESTER_NAME: &str = "c8y-mapper";
 const EARLY_MESSAGE_BUFFER_SIZE: usize = 100;
 
 #[derive(Debug)]
@@ -186,7 +186,7 @@ pub struct CumulocityConverter {
     // Keep active command IDs to avoid creation of multiple commands for an operation
     pub active_commands: HashSet<CmdId>,
 
-    pub operation_handler: Arc<OperationHandler>,
+    pub operation_handler: OperationHandler,
 }
 
 impl CumulocityConverter {
@@ -245,25 +245,14 @@ impl CumulocityConverter {
 
         let command_id = IdGenerator::new(REQUESTER_NAME);
 
-        let operation_handler = Arc::new(OperationHandler {
-            capabilities: config.capabilities,
-            auto_log_upload: config.auto_log_upload,
-            tedge_http_host: config.tedge_http_host.clone(),
-            tmp_dir: config.tmp_dir.clone(),
-            mqtt_schema: mqtt_schema.clone(),
-            c8y_prefix: prefix.clone(),
-            mqtt_publisher: mqtt_publisher.clone(),
-            software_management_api: config.software_management_api,
-            command_id: command_id.clone(),
-
+        let operation_handler = OperationHandler::new(
+            &config,
             downloader,
             uploader,
-
-            c8y_endpoint: c8y_endpoint.clone(),
-            auth_proxy: auth_proxy.clone(),
-            http_proxy: http_proxy.clone(),
-            running_operations: Default::default(),
-        });
+            mqtt_publisher.clone(),
+            http_proxy.clone(),
+            auth_proxy.clone(),
+        );
 
         Ok(CumulocityConverter {
             size_threshold,

--- a/crates/extensions/c8y_mapper_ext/src/lib.rs
+++ b/crates/extensions/c8y_mapper_ext/src/lib.rs
@@ -15,7 +15,7 @@ pub mod service_monitor;
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
 pub struct Capabilities {
     log_upload: bool,
     config_snapshot: bool,

--- a/crates/extensions/c8y_mapper_ext/src/operations/config_snapshot.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/config_snapshot.rs
@@ -1,4 +1,4 @@
-use super::Entity;
+use super::EntityTarget;
 use super::OperationHandler;
 use crate::converter::CumulocityConverter;
 use crate::error::ConversionError;
@@ -91,7 +91,7 @@ impl OperationHandler {
     /// - "failed", it converts the message to SmartREST "Failed".
     pub async fn handle_config_snapshot_state_change(
         &self,
-        entity: Entity,
+        entity: EntityTarget,
         cmd_id: &str,
         message: &MqttMessage,
     ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {

--- a/crates/extensions/c8y_mapper_ext/src/operations/config_snapshot.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/config_snapshot.rs
@@ -1,7 +1,6 @@
 use super::Entity;
 use super::OperationHandler;
 use crate::converter::CumulocityConverter;
-use crate::converter::UploadOperationData;
 use crate::error::ConversionError;
 use crate::error::CumulocityMapperError;
 use anyhow::Context;
@@ -121,7 +120,7 @@ impl OperationHandler {
                 let event_type = command.payload.config_type.clone();
 
                 // Create an event in c8y
-                let binary_upload_event_url = self
+                let (c8y_binary_url, upload_result) = self
                     .upload_file(
                         &target.external_id,
                         &file_path,
@@ -133,21 +132,26 @@ impl OperationHandler {
                     )
                     .await?;
 
-                self.pending_upload_operations.lock().await.insert(
-                    cmd_id.to_string(),
-                    UploadOperationData {
-                        topic_id: topic_id.clone(),
-                        file_dir: destination_dir,
-                        smartrest_topic,
-                        clear_cmd_topic: message.topic.clone(),
-                        c8y_binary_url: binary_upload_event_url.to_string(),
-                        operation: CumulocitySupportedOperations::C8yUploadConfigFile,
-                        command: command.clone().into_generic_command(&self.mqtt_schema),
-                    }
-                    .into(),
+                let smartrest_response = super::get_smartrest_response_for_upload_result(
+                    upload_result,
+                    c8y_binary_url.as_str(),
+                    CumulocitySupportedOperations::C8yUploadConfigFile,
                 );
 
-                vec![] // No mqtt message can be published in this state
+                let c8y_notification = MqttMessage::new(&smartrest_topic, smartrest_response);
+                let clear_local_cmd = MqttMessage::new(&message.topic, "")
+                    .with_retain()
+                    .with_qos(QoS::AtLeastOnce);
+
+                self.upload_operation_log(
+                    &target.external_id,
+                    cmd_id,
+                    &CumulocitySupportedOperations::C8yUploadConfigFile.into(),
+                    command.clone().into_generic_command(&self.mqtt_schema),
+                )
+                .await?;
+
+                vec![c8y_notification, clear_local_cmd]
             }
             CommandStatus::Failed { reason } => {
                 let smartrest_operation_status =

--- a/crates/extensions/c8y_mapper_ext/src/operations/config_snapshot.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/config_snapshot.rs
@@ -1,5 +1,5 @@
 use super::EntityTarget;
-use super::OperationHandler;
+use super::OperationContext;
 use crate::converter::CumulocityConverter;
 use crate::error::ConversionError;
 use crate::error::CumulocityMapperError;
@@ -84,7 +84,7 @@ impl CumulocityConverter {
     }
 }
 
-impl OperationHandler {
+impl OperationContext {
     /// Address received ThinEdge config_snapshot command. If its status is
     /// - "executing", it converts the message to SmartREST "Executing".
     /// - "successful", it uploads a config snapshot to c8y and converts the message to SmartREST "Successful".

--- a/crates/extensions/c8y_mapper_ext/src/operations/config_snapshot.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/config_snapshot.rs
@@ -15,7 +15,6 @@ use c8y_api::smartrest::smartrest_serializer::set_operation_executing;
 use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations;
 use camino::Utf8PathBuf;
 use std::collections::HashMap;
-use tedge_actors::Sender;
 use tedge_api::commands::CommandStatus;
 use tedge_api::commands::ConfigSnapshotCmd;
 use tedge_api::commands::ConfigSnapshotCmdPayload;
@@ -40,7 +39,7 @@ impl OperationHandler {
     /// - "successful", it uploads a config snapshot to c8y and converts the message to SmartREST "Successful".
     /// - "failed", it converts the message to SmartREST "Failed".
     pub async fn handle_config_snapshot_state_change(
-        &mut self,
+        &self,
         entity: Entity,
         cmd_id: &str,
         message: &MqttMessage,
@@ -147,7 +146,7 @@ impl OperationHandler {
     /// Resumes `config_snapshot` operation after required file was downloaded
     /// from the File Transfer Service.
     pub async fn handle_fts_config_download_result(
-        &mut self,
+        &self,
         cmd_id: CmdId,
         download_result: DownloadResult,
         fts_download: FtsDownloadOperationData,

--- a/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
@@ -25,6 +25,9 @@ use tedge_mqtt_ext::QoS;
 use tedge_mqtt_ext::TopicFilter;
 use tracing::log::warn;
 
+use super::Entity;
+use super::OperationHandler;
+
 pub fn topic_filter(mqtt_schema: &MqttSchema) -> TopicFilter {
     [
         mqtt_schema.topics(
@@ -40,24 +43,24 @@ pub fn topic_filter(mqtt_schema: &MqttSchema) -> TopicFilter {
     .collect()
 }
 
-impl CumulocityConverter {
+impl OperationHandler {
     /// Address a received ThinEdge config_update command. If its status is
     /// - "executing", it converts the message to SmartREST "Executing".
     /// - "successful", it converts the message to SmartREST "Successful".
     /// - "failed", it converts the message to SmartREST "Failed".
     pub async fn handle_config_update_state_change(
         &mut self,
-        topic_id: &EntityTopicId,
+        target: Entity,
         cmd_id: &str,
         message: &MqttMessage,
     ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {
-        if !self.config.capabilities.config_update {
+        if !self.capabilities.config_update {
             warn!("Received a config_update command, however, config_update feature is disabled");
             return Ok((vec![], None));
         }
 
         let command = match ConfigUpdateCmd::try_from_bytes(
-            topic_id.clone(),
+            target.topic_id.clone(),
             cmd_id.into(),
             message.payload_bytes(),
         )? {
@@ -68,7 +71,7 @@ impl CumulocityConverter {
             }
         };
 
-        let sm_topic = self.smartrest_publish_topic_for_entity(topic_id)?;
+        let sm_topic = target.smartrest_publish_topic;
 
         let messages = match command.status() {
             CommandStatus::Executing => {
@@ -110,7 +113,9 @@ impl CumulocityConverter {
             Some(command.into_generic_command(&self.mqtt_schema)),
         ))
     }
+}
 
+impl CumulocityConverter {
     /// Upon receiving a SmartREST c8y_DownloadConfigFile request, convert it to a message on the
     /// command channel.
     pub async fn convert_config_update_request(

--- a/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
@@ -49,7 +49,7 @@ impl OperationHandler {
     /// - "successful", it converts the message to SmartREST "Successful".
     /// - "failed", it converts the message to SmartREST "Failed".
     pub async fn handle_config_update_state_change(
-        &mut self,
+        &self,
         target: Entity,
         cmd_id: &str,
         message: &MqttMessage,
@@ -119,7 +119,7 @@ impl CumulocityConverter {
     /// Upon receiving a SmartREST c8y_DownloadConfigFile request, convert it to a message on the
     /// command channel.
     pub async fn convert_config_update_request(
-        &mut self,
+        &self,
         device_xid: String,
         cmd_id: String,
         config_download_request: C8yDownloadConfigFile,

--- a/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
@@ -26,7 +26,7 @@ use tedge_mqtt_ext::TopicFilter;
 use tracing::log::warn;
 
 use super::EntityTarget;
-use super::OperationHandler;
+use super::OperationContext;
 
 pub fn topic_filter(mqtt_schema: &MqttSchema) -> TopicFilter {
     [
@@ -43,7 +43,7 @@ pub fn topic_filter(mqtt_schema: &MqttSchema) -> TopicFilter {
     .collect()
 }
 
-impl OperationHandler {
+impl OperationContext {
     /// Address a received ThinEdge config_update command. If its status is
     /// - "executing", it converts the message to SmartREST "Executing".
     /// - "successful", it converts the message to SmartREST "Successful".

--- a/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/config_update.rs
@@ -25,7 +25,7 @@ use tedge_mqtt_ext::QoS;
 use tedge_mqtt_ext::TopicFilter;
 use tracing::log::warn;
 
-use super::Entity;
+use super::EntityTarget;
 use super::OperationHandler;
 
 pub fn topic_filter(mqtt_schema: &MqttSchema) -> TopicFilter {
@@ -50,7 +50,7 @@ impl OperationHandler {
     /// - "failed", it converts the message to SmartREST "Failed".
     pub async fn handle_config_update_state_change(
         &self,
-        target: Entity,
+        target: EntityTarget,
         cmd_id: &str,
         message: &MqttMessage,
     ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {

--- a/crates/extensions/c8y_mapper_ext/src/operations/firmware_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/firmware_update.rs
@@ -34,7 +34,7 @@ impl OperationHandler {
     /// - "successful", it converts the message to SmartREST "Successful" and update the current installed firmware.
     /// - "failed", it converts the message to SmartREST "Failed".
     pub async fn handle_firmware_update_state_change(
-        &mut self,
+        &self,
         target: Entity,
         cmd_id: &str,
         message: &MqttMessage,

--- a/crates/extensions/c8y_mapper_ext/src/operations/firmware_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/firmware_update.rs
@@ -1,4 +1,4 @@
-use super::Entity;
+use super::EntityTarget;
 use super::OperationHandler;
 use crate::converter::CumulocityConverter;
 use crate::error::ConversionError;
@@ -85,7 +85,7 @@ impl OperationHandler {
     /// - "failed", it converts the message to SmartREST "Failed".
     pub async fn handle_firmware_update_state_change(
         &self,
-        target: Entity,
+        target: EntityTarget,
         cmd_id: &str,
         message: &MqttMessage,
     ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {

--- a/crates/extensions/c8y_mapper_ext/src/operations/firmware_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/firmware_update.rs
@@ -1,5 +1,5 @@
 use super::EntityTarget;
-use super::OperationHandler;
+use super::OperationContext;
 use crate::converter::CumulocityConverter;
 use crate::error::ConversionError;
 use crate::error::CumulocityMapperError;
@@ -78,7 +78,7 @@ impl CumulocityConverter {
     }
 }
 
-impl OperationHandler {
+impl OperationContext {
     /// Address a received ThinEdge firmware_update command. If its status is
     /// - "executing", it converts the message to SmartREST "Executing".
     /// - "successful", it converts the message to SmartREST "Successful" and update the current installed firmware.

--- a/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
@@ -15,7 +15,6 @@ use c8y_api::smartrest::smartrest_serializer::set_operation_executing;
 use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations;
 use camino::Utf8PathBuf;
 use std::collections::HashMap;
-use tedge_actors::Sender;
 use tedge_api::commands::CommandStatus;
 use tedge_api::commands::LogMetadata;
 use tedge_api::commands::LogUploadCmd;
@@ -53,7 +52,7 @@ impl OperationHandler {
     /// - "successful", it creates an event in c8y, then creates an UploadRequest for the uploader actor.
     /// - "failed", it converts the message to SmartREST "Failed" with that event URL.
     pub async fn handle_log_upload_state_change(
-        &mut self,
+        &self,
         target: Entity,
         cmd_id: &str,
         message: &MqttMessage,
@@ -153,7 +152,7 @@ impl OperationHandler {
     /// Resumes `log_upload` operation after required file was downloaded from
     /// the File Transfer Service.
     pub async fn handle_fts_log_download_result(
-        &mut self,
+        &self,
         cmd_id: CmdId,
         download_result: DownloadResult,
         fts_download: FtsDownloadOperationData,
@@ -322,6 +321,7 @@ mod tests {
     use std::time::Duration;
     use tedge_actors::test_helpers::MessageReceiverExt;
     use tedge_actors::MessageReceiver;
+    use tedge_actors::Sender;
     use tedge_downloader_ext::DownloadResponse;
     use tedge_mqtt_ext::test_helpers::assert_received_contains_str;
     use tedge_mqtt_ext::test_helpers::assert_received_includes_json;

--- a/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
@@ -1,4 +1,4 @@
-use super::Entity;
+use super::EntityTarget;
 use super::OperationHandler;
 use crate::converter::CumulocityConverter;
 use crate::error::ConversionError;
@@ -89,7 +89,7 @@ impl OperationHandler {
     /// - "failed", it converts the message to SmartREST "Failed" with that event URL.
     pub async fn handle_log_upload_state_change(
         &self,
-        target: Entity,
+        target: EntityTarget,
         cmd_id: &str,
         message: &MqttMessage,
     ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {

--- a/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
@@ -4,7 +4,6 @@ use super::FtsDownloadOperationType;
 use super::OperationHandler;
 use crate::actor::CmdId;
 use crate::converter::CumulocityConverter;
-use crate::converter::UploadContext;
 use crate::converter::UploadOperationData;
 use crate::error::ConversionError;
 use crate::error::CumulocityMapperError;
@@ -14,7 +13,6 @@ use c8y_api::smartrest::smartrest_serializer::fail_operation;
 use c8y_api::smartrest::smartrest_serializer::set_operation_executing;
 use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations;
 use camino::Utf8PathBuf;
-use std::collections::HashMap;
 use tedge_api::commands::CommandStatus;
 use tedge_api::commands::LogMetadata;
 use tedge_api::commands::LogUploadCmd;
@@ -56,7 +54,6 @@ impl OperationHandler {
         target: Entity,
         cmd_id: &str,
         message: &MqttMessage,
-        pending_fts_download_operations: &mut HashMap<CmdId, FtsDownloadOperationData>,
     ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {
         if !self.capabilities.log_upload {
             warn!("Received a log_upload command, however, log_upload feature is disabled");
@@ -101,7 +98,7 @@ impl OperationHandler {
                     .context("Failed to create a temporary directory")?;
                 let destination_path = destination_dir.path().join(log_filename);
 
-                pending_fts_download_operations.insert(
+                self.pending_fts_download_operations.lock().await.insert(
                     cmd_id.into(),
                     FtsDownloadOperationData {
                         download_type: FtsDownloadOperationType::LogDownload,
@@ -156,7 +153,6 @@ impl OperationHandler {
         cmd_id: CmdId,
         download_result: DownloadResult,
         fts_download: FtsDownloadOperationData,
-        pending_upload_operations: &mut HashMap<CmdId, UploadContext>,
     ) -> Result<Vec<MqttMessage>, ConversionError> {
         let topic_id = fts_download.entity_topic_id;
         let smartrest_topic = fts_download.smartrest_publish_topic;
@@ -197,7 +193,7 @@ impl OperationHandler {
             )
             .await?;
 
-        pending_upload_operations.insert(
+        self.pending_upload_operations.lock().await.insert(
             cmd_id,
             UploadOperationData {
                 topic_id,
@@ -267,12 +263,7 @@ impl CumulocityConverter {
         fts_download: FtsDownloadOperationData,
     ) -> Result<Vec<MqttMessage>, ConversionError> {
         self.operation_handler
-            .handle_fts_log_download_result(
-                cmd_id,
-                download_result,
-                fts_download,
-                &mut self.pending_upload_operations,
-            )
+            .handle_fts_log_download_result(cmd_id, download_result, fts_download)
             .await
     }
 

--- a/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/log_upload.rs
@@ -1,5 +1,5 @@
 use super::EntityTarget;
-use super::OperationHandler;
+use super::OperationContext;
 use crate::converter::CumulocityConverter;
 use crate::error::ConversionError;
 use crate::error::CumulocityMapperError;
@@ -82,7 +82,7 @@ impl CumulocityConverter {
     }
 }
 
-impl OperationHandler {
+impl OperationContext {
     /// Address a received log_upload command. If its status is
     /// - "executing", it converts the message to SmartREST "Executing".
     /// - "successful", it creates an event in c8y, then creates an UploadRequest for the uploader actor.

--- a/crates/extensions/c8y_mapper_ext/src/operations/mod.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/mod.rs
@@ -24,12 +24,15 @@ use c8y_api::http_proxy::C8yEndPoint;
 use c8y_auth_proxy::url::ProxyUrlGenerator;
 use c8y_http_proxy::handle::C8YHttpProxy;
 use camino::Utf8Path;
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::Mutex;
 use tedge_actors::ClientMessageBox;
 use tedge_actors::LoggingSender;
 use tedge_actors::Sender;
 use tedge_api::commands::ConfigMetadata;
 use tedge_api::entity_store::EntityExternalId;
+use tedge_api::mqtt_topics::Channel;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::IdGenerator;
 use tedge_api::mqtt_topics::MqttSchema;
@@ -56,17 +59,17 @@ mod upload;
 ///
 /// 1. Receive a smartrest message which is an operation request, convert it to thin-edge message,
 ///    and publish on local MQTT (done by the converter).
-/// 2. Various local thin-edge components/services execute the operation, and when they're done,
-///    they publish an MQTT message with 'status: successful/failed'
+/// 2. Various local thin-edge components/services (e.g. tedge-agent) execute the operation, and
+///    when they're done, they publish an MQTT message with 'status: successful/failed'
 /// 3. The cumulocity mapper needs to do some additional steps, like downloading/uploading files via
 ///    HTTP, or talking to C8y via HTTP proxy, before it can send operation response via the bridge
 ///    and then clear the local MQTT operation topic.
 ///
-/// This struct concerns itself with performing step 3. We need to handle multiple operations
-/// concurrently, so we need an object separate from [`CumulocityConverter`], where many `&mut self`
-/// methods prevent us from concurrent data access. Instead, this object has all necessary data for
-/// operation handling, and `&self` methods so it can be run concurrently.
-#[derive(Clone)]
+/// This struct concerns itself with performing step 3.
+///
+/// Incoming operation-related MQTT messages need to be passed to the [`Self::handle`] method, which
+/// performs an operation in the background in separate tasks. The operation tasks themselves handle
+/// reporting their success/failure.
 pub struct OperationHandler {
     pub capabilities: Capabilities,
     pub auto_log_upload: AutoLogUpload,
@@ -84,83 +87,185 @@ pub struct OperationHandler {
     pub downloader: ClientMessageBox<IdDownloadRequest, IdDownloadResult>,
     pub uploader: ClientMessageBox<IdUploadRequest, IdUploadResult>,
     pub mqtt_publisher: LoggingSender<MqttMessage>,
+
+    pub running_operations: Arc<Mutex<HashMap<Arc<str>, RunningOperation>>>,
 }
 
 impl OperationHandler {
-    pub async fn handle_operation(
-        self: &Arc<Self>,
-        operation: OperationType,
-        entity: Entity,
-        cmd_id: Arc<str>,
-        message: MqttMessage,
-    ) {
-        let handler = self.clone();
-        let external_id = entity.external_id.clone();
-        tokio::spawn(async move {
-            let res = match operation {
-                OperationType::Health | OperationType::Custom(_) => Ok((vec![], None)),
+    /// Handles an MQTT command id message.
+    ///
+    /// All MQTT messages with a topic that contains an operation id, e.g.
+    /// `te/device/child001///cmd/software_list/c8y-2023-09-25T14:34:00` need to be passed here for
+    /// operations to be processed. Messages not related to operations are ignored.
+    ///
+    /// `entity` needs to be the same entity as in `message`.
+    ///
+    /// When a message with a new id is handled, a task will be spawned that processes this
+    /// operation. For the operation to be completed, subsequent messages with the same command id
+    /// need to be handled as well.
+    ///
+    /// When an operation terminates (successfully or unsuccessfully), an MQTT operation clearing
+    /// message will be published automatically, which does not need to be handled.
+    pub async fn handle(self: &Arc<Self>, entity: EntityTarget, message: MqttMessage) {
+        let Ok((_, channel)) = self.mqtt_schema.entity_channel_of(&message.topic) else {
+            return;
+        };
 
-                OperationType::Restart => {
-                    handler
-                        .publish_restart_operation_status(entity, &cmd_id, message)
-                        .await
-                }
-                OperationType::SoftwareList => {
-                    handler
-                        .publish_software_list(entity, &cmd_id, &message)
-                        .await
-                }
-                OperationType::SoftwareUpdate => {
-                    handler
-                        .publish_software_update_status(entity, &cmd_id, &message)
-                        .await
-                }
-                OperationType::LogUpload => {
-                    handler
-                        .handle_log_upload_state_change(entity, &cmd_id, &message)
-                        .await
-                }
-                OperationType::ConfigSnapshot => {
-                    handler
-                        .handle_config_snapshot_state_change(entity, &cmd_id, &message)
-                        .await
-                }
-                OperationType::ConfigUpdate => {
-                    handler
-                        .handle_config_update_state_change(entity, &cmd_id, &message)
-                        .await
-                }
-                OperationType::FirmwareUpdate => {
-                    handler
-                        .handle_firmware_update_state_change(entity, &cmd_id, &message)
-                        .await
-                }
-            };
+        let Channel::Command { operation, cmd_id } = channel else {
+            return;
+        };
 
-            let mut mqtt_publisher = handler.mqtt_publisher.clone();
-            match res {
-                // If there are mapped final status messages to be published, they are cached until the operation log is uploaded
-                Ok((messages, Some(command))) if !messages.is_empty() => {
-                    if let Err(e) = handler
-                        .upload_operation_log(&external_id, &cmd_id, &operation, command)
-                        .await
-                    {
-                        error!("failed to upload operation logs: {e}");
-                    }
+        let message = OperationMessage {
+            operation,
+            entity,
+            cmd_id: cmd_id.into(),
+            message,
+        };
 
-                    for message in messages {
-                        mqtt_publisher.send(message).await.unwrap();
-                    }
+        let topic: Arc<str> = message.message.topic.name.clone().into();
+        let running_operation = {
+            let mut lock = self.running_operations.lock().unwrap();
+            let op = lock.get(&topic);
+
+            if let Some(running_operation) = op {
+                // task already terminated
+                if running_operation.tx.send(message).is_err() {
+                    let running_operation = lock.remove(&topic).unwrap();
+                    Some(running_operation)
+                } else {
+                    None
                 }
-                Ok((messages, _)) => {
-                    for message in messages {
-                        mqtt_publisher.send(message).await.unwrap();
-                    }
+            } else {
+                let handler = self.clone();
+                let running_operation = RunningOperation::spawn(message, handler);
+
+                lock.insert(topic, running_operation);
+                None
+            }
+        };
+
+        if let Some(running_operation) = running_operation {
+            let join_result = running_operation.handle.await;
+            error!("handle: {join_result:?}");
+        }
+    }
+}
+
+pub struct RunningOperation {
+    handle: tokio::task::JoinHandle<()>,
+    tx: tokio::sync::mpsc::UnboundedSender<OperationMessage>,
+}
+
+impl RunningOperation {
+    /// Spawns a task that handles the operation.
+    ///
+    /// The task handles a single operation with a given command id, and via a channel it receives
+    /// operation state changes (if any) to drive an operation to completion.
+    fn spawn(message: OperationMessage, handler: Arc<OperationHandler>) -> Self {
+        let cmd_id = message.cmd_id.clone();
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tx.send(message).unwrap();
+
+        let handle = tokio::spawn(async move {
+            while let Some(message) = rx.recv().await {
+                if message.cmd_id != cmd_id {
+                    continue;
                 }
-                Err(e) => error!("{e}"),
+
+                let OperationMessage {
+                    entity,
+                    cmd_id,
+                    message,
+                    operation,
+                } = message;
+                let external_id = entity.external_id.clone();
+
+                let command_topic = message.topic.clone();
+                let res = match operation {
+                    OperationType::Health | OperationType::Custom(_) => Ok((vec![], None)),
+
+                    OperationType::Restart => {
+                        handler
+                            .publish_restart_operation_status(entity, &cmd_id, message)
+                            .await
+                    }
+                    OperationType::SoftwareList => {
+                        handler
+                            .publish_software_list(entity, &cmd_id, &message)
+                            .await
+                    }
+                    OperationType::SoftwareUpdate => {
+                        handler
+                            .publish_software_update_status(entity, &cmd_id, &message)
+                            .await
+                    }
+                    OperationType::LogUpload => {
+                        handler
+                            .handle_log_upload_state_change(entity, &cmd_id, &message)
+                            .await
+                    }
+                    OperationType::ConfigSnapshot => {
+                        handler
+                            .handle_config_snapshot_state_change(entity, &cmd_id, &message)
+                            .await
+                    }
+                    OperationType::ConfigUpdate => {
+                        handler
+                            .handle_config_update_state_change(entity, &cmd_id, &message)
+                            .await
+                    }
+                    OperationType::FirmwareUpdate => {
+                        handler
+                            .handle_firmware_update_state_change(entity, &cmd_id, &message)
+                            .await
+                    }
+                };
+
+                let mut mqtt_publisher = handler.mqtt_publisher.clone();
+                match res {
+                    // If there are mapped final status messages to be published, they are cached until the operation
+                    // log is uploaded
+                    Ok((messages, command)) => {
+                        if let Some(command) = command {
+                            if let Err(e) = handler
+                                .upload_operation_log(&external_id, &cmd_id, &operation, command)
+                                .await
+                            {
+                                error!("failed to upload operation logs: {e}");
+                            }
+                        }
+
+                        for message in messages {
+                            // if task publishes MQTT clearing message, an operation is considered finished, so we can
+                            // terminate the task as well
+                            if message.retain
+                                && message.payload_bytes().is_empty()
+                                && message.topic == command_topic
+                            {
+                                rx.close();
+                            }
+                            mqtt_publisher.send(message).await.unwrap();
+                        }
+                    }
+                    Err(e) => error!("{e}"),
+                }
             }
         });
+
+        Self { handle, tx }
     }
+}
+
+/// An MQTT message that contains an operation payload.
+///
+/// These are MQTT messages that contain operation payloads. These messages need to be passed to
+/// tasks that handle a given operation to advance the operation and eventually complete it.
+struct OperationMessage {
+    operation: OperationType,
+    entity: EntityTarget,
+    cmd_id: Arc<str>,
+    message: MqttMessage,
 }
 
 /// A subset of entity-related information necessary to handle an operation.
@@ -168,7 +273,7 @@ impl OperationHandler {
 /// Because the operation may take time and other operations may run concurrently, we don't want to
 /// query the entity store.
 #[derive(Clone, Debug)]
-pub struct Entity {
+pub struct EntityTarget {
     pub topic_id: EntityTopicId,
     pub external_id: EntityExternalId,
     pub smartrest_publish_topic: Topic,

--- a/crates/extensions/c8y_mapper_ext/src/operations/restart.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/restart.rs
@@ -8,9 +8,9 @@ use tedge_mqtt_ext::MqttMessage;
 use crate::error::ConversionError;
 
 use super::EntityTarget;
-use super::OperationHandler;
+use super::OperationContext;
 
-impl OperationHandler {
+impl OperationContext {
     pub async fn publish_restart_operation_status(
         &self,
         target: EntityTarget,

--- a/crates/extensions/c8y_mapper_ext/src/operations/restart.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/restart.rs
@@ -1,15 +1,19 @@
-use c8y_api::smartrest::{self, smartrest_serializer::CumulocitySupportedOperations};
-use tedge_api::{workflow::GenericCommandState, CommandStatus, RestartCommand};
+use c8y_api::smartrest;
+use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations;
+use tedge_api::workflow::GenericCommandState;
+use tedge_api::CommandStatus;
+use tedge_api::RestartCommand;
 use tedge_mqtt_ext::MqttMessage;
 
 use crate::error::ConversionError;
 
-use super::{Entity, OperationHandler};
+use super::EntityTarget;
+use super::OperationHandler;
 
 impl OperationHandler {
     pub async fn publish_restart_operation_status(
         &self,
-        target: Entity,
+        target: EntityTarget,
         cmd_id: &str,
         message: MqttMessage,
     ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {

--- a/crates/extensions/c8y_mapper_ext/src/operations/restart.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/restart.rs
@@ -1,0 +1,70 @@
+use c8y_api::smartrest::{self, smartrest_serializer::CumulocitySupportedOperations};
+use tedge_api::{workflow::GenericCommandState, CommandStatus, RestartCommand};
+use tedge_mqtt_ext::MqttMessage;
+
+use crate::error::ConversionError;
+
+use super::{Entity, OperationHandler};
+
+impl OperationHandler {
+    pub async fn publish_restart_operation_status(
+        &self,
+        target: Entity,
+        cmd_id: &str,
+        message: MqttMessage,
+    ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {
+        let command = match RestartCommand::try_from_bytes(
+            target.topic_id,
+            cmd_id.to_owned(),
+            message.payload_bytes(),
+        )? {
+            Some(command) => command,
+            None => {
+                // The command has been fully processed
+                return Ok((vec![], None));
+            }
+        };
+        let topic = target.smartrest_publish_topic;
+
+        let messages = match command.status() {
+            CommandStatus::Executing => {
+                let smartrest_set_operation =
+                    smartrest::smartrest_serializer::set_operation_executing(
+                        CumulocitySupportedOperations::C8yRestartRequest,
+                    );
+                vec![MqttMessage::new(&topic, smartrest_set_operation)]
+            }
+            CommandStatus::Successful => {
+                let smartrest_set_operation =
+                    smartrest::smartrest_serializer::succeed_operation_no_payload(
+                        CumulocitySupportedOperations::C8yRestartRequest,
+                    );
+
+                vec![
+                    command.clearing_message(&self.mqtt_schema),
+                    MqttMessage::new(&topic, smartrest_set_operation),
+                ]
+            }
+            CommandStatus::Failed { ref reason } => {
+                let smartrest_set_operation = smartrest::smartrest_serializer::fail_operation(
+                    CumulocitySupportedOperations::C8yRestartRequest,
+                    &format!("Restart Failed: {reason}"),
+                );
+
+                vec![
+                    command.clearing_message(&self.mqtt_schema),
+                    MqttMessage::new(&topic, smartrest_set_operation),
+                ]
+            }
+            _ => {
+                // The other states are ignored
+                vec![]
+            }
+        };
+
+        Ok((
+            messages,
+            Some(command.into_generic_command(&self.mqtt_schema)),
+        ))
+    }
+}

--- a/crates/extensions/c8y_mapper_ext/src/operations/software_list.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/software_list.rs
@@ -10,11 +10,11 @@ use tracing::error;
 use crate::error::ConversionError;
 
 use super::EntityTarget;
-use super::OperationHandler;
+use super::OperationContext;
 
 const SOFTWARE_LIST_CHUNK_SIZE: usize = 100;
 
-impl OperationHandler {
+impl OperationContext {
     pub async fn publish_software_list(
         &self,
         target: EntityTarget,

--- a/crates/extensions/c8y_mapper_ext/src/operations/software_list.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/software_list.rs
@@ -1,0 +1,81 @@
+use c8y_api::{json_c8y::C8yUpdateSoftwareListResponse, smartrest};
+use tedge_api::{workflow::GenericCommandState, CommandStatus, SoftwareListCommand};
+use tedge_config::SoftwareManagementApiFlag;
+use tedge_mqtt_ext::MqttMessage;
+use tracing::error;
+
+use crate::error::ConversionError;
+
+use super::{Entity, OperationHandler};
+
+const SOFTWARE_LIST_CHUNK_SIZE: usize = 100;
+
+impl OperationHandler {
+    pub async fn publish_software_list(
+        &self,
+        target: Entity,
+        cmd_id: &str,
+        message: &MqttMessage,
+    ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {
+        let command = match SoftwareListCommand::try_from_bytes(
+            target.topic_id,
+            cmd_id.to_owned(),
+            message.payload_bytes(),
+        )? {
+            Some(command) => command,
+            None => {
+                // The command has been fully processed
+                return Ok((Vec::new(), None));
+            }
+        };
+
+        let messages = match command.status() {
+            CommandStatus::Successful => {
+                // Send a list via HTTP to support backwards compatibility to c8y < 10.14
+                if self.software_management_api == SoftwareManagementApiFlag::Legacy {
+                    let c8y_software_list: C8yUpdateSoftwareListResponse = (&command).into();
+                    self.http_proxy
+                        .clone()
+                        .send_software_list_http(
+                            c8y_software_list,
+                            target.external_id.as_ref().to_string(),
+                        )
+                        .await?;
+                    return Ok((vec![command.clearing_message(&self.mqtt_schema)], None));
+                }
+
+                // Send a list via SmartREST, "advanced software list" feature c8y >= 10.14
+                let topic = target.smartrest_publish_topic;
+                let payloads = smartrest::smartrest_serializer::get_advanced_software_list_payloads(
+                    &command,
+                    SOFTWARE_LIST_CHUNK_SIZE,
+                );
+
+                let mut messages: Vec<MqttMessage> = Vec::new();
+                for payload in payloads {
+                    messages.push(MqttMessage::new(&topic, payload))
+                }
+                messages.push(command.clearing_message(&self.mqtt_schema));
+                messages
+            }
+
+            CommandStatus::Failed { reason } => {
+                error!("Fail to list installed software packages: {reason}");
+                vec![command.clearing_message(&self.mqtt_schema)]
+            }
+
+            CommandStatus::Init
+            | CommandStatus::Scheduled
+            | CommandStatus::Executing
+            | CommandStatus::Unknown => {
+                // C8Y doesn't expect any message to be published
+                Vec::new()
+            }
+        };
+
+        Ok((
+            messages,
+            Some(command.into_generic_command(&self.mqtt_schema)),
+        ))
+    }
+}

--- a/crates/extensions/c8y_mapper_ext/src/operations/software_list.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/software_list.rs
@@ -1,19 +1,23 @@
-use c8y_api::{json_c8y::C8yUpdateSoftwareListResponse, smartrest};
-use tedge_api::{workflow::GenericCommandState, CommandStatus, SoftwareListCommand};
+use c8y_api::json_c8y::C8yUpdateSoftwareListResponse;
+use c8y_api::smartrest;
+use tedge_api::workflow::GenericCommandState;
+use tedge_api::CommandStatus;
+use tedge_api::SoftwareListCommand;
 use tedge_config::SoftwareManagementApiFlag;
 use tedge_mqtt_ext::MqttMessage;
 use tracing::error;
 
 use crate::error::ConversionError;
 
-use super::{Entity, OperationHandler};
+use super::EntityTarget;
+use super::OperationHandler;
 
 const SOFTWARE_LIST_CHUNK_SIZE: usize = 100;
 
 impl OperationHandler {
     pub async fn publish_software_list(
         &self,
-        target: Entity,
+        target: EntityTarget,
         cmd_id: &str,
         message: &MqttMessage,
     ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {

--- a/crates/extensions/c8y_mapper_ext/src/operations/software_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/software_update.rs
@@ -10,9 +10,9 @@ use tedge_mqtt_ext::MqttMessage;
 use crate::error::ConversionError;
 
 use super::EntityTarget;
-use super::OperationHandler;
+use super::OperationContext;
 
-impl OperationHandler {
+impl OperationContext {
     pub async fn publish_software_update_status(
         &self,
         target: EntityTarget,

--- a/crates/extensions/c8y_mapper_ext/src/operations/software_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/software_update.rs
@@ -1,0 +1,81 @@
+use c8y_api::smartrest::{self, smartrest_serializer::CumulocitySupportedOperations};
+use tedge_api::{
+    mqtt_topics::EntityTopicId, workflow::GenericCommandState, CommandStatus, SoftwareListCommand,
+    SoftwareUpdateCommand,
+};
+use tedge_mqtt_ext::MqttMessage;
+
+use crate::error::ConversionError;
+
+use super::{Entity, OperationHandler};
+
+impl OperationHandler {
+    pub async fn publish_software_update_status(
+        &self,
+        target: Entity,
+        cmd_id: &str,
+        message: &MqttMessage,
+    ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {
+        let command = match SoftwareUpdateCommand::try_from_bytes(
+            target.topic_id.clone(),
+            cmd_id.to_string(),
+            message.payload_bytes(),
+        )? {
+            Some(command) => command,
+            None => {
+                // The command has been fully processed
+                return Ok((vec![], None));
+            }
+        };
+
+        let topic = target.smartrest_publish_topic;
+        let messages = match command.status() {
+            CommandStatus::Init | CommandStatus::Scheduled | CommandStatus::Unknown => {
+                // The command has not been processed yet
+                vec![]
+            }
+            CommandStatus::Executing => {
+                let smartrest_set_operation_status =
+                    smartrest::smartrest_serializer::set_operation_executing(
+                        CumulocitySupportedOperations::C8ySoftwareUpdate,
+                    );
+                vec![MqttMessage::new(&topic, smartrest_set_operation_status)]
+            }
+            CommandStatus::Successful => {
+                let smartrest_set_operation =
+                    smartrest::smartrest_serializer::succeed_operation_no_payload(
+                        CumulocitySupportedOperations::C8ySoftwareUpdate,
+                    );
+
+                vec![
+                    MqttMessage::new(&topic, smartrest_set_operation),
+                    command.clearing_message(&self.mqtt_schema),
+                    self.request_software_list(&target.topic_id),
+                ]
+            }
+            CommandStatus::Failed { reason } => {
+                let smartrest_set_operation = smartrest::smartrest_serializer::fail_operation(
+                    CumulocitySupportedOperations::C8ySoftwareUpdate,
+                    &reason,
+                );
+
+                vec![
+                    MqttMessage::new(&topic, smartrest_set_operation),
+                    command.clearing_message(&self.mqtt_schema),
+                    self.request_software_list(&target.topic_id),
+                ]
+            }
+        };
+
+        Ok((
+            messages,
+            Some(command.into_generic_command(&self.mqtt_schema)),
+        ))
+    }
+
+    fn request_software_list(&self, target: &EntityTopicId) -> MqttMessage {
+        let cmd_id = self.command_id.new_id();
+        let request = SoftwareListCommand::new(target, cmd_id);
+        request.command_message(&self.mqtt_schema)
+    }
+}

--- a/crates/extensions/c8y_mapper_ext/src/operations/software_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/software_update.rs
@@ -1,18 +1,21 @@
-use c8y_api::smartrest::{self, smartrest_serializer::CumulocitySupportedOperations};
-use tedge_api::{
-    mqtt_topics::EntityTopicId, workflow::GenericCommandState, CommandStatus, SoftwareListCommand,
-    SoftwareUpdateCommand,
-};
+use c8y_api::smartrest;
+use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations;
+use tedge_api::mqtt_topics::EntityTopicId;
+use tedge_api::workflow::GenericCommandState;
+use tedge_api::CommandStatus;
+use tedge_api::SoftwareListCommand;
+use tedge_api::SoftwareUpdateCommand;
 use tedge_mqtt_ext::MqttMessage;
 
 use crate::error::ConversionError;
 
-use super::{Entity, OperationHandler};
+use super::EntityTarget;
+use super::OperationHandler;
 
 impl OperationHandler {
     pub async fn publish_software_update_status(
         &self,
-        target: Entity,
+        target: EntityTarget,
         cmd_id: &str,
         message: &MqttMessage,
     ) -> Result<(Vec<MqttMessage>, Option<GenericCommandState>), ConversionError> {

--- a/crates/extensions/c8y_mapper_ext/src/operations/upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/upload.rs
@@ -37,7 +37,7 @@ impl OperationHandler {
             device_id: external_id.into(),
         };
 
-        let mut c8y_http_proxy = self.http_proxy.lock().await.clone();
+        let mut c8y_http_proxy = self.http_proxy.clone();
         let event_response_id = c8y_http_proxy.send_event(create_event).await?;
 
         let binary_upload_event_url = self
@@ -63,9 +63,9 @@ impl OperationHandler {
             .post()
             .with_content_type(ContentType::FormData(form_data));
 
-        let mut uploader = self.uploader.lock().await;
-
-        let (_, download_result) = uploader
+        let (_, download_result) = self
+            .uploader
+            .clone()
             .await_response((cmd_id.into(), upload_request))
             .await?;
 

--- a/crates/extensions/c8y_mapper_ext/src/operations/upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/upload.rs
@@ -1,0 +1,65 @@
+use std::collections::HashMap;
+
+use c8y_http_proxy::messages::CreateEvent;
+use camino::Utf8Path;
+use mime::Mime;
+use tedge_actors::Sender;
+use tedge_api::entity_store::EntityExternalId;
+use tedge_uploader_ext::{ContentType, FormData, UploadRequest};
+use time::OffsetDateTime;
+use url::Url;
+
+use crate::error::ConversionError;
+
+use super::OperationHandler;
+
+impl OperationHandler {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn upload_file(
+        &mut self,
+        external_id: &EntityExternalId,
+        file_path: &Utf8Path,
+        file_name: Option<String>,
+        mime_type: Option<Mime>,
+        cmd_id: &str,
+        event_type: String,
+        event_text: Option<String>,
+    ) -> Result<Url, ConversionError> {
+        let create_event = CreateEvent {
+            event_type: event_type.clone(),
+            time: OffsetDateTime::now_utc(),
+            text: event_text.unwrap_or(event_type),
+            extras: HashMap::new(),
+            device_id: external_id.into(),
+        };
+        let event_response_id = self.http_proxy.send_event(create_event).await?;
+        let binary_upload_event_url = self
+            .c8y_endpoint
+            .get_url_for_event_binary_upload_unchecked(&event_response_id);
+
+        let proxy_url = self.auth_proxy.proxy_url(binary_upload_event_url.clone());
+
+        let external_id = external_id.as_ref();
+        let file_name = file_name.unwrap_or_else(|| {
+            format!(
+                "{external_id}_{filename}",
+                filename = file_path.file_name().unwrap_or(cmd_id)
+            )
+        });
+        let form_data = if let Some(mime) = mime_type {
+            FormData::new(file_name).set_mime(mime)
+        } else {
+            FormData::new(file_name)
+        };
+        // The method must be POST, otherwise file name won't be supported.
+        let upload_request = UploadRequest::new(proxy_url.as_str(), file_path)
+            .post()
+            .with_content_type(ContentType::FormData(form_data));
+
+        self.uploader_sender
+            .send((cmd_id.into(), upload_request))
+            .await?;
+
+        Ok(binary_upload_event_url)
+    }
+}

--- a/crates/extensions/c8y_mapper_ext/src/operations/upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/upload.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
-
 use c8y_http_proxy::messages::CreateEvent;
 use camino::Utf8Path;
 use mime::Mime;
-use tedge_actors::Sender;
+use std::collections::HashMap;
 use tedge_api::entity_store::EntityExternalId;
 use tedge_uploader_ext::{ContentType, FormData, UploadRequest};
 use time::OffsetDateTime;
@@ -16,7 +14,7 @@ use super::OperationHandler;
 impl OperationHandler {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn upload_file(
-        &mut self,
+        &self,
         external_id: &EntityExternalId,
         file_path: &Utf8Path,
         file_name: Option<String>,
@@ -32,7 +30,14 @@ impl OperationHandler {
             extras: HashMap::new(),
             device_id: external_id.into(),
         };
-        let event_response_id = self.http_proxy.send_event(create_event).await?;
+
+        let event_response_id = self
+            .http_proxy
+            .lock()
+            .await
+            .send_event(create_event)
+            .await?;
+
         let binary_upload_event_url = self
             .c8y_endpoint
             .get_url_for_event_binary_upload_unchecked(&event_response_id);

--- a/crates/extensions/c8y_mapper_ext/src/operations/upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/upload.rs
@@ -15,9 +15,9 @@ use url::Url;
 
 use crate::error::ConversionError;
 
-use super::OperationHandler;
+use super::OperationContext;
 
-impl OperationHandler {
+impl OperationContext {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn upload_file(
         &self,

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -2576,6 +2576,22 @@ async fn mapper_processes_operations_concurrently() {
     // simulate many successful operations that needs to be handled by the mapper
     for i in 0..num_operations {
         mqtt.send(MqttMessage::new(
+            &Topic::new_unchecked(&format!("te/device/main///cmd/log_upload/c8y-mapper-{i}")),
+            json!({
+            "status": "successful",
+            "tedgeUrl": format!("http://{host_port}/tedge/file-transfer/test-device/log_upload/c8y-mapper-1234"),
+            "type": "mosquitto",
+            "dateFrom": "2023-11-28T16:33:50+01:00",
+            "dateTo": "2023-11-29T16:33:50+01:00",
+            "searchText": "ERROR",
+            "lines": 1000
+
+        })
+                .to_string(),
+        ))
+            .await.unwrap();
+
+        mqtt.send(MqttMessage::new(
             &Topic::new_unchecked(&format!("te/device/main///cmd/config_snapshot/c8y-mapper-{i}")),
             json!({
             "status": "successful",
@@ -2587,7 +2603,7 @@ async fn mapper_processes_operations_concurrently() {
             .await.unwrap();
     }
 
-    for _ in 0..num_operations {
+    for _ in 0..(num_operations * 2) {
         dl.recv()
             .await
             .expect("there should be one DownloadRequest per operation");


### PR DESCRIPTION
## TODO

- [x] ~~add more tests to see which operations are blocked/executed concurrently~~ added `log_upload`, no other operations downloading from the FTS (from the perspective of the mapper)
- [x] ~~remove remaining mutexes/locks~~ replaced with ordinary sender clones
- [ ] ~~clean up operation handling code~~ will be done in next PR

## Proposed changes

This PR is a 2nd attempt at simplifying operation control flow. I found that the top-down approach in #2881 of spawning a task for every main actor message would be too tedious to get working, because to remove the lock on the converter would require to change `convert` method to `&self`, which at this moment is infeasible because of how many things it does/how many other functions it calls.

Instead, the approach taken here was a bottom-up one:
1. It was identified that the operation handling and its properties do not fit into `convert` method's assumptions:
    - `convert()` needs to convert MQTT messages in both directions without blocking
    - but operation handling can block, and it can take some time before MQTT response is ready
2. As such, some operations (not all) were pulled out of `CumulocityConverter` and placed in a newly created `OperationHandler`. The operation handler was later made to `tokio::spawn` the operation handlers. This separates the scope of operation handling from the converter, and makes it so the converter can immediately return.
3. `pending_upload_operations` and `pending_fts_download_operations` hashmaps were removed.

In contrast to the previous attempt, the stated aims, i.e.: simplifying the control flow without impacting the ability to execute multiple operations concurrently, appear to have been achieved.

cont. in _Further comments_

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- #2880

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Caveats

#### Testing and correctness 

There was a test created, but it only tests `config_snapshot` and `log_upload` command, and it only tests if it's concurrent by checking if the download requests were created. Ideally we'd spawn operations of all types and check if they're progressing equally, but the only view into their execution is messages they send to other actors, but some don't do this at all.

https://github.com/Bravo555/thin-edge.io/blob/4f53e990e160924aec0931ba1afe771f9301195f/crates/extensions/c8y_mapper_ext/src/tests.rs#L2421-L2469