### PR TITLE
feat(fs): add extra context to errors when atomically writing to file

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/error.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/error.rs
@@ -32,6 +32,9 @@ pub enum TEdgeConfigError {
 
     #[error(transparent)]
     FromParseHostPortError(#[from] crate::tedge_config_cli::models::host_port::ParseHostPortError),
+
+    #[error(transparent)]
+    FromAtomFileError(#[from] tedge_utils::fs::AtomFileError),
 }
 
 impl TEdgeConfigError {

--- a/crates/core/tedge_agent/src/restart_manager/error.rs
+++ b/crates/core/tedge_agent/src/restart_manager/error.rs
@@ -21,4 +21,7 @@ pub enum RestartManagerError {
 
     #[error("Could not convert {timestamp:?} to unix timestamp. Error message: {error_msg}")]
     TimestampConversionError { timestamp: i64, error_msg: String },
+
+    #[error(transparent)]
+    FromAtomFileError(#[from] tedge_utils::fs::AtomFileError),
 }

--- a/crates/core/tedge_agent/src/state_repository/error.rs
+++ b/crates/core/tedge_agent/src/state_repository/error.rs
@@ -23,4 +23,7 @@ pub enum StateError {
 
     #[error(transparent)]
     FromUtf8Error(#[from] std::string::FromUtf8Error),
+
+    #[error(transparent)]
+    FromAtomFileError(#[from] tedge_utils::fs::AtomFileError),
 }

--- a/crates/extensions/tedge_config_manager/src/error.rs
+++ b/crates/extensions/tedge_config_manager/src/error.rs
@@ -33,6 +33,9 @@ pub enum ConfigManagementError {
     FromEntityTopicError(#[from] tedge_api::mqtt_topics::EntityTopicError),
 
     #[error(transparent)]
+    FromAtomFileError(#[from] tedge_utils::fs::AtomFileError),
+
+    #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
 


### PR DESCRIPTION
## Proposed changes
This PR adds extra info to error messages when atomically writing to file.

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

#2959

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

