### PR TITLE
fix: tedge-agent use the root topic when provided by the cli flag

### DIFF
--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -138,8 +138,11 @@ impl AgentConfig {
         let sw_update_config = SoftwareManagerConfig::from_tedge_config(tedge_config_location)?;
 
         // Operation Workflow config
-        let operation_config =
-            OperationConfig::from_tedge_config(&mqtt_device_topic_id, tedge_config_location)?;
+        let operation_config = OperationConfig::from_tedge_config(
+            mqtt_topic_root.to_string(),
+            &mqtt_device_topic_id,
+            tedge_config_location,
+        )?;
 
         // For flockfile
         let run_dir = tedge_config.run.path.clone();

--- a/crates/core/tedge_agent/src/operation_workflows/config.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/config.rs
@@ -13,13 +13,14 @@ pub struct OperationConfig {
 
 impl OperationConfig {
     pub fn from_tedge_config(
+        topic_root: String,
         device_topic_id: &EntityTopicId,
         tedge_config_location: &tedge_config::TEdgeConfigLocation,
     ) -> Result<OperationConfig, tedge_config::TEdgeConfigError> {
         let tedge_config = tedge_config::TEdgeConfig::try_new(tedge_config_location.clone())?;
 
         Ok(OperationConfig {
-            mqtt_schema: MqttSchema::with_root(tedge_config.mqtt.topic_root.clone()),
+            mqtt_schema: MqttSchema::with_root(topic_root),
             device_topic_id: device_topic_id.clone(),
             log_dir: tedge_config.logs.path.join("agent"),
             config_dir: tedge_config_location.tedge_config_root_path.clone(),

--- a/tests/RobotFramework/tests/tedge_agent/tedge_agent_as_child.robot
+++ b/tests/RobotFramework/tests/tedge_agent/tedge_agent_as_child.robot
@@ -1,0 +1,23 @@
+*** Settings ***
+Resource            ../../resources/common.resource
+Library    ThinEdgeIO
+
+Test Tags           theme:tedge_agent
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+*** Test Cases ***
+
+Run agent with a custom topic prefix #3031
+    # Only run tedge-agent for a few seconds
+    ${output}=    Execute Command    timeout 5 tedge-agent --mqtt-topic-root "custom_root" --mqtt-device-topic-id "device/customname//" 2>&1    ignore_exit_code=${True}
+    Should Not Contain    ${output}    te/
+    Should Contain    ${output}    custom_root/device/customname//
+
+
+*** Keywords ***
+
+Custom Setup
+    ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
+     Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect
+    Set Suite Variable    $DEVICE_SN


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

The tedge-agent now respects the root topic value when passed via the `--mqtt-topic-root` flag.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

* https://github.com/thin-edge/thin-edge.io/issues/3031

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

