### PR TITLE
feat: use custom topic prefix in mapper service name

### DIFF
--- a/crates/core/tedge_mapper/src/collectd/mapper.rs
+++ b/crates/core/tedge_mapper/src/collectd/mapper.rs
@@ -28,17 +28,13 @@ impl CollectdMapper {
 
 #[async_trait]
 impl TEdgeComponent for CollectdMapper {
-    fn session_name(&self) -> &str {
-        COLLECTD_MAPPER_NAME
-    }
-
     async fn start(
         &self,
         tedge_config: TEdgeConfig,
         _config_dir: &tedge_config::Path,
     ) -> Result<(), anyhow::Error> {
         let (mut runtime, mut mqtt_actor) =
-            start_basic_actors(self.session_name(), &tedge_config).await?;
+            start_basic_actors(COLLECTD_MAPPER_NAME, &tedge_config).await?;
 
         let input_topic = CollectdMapper::input_topics();
         let output_topic = CollectdMapper::output_topic();

--- a/crates/core/tedge_mapper/src/core/component.rs
+++ b/crates/core/tedge_mapper/src/core/component.rs
@@ -3,8 +3,6 @@ use tedge_config::TEdgeConfig;
 
 #[async_trait]
 pub trait TEdgeComponent: Sync + Send {
-    fn session_name(&self) -> &str;
-
     async fn start(
         &self,
         tedge_config: TEdgeConfig,

--- a/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry_built-in_bridge.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry_built-in_bridge.robot
@@ -25,6 +25,7 @@ Bridge stops if mapper stops running
     Log    ${measurements}
     Execute Command    systemctl stop tedge-mapper-c8y
     Service Health Status Should Be Down    tedge-mapper-bridge-custom-c8y-prefix
+    Service Health Status Should Be Down    tedge-mapper-custom-c8y-prefix
     Execute Command    tedge mqtt pub ${C8Y_TOPIC_PREFIX}/s/us '200,CustomMeasurement,temperature,25'
     ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomMeasurement    series=temperature
     Log    ${measurements}
@@ -277,6 +278,6 @@ Custom Setup
     ThinEdgeIO.Execute Command    tedge config set mqtt.bridge.built_in true
     ThinEdgeIO.Execute Command    tedge config set c8y.bridge.topic_prefix custom-c8y-prefix
     ThinEdgeIO.Execute Command    tedge reconnect c8y
-    Service Health Status Should Be Up    tedge-mapper-c8y
+    Service Health Status Should Be Up    tedge-mapper-custom-c8y-prefix
     ${output}=    Execute Command    sudo tedge connect c8y --test
     Should Contain    ${output}    Connection check to c8y cloud is successful.


### PR DESCRIPTION
## Proposed changes
When the topic prefix is customised for the bridge, use that prefix in the mapper service name. If the topic prefix is set to e.g. `c8y-edge`, the resulting service name (in Cumulocity/the entity store, not systemd) will be `tedge-mapper-c8y-edge`. 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

