### PR TITLE
feat: tedge cert upload usability improvements

### DIFF
--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -22,6 +22,7 @@ certificate = { workspace = true }
 clap = { workspace = true, features = [
     "cargo",
     "derive",
+    "env",
     "string",
     "unstable-styles",
 ] }

--- a/crates/core/tedge/src/cli/certificate/cli.rs
+++ b/crates/core/tedge/src/cli/certificate/cli.rs
@@ -127,8 +127,9 @@ pub enum UploadCertCli {
     /// The command will upload root certificate to Cumulocity.
     C8y {
         #[clap(long = "user")]
+        #[arg(env = "C8Y_USER", default_value = "")]
         /// Provided username should be a Cumulocity user with tenant management permissions.
-        /// The password is requested on /dev/tty, unless the $C8YPASS env var is set to the user password.
+        /// The username is requested on stdin unless provided by the --user flag, or the C8Y_USER env var.
         username: String,
     },
 }

--- a/crates/core/tedge/src/cli/certificate/cli.rs
+++ b/crates/core/tedge/src/cli/certificate/cli.rs
@@ -98,11 +98,12 @@ impl BuildCommand for TEdgeCertCli {
 
             TEdgeCertCli::Upload(cmd) => {
                 let cmd = match cmd {
-                    UploadCertCli::C8y { username } => UploadCertCmd {
+                    UploadCertCli::C8y { username, password } => UploadCertCmd {
                         device_id: config.device.id.try_read(&config)?.clone(),
                         path: config.device.cert_path.clone(),
                         host: config.c8y.http.or_err()?.to_owned(),
                         username,
+                        password,
                     },
                 };
                 cmd.into_boxed()
@@ -127,9 +128,23 @@ pub enum UploadCertCli {
     /// The command will upload root certificate to Cumulocity.
     C8y {
         #[clap(long = "user")]
-        #[arg(env = "C8Y_USER", default_value = "")]
-        /// Provided username should be a Cumulocity user with tenant management permissions.
-        /// The username is requested on stdin unless provided by the --user flag, or the C8Y_USER env var.
+        #[arg(
+            env = "C8Y_USER",
+            hide_env_values = true,
+            hide_default_value = true,
+            default_value = ""
+        )]
+        /// Provided username should be a Cumulocity IoT user with tenant management permissions.
+        /// You will be prompted for input if the value is not provided or is empty
         username: String,
+
+        #[clap(long = "password")]
+        #[arg(env = "C8Y_PASSWORD", hide_env_values = true, hide_default_value = true, default_value_t = std::env::var("C8YPASS").unwrap_or_default().to_string())]
+        // Note: Prefer C8Y_PASSWORD over the now deprecated C8YPASS env variable as the former is also supported by other tooling such as go-c8y-cli
+        /// Cumulocity IoT Password.
+        /// You will be prompted for input if the value is not provided or is empty
+        ///
+        /// Notes: `C8YPASS` is deprecated. Please use the `C8Y_PASSWORD` env variable instead
+        password: String,
     },
 }

--- a/tests/RobotFramework/requirements/requirements.adapter-docker.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-docker.txt
@@ -1,1 +1,1 @@
-robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.15.0
+robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.15.1

--- a/tests/RobotFramework/requirements/requirements.adapter-local.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-local.txt
@@ -1,1 +1,1 @@
-robotframework-devicelibrary[local] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.15.0
+robotframework-devicelibrary[local] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.15.1

--- a/tests/RobotFramework/requirements/requirements.adapter-ssh.txt
+++ b/tests/RobotFramework/requirements/requirements.adapter-ssh.txt
@@ -1,2 +1,2 @@
-robotframework-devicelibrary[ssh] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.15.0
+robotframework-devicelibrary[ssh] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.15.1
 robotframework-sshlibrary~=3.8.0

--- a/tests/RobotFramework/tests/tedge/tedge_upload_cert.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_upload_cert.robot
@@ -29,6 +29,24 @@ Renew the certificate
     ${output}=    Execute Command    sudo tedge connect c8y    
     Should Contain    ${output}    Connection check is successful.
 
+Cert upload prompts for username (from stdin)
+    # Note: Use bash process substitution to simulate user input from /dev/stdin
+    [Setup]    Setup With Self-Signed Certificate
+    Execute Command    sudo tedge disconnect c8y
+    ${output}=    Execute Command    sudo tedge cert renew    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
+    Should Contain    ${output}    Certificate was successfully renewed, for un-interrupted service, the certificate has to be uploaded to the cloud
+    Execute Command    cmd=sudo env --unset=C8Y_USER C8Y_PASSWORD='${C8Y_CONFIG.password}' bash -c "tedge cert upload c8y < <(echo '${C8Y_CONFIG.username}')"    log_output=${False}
+    ${output}=    Execute Command    sudo tedge connect c8y
+    Should Contain    ${output}    Connection check is successful.
+
+Cert upload supports reading username/password from go-c8y-cli env variables
+    [Setup]    Setup With Self-Signed Certificate
+    Execute Command    sudo tedge disconnect c8y
+    ${output}=    Execute Command    sudo tedge cert renew    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
+    Should Contain    ${output}    Certificate was successfully renewed, for un-interrupted service, the certificate has to be uploaded to the cloud
+    Execute Command    cmd=sudo env C8Y_USER='${C8Y_CONFIG.username}' C8Y_PASSWORD='${C8Y_CONFIG.password}' tedge cert upload c8y   log_output=${False}
+    ${output}=    Execute Command    sudo tedge connect c8y
+    Should Contain    ${output}    Connection check is successful.
 
 Renew certificate fails
     [Setup]    Setup Without Certificate

--- a/tests/RobotFramework/tests/tedge/tedge_upload_cert.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_upload_cert.robot
@@ -25,7 +25,7 @@ Renew the certificate
     Execute Command    sudo tedge disconnect c8y 
     ${output}=    Execute Command    sudo tedge cert renew    stderr=${True}    stdout=${False}    ignore_exit_code=${True}    
     Should Contain    ${output}    Certificate was successfully renewed, for un-interrupted service, the certificate has to be uploaded to the cloud
-    Execute Command    sudo env C8YPASS\='${C8Y_CONFIG.password}' tedge cert upload c8y --user ${C8Y_CONFIG.username}
+    Execute Command    sudo env C8YPASS\='${C8Y_CONFIG.password}' tedge cert upload c8y --user ${C8Y_CONFIG.username}      log_output=${False}
     ${output}=    Execute Command    sudo tedge connect c8y    
     Should Contain    ${output}    Connection check is successful.
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Small usability improvements around the `tedge cert upload c8y` command:

* Support reading the username from the env variable via `C8Y_USER` (if provided)
* If user is not provided by the `--user` flag, or the `C8Y_USER`, then the user will be prompted to enter their username => **Reason:** Users generally don't know that they have to provide the `--user` flag, so it is more intuitive to prompt them for the missing information rather than throwing an error about the missing `--user` flag
* Password can also be set via the more common env variable, `C8Y_PASSWORD`, though `C8YPASS` is still supported, but it has been deprecated and a warning is printed to the console => **Reason:** other Cumulocity tooling (like go-c8y-cli) uses C8Y_PASSWORD which means the tools work well with each other

The new changes makes the following usage possible:

```sh
# Prompt for both username and password
tedge cert upload c8y

# Reuse go-c8y-cli session variables (which provide the username/password)
export C8Y_USER="foo"
export C8Y_PASSWORD="bar"
tedge cert upload c8y

# Use the existing method (the user is prompted for the password if the C8Y_PASSWORD env var is not defined)
tedge cert upload c8y --user "foo"

# Force prompting of the password (regardless if C8Y_PASSWORD env var is defined)
tedge cert upload c8y --user "foo" --password ""
```

Since the new code is using clap to handle the reading of the values from either the flags, or env variables, the default --help text is much more helpful now and the each flag has the linked env variable documented:

```sh
Upload root certificate to Cumulocity

The command will upload root certificate to Cumulocity.

Usage: tedge cert upload c8y [OPTIONS]

Options:
      --user <USERNAME>
          Provided username should be a Cumulocity IoT user with tenant management permissions. You will be prompted for input if the value is not provided or is empty
          
          [env: C8Y_USER]

      --password <PASSWORD>
          Cumulocity IoT Password. You will be prompted for input if the value is not provided or is empty
          
          Notes: `C8YPASS` is deprecated. Please use the `C8Y_PASSWORD` env variable instead
          
          [env: C8Y_PASSWORD]

      --config-dir <CONFIG_DIR>
          [default: /etc/tedge]

  -h, --help
          Print help (see a summary with '-h')
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

