### PR TITLE
fix: use octal format for file permission in generated example file

### DIFF
--- a/crates/extensions/tedge_config_manager/src/lib.rs
+++ b/crates/extensions/tedge_config_manager/src/lib.rs
@@ -133,7 +133,7 @@ impl ConfigManagerBuilder {
             type = "tedge-log-plugin"
             user = "tedge"
             group = "tedge"
-            mode = 644
+            mode = 0o644
         }
         .to_string();
         create_file_with_defaults(&config.plugin_config_path, Some(&example_config))?;

--- a/crates/extensions/tedge_config_manager/src/tests.rs
+++ b/crates/extensions/tedge_config_manager/src/tests.rs
@@ -163,7 +163,7 @@ async fn default_plugin_config() {
         type = "tedge-log-plugin"
         user = "tedge"
         group = "tedge"
-        mode = 644
+        mode = 0o644
     };
 
     assert_eq!(plugin_config_toml, expected_config);


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

All of our other examples use octal when declaring the file permissions for the tedge-configuration-plugin.toml file, so we should also use it when generating the default `tedge-configuration-plugin.toml` file if it does not already exist.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

