### PR TITLE
test: fix unit test to pass when the unit socket file exists

### DIFF
--- a/plugins/c8y_remote_access_plugin/src/input.rs
+++ b/plugins/c8y_remote_access_plugin/src/input.rs
@@ -156,12 +156,16 @@ mod tests {
     }
 
     #[test]
-    fn parses_spawn_child_if_no_flag_is_provided() {
+    fn parses_spawn_child_or_connect_unix_socket_if_no_flag_is_provided() {
         let input = "530,jrh-rc-test0,127.0.0.1,22,cd8fc847-f4f2-4712-8dd7-31496aef0a7d";
 
         let command = try_parse_arguments(&[input]).unwrap();
 
-        assert_eq!(command, Command::SpawnChild(input.to_owned()))
+        if Path::new(UNIX_SOCKFILE).exists() {
+            assert_eq!(command, Command::TryConnectUnixSocket(input.to_owned()))
+        } else {
+            assert_eq!(command, Command::SpawnChild(input.to_owned()))
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Proposed changes
Fix the issue of a unit test reported in https://github.com/thin-edge/thin-edge.io/pull/3007#discussion_r1699906163

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

