### PR TITLE
feat(sm-plugin): skip package download if the url is empty

### DIFF
--- a/crates/common/download/src/download.rs
+++ b/crates/common/download/src/download.rs
@@ -79,6 +79,10 @@ impl DownloadInfo {
     pub fn url(&self) -> &str {
         self.url.as_str()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.url.trim().is_empty()
+    }
 }
 
 /// Possible authentication schemes

--- a/crates/core/tedge_api/src/commands.rs
+++ b/crates/core/tedge_api/src/commands.rs
@@ -406,13 +406,14 @@ impl SoftwareUpdateCommand {
             .find(|&items| items.plugin_type == module_type)
         {
             for item in items.modules.iter() {
-                let module = SoftwareModule {
-                    module_type: Some(module_type.to_string()),
-                    name: item.name.clone(),
-                    version: item.version.clone(),
-                    url: item.url.clone(),
-                    file_path: None,
-                };
+                let module = SoftwareModule::new(
+                    Some(module_type.to_string()),
+                    item.name.clone(),
+                    item.version.clone(),
+                    item.url.clone(),
+                    None,
+                );
+
                 match item.action {
                     None => {}
                     Some(SoftwareModuleAction::Install) => {

--- a/crates/core/tedge_api/src/software.rs
+++ b/crates/core/tedge_api/src/software.rs
@@ -59,6 +59,11 @@ impl SoftwareModule {
             Some(version) if version.is_empty() => self.version = None,
             _ => {}
         };
+
+        match &self.url {
+            Some(url) if url.is_empty() => self.url = None,
+            _ => {}
+        };
     }
 }
 

--- a/tests/RobotFramework/tests/cumulocity/software_management/software.robot
+++ b/tests/RobotFramework/tests/cumulocity/software_management/software.robot
@@ -69,6 +69,13 @@ Manual software_update operation request
     ...    expected_status=failed
     ...    c8y_fragment=c8y_SoftwareUpdate
 
+Manual software_update operation request with empty url
+    Publish and Verify Local Command
+    ...    topic=te/device/main///cmd/software_update/local-3333
+    ...    payload={"status":"init","updateList":[{"type":"apt","modules":[{"name":"tedge","version":"latest","url":"","action":"install"}]}]}
+    ...    expected_status=successful
+    ...    c8y_fragment=c8y_SoftwareUpdate
+
 Operation log uploaded automatically with auto_log_upload setting as on-failure
     Execute Command    tedge config set c8y.operations.auto_log_upload on-failure
     Restart Service    tedge-mapper-c8y


### PR DESCRIPTION
## Proposed changes
This PR adds an extra check in `software_update` to skip the download process if the payload contains an empty url. A system test was added to prove that the error no longer exists when an empty url is provided in the local command.
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #2857
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

