### PR TITLE
feat: retry aws connection check when establishing initial connection

### DIFF
--- a/crates/core/tedge/src/bridge/aws.rs
+++ b/crates/core/tedge/src/bridge/aws.rs
@@ -76,6 +76,10 @@ impl From<BridgeConfigAwsParams> for BridgeConfig {
                 connection_check_sub_msg_topic,
             ],
             bridge_location,
+            // AWS IoT Just In Time Provisioning (JITP) uses the first connection
+            // to create the "Thing", so the first connection attempt can fail, but retrying
+            // will give it a higher chance of success
+            connection_check_attempts: 5,
         }
     }
 }
@@ -126,6 +130,7 @@ fn test_bridge_config_from_aws_params() -> anyhow::Result<()> {
         notification_topic: MOSQUITTO_BRIDGE_TOPIC.into(),
         bridge_attempt_unsubscribe: false,
         bridge_location: BridgeLocation::Mosquitto,
+        connection_check_attempts: 5,
     };
 
     assert_eq!(bridge, expected);

--- a/crates/core/tedge/src/bridge/azure.rs
+++ b/crates/core/tedge/src/bridge/azure.rs
@@ -76,6 +76,7 @@ impl From<BridgeConfigAzureParams> for BridgeConfig {
                 "twin/PATCH/# out 1 az/ $iothub/".into(),
             ],
             bridge_location,
+            connection_check_attempts: 1,
         }
     }
 }
@@ -128,6 +129,7 @@ fn test_bridge_config_from_azure_params() -> anyhow::Result<()> {
         notification_topic: MOSQUITTO_BRIDGE_TOPIC.into(),
         bridge_attempt_unsubscribe: false,
         bridge_location: BridgeLocation::Mosquitto,
+        connection_check_attempts: 1,
     };
 
     assert_eq!(bridge, expected);

--- a/crates/core/tedge/src/bridge/c8y.rs
+++ b/crates/core/tedge/src/bridge/c8y.rs
@@ -115,6 +115,7 @@ impl From<BridgeConfigC8yParams> for BridgeConfig {
             bridge_attempt_unsubscribe: false,
             topics,
             bridge_location,
+            connection_check_attempts: 1,
         }
     }
 }
@@ -227,6 +228,7 @@ mod tests {
             notification_topic: C8Y_BRIDGE_HEALTH_TOPIC.into(),
             bridge_attempt_unsubscribe: false,
             bridge_location: BridgeLocation::Mosquitto,
+            connection_check_attempts: 1,
         };
 
         assert_eq!(bridge, expected);

--- a/crates/core/tedge/src/bridge/config.rs
+++ b/crates/core/tedge/src/bridge/config.rs
@@ -34,6 +34,7 @@ pub struct BridgeConfig {
     pub notification_topic: String,
     pub bridge_attempt_unsubscribe: bool,
     pub topics: Vec<String>,
+    pub connection_check_attempts: i32,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
@@ -173,6 +174,7 @@ mod test {
             notification_topic: "test_topic".into(),
             bridge_attempt_unsubscribe: false,
             bridge_location: BridgeLocation::Mosquitto,
+            connection_check_attempts: 1,
         };
 
         let mut serialized_config = Vec::<u8>::new();
@@ -239,6 +241,7 @@ bridge_attempt_unsubscribe false
             notification_topic: "test_topic".into(),
             bridge_attempt_unsubscribe: false,
             bridge_location: BridgeLocation::Mosquitto,
+            connection_check_attempts: 1,
         };
         let mut serialized_config = Vec::<u8>::new();
         bridge.serialize(&mut serialized_config)?;
@@ -307,6 +310,7 @@ bridge_attempt_unsubscribe false
             notification_topic: "test_topic".into(),
             bridge_attempt_unsubscribe: false,
             bridge_location: BridgeLocation::Mosquitto,
+            connection_check_attempts: 1,
         };
 
         let mut buffer = Vec::new();
@@ -424,6 +428,7 @@ bridge_attempt_unsubscribe false
             bridge_attempt_unsubscribe: false,
             topics: vec![],
             bridge_location: BridgeLocation::Mosquitto,
+            connection_check_attempts: 1,
         }
     }
 }

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -384,7 +384,7 @@ fn check_device_status_azure(tedge_config: &TEdgeConfig) -> Result<DeviceStatus,
             Ok(Event::Incoming(Packet::Publish(response))) => {
                 // We got a response
                 if response.topic.contains(REGISTRATION_OK) {
-                    println!("Received expected response message, connection check is successful.");
+                    println!("Received expected response message.");
                     return Ok(DeviceStatus::AlreadyExists);
                 } else {
                     break;
@@ -450,10 +450,7 @@ fn check_device_status_aws(tedge_config: &TEdgeConfig) -> Result<DeviceStatus, C
             }
             Ok(Event::Incoming(Packet::Publish(response))) => {
                 // We got a response
-                println!(
-                    "Received expected response on topic {}, connection check is successful.",
-                    response.topic
-                );
+                println!("Received expected response on topic {}.", response.topic);
                 return Ok(DeviceStatus::AlreadyExists);
             }
             Ok(Event::Outgoing(Outgoing::PingReq)) => {

--- a/tests/RobotFramework/resources/common.resource
+++ b/tests/RobotFramework/resources/common.resource
@@ -8,3 +8,6 @@ ${DEVICE_ADAPTER}    %{DEVICE_ADAPTER=docker}
 
 # Cumulocity settings
 &{C8Y_CONFIG}        host=%{C8Y_BASEURL= }    username=%{C8Y_USER= }    password=%{C8Y_PASSWORD= }
+
+# AWS settings
+&{AWS_CONFIG}        host=%{AWS_URL= }

--- a/tests/RobotFramework/tests/aws/aws_connect.robot
+++ b/tests/RobotFramework/tests/aws/aws_connect.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Documentation       Verify that thin-edge.io can successfully connect to AWS IoT Core
+    ...             The test assumes that the Just in Time Provisioning (JITP) is setup in AWS
+
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+
+Test Setup         Custom Setup
+Test Teardown      Get Logs
+
+Test Tags           theme:mqtt    theme:aws    test:on_demand
+
+
+*** Test Cases ***
+
+Connect to AWS using mosquitto bridge
+    Execute Command    tedge config set mqtt.bridge.built_in false
+    Execute Command    sudo tedge config set aws.url ${AWS_CONFIG.host}
+    ${stdout}=    Execute Command    sudo tedge connect aws    retries=0
+    Should Not Contain    ${stdout}    Warning: Bridge has been configured, but Aws connection check failed
+    ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-aws
+    Should Have MQTT Messages    te/device/main/service/mosquitto-aws-bridge/status/health    message_pattern=^1$
+
+
+Connect to AWS using built-in bridge
+    Execute Command    tedge config set mqtt.bridge.built_in true
+    Execute Command    sudo tedge config set aws.url ${AWS_CONFIG.host}
+    ${stdout}=    Execute Command    sudo tedge connect aws    retries=0
+    Should Not Contain    ${stdout}    Warning: Bridge has been configured, but Aws connection check failed
+    ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-aws
+    Should Have MQTT Messages    te/device/main/service/tedge-mapper-bridge-aws/status/health    message_contains="status":"up"
+
+
+*** Keywords ***
+
+Custom Setup
+    Setup


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Add simple cloud specific retry mechanism when running `tedge connect xxx`. At the moment, only `aws` uses a retries > 0, as AWS has a [Just In Time Provisioning](https://docs.aws.amazon.com/iot/latest/developerguide/jit-provisioning.html) feature which creates the "Thing" on first connection, but this leads to the first connection check failing, so retrying the connection leads to a higher success of passing.

A on-demand system test has also been added to support testing the AWS connection manually, as some infrastructure and automation scripts needs to be created before the tests can be included in the standard build-workflow runs (e.g. a script to delete the device(thing) and certificate from AWS after the test has completed). This automation will be done in a subsequent PR.

**Note** Feel free to change the retry implementation. The implementation and the tests were done in two individual commits to make it easier to adjust.


**Example connection output**

The following shows the new output of the connection check for AWS.

```
Checking if systemd is available.

Checking if configuration for requested bridge already exists.

Validating the bridge certificates.

Saving configuration for requested bridge.

Restarting mosquitto service.

Awaiting mosquitto to start. This may take up to 5 seconds.

Enabling mosquitto service on reboots.

Successfully created bridge connection!

Sending packets to check connection. This may take up to 2 seconds.

Connection test failed, attempt 1 of 5

Sending packets to check connection. This may take up to 2 seconds.

Received expected response on topic aws/connection-success.
Connection check is successful.

Checking if tedge-mapper is installed.

Starting tedge-mapper-aws service.

Persisting tedge-mapper-aws on reboot.

tedge-mapper-aws service successfully started and enabled!
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3001

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

