### PR TITLE
add missing timeout to service monitoring asserts

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
+++ b/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
@@ -76,7 +76,7 @@ Test if all c8y services using default service type when service type configured
 
 Check health status of tedge-mapper-c8y service on broker stop start
     Device Should Exist                      ${DEVICE_SN}:device:main:service:tedge-mapper-c8y    show_info=False
-    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up
+    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up    timeout=${TIMEOUT}
     Should Be Equal    ${SERVICE["name"]}    tedge-mapper-c8y
     Should Be Equal    ${SERVICE["status"]}    up
 
@@ -84,7 +84,7 @@ Check health status of tedge-mapper-c8y service on broker stop start
     ThinEdgeIO.Service Should Be Stopped  mosquitto.service
 
     Device Should Exist                      ${DEVICE_SN}:device:main:service:tedge-mapper-c8y    show_info=False
-    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=down
+    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=down    timeout=${TIMEOUT}
     Should Be Equal    ${SERVICE["name"]}    tedge-mapper-c8y
     Should Be Equal    ${SERVICE["status"]}    down
 
@@ -126,7 +126,7 @@ Check health status of child device service
 
     # Check created service entries
     Device Should Exist                      ${child_sn}:service:childservice    show_info=False
-    ${SERVICE}=    Device Should Have Fragment Values    status\=unknown
+    ${SERVICE}=    Device Should Have Fragment Values    status\=unknown    timeout=${TIMEOUT}
     Should Be Equal    ${SERVICE["name"]}    childservice
     Should Be Equal    ${SERVICE["serviceType"]}    service
     Should Be Equal    ${SERVICE["status"]}    unknown
@@ -162,7 +162,7 @@ Check if a service is down
     ThinEdgeIO.Service Should Be Stopped  ${service_name}
 
     Device Should Exist                      ${DEVICE_SN}:device:main:service:${service_name}    show_info=False
-    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=down
+    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=down    timeout=${TIMEOUT}
 
     Should Be Equal    ${SERVICE["name"]}    ${service_name}
     Should Be Equal    ${SERVICE["serviceType"]}    service


### PR DESCRIPTION
## Proposed changes

Before the change, sometimes the test would get "stuck" when running locally, because some asserts did not have a timeout. This commit adds missing timeout so that this test suite no longer gets stuck.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

