### PR TITLE
test: use more robust http parsing in the c8y-proxy host header tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,7 @@ dependencies = [
  "camino",
  "env_logger",
  "futures",
+ "httparse",
  "hyper",
  "mockito",
  "rcgen",
@@ -1577,9 +1578,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ glob = "0.3"
 heck = "0.4.1"
 http = "0.2"
 http-body = "0.4"
+httparse = "1.9.3"
 humantime = "2.1.0"
 hyper = { version = "0.14", default-features = false }
 hyper-rustls = { version = "0.24", default_features = false, features = [

--- a/crates/extensions/c8y_auth_proxy/Cargo.toml
+++ b/crates/extensions/c8y_auth_proxy/Cargo.toml
@@ -35,6 +35,7 @@ url = { workspace = true }
 
 [dev-dependencies]
 env_logger = { workspace = true }
+httparse = { workspace = true }
 mockito = { workspace = true }
 rcgen = { workspace = true }
 rustls = { workspace = true, features = ["dangerous_configuration"] }


### PR DESCRIPTION
## Proposed changes
Improve the host header tests introduced in #2946 by actually parsing the headers instead of simply checking for the presence of a string in the incoming request. Additionally simplify the logic for obtaining the websocket host.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

