### PR TITLE
fix: tedge write remove hardcoded path

### DIFF
--- a/crates/common/tedge_config/src/sudo.rs
+++ b/crates/common/tedge_config/src/sudo.rs
@@ -54,6 +54,8 @@ impl SudoCommandBuilder {
         match which::which(self.sudo_program.as_ref()) {
             Ok(sudo) => {
                 let mut c = Command::new(sudo);
+                // non-interactive
+                c.arg("-n");
                 c.arg(program);
                 c
             }

--- a/crates/core/tedge_write/src/lib.rs
+++ b/crates/core/tedge_write/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! https://github.com/thin-edge/thin-edge.io/issues/2456
 
-const TEDGE_WRITE_PATH: &str = "/usr/bin/tedge-write";
+const TEDGE_WRITE_BINARY: &str = "tedge-write";
 
 pub mod bin;
 


### PR DESCRIPTION
## Proposed changes

API for spawning a tedge-write process no longer uses a hardcoded `/usr/bin/tedge-write` path.

The path was hardcoded because of the wrong assumption of how `sudo` works: when provided with a command without the full path, e.g. `sudo tedge-write /etc/config1`, `sudo` will internally look for `tedge-write` in $PATH and then compare path with its sudoers entry, so it's not necessary to use full path for binaries used with `sudo`.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- #3073

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments


