### PR TITLE
fix: mapper does not convert url to proxy_url and does not update the software list for the device profile operation

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/software_update.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/software_update.rs
@@ -72,7 +72,7 @@ impl OperationContext {
         }
     }
 
-    fn request_software_list(&self, target: &EntityTopicId) -> MqttMessage {
+    pub fn request_software_list(&self, target: &EntityTopicId) -> MqttMessage {
         let cmd_id = self.command_id.new_id();
         let request = SoftwareListCommand::new(target, cmd_id);
         request.command_message(&self.mqtt_schema)


### PR DESCRIPTION
## Proposed changes
This PR solves two issues with mapping device profile operation:

- Mapper does not map `tenant_url` to `proxy_url` for device profile.
- Mapper does not update software list after finished operation.

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #2920 
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

