### PR TITLE
Fix process exit code and stderr printing 2 times

### DIFF
--- a/crates/extensions/tedge_config_manager/src/actor.rs
+++ b/crates/extensions/tedge_config_manager/src/actor.rs
@@ -378,7 +378,7 @@ impl ConfigManagerWorker {
         &self,
         from: &Utf8Path,
         config_type: &str,
-    ) -> Result<Utf8PathBuf, ConfigManagementError> {
+    ) -> anyhow::Result<Utf8PathBuf> {
         let file_entry = self.plugin_config.get_file_entry_from_type(config_type)?;
 
         let to = Utf8PathBuf::from(&file_entry.path);
@@ -421,13 +421,13 @@ impl ConfigManagerWorker {
 
         if let Some(io_error) = err.downcast_ref::<std::io::Error>() {
             if io_error.kind() != ErrorKind::PermissionDenied {
-                return Err(err.into());
+                return Err(err);
             }
         }
 
         match self.config.use_tedge_write.clone() {
             TedgeWriteStatus::Disabled => {
-                return Err(err.into());
+                return Err(err);
             }
 
             TedgeWriteStatus::Enabled { sudo } => {


### PR DESCRIPTION
## Proposed changes

If tedge-failed, process error code and stderr were printed 2 times like this:

```
failed to deploy configuration file: process '/usr/bin/sudo' returned non-zero exit code (1); stderr="sudo: a password is required": process '/usr/bin/sudo' returned non-zero exit code (1); stderr="sudo: a password is required"
```

Now it doesn't contain a duplicate:

```
failed to deploy configuration file: process '/usr/bin/sudo' returned non-zero exit code (1); stderr="sudo: a password is required"
```

This was due to unnoticed wrapping of the error types: all the functions returned `ConfigManagementError`, but we still wanted to attach context, so we had the following nesting, which screwed up anyhow's error causes formatting:

ConfigManagementError::Other(anyhow::Error(source: ConfigManagementError::Other(anyhow::Error)))

Immediate function error type was changed to anyhow::Error, so now we only have a single conversion to ConfigManagementError on the outermost function.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Question to @reubenmiller: how to tag these small PRs that are fixes, but minor ones, for which no issue was reported? I could tag this as an improvement, but it would probably be a bit misleading since the previous behaviour really was unintended, so for release notes perhaps it should categorised as a fix?
