### PR TITLE
fix: stop OperationHandler spawning extra tasks

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/operations/handler.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handler.rs
@@ -138,7 +138,7 @@ impl OperationHandler {
         let running_operation = self.running_operations.remove(&topic);
 
         let running_operation =
-            running_operation.unwrap_or(RunningOperation::spawn(Arc::clone(&self.context)));
+            running_operation.unwrap_or_else(|| RunningOperation::spawn(Arc::clone(&self.context)));
 
         let operation_status = running_operation
             .update(message)


### PR DESCRIPTION


## Proposed changes

When receiving multiple MQTT messages on a command topic, `OperationHandler::handle` method spawned extra tokio tasks, because `.unwrap_or` and not `.unwrap_or_else` was used when checking if a task for that topic already existed. Fortunately because returned object, and along it the sender to the task, was immediately dropped, the task exited and so we weren't leaking anything.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

