### PR TITLE
feat: add an option to use c8y operation ID to update its status

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -469,6 +469,10 @@ define_tedge_config! {
             /// Set of SmartREST template IDs the device should subscribe to
             #[tedge_config(example = "templateId1,templateId2", default(function = "TemplatesSet::default"))]
             templates: TemplatesSet,
+
+            /// Switch using 501-503 (without operation ID) or 504-506 (with operation ID) SmartREST messages for operation status update
+            #[tedge_config(example = "true", default(value = true))]
+            use_operation_id: bool,
         },
 
 

--- a/crates/core/tedge_api/src/mqtt_topics.rs
+++ b/crates/core/tedge_api/src/mqtt_topics.rs
@@ -803,6 +803,12 @@ impl IdGenerator {
     pub fn is_generator_of(&self, cmd_id: &str) -> bool {
         cmd_id.contains(&self.prefix)
     }
+
+    pub fn get_value<'a>(&self, cmd_id: &'a str) -> Option<&'a str> {
+        cmd_id
+            .strip_prefix(&self.prefix)
+            .and_then(|s| s.strip_prefix('-'))
+    }
 }
 
 #[cfg(test)]
@@ -1011,5 +1017,15 @@ mod tests {
             mqtt_schema.topic_for(&device, &Channel::Health),
             mqtt_channel::Topic::new_unchecked("te/device/main///status/health")
         );
+    }
+
+    #[test_case("abc-1234", Some("1234"))]
+    #[test_case("abc-", Some(""))]
+    #[test_case("abc", None)]
+    #[test_case("1234", None)]
+    fn extract_value_from_cmd_id(cmd_id: &str, expected: Option<&str>) {
+        let id_generator = IdGenerator::new("abc");
+        let maybe_id = id_generator.get_value(cmd_id);
+        assert_eq!(maybe_id, expected);
     }
 }

--- a/crates/extensions/c8y_firmware_manager/src/message.rs
+++ b/crates/extensions/c8y_firmware_manager/src/message.rs
@@ -1,13 +1,6 @@
 use crate::error::FirmwareManagementError;
 use crate::operation::FirmwareOperationEntry;
 
-use c8y_api::smartrest::smartrest_serializer::fail_operation;
-use c8y_api::smartrest::smartrest_serializer::set_operation_executing;
-use c8y_api::smartrest::smartrest_serializer::succeed_static_operation;
-use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations;
-use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations::C8yFirmware;
-use c8y_api::smartrest::smartrest_serializer::OperationStatusMessage;
-use c8y_api::smartrest::smartrest_serializer::SmartRest;
 use tedge_api::OperationStatus;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::Topic;
@@ -114,26 +107,6 @@ impl TryFrom<&MqttMessage> for FirmwareOperationResponse {
             child_id,
             payload: request_payload,
         })
-    }
-}
-
-pub struct DownloadFirmwareStatusMessage {}
-
-impl DownloadFirmwareStatusMessage {
-    const OP: CumulocitySupportedOperations = C8yFirmware;
-}
-
-impl OperationStatusMessage for DownloadFirmwareStatusMessage {
-    fn status_executing() -> SmartRest {
-        set_operation_executing(Self::OP)
-    }
-
-    fn status_successful(parameter: Option<&str>) -> SmartRest {
-        succeed_static_operation(Self::OP, parameter)
-    }
-
-    fn status_failed(failure_reason: &str) -> SmartRest {
-        fail_operation(Self::OP, failure_reason)
     }
 }
 

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -58,6 +58,7 @@ pub struct C8yMapperConfig {
     pub auto_log_upload: AutoLogUpload,
     pub bridge_service_name: String,
     pub bridge_health_topic: Topic,
+    pub smartrest_use_operation_id: bool,
 
     pub data_dir: DataDir,
     pub config_dir: Arc<Utf8Path>,
@@ -95,6 +96,7 @@ impl C8yMapperConfig {
         software_management_api: SoftwareManagementApiFlag,
         software_management_with_types: bool,
         auto_log_upload: AutoLogUpload,
+        smartrest_use_operation_id: bool,
     ) -> Self {
         let ops_dir = config_dir
             .join(SUPPORTED_OPERATIONS_DIRECTORY)
@@ -134,6 +136,7 @@ impl C8yMapperConfig {
             auto_log_upload,
             bridge_service_name,
             bridge_health_topic,
+            smartrest_use_operation_id,
 
             config_dir,
             logs_path,
@@ -190,6 +193,7 @@ impl C8yMapperConfig {
         let software_management_with_types = tedge_config.c8y.software_management.with_types;
 
         let auto_log_upload = tedge_config.c8y.operations.auto_log_upload;
+        let smartrest_use_operation_id = tedge_config.c8y.smartrest.use_operation_id;
 
         // Add feature topic filters
         for cmd in [
@@ -241,6 +245,7 @@ impl C8yMapperConfig {
             software_management_api,
             software_management_with_types,
             auto_log_upload,
+            smartrest_use_operation_id,
         ))
     }
 

--- a/crates/extensions/c8y_mapper_ext/src/operations/handler.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handler.rs
@@ -66,6 +66,7 @@ impl OperationHandler {
                 mqtt_schema: c8y_mapper_config.mqtt_schema.clone(),
                 mqtt_publisher: mqtt_publisher.clone(),
                 software_management_api: c8y_mapper_config.software_management_api,
+                smart_rest_use_operation_id: c8y_mapper_config.smartrest_use_operation_id,
 
                 // TODO(marcel): would be good not to generate new ids from running operations, see if
                 // we can remove it somehow

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/log_upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/log_upload.rs
@@ -93,6 +93,8 @@ impl OperationContext {
                     upload_result,
                     binary_upload_event_url.as_str(),
                     CumulocitySupportedOperations::C8yLogFileRequest,
+                    self.smart_rest_use_operation_id,
+                    self.get_operation_id(cmd_id),
                 );
 
                 let c8y_notification = MqttMessage::new(smartrest_topic, smartrest_response);
@@ -122,6 +124,7 @@ impl OperationContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::C8yMapperConfig;
     use crate::tests::*;
     use c8y_api::json_c8y_deserializer::C8yDeviceControlTopic;
     use serde_json::json;
@@ -491,6 +494,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_log_upload_executing_and_failed_cmd_with_op_id() {
+        let ttd = TempTedgeDir::new();
+        let config = C8yMapperConfig {
+            smartrest_use_operation_id: true,
+            ..test_mapper_config(&ttd)
+        };
+        let test_handle = spawn_c8y_mapper_actor_with_config(&ttd, config, true).await;
+
+        let TestHandle { mqtt, .. } = test_handle;
+
+        let mut mqtt = mqtt.with_timeout(TEST_TIMEOUT_MS);
+        skip_init_messages(&mut mqtt).await;
+
+        // Simulate log_upload command with "executing" state
+        mqtt.send(MqttMessage::new(
+            &Topic::new_unchecked("te/device/main///cmd/log_upload/c8y-mapper-1234"),
+            json!({
+            "status": "executing",
+            "tedgeUrl": format!("http://localhost:8888/tedge/file-transfer/test-device/log_upload/typeA-c8y-mapper-1234"),
+            "type": "typeA",
+            "dateFrom": "2013-06-22T17:03:14.123+02:00",
+            "dateTo": "2013-06-23T18:03:14.123+02:00",
+            "searchText": "ERROR",
+            "lines": 1000
+        })
+                .to_string(),
+        ))
+            .await
+            .expect("Send failed");
+
+        // Expect `504` smartrest message on `c8y/s/us`.
+        assert_received_contains_str(&mut mqtt, [("c8y/s/us", "504,1234")]).await;
+
+        // Simulate log_upload command with "failed" state
+        mqtt.send(MqttMessage::new(
+            &Topic::new_unchecked("te/device/main///cmd/log_upload/c8y-mapper-1234"),
+            json!({
+            "status": "failed",
+            "tedgeUrl": format!("http://localhost:8888/tedge/file-transfer/test-device/log_upload/typeA-c8y-mapper-1234"),
+            "type": "typeA",
+            "dateFrom": "2013-06-22T17:03:14.123+02:00",
+            "dateTo": "2013-06-23T18:03:14.123+02:00",
+            "searchText": "ERROR",
+            "lines": 1000
+        })
+                .to_string(),
+        ))
+            .await
+            .expect("Send failed");
+
+        // Expect `505` smartrest message on `c8y/s/us`.
+        assert_received_contains_str(&mut mqtt, [("c8y/s/us", "505,1234,Unknown reason")]).await;
+    }
+
+    #[tokio::test]
     async fn handle_log_upload_successful_cmd_for_main_device() {
         let ttd = TempTedgeDir::new();
         let test_handle = spawn_c8y_mapper_actor(&ttd, true).await;
@@ -642,5 +700,85 @@ mod tests {
             )],
         )
             .await;
+    }
+
+    #[tokio::test]
+    async fn handle_log_upload_successful_cmd_with_id() {
+        let ttd = TempTedgeDir::new();
+        let config = C8yMapperConfig {
+            smartrest_use_operation_id: true,
+            ..test_mapper_config(&ttd)
+        };
+        let test_handle = spawn_c8y_mapper_actor_with_config(&ttd, config, true).await;
+        let TestHandle {
+            mqtt, http, ul, dl, ..
+        } = test_handle;
+        spawn_dummy_c8y_http_proxy(http);
+
+        let mut mqtt = mqtt.with_timeout(TEST_TIMEOUT_MS);
+        let mut ul = ul.with_timeout(TEST_TIMEOUT_MS);
+        let mut dl = dl.with_timeout(TEST_TIMEOUT_MS);
+        skip_init_messages(&mut mqtt).await;
+
+        // Simulate log_upload command with "successful" state
+        mqtt.send(MqttMessage::new(
+            &Topic::new_unchecked("te/device/main///cmd/log_upload/c8y-mapper-1234"),
+            json!({
+            "status": "successful",
+            "tedgeUrl": "http://localhost:8888/tedge/file-transfer/test-device/log_upload/typeA-c8y-mapper-1234",
+            "type": "typeA",
+            "dateFrom": "2013-06-22T17:03:14.123+02:00",
+            "dateTo": "2013-06-23T18:03:14.123+02:00",
+            "searchText": "ERROR",
+            "lines": 1000
+        })
+                .to_string(),
+        ))
+            .await
+            .expect("Send failed");
+
+        // Downloader gets a download request
+        let download_request = dl.recv().await.expect("timeout");
+        assert_eq!(download_request.0, "c8y-mapper-1234"); // Command ID
+
+        // simulate downloader returns result
+        dl.send((
+            download_request.0,
+            Ok(DownloadResponse {
+                url: download_request.1.url,
+                file_path: download_request.1.file_path,
+            }),
+        ))
+        .await
+        .unwrap();
+
+        // Uploader gets a upload request and assert that
+        let request = ul.recv().await.expect("timeout");
+        assert_eq!(request.0, "c8y-mapper-1234"); // Command ID
+        assert_eq!(
+            request.1.url,
+            "http://127.0.0.1:8001/c8y/event/events/dummy-event-id-1234/binaries"
+        );
+
+        // Simulate Uploader returns a result
+        ul.send((
+            request.0,
+            Ok(UploadResponse {
+                url: request.1.url,
+                file_path: request.1.file_path,
+            }),
+        ))
+        .await
+        .unwrap();
+
+        // Expect `506` smartrest message on `c8y/s/us`.
+        assert_received_contains_str(
+            &mut mqtt,
+            [(
+                "c8y/s/us",
+                "506,1234,https://test.c8y.io/event/events/dummy-event-id-1234/binaries",
+            )],
+        )
+        .await;
     }
 }

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/restart.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/restart.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use c8y_api::smartrest;
 use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations;
 use tedge_api::CommandStatus;
 use tedge_api::RestartCommand;
@@ -37,10 +36,10 @@ impl OperationContext {
                 extra_messages: vec![],
             }),
             CommandStatus::Successful => {
-                let smartrest_set_operation =
-                    smartrest::smartrest_serializer::succeed_operation_no_payload(
-                        CumulocitySupportedOperations::C8yRestartRequest,
-                    );
+                let smartrest_set_operation = self.get_smartrest_successful_status_payload(
+                    CumulocitySupportedOperations::C8yRestartRequest,
+                    cmd_id,
+                );
 
                 Ok(OperationOutcome::Finished {
                     messages: vec![MqttMessage::new(topic, smartrest_set_operation)],

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -2880,6 +2880,7 @@ pub(crate) fn test_mapper_config(tmp_dir: &TempTedgeDir) -> C8yMapperConfig {
         SoftwareManagementApiFlag::Advanced,
         true,
         AutoLogUpload::Never,
+        false,
     )
 }
 

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -549,8 +549,8 @@ Publish and Verify Local Command
     IF    "${c8y_fragment}"
         # There should not be any c8y related operation transition messages sent: https://cumulocity.com/guides/reference/smartrest-two/#updating-operations
         Should Have MQTT Messages
-        ...    c8y/s/ds
-        ...    message_pattern=^(501|502|503),${c8y_fragment}.*
+        ...    c8y/s/us
+        ...    message_pattern=^(501|502|503|504|505|506),${c8y_fragment}.*
         ...    minimum=0
         ...    maximum=0
     END

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -322,5 +322,5 @@ Publish and Verify Local Command
 
     IF    "${c8y_fragment}"
         # There should not be any c8y related operation transition messages sent: https://cumulocity.com/guides/reference/smartrest-two/#updating-operations
-        Should Have MQTT Messages    c8y/s/ds    message_pattern=^(501|502|503),${c8y_fragment}.*    minimum=0    maximum=0
+        Should Have MQTT Messages    c8y/s/us    message_pattern=^(501|502|503|504|505|506),${c8y_fragment}.*    minimum=0    maximum=0
     END

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
@@ -187,8 +187,8 @@ Publish and Verify Local Command
     IF    "${c8y_fragment}"
         # There should not be any c8y related operation transition messages sent: https://cumulocity.com/guides/reference/smartrest-two/#updating-operations
         Should Have MQTT Messages
-        ...    c8y/s/ds
-        ...    message_pattern=^(501|502|503),${c8y_fragment}.*
+        ...    c8y/s/us
+        ...    message_pattern=^(501|502|503|504|505|506),${c8y_fragment}.*
         ...    minimum=0
         ...    maximum=0
     END

--- a/tests/RobotFramework/tests/cumulocity/restart/restart_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/restart/restart_device.robot
@@ -67,5 +67,5 @@ Publish and Verify Local Command
 
     IF    "${c8y_fragment}"
         # There should not be any c8y related operation transition messages sent: https://cumulocity.com/guides/reference/smartrest-two/#updating-operations
-        Should Have MQTT Messages    c8y/s/ds    message_pattern=^(501|502|503),${c8y_fragment}.*    minimum=0    maximum=0
+        Should Have MQTT Messages    c8y/s/us    message_pattern=^(501|502|503|504|505|506),${c8y_fragment}.*    minimum=0    maximum=0
     END

--- a/tests/RobotFramework/tests/cumulocity/software_management/software.robot
+++ b/tests/RobotFramework/tests/cumulocity/software_management/software.robot
@@ -154,7 +154,7 @@ Publish and Verify Local Command
 
     IF    "${c8y_fragment}"
         # There should not be any c8y related operation transition messages sent: https://cumulocity.com/guides/reference/smartrest-two/#updating-operations
-        Should Have MQTT Messages    c8y/s/ds    message_pattern=^(501|502|503),${c8y_fragment}.*    minimum=0    maximum=0
+        Should Have MQTT Messages    c8y/s/us    message_pattern=^(501|502|503|504|505|506),${c8y_fragment}.*    minimum=0    maximum=0
     END
 
 Validate operation log uploaded


### PR DESCRIPTION
## Proposed changes
Cumulocity 10.18 version added [504-506](https://cumulocity.com/docs/smartrest/mqtt-static-templates/#504) SmartREST static templates, which enables users to update operation status with its operation ID. This PR adds a new tedge config to switch either 501-503 or 504-506 for operation status updates.

One can change the setting by `tedge config`. `true` (504-506), `false` (501-503). Ideally making `auto` option, however, this is out of scope of this PR.
```sh
tedge config set c8y.smartrest.use_operation_id true
```

Note: for the naming decision, see this [thread](https://github.com/thin-edge/thin-edge.io/pull/3076#discussion_r1732377605).

This change **excludes** the supports for below since they react to SmartREST operation messages, not JSON over MQTT. This means it's not possible to take its operation ID. Also, we don't generate thin-edge commands for these operations.
- custom operation plugin
- legacy c8y-firmware-plugin 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#2616

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

