### PR TITLE
Revert "minor version bump"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws_mapper_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "assert-json-diff",
  "assert_matches",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "axum_tls"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "az_mapper_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "assert-json-diff",
  "assert_matches",
@@ -520,7 +520,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "batcher"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "tedge_actors",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "c8y-firmware-plugin"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "c8y_firmware_manager",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "c8y-remote-access-plugin"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "async-compat",
  "async-tungstenite 0.23.0",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "c8y_api"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "c8y_auth_proxy"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "axum 0.6.20",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "c8y_firmware_manager"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "assert-json-diff",
  "assert_matches",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "c8y_http_proxy"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "c8y_mapper_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "certificate"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -900,7 +900,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clock"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "mockall",
  "time",
@@ -908,7 +908,7 @@ dependencies = [
 
 [[package]]
 name = "collectd_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1248,7 +1248,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "download"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "axum_tls",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "flockfile"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "assert_matches",
  "nix",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "json-writer"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -2013,7 +2013,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "log_manager"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "easy_reader",
  "filetime",
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt_channel"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "mqtt_tests"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "fastrand 1.9.0",
@@ -2636,7 +2636,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plugin_sm"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3676,7 +3676,7 @@ dependencies = [
 
 [[package]]
 name = "tedge"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "tedge-agent"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "tedge-apt-plugin"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "tedge-mapper"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "tedge-watchdog"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3852,7 +3852,7 @@ dependencies = [
 
 [[package]]
 name = "tedge-write"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "camino",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_actors"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "env_logger",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_api"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_config"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_config_macros"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "camino",
  "doku",
@@ -3956,7 +3956,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_config_macros-impl"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "darling 0.20.3",
  "heck",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_config_macros-macro"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3978,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_config_manager"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4004,7 +4004,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_downloader_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "camino",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_file_system_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "log",
@@ -4036,7 +4036,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_health_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_http_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_log_manager"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -4098,7 +4098,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_mqtt_bridge"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4123,7 +4123,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_mqtt_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "assert-json-diff",
  "async-trait",
@@ -4139,7 +4139,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_script_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "nix",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_signal_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "signal-hook",
@@ -4161,7 +4161,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_test_utils"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "camino",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_timer_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "tedge_actors",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_uploader_ext"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "async-trait",
  "camino",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "tedge_utils"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4761,7 +4761,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "upload"
-version = "1.2.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "axum 0.6.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.1.1"
 authors = ["thin-edge.io team <info@thin-edge.io>"]
 edition = "2021"
 rust-version = "1.78"


### PR DESCRIPTION
Reverting the version bump due to spotting an addition bug which should be fixed before the release thin-edge/thin-edge.io#3042. Reverting the version bump is required as if another PR is merged, then the "autotag" workflow will create the release tag again (which we want to prevent until we're ready for the official release).