### PR TITLE
docs: add advanced software mgmt descriptions

### DIFF
--- a/docs/src/operate/c8y/software-management.md
+++ b/docs/src/operate/c8y/software-management.md
@@ -112,6 +112,27 @@ If you are upgrading %%te%% from any version prior to `1.0.0` (including `1.0.0-
 
 ## Configuration {#configuration}
 
+### Switching to Advanced Software Management
+
+%%te%% supports both [Legacy Software Management](https://cumulocity.com/docs/device-integration/fragment-library/#legacy-software-management) and [Advanced Software Management](https://cumulocity.com/docs/device-integration/fragment-library/#advanced-software-management) features of Cumulocity IoT.
+By default, Legacy Software Management is selected.
+To switch to Advanced Software Management, use the `tedge` command to change the following configurations:
+
+```sh
+sudo tedge config set c8y.software_management.api advanced
+sudo tedge config set c8y.software_management.with_types true
+```
+
+* The first key `c8y.software_management.api` can be set to either `legacy` or `advanced`.
+* If the second key `c8y.software_management.with_types`  is set to `true`, the `c8y_SupportedSoftwareTypes` fragment is sent based on the software types reported by the [software_list MQTT API](../../references/agent/software-management.md#software_list-mqtt-api).
+
+After changing the configurations, a restart of the `tedge-mapper-c8y` service is required.
+To restart the service using `systemctl`, run this command:
+
+```sh
+sudo systemctl restart tedge-mapper-c8y
+```
+
 ### tedge-apt-plugin: Filter packages by name and maintainer
 
 By default the `tedge-apt-plugin` lists all of the installed Debian (*.deb) packages. On typical Debian installations, the list of packages could easily be more than 500 packages. In order to focus on the Debian packages which are important for your device, the `tedge-apt-plugin` supports filtering by either name or maintainer.


### PR DESCRIPTION
## Proposed changes

These config keys were not described anywhere, so I would add a short explanation.
```sh
sudo tedge config set c8y.software_management.api advanced
sudo tedge config set c8y.software_management.with_types true
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

