### PR TITLE
fix: tedge mqtt ignoring ctrl-c when connection fails

### DIFF
--- a/crates/core/tedge/src/cli/mqtt/mod.rs
+++ b/crates/core/tedge/src/cli/mqtt/mod.rs
@@ -1,6 +1,10 @@
 pub use self::cli::TEdgeMqttCli;
 pub use self::error::MqttError;
 use rumqttc::Client;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 mod cli;
 mod error;
@@ -9,17 +13,19 @@ mod subscribe;
 
 const MAX_PACKET_SIZE: usize = 10 * 1024 * 1024;
 
-fn disconnect_if_interrupted(client: Client) {
-    use std::sync::Arc;
-    use std::sync::Mutex;
+fn disconnect_if_interrupted(client: Client) -> Arc<AtomicBool> {
     let interrupter = Arc::new(Mutex::new(client));
+    let interrupted = Arc::new(AtomicBool::new(false));
     for signal in signal_hook::consts::TERM_SIGNALS {
         let interrupter = interrupter.clone();
+        let interrupted = interrupted.clone();
         unsafe {
             let _ = signal_hook::low_level::register(*signal, move || {
+                interrupted.store(true, Ordering::Relaxed);
                 let mut client = interrupter.lock().unwrap();
                 let _ = client.disconnect();
             });
         }
     }
+    interrupted
 }


### PR DESCRIPTION
## Proposed changes

As rumqttc doesn't trigger a client disconnect when the connection is not established,
one has to combine a client disconnect with the use of an `AtomicBool` to break the event loop
if for some reason the connection is not established when the user hits ctrl-c. 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2949

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

