### PR TITLE
tests: improve debugging of bootstrap script and include systemd/cgroup compat check

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -184,7 +184,7 @@ jobs:
     needs: [approve, check-build]
     environment:
       name: Test Auto
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         job:


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

The root cause to the problem that prompted the change in https://github.com/thin-edge/thin-edge.io/pull/2979 has been identified. Previously the debian `sid` repository was being used to install mosquitto 2.0.18, then around 2024-07-05, the usage of the `sid` repository also resulted in the systemd version being upgraded to 256 where support for cgroup v1 has been deprecated (see the [systemd news](https://github.com/systemd/systemd/blob/main/NEWS)). The Github runner ubuntu-20.04 was being used to run the system tests which uses cgroup v1 resulting in some system test failures due to some systemctl commands not functioning as expected. Using the Github runner `ubuntu-22.04` fixes the issue as the OS uses cgroup v2 by default.

In addition to using switching to the Github runner ubuntu-22.04, the following changes were made:
* Add an explicit systemd/cgroup check in the bootstrap.sh script to fail loudly if the incompatibility is detected
* Add additional logging to indicate which sections completed successfully and if key parts failed (e.g. the restarting of the mosquitto service)

To verify if the ubuntu-22.04 runner would make the tests pass, the build-workflow was run on a fork directly from the PR branch (as changing the runner OS does not activate for the initial PR workflow run, only after the PR has been approved). The following test runs shows that the system tests are passing with the systemd 256 (installed indirectly via the debian sid repository), but the PR will not include the debian sid repo as the bookworm-backports is the more desired approach as it is deemed as "stable" incomparison with the "sid" repo.
* https://github.com/reubenmiller/thin-edge.io/actions/runs/9870745687

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

The PR which prompted this investigation and changes:
* https://github.com/thin-edge/thin-edge.io/pull/2979

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

