### PR TITLE
feat: upload c8y log file on failure by default

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -576,7 +576,7 @@ define_tedge_config! {
 
         operations: {
             /// Auto-upload the operation log once it finishes.
-            #[tedge_config(example = "always", example = "never", example = "on-failure", default(variable = "AutoLogUpload::Never"))]
+            #[tedge_config(example = "always", example = "never", example = "on-failure", default(variable = "AutoLogUpload::OnFailure"))]
             auto_log_upload: AutoLogUpload,
         },
 

--- a/tests/RobotFramework/tests/cumulocity/software_management/software.robot
+++ b/tests/RobotFramework/tests/cumulocity/software_management/software.robot
@@ -76,9 +76,9 @@ Manual software_update operation request with empty url
     ...    expected_status=successful
     ...    c8y_fragment=c8y_SoftwareUpdate
 
-Operation log uploaded automatically with auto_log_upload setting as on-failure
-    Execute Command    tedge config set c8y.operations.auto_log_upload on-failure
-    Restart Service    tedge-mapper-c8y
+Operation log uploaded automatically with default auto_log_upload setting as on-failure
+    ${default_value}=    Execute Command    tedge config get c8y.operations.auto_log_upload    strip=${True}
+    Should Be Equal    ${default_value}    on-failure
 
     # Validate that the operation log is NOT uploaded for a successful operation
     ${OPERATION}=    Install Software        c8y-remote-access-plugin
@@ -104,7 +104,10 @@ Operation log uploaded automatically with auto_log_upload setting as always
     Operation Should Be FAILED    ${OPERATION}    timeout=60
     Validate operation log uploaded
 
-Operation log uploaded automatically with default auto_log_upload setting as never
+Operation log uploaded automatically with auto_log_upload setting as never
+    Execute Command    tedge config set c8y.operations.auto_log_upload never
+    Restart Service    tedge-mapper-c8y
+
     # Validate that the operation log is NOT uploaded for a successful operation
     ${OPERATION}=    Install Software        c8y-remote-access-plugin
     Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Change the default value of `c8y.operations.auto_log_upload` from `never` to `on-failure`, so that the failed operations will automatically have their associated log files uploaded to Cumulocity IoT.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

* https://github.com/thin-edge/thin-edge.io/issues/2761
* Original PR which introduced the `c8y.operations.auto_log_upload` setting: https://github.com/thin-edge/thin-edge.io/pull/2833

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

