### PR TITLE
chore: bump MSRV in the workflow to 1.78

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -54,12 +54,14 @@ jobs:
           - armv5te-unknown-linux-musleabi
           - x86_64-unknown-linux-musl
           - i686-unknown-linux-musl
+          - riscv64gc-unknown-linux-gnu
+          - aarch64-apple-darwin
           - x86_64-apple-darwin
         mode:
           - --release
 
         rust_channel:
-          - "1.70"
+          - "1.78"
 
         include:
           - target: aarch64-unknown-linux-musl
@@ -90,19 +92,10 @@ jobs:
             cargo_options: --no-run
 
           - target: riscv64gc-unknown-linux-gnu
-            mode: '--release'
-            # Using < 1.73 causes a segmentation fault when running a binary built with the --release flag
-            # Rust 1.73 includes both an updated llvm version and updated binutils which is like to have improved compatibility
-            # See: https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1730-2023-10-05
-            # There is a comment in the https://github.com/rust-lang/rust/pull/114048/ which refers to riscv64 support:
-            # * "Updated dist-riscv64-linux to use binutils 2.36 in order to recognize the zicsr feature, which is no longer part of the base ISA."
-            rust_channel: "1.73" 
             host_os: ubuntu-22.04
             cargo_options: --no-run
 
           - target: aarch64-apple-darwin
-            mode: --release
-            rust_channel: "1.72" # ahash uses "stdsimd" feature which was stabilized in 1.72, https://github.com/tkaitchuck/aHash/issues/195
             host_os: macos-14
             cargo_options: --no-run
 


### PR DESCRIPTION
## Proposed changes
This PR bumps MSRV in the workflow.  Version 1.78 introduced [diagnostic_attribute](https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html#diagnostic-attributes) that will be used in #2943.
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

