### PR TITLE
refactor: CommandStatus::Executing takes extra MQTT messages

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/config_snapshot.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/config_snapshot.rs
@@ -49,7 +49,9 @@ impl OperationContext {
         let cmd_id = command.cmd_id.as_str();
 
         match command.status() {
-            CommandStatus::Executing => Ok(OperationOutcome::Executing),
+            CommandStatus::Executing => Ok(OperationOutcome::Executing {
+                extra_messages: vec![],
+            }),
             CommandStatus::Successful => {
                 // Send a request to the Downloader to download the file asynchronously from FTS
                 let config_filename = format!(

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/config_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/config_update.rs
@@ -44,7 +44,9 @@ impl OperationContext {
         let sm_topic = &target.smartrest_publish_topic;
 
         match command.status() {
-            CommandStatus::Executing => Ok(OperationOutcome::Executing),
+            CommandStatus::Executing => Ok(OperationOutcome::Executing {
+                extra_messages: vec![],
+            }),
             CommandStatus::Successful => {
                 let smartrest_operation_status = succeed_operation_no_payload(
                     CumulocitySupportedOperations::C8yDownloadConfigFile,

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/firmware_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/firmware_update.rs
@@ -49,7 +49,9 @@ impl OperationContext {
         let sm_topic = &target.smartrest_publish_topic;
 
         match command.status() {
-            CommandStatus::Executing => Ok(OperationOutcome::Executing),
+            CommandStatus::Executing => Ok(OperationOutcome::Executing {
+                extra_messages: vec![],
+            }),
             CommandStatus::Successful => {
                 let smartrest_operation_status =
                     succeed_operation_no_payload(CumulocitySupportedOperations::C8yFirmware);

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/log_upload.rs
@@ -45,7 +45,9 @@ impl OperationContext {
         let smartrest_topic = &target.smartrest_publish_topic;
 
         match command.status() {
-            CommandStatus::Executing => Ok(OperationOutcome::Executing),
+            CommandStatus::Executing => Ok(OperationOutcome::Executing {
+                extra_messages: vec![],
+            }),
             CommandStatus::Successful => {
                 // Send a request to the Downloader to download the file asynchronously from FTS
                 let log_filename = format!("{}-{}", command.payload.log_type, cmd_id);

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/restart.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/restart.rs
@@ -33,7 +33,9 @@ impl OperationContext {
         let topic = &target.smartrest_publish_topic;
 
         match command.status() {
-            CommandStatus::Executing => Ok(OperationOutcome::Executing),
+            CommandStatus::Executing => Ok(OperationOutcome::Executing {
+                extra_messages: vec![],
+            }),
             CommandStatus::Successful => {
                 let smartrest_set_operation =
                     smartrest::smartrest_serializer::succeed_operation_no_payload(

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/software_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/software_update.rs
@@ -39,7 +39,9 @@ impl OperationContext {
                 // The command has not been processed yet
                 Ok(OperationOutcome::Ignored)
             }
-            CommandStatus::Executing => Ok(OperationOutcome::Executing),
+            CommandStatus::Executing => Ok(OperationOutcome::Executing {
+                extra_messages: vec![],
+            }),
             CommandStatus::Successful => {
                 let smartrest_set_operation =
                     smartrest::smartrest_serializer::succeed_operation_no_payload(


### PR DESCRIPTION
## Proposed changes
Unlike other c8y operations that we support so far, `c8y_DeviceProfile` operation requires a inventory update MQTT message after `EXECUTING` message. Refer to the [doc](https://cumulocity.com/docs/device-integration/fragment-library/#device-profile).

This PR changes `CommandStatus::Executing` to take extra MQTT messages after sending `EXECUTING` message to c8y.

P.S.
If we have a requirement that extra messages need to be send right **before** the `EXECUTING` message, this API need to be changed again. It will probably look like `CommandStatus::Executing {messages: Vec<MqttMessage>}` and all operation handlers need to add `501,<op_type` message to the vector explicitly. Since there is no such a requirement as of now, I prefer to hide `501` message creation inside the API as it is.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

