### PR TITLE
refactor: include topic prefix in c8y last-will service name

### DIFF
--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -280,6 +280,7 @@ pub fn service_monitor_client_config(
         .clone()
         .parse()
         .context("Invalid device_topic_id")?;
+    let prefix = &tedge_config.c8y.bridge.topic_prefix;
 
     let mapper_service_topic_id = entity_topic_id
         .default_service_for_device(c8y_mapper_name)
@@ -294,12 +295,12 @@ pub fn service_monitor_client_config(
         service_type.as_str(),
         "down",
         &[],
-        &tedge_config.c8y.bridge.topic_prefix,
+        prefix,
     )?;
 
     let mqtt_config = tedge_config
         .mqtt_config()?
-        .with_session_name("last_will_c8y_mapper")
+        .with_session_name(format!("last_will_{prefix}_mapper"))
         .with_last_will_message(last_will_message);
     Ok(mqtt_config)
 }


### PR DESCRIPTION
## Proposed changes
Change the MQTT client ID for `last_will_c8y_mapper` to use the topic prefix in place of `c8y`, so multiple mappers can connect to the same mosquitto.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

