### PR TITLE
feat: add path and method used to HTTP error messages to improve debugability

### DIFF
--- a/crates/extensions/tedge_http_ext/src/actor.rs
+++ b/crates/extensions/tedge_http_ext/src/actor.rs
@@ -1,4 +1,5 @@
 use crate::HttpRequest;
+use crate::HttpResponse;
 use crate::HttpResult;
 use async_trait::async_trait;
 use hyper::client::Client;
@@ -35,6 +36,10 @@ impl Server for HttpService {
     }
 
     async fn handle(&mut self, request: Self::Request) -> Self::Response {
-        Ok(self.client.request(request).await?)
+        Ok(HttpResponse {
+            endpoint: request.uri().path().to_owned(),
+            method: request.method().to_owned(),
+            response: self.client.request(request).await?,
+        })
     }
 }

--- a/crates/extensions/tedge_http_ext/src/test_helpers.rs
+++ b/crates/extensions/tedge_http_ext/src/test_helpers.rs
@@ -1,5 +1,6 @@
 use crate::HttpError;
 use crate::HttpRequest;
+use crate::HttpResponse;
 use crate::HttpResult;
 use http::StatusCode;
 
@@ -48,8 +49,16 @@ impl HttpResponseBuilder {
 
     /// Build the response
     pub fn build(self) -> HttpResult {
-        self.body
-            .and_then(|body| self.inner.body(body).map_err(|err| err.into()))
+        self.body.and_then(|body| {
+            self.inner
+                .body(body)
+                .map(|body| HttpResponse {
+                    response: body,
+                    endpoint: "<test response>".to_string(),
+                    method: "TEST".parse().unwrap(),
+                })
+                .map_err(|err| err.into())
+        })
     }
 }
 


### PR DESCRIPTION
## Proposed changes
Add information to the HTTP status code error messages, specifically the path (e.g. `/inventory/managedObjects/12345`) and method (e.g. `PUT`). Previously the error messages just quoted the status code, which meant that without further context it was near enough impossible to work out what tedge was trying to do when it encountered the error.

This also adds a small bit of context to the specific case I encountered testing the mapper against a fake Cumulocity.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

