### PR TITLE
don't process operation status duplicates

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/mod.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/mod.rs
@@ -61,7 +61,7 @@ pub(super) struct OperationContext {
 }
 
 impl OperationContext {
-    pub async fn update(&self, message: OperationMessage) -> UpdateStatus {
+    pub async fn update(&self, message: OperationMessage) {
         let OperationMessage {
             entity,
             cmd_id,
@@ -74,7 +74,7 @@ impl OperationContext {
             Ok(command) => command,
             Err(err) => {
                 error!(%err, ?message, "could not parse command payload");
-                return UpdateStatus::Terminated;
+                return;
             }
         };
 
@@ -109,11 +109,11 @@ impl OperationContext {
                         }
                     }
                     // command is not yet finished, avoid clearing the command topic
-                    Ok(_) => return UpdateStatus::Ongoing,
+                    Ok(_) => return,
                 }
 
                 clear_command_topic(command, &mut mqtt_publisher).await;
-                return UpdateStatus::Terminated;
+                return;
             }
             OperationType::SoftwareUpdate => {
                 self.publish_software_update_status(&entity, &cmd_id, &message)
@@ -152,7 +152,7 @@ impl OperationContext {
             c8y_operation,
             &entity.smartrest_publish_topic,
         ) {
-            OperationOutcome::Ignored => UpdateStatus::Ongoing,
+            OperationOutcome::Ignored => {}
             OperationOutcome::Executing { mut extra_messages } => {
                 let c8y_state_executing_payload = set_operation_executing(c8y_operation);
                 let c8y_state_executing_message =
@@ -164,8 +164,6 @@ impl OperationContext {
                 for message in messages {
                     mqtt_publisher.send(message).await.unwrap();
                 }
-
-                UpdateStatus::Ongoing
             }
             OperationOutcome::Finished { messages } => {
                 if let Err(e) = self
@@ -180,17 +178,9 @@ impl OperationContext {
                 }
 
                 clear_command_topic(command, &mut mqtt_publisher).await;
-
-                UpdateStatus::Terminated
             }
         }
     }
-}
-
-/// Whether or not this operation requires more messages to be handled or is it terminated.
-pub enum UpdateStatus {
-    Ongoing,
-    Terminated,
 }
 
 async fn clear_command_topic(
@@ -276,6 +266,7 @@ fn to_c8y_operation(operation_type: &OperationType) -> Option<CumulocitySupporte
 ///
 /// These are MQTT messages that contain operation payloads. These messages need to be passed to
 /// tasks that handle a given operation to advance the operation and eventually complete it.
+#[derive(Debug, Clone)]
 pub(super) struct OperationMessage {
     pub(super) operation: OperationType,
     pub(super) entity: EntityTarget,

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -2480,6 +2480,43 @@ async fn mapper_doesnt_update_status_of_subworkflow_commands_3048() {
 }
 
 #[tokio::test]
+async fn mapper_doesnt_send_duplicate_operation_status() {
+    tedge_config::system_services::set_log_level(tracing::Level::DEBUG);
+    let ttd = TempTedgeDir::new();
+    let test_handle = spawn_c8y_mapper_actor(&ttd, true).await;
+    let TestHandle {
+        mqtt, mut timer, ..
+    } = test_handle;
+
+    // Complete sync phase so that alarm mapping starts
+    trigger_timeout(&mut timer).await;
+
+    let mut mqtt = mqtt.with_timeout(TEST_TIMEOUT_MS);
+    skip_init_messages(&mut mqtt).await;
+
+    for _ in 0..3 {
+        mqtt.send(
+            MqttMessage::new(
+                &Topic::new_unchecked("te/device/main///cmd/config_snapshot/c8y-mapper-1"),
+                r#"{"status":"executing", "type": "typeA"}"#,
+            )
+            .with_retain(),
+        )
+        .await
+        .unwrap();
+    }
+
+    assert_eq!(
+        mqtt.recv().await.unwrap().payload_str().unwrap(),
+        "501,c8y_UploadConfigFile"
+    );
+
+    while let Some(msg) = mqtt.recv().await {
+        assert_ne!(msg.payload_str().unwrap(), "501,c8y_UploadConfigFile");
+    }
+}
+
+#[tokio::test]
 async fn mapper_converts_config_metadata_to_supported_op_and_types_for_main_device() {
     let ttd = TempTedgeDir::new();
     let test_handle = spawn_c8y_mapper_actor(&ttd, true).await;


### PR DESCRIPTION
## Proposed changes

If c8y mapper receives operation message with the same status again, don't send smartrest operation status message again.

It's still not clear what should be done if operation is cleared while processing or if some component publishes a previous status (e.g. c8y mapper received operation message with status SUCCESSFUL, but later received operation with the same ID with status EXECUTING).

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

