### PR TITLE
feat: use direct c8y connection for c8y-remote-access-plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,6 +631,7 @@ dependencies = [
  "async-compat",
  "async-tungstenite 0.23.0",
  "base64 0.13.1",
+ "c8y_api",
  "camino",
  "certificate",
  "clap",

--- a/plugins/c8y_remote_access_plugin/Cargo.toml
+++ b/plugins/c8y_remote_access_plugin/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 async-compat = { workspace = true }
 async-tungstenite = { workspace = true }
 base64 = { workspace = true }
+c8y_api = { workspace = true }
 camino = { workspace = true }
 certificate = { workspace = true }
 clap = { workspace = true }

--- a/plugins/c8y_remote_access_plugin/src/auth.rs
+++ b/plugins/c8y_remote_access_plugin/src/auth.rs
@@ -1,0 +1,22 @@
+use c8y_api::http_proxy::C8yMqttJwtTokenRetriever;
+use miette::IntoDiagnostic;
+use tedge_config::TEdgeConfig;
+
+pub struct Jwt(String);
+
+impl Jwt {
+    pub fn authorization_header(&self) -> String {
+        format!("Bearer {}", self.0)
+    }
+
+    pub async fn retrieve(config: &TEdgeConfig) -> miette::Result<Jwt> {
+        let mut retriever =
+            C8yMqttJwtTokenRetriever::from_tedge_config(config).into_diagnostic()?;
+
+        retriever
+            .get_jwt_token()
+            .await
+            .map(|resp| Jwt(resp.token()))
+            .into_diagnostic()
+    }
+}

--- a/tests/RobotFramework/bin/setup.sh
+++ b/tests/RobotFramework/bin/setup.sh
@@ -74,6 +74,21 @@ else
     exit 1
 fi
 
+# install go-c8y-cli (required for the remoteaccess tests)
+if ! command c8y >/dev/null 2>&1; then
+    if command -V apt-get > /dev/null 2>&1; then
+        echo "installing go-c8y-cli using apt"
+        curl https://reubenmiller.github.io/go-c8y-cli-repo/debian/PUBLIC.KEY | gpg --dearmor | sudo tee /usr/share/keyrings/go-c8y-cli-archive-keyring.gpg >/dev/null
+        sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/go-c8y-cli-archive-keyring.gpg] http://reubenmiller.github.io/go-c8y-cli-repo/debian stable main' >> /etc/apt/sources.list.d/go-c8y-cli.list"
+        sudo apt-get update
+        sudo apt-get install go-c8y-cli
+    elif command -V brew >/dev/null 2>&1; then
+        echo "installing go-c8y-cli using homebrew"
+        brew tap reubenmiller/go-c8y-cli
+        brew install go-c8y-cli
+    fi
+fi
+
 #
 # Setup dotenv file
 #

--- a/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
+++ b/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
@@ -9,12 +9,17 @@ Test Teardown    Get Logs
 
 *** Test Cases ***
 
-Install c8y-remote-access-plugin
-    Skip    remote-access is not yet part of the official release. Enable when it is
+Install/uninstall c8y-remote-access-plugin
     Device Should Have Installed Software    c8y-remote-access-plugin
     File Should Exist    /etc/tedge/operations/c8y/c8y_RemoteAccessConnect
     Execute Command    dpkg -r c8y-remote-access-plugin
     File Should Not Exist    /etc/tedge/operations/c8y/c8y_RemoteAccessConnect
+
+Execute ssh command using PASSTHROUGH
+    ${KEY_FILE}=    Configure SSH
+    Add Remote Access Passthrough Configuration
+    ${stdout}=    Execute Remote Access Command    command=tedge --version    exp_exit_code=0    user=root    key_file=${KEY_FILE}
+    Should Match Regexp    ${stdout}    tedge .+
 
 *** Keywords ***
 
@@ -22,7 +27,5 @@ Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
     Device Should Exist    ${DEVICE_SN}
-
-    Execute Command    find /setup -type f -name "c8y-remote-access-plugin_*.deb" -exec dpkg -i {} \\;
-    Restart Service    tedge-mapper-c8y
-    Execute Command    systemctl start sshd
+    Enable Service    ssh
+    Start Service    ssh


### PR DESCRIPTION
## Proposed changes

Remove the c8y-remote-access-plugin connection dependency on the c8y local proxy which is launched by the **tedge-mapper-c8y** service. This is part one of the large ticket (#2859) which looks at creating the remote access connection which is fully independent to the **tedge-mapper-c8y** service, thus allowing the user to execute `tedge reconnect c8y` without the remote access connection from being dropped.

**Note**

Prior to the c8y local proxy feature, the c8y-remote-access-plugin did use a direct connection to Cumulocity IoT, however the implementation was switch to use the local proxy which adds an additional connection dependency on the tedge-mapper-c8y (e.g. if you restart the tedge-mapper-c8y, the local proxy will also restart thus stopping the connection). This PR does not change the fact that there is still a process dependency between the spawned c8y-remote-access-plugin instance and the **tedge-mapper-c8y** service, however this will be addressed via #3007 

The PR is based on reverting the c8y local proxy commit: https://github.com/thin-edge/thin-edge.io/commit/845480e066769b51a8d4114ffe2fc79c1ced8fa9

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2859

> Use a direct connection to the Cumulocity IoT URL instead of using the local c8y proxy service (as the service is maintained by the tedge-mapper-c8y service) - (technically this will be reverting the change where we switched to using the local c8y proxy)

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

