### PR TITLE
fix: software artifacts are downloaded twice when the `update-list` feature is not available

### DIFF
--- a/crates/core/plugin_sm/src/plugin.rs
+++ b/crates/core/plugin_sm/src/plugin.rs
@@ -20,6 +20,7 @@ use tedge_api::DEFAULT;
 use tedge_config::SudoCommandBuilder;
 use tokio::io::AsyncWriteExt;
 use tracing::error;
+use tracing::info;
 
 #[async_trait]
 pub trait Plugin {
@@ -134,7 +135,8 @@ pub trait Plugin {
         // Execute the updates
         if failed_updates.is_empty() {
             let outcome = self.update_list(&updates, command_log.as_deref_mut()).await;
-            if let Err(SoftwareError::UpdateListNotSupported(_)) = outcome {
+            if let Err(err @ SoftwareError::UpdateListNotSupported(_)) = outcome {
+                info!("{err}");
                 for update in updates.iter() {
                     if let Err(error) = self
                         .apply(update, command_log.as_deref_mut(), download_path)

--- a/crates/core/plugin_sm/src/plugin.rs
+++ b/crates/core/plugin_sm/src/plugin.rs
@@ -66,7 +66,7 @@ pub trait Plugin {
             SoftwareModuleUpdate::Install { mut module } => {
                 let module_url = module.url.clone();
                 match module_url {
-                    Some(url) => {
+                    Some(url) if module.file_path.is_none() => {
                         self.install_from_url(
                             &mut module,
                             &url,
@@ -77,7 +77,7 @@ pub trait Plugin {
                         )
                         .await?
                     }
-                    None => self.install(&module, command_log).await?,
+                    _ => self.install(&module, command_log).await?,
                 }
 
                 Ok(())

--- a/tests/RobotFramework/tests/cumulocity/software_management/dummy-plugin.sh
+++ b/tests/RobotFramework/tests/cumulocity/software_management/dummy-plugin.sh
@@ -7,11 +7,18 @@ case "$1" in
       done
       exit 0
       ;;
+  install)
+      exit 0
+      ;;
+  remove)
+      exit 0
+      ;;
   prepare)
       exit 0
       ;;
   update-list)
-      exit 0
+      # means update-list is unsupported by this plugin
+      exit 1
       ;;
   finalize)
       exit 0

--- a/tests/RobotFramework/tests/cumulocity/software_management/sm-plugin.robot
+++ b/tests/RobotFramework/tests/cumulocity/software_management/sm-plugin.robot
@@ -3,6 +3,7 @@
 Resource            ../../../resources/common.resource
 Library             ThinEdgeIO
 Library             Cumulocity
+Library             Collections
 
 Test Setup         Custom Setup
 Test Teardown      Custom Teardown
@@ -118,6 +119,16 @@ Filter packages list using both patterns
     ...    {"name": "dummy2-0001", "version": "1.0.0", "softwareType": "dummy2"}
     ...    {"name": "dummy2-1500", "version": "1.0.0", "softwareType": "dummy2"}
     Length Should Be    ${software}    1504
+
+Software updates download software packages only once #3062
+    Connect Mapper    c8y
+    Device Should Exist    ${DEVICE_SN}
+    ${file_url}=    Cumulocity.Create Inventory Binary    sm-plugin-test-file    software1    contents=Testing a thing
+    ${OPERATION}=    Install Software    dummy-software,1.0.0::dummy1,${file_url}
+    ${OPERATION}=    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
+    ${op_id}=    Get From Dictionary    ${OPERATION}    id
+    ${count}=    Execute Command    grep Downloading /var/log/tedge/agent/workflow-software_update-c8y-mapper-${op_id}.log -c
+    Should Be Equal As Numbers    ${count}    1
 
 *** Keywords ***
 Custom Setup


### PR DESCRIPTION
This small PR fixes issue with software artifacts being downloaded twice when `update-list` is not available. Extra validation step was introduced to check if artifact is downloaded.

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #3062 
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

