### PR TITLE
fix: create device_profile workflow before loading workflows from disk

### DIFF
--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -239,6 +239,10 @@ impl Agent {
         // Runtime
         let mut runtime = Runtime::new();
 
+        // Load device profile manager before the workflow actor
+        // as it will create the device_profile workflow if it does not already exist
+        DeviceProfileManagerBuilder::try_new(&self.config.operations_dir)?;
+
         // Operation workflows
         let workflows = load_operation_workflows(&self.config.operations_dir).await?;
         let mut script_runner: ServerActorBuilder<ScriptActor, Concurrent> = ScriptActor::builder();
@@ -251,8 +255,6 @@ impl Agent {
 
         // Software update actor
         let mut software_update_builder = SoftwareManagerBuilder::new(self.config.sw_update_config);
-
-        DeviceProfileManagerBuilder::try_new(&self.config.operations_dir)?;
 
         // Converter actor
         let mut converter_actor_builder = WorkflowActorBuilder::new(

--- a/tests/RobotFramework/tests/cumulocity/supported_operations/mapper-publishing-agent-supported-ops.robot
+++ b/tests/RobotFramework/tests/cumulocity/supported_operations/mapper-publishing-agent-supported-ops.robot
@@ -10,7 +10,7 @@ Test Teardown    Get Logs
 *** Test Cases ***
 
 Full supported operations message has no duplicates
-    Should Have MQTT Messages    c8y/s/us    message_pattern=114,c8y_DownloadConfigFile,c8y_LogfileRequest,c8y_RemoteAccessConnect,c8y_Restart,c8y_SoftwareUpdate,c8y_UploadConfigFile    minimum=1    maximum=1
+    Should Have MQTT Messages    c8y/s/us    message_pattern=114,c8y_DeviceProfile,c8y_DownloadConfigFile,c8y_LogfileRequest,c8y_RemoteAccessConnect,c8y_Restart,c8y_SoftwareUpdate,c8y_UploadConfigFile    minimum=1    maximum=1
 
 Create and publish the tedge agent supported operations on mapper restart
     # stop mapper and remove the supported operations

--- a/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_initialization.robot
+++ b/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_initialization.robot
@@ -1,0 +1,22 @@
+*** Settings ***
+Resource            ../../../resources/common.resource
+Library             ThinEdgeIO
+Library             Cumulocity
+
+Test Tags           theme:tedge_agent
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+*** Test Cases ***
+
+Device profile is included in supported operations
+    Should Have MQTT Messages    te/device/main///cmd/device_profile    message_pattern=^{}$
+    Should Contain Supported Operations    c8y_DeviceProfile
+
+
+*** Keywords ***
+
+Custom Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Device Should Exist    ${DEVICE_SN}

--- a/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
+++ b/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
@@ -12,12 +12,6 @@ Test Teardown       Get Logs
 
 *** Test Cases ***
 
-Device profile is included in supported operations
-    ${CAPABILITY_MESSAGE}=    Execute Command    timeout 1 tedge mqtt sub 'te/device/main///cmd/device_profile'    strip=${True}    ignore_exit_code=${True}
-    Should Be Equal    ${CAPABILITY_MESSAGE}    [te/device/main///cmd/device_profile] {}
-    Should Contain Supported Operations    c8y_DeviceProfile
-
-
 Send device profile operation from Cumulocity IoT
     ${config_url}=    Create Inventory Binary    tedge-configuration-plugin    tedge-configuration-plugin    file=${CURDIR}/tedge-configuration-plugin.toml
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Run the device profile manager builder before the loading the workflows, otherwise the newly created device_profile workflow will not be detected until the service is restarted.

The problem was being masked in the existing system test as the test restarted the tedge-agent in the setup due to adding an additional workflow (firmware_update). The system test to check the supported operation has been moved to an independent test which does not restart the tedge-agent in the test setup.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

Partially solves https://github.com/thin-edge/thin-edge.io/issues/3088

**Note** installing thin-edge.io via the install.sh script will still require the tedge-agent to be restarted, however this is less of an issue

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

