### PR TITLE
refactor: restore visibility of tedge api relied upon by thick edge

### DIFF
--- a/crates/core/tedge/src/cli/connect/mod.rs
+++ b/crates/core/tedge/src/cli/connect/mod.rs
@@ -1,3 +1,4 @@
+pub use self::c8y_direct_connection::*;
 pub use self::cli::*;
 pub use self::command::*;
 pub use self::error::*;

--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -7,7 +7,7 @@ use crate::command::BuildContext;
 use crate::command::Command;
 use c8y_firmware_plugin::FirmwarePluginOpt;
 use c8y_remote_access_plugin::C8yRemoteAccessPluginOpt;
-pub use connect::ConnectError;
+pub use connect::*;
 use tedge_agent::AgentOpt;
 use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 use tedge_mapper::MapperOpt;


### PR DESCRIPTION
## Proposed changes
Thick edge depends on a few parts of the `tedge` crate library that were previously public but have since been made private in a refactoring PR. The goal of this is so thick edge can only do the parts of the connection process it cares about (e.g. the direct connection and mosquitto configuration) for connecting to c8y in an automated fashion. This PR restores the public visibility of those items.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

