### PR TITLE
format: Reformat Robot Framework files with robotframework-tidy

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,10 +46,21 @@ check-tools:
         exit 1
     fi
 
-# Format code
+# Format code and tests
 format: check-tools
+    #!/usr/bin/env bash
+    set -e
+
     cargo +nightly fmt
     taplo fmt
+
+    if [ ! -d tests/RobotFramework/.venv ]; then
+        just -f {{justfile()}} setup-integration-test
+    fi
+    cd tests/RobotFramework
+    source .venv/bin/activate
+    echo Formatting tests...
+    invoke format-tests
 
 # Check code formatting
 format-check: check-tools
@@ -58,8 +69,19 @@ format-check: check-tools
 
 # Check code
 check TARGET=DEFAULT_TARGET:
+    #!/usr/bin/env bash
+    set -e
+
     {{CARGO}} check --target {{TARGET}}
     {{CARGO}} clippy --all-targets --all-features --target {{TARGET}}
+
+    if [ ! -d tests/RobotFramework/.venv ]; then
+        just -f {{justfile()}} setup-integration-test
+    fi
+    cd tests/RobotFramework
+    source .venv/bin/activate
+    echo Checking tests...
+    invoke lint-tests
 
 # Release, building all binaries and debian packages
 release *ARGS:

--- a/tests/RobotFramework/pyproject.toml
+++ b/tests/RobotFramework/pyproject.toml
@@ -17,6 +17,8 @@ exclude = [
 
     # Naming
     "not-allowed-char-in-name",
+    # Some Keywords are more descriptive with the usage of underscore
+    # as they can include important info like 'c8y_Firmware'
     "underscore-in-keyword-name",
     "non-local-variables-should-be-uppercase",
     "section-variable-not-uppercase",
@@ -26,13 +28,6 @@ exclude = [
     # Styling
     "not-capitalized-test-case-title",
     "wrong-case-in-keyword-name",
-
-    # Don't enfource RF 7.0 syntax
-    "replace-set-variable-with-var",
-    "replace-create-with-var",
-
-    # Cleanup
-    "unused-variable",
 ]
 
 configure = [

--- a/tests/RobotFramework/pyproject.toml
+++ b/tests/RobotFramework/pyproject.toml
@@ -1,0 +1,41 @@
+# See the robocop rules list for more information about the linting rules:
+# https://robocop.readthedocs.io/en/stable/rules_list.html
+[tool.robocop]
+exclude = [
+    # Docs
+    "missing-doc-suite",
+    "missing-doc-test-case",
+    "missing-doc-keyword",
+
+    # Size
+    "too-long-test-case",
+    "file-too-long",
+    "line-too-long",
+    "too-many-calls-in-test-case",
+    "too-many-calls-in-keyword",
+    "too-many-arguments",
+
+    # Naming
+    "not-allowed-char-in-name",
+    "underscore-in-keyword-name",
+    "non-local-variables-should-be-uppercase",
+    "section-variable-not-uppercase",
+    "inconsistent-variable-name",
+    "too-long-keyword",
+
+    # Styling
+    "not-capitalized-test-case-title",
+    "wrong-case-in-keyword-name",
+
+    # Don't enfource RF 7.0 syntax
+    "replace-set-variable-with-var",
+    "replace-create-with-var",
+
+    # Cleanup
+    "unused-variable",
+]
+
+configure = [
+    "line-too-long:line_length:220",
+    "todo-in-comment:severity:I"
+]

--- a/tests/RobotFramework/requirements/requirements.dev.txt
+++ b/tests/RobotFramework/requirements/requirements.dev.txt
@@ -1,3 +1,4 @@
 black~=24.4.2
 invoke~=2.2.0
 pylint~=3.1.0
+robotframework-tidy~=4.14.0

--- a/tests/RobotFramework/requirements/requirements.dev.txt
+++ b/tests/RobotFramework/requirements/requirements.dev.txt
@@ -2,3 +2,4 @@ black~=24.4.2
 invoke~=2.2.0
 pylint~=3.1.0
 robotframework-tidy~=4.14.0
+robotframework-robocop~=5.4.0

--- a/tests/RobotFramework/resources/common.resource
+++ b/tests/RobotFramework/resources/common.resource
@@ -1,3 +1,7 @@
+*** Settings ***
+Documentation       Test parameterization
+
+
 *** Variables ***
 # Adapter settings
 ${DEVICE_ADAPTER}       %{DEVICE_ADAPTER=docker}

--- a/tests/RobotFramework/resources/common.resource
+++ b/tests/RobotFramework/resources/common.resource
@@ -1,13 +1,20 @@
 *** Variables ***
-
 # Adapter settings
-${DEVICE_ADAPTER}    %{DEVICE_ADAPTER=docker}
-&{SSH_CONFIG}        hostname=%{SSH_CONFIG_HOSTNAME= }    username=%{SSH_CONFIG_USERNAME= }    password=%{SSH_CONFIG_PASSWORD= }    skip_bootstrap=False    bootstrap_script=%{SSH_CONFIG_BOOTSTRAP_SCRIPT= }    configpath=%{SSH_CONFIG_CONFIGPATH= }
-&{DOCKER_CONFIG}     image=%{DOCKER_CONFIG_IMAGE=debian-systemd}    bootstrap_script=%{DOCKER_CONFIG_BOOTSTRAP_SCRIPT=/setup/bootstrap.sh}
-&{LOCAL_CONFIG}      skip_bootstrap=False    bootstrap_script=%{LOCAL_CONFIG_BOOTSTRAP_SCRIPT= }
+${DEVICE_ADAPTER}       %{DEVICE_ADAPTER=docker}
+&{SSH_CONFIG}
+...                     hostname=%{SSH_CONFIG_HOSTNAME= }
+...                     username=%{SSH_CONFIG_USERNAME= }
+...                     password=%{SSH_CONFIG_PASSWORD= }
+...                     skip_bootstrap=False
+...                     bootstrap_script=%{SSH_CONFIG_BOOTSTRAP_SCRIPT= }
+...                     configpath=%{SSH_CONFIG_CONFIGPATH= }
+&{DOCKER_CONFIG}
+...                     image=%{DOCKER_CONFIG_IMAGE=debian-systemd}
+...                     bootstrap_script=%{DOCKER_CONFIG_BOOTSTRAP_SCRIPT=/setup/bootstrap.sh}
+&{LOCAL_CONFIG}         skip_bootstrap=False    bootstrap_script=%{LOCAL_CONFIG_BOOTSTRAP_SCRIPT= }
 
 # Cumulocity settings
-&{C8Y_CONFIG}        host=%{C8Y_BASEURL= }    username=%{C8Y_USER= }    password=%{C8Y_PASSWORD= }
+&{C8Y_CONFIG}           host=%{C8Y_BASEURL= }    username=%{C8Y_USER= }    password=%{C8Y_PASSWORD= }
 
 # AWS settings
-&{AWS_CONFIG}        host=%{AWS_URL= }
+&{AWS_CONFIG}           host=%{AWS_URL= }

--- a/tests/RobotFramework/tasks.py
+++ b/tests/RobotFramework/tasks.py
@@ -125,11 +125,26 @@ def lint(c):
     """Run linter"""
     c.run(f"{sys.executable} -m pylint libraries")
 
+@task
+def lint_tests(c, threshold="W"):
+    """Run RobotFramework Test Linter
+
+    Example:
+        $ invoke lint-tests --threshold I
+        # Run linting and include Info level messages
+    """
+    c.run(f"{sys.executable} -m robocop --report rules_by_error_type --threshold {threshold}")
 
 @task(name="format")
 def formatcode(c):
     """Format python code"""
     c.run(f"{sys.executable} -m black libraries")
+
+@task
+def format_tests(c):
+    """Format RobotFramework tests
+    """
+    c.run(f"{sys.executable} -m robotidy tests")
 
 
 @task(name="reports")

--- a/tests/RobotFramework/tasks/E2E_Tutorials/Connect_to_c8y.robot
+++ b/tests/RobotFramework/tasks/E2E_Tutorials/Connect_to_c8y.robot
@@ -4,8 +4,8 @@
 
 *** Settings ***
 Resource            ../../resources/common.resource
-Library             ThinEdgeIO
 Library             String
+Library             ThinEdgeIO
 Library             Cumulocity
 
 Suite Teardown      Get Logs

--- a/tests/RobotFramework/tasks/E2E_Tutorials/Connect_to_c8y.robot
+++ b/tests/RobotFramework/tasks/E2E_Tutorials/Connect_to_c8y.robot
@@ -1,36 +1,38 @@
-#Command to execute:    robot -d \results --timestampoutputs --log health_tedge_mapper.html --report NONE health_tedge_mapper.robot
+*** Comments ***
+# Command to execute:    robot -d \results --timestampoutputs --log health_tedge_mapper.html --report NONE health_tedge_mapper.robot
+
 
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
-Library    String
-Library    Cumulocity
-Suite Teardown         Get Logs
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+Library             String
+Library             Cumulocity
+
+Suite Teardown      Get Logs
+
 
 *** Variables ***
-
-${DEVICE_SN}
+${DEVICE_SN}    ${EMPTY}
 
 
 *** Tasks ***
-
 Install thin-edge.io on your device
-    ${device_sn}=    Setup       skip_bootstrap=True
+    ${device_sn}=    Setup    skip_bootstrap=True
     Set Suite Variable    $DEVICE_SN    ${device_sn}
     Uninstall tedge with purge
     Clear previous downloaded files if any
     Install thin-edge.io
 
 Set the URL of your Cumulocity IoT tenant
-    ${HOSTNAME}=      Replace String Using Regexp    ${C8Y_CONFIG.host}    ^.*://    ${EMPTY}
-    ${HOSTNAME}=      Strip String    ${HOSTNAME}    characters=/
+    ${HOSTNAME}=    Replace String Using Regexp    ${C8Y_CONFIG.host}    ^.*://    ${EMPTY}
+    ${HOSTNAME}=    Strip String    ${HOSTNAME}    characters=/
     Execute Command    sudo tedge config set c8y.url ${HOSTNAME}    # Set the URL of your Cumulocity IoT tenant
 
 Create the certificate
     Execute Command    sudo tedge cert create --device-id ${DEVICE_SN}
 
-    #You can then check the content of that certificate.
-    ${output}=    Execute Command    sudo tedge cert show    #You can then check the content of that certificate.
+    # You can then check the content of that certificate.
+    ${output}=    Execute Command    sudo tedge cert show    # You can then check the content of that certificate.
     Should Contain    ${output}    Device certificate: /etc/tedge/device-certs/tedge-certificate.pem
     Should Contain    ${output}    Subject: CN=${DEVICE_SN}, O=Thin Edge, OU=Test Device
     Should Contain    ${output}    Issuer: CN=${DEVICE_SN}, O=Thin Edge, OU=Test Device
@@ -43,7 +45,7 @@ tedge cert upload c8y command
     Sleep    3s    # Wait for cert to be processed/distributed to all cores (in Cumulocity IoT)
 
 Connect the device
-    ${output}=    Execute Command    sudo tedge connect c8y    #You can then check the content of that certificate.
+    ${output}=    Execute Command    sudo tedge connect c8y    # You can then check the content of that certificate.
     Sleep    3s
     Should Contain    ${output}    Checking if systemd is available.
     Should Contain    ${output}    Checking if configuration for requested bridge already exists.
@@ -67,7 +69,7 @@ Connect the device
     Should Contain    ${output}    tedge-agent service successfully started and enabled!
 
 Sending your first telemetry data
-    Execute Command    tedge mqtt pub c8y/s/us 211,20    #Set the URL of your Cumulocity IoT tenant
+    Execute Command    tedge mqtt pub c8y/s/us 211,20    # Set the URL of your Cumulocity IoT tenant
 
 Download the measurements report file
     Device Should Exist    ${DEVICE_SN}
@@ -78,14 +80,14 @@ Monitor the device
     Execute Command    sudo apt-get update && sudo apt-get install libmosquitto1 -y
     Execute Command    sudo apt-get install collectd-core -y
     # Configure collectd
-    Execute Command    sudo cp /etc/tedge/contrib/collectd/collectd.conf /etc/collectd/collectd.conf; sudo systemctl restart collectd
-    #Enable Collectd
+    Execute Command
+    ...    sudo cp /etc/tedge/contrib/collectd/collectd.conf /etc/collectd/collectd.conf; sudo systemctl restart collectd
+    # Enable Collectd
     Execute Command    sudo systemctl start tedge-mapper-collectd && sudo systemctl enable tedge-mapper-collectd
-    ${measure}    Device Should Have Measurements    minimum=1
+    ${measure}=    Device Should Have Measurements    minimum=1
 
 
 *** Keywords ***
-
 Uninstall tedge with purge
     Execute Command    wget https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/uninstall-thin-edge_io.sh
     Execute Command    chmod a+x uninstall-thin-edge_io.sh

--- a/tests/RobotFramework/tasks/build_install_rpi.robot
+++ b/tests/RobotFramework/tasks/build_install_rpi.robot
@@ -1,133 +1,186 @@
-#Command to execute:    robot -d \results --timestampoutputs --log build_install_rpi.html --report NONE --variable BUILD:840 --variable HOST:192.168.1.130 QA/System-tests/tasks/build_install_rpi.robot
+*** Comments ***
+# Command to execute:    robot -d \results --timestampoutputs --log build_install_rpi.html --report NONE --variable BUILD:840 --variable HOST:192.168.1.130 QA/System-tests/tasks/build_install_rpi.robot
+
+
 *** Settings ***
-Library    Browser
-Library    OperatingSystem
-Library    SSHLibrary
-Library    DateTime
-Library    CryptoLibrary    variable_decryption=True
-Suite Setup            Open Connection And Log In
-Suite Teardown         SSHLibrary.Close All Connections
+Library             Browser
+Library             OperatingSystem
+Library             SSHLibrary
+Library             DateTime
+Library             CryptoLibrary    variable_decryption=True
+
+Suite Setup         Open Connection And Log In
+Suite Teardown      SSHLibrary.Close All Connections
+
 
 *** Variables ***
-${HOST}           
-${USERNAME}       pi
-${PASSWORD}       crypt:LO3wCxZPltyviM8gEyBkRylToqtWm+hvq9mMVEPxtn0BXB65v/5wxUu7EqicpOgGhgNZVgFjY0o=    
-${DeviceID}       
-${Version}        *.*
-${download_dir}    /home/pi/
-${url_dow}    https://github.com/thin-edge/thin-edge.io/actions
-${user_git}    crypt:3Uk76kNdyyYOXxus2GFoLf8eRlt/W77eEkcSiswwh04HNfwt0NlJwI7ATKPABmxKk8K1a8NsI5QH0w8EmT8GWeqrFwX2    
-${pass_git}    crypt:IcTs6FyNl16ThjeG6lql0zNTsjCAwg5s6PhjRrcEwQ9DVHHRB4TjrGcpblR6R1v7j9oUlL3RzwxGpfBfsijVnQ==    
-${FILENAME}
-${DIRECTORY}    /home/pi/
-${url}    https://thin-edge-io.eu-latest.cumulocity.com/
-${url_tedge}    thin-edge-io.eu-latest.cumulocity.com
-${user}    systest_preparation
-${pass}    crypt:34mpoxueRYy/gDerrLeBThQ2wp9F+2cw50XaNyjiGUpK488+1fgEfE6drOEcR+qZQ6dcjIWETukbqLU=    
-${BUILD}
-${ARCH}
-${dir}
+${HOST}             ${EMPTY}
+${USERNAME}         pi
+${PASSWORD}         crypt:LO3wCxZPltyviM8gEyBkRylToqtWm+hvq9mMVEPxtn0BXB65v/5wxUu7EqicpOgGhgNZVgFjY0o=
+${DeviceID}         ${EMPTY}
+${Version}          *.*
+${download_dir}     /home/pi/
+${url_dow}          https://github.com/thin-edge/thin-edge.io/actions
+${user_git}         crypt:3Uk76kNdyyYOXxus2GFoLf8eRlt/W77eEkcSiswwh04HNfwt0NlJwI7ATKPABmxKk8K1a8NsI5QH0w8EmT8GWeqrFwX2
+${pass_git}         crypt:IcTs6FyNl16ThjeG6lql0zNTsjCAwg5s6PhjRrcEwQ9DVHHRB4TjrGcpblR6R1v7j9oUlL3RzwxGpfBfsijVnQ==
+${FILENAME}         ${EMPTY}
+${DIRECTORY}        /home/pi/
+${url}              https://thin-edge-io.eu-latest.cumulocity.com/
+${url_tedge}        thin-edge-io.eu-latest.cumulocity.com
+${user}             systest_preparation
+${pass}             crypt:34mpoxueRYy/gDerrLeBThQ2wp9F+2cw50XaNyjiGUpK488+1fgEfE6drOEcR+qZQ6dcjIWETukbqLU=
+${BUILD}            ${EMPTY}
+${ARCH}             ${EMPTY}
+${dir}              ${EMPTY}
+
 
 *** Tasks ***
-Create Timestamp    #Creating timestamp to be used for Device ID
-        ${timestamp}=    get current date    result_format=%d%m%Y%H%M%S
-        log    ${timestamp}
-        Set Global Variable    ${timestamp}
-Define Device id    #Defining the Device ID, structure is (ST'timestamp') (eg. ST01092022091654)
-        ${DeviceID}   Set Variable    ST${timestamp}
-        Set Suite Variable    ${DeviceID}
-Check Architecture    #Checking the architecture in order to download the right SW
-    ${output}=    Execute Command   uname -m
-    ${ARCH}    Set Variable    ${output}
+Create Timestamp    # Creating timestamp to be used for Device ID
+    ${timestamp}=    get current date    result_format=%d%m%Y%H%M%S
+    log    ${timestamp}
+    Set Global Variable    ${timestamp}
+
+Define Device id    # Defining the Device ID, structure is (ST'timestamp') (eg. ST01092022091654)
+    ${DeviceID}=    Set Variable    ST${timestamp}
+    Set Suite Variable    ${DeviceID}
+
+Check Architecture    # Checking the architecture in order to download the right SW
+    ${output}=    Execute Command    uname -m
+    ${ARCH}=    Set Variable    ${output}
     Set Global Variable    ${ARCH}
 
-Set File Name    #Setting the file name for download
-    Run Keyword If    '${ARCH}'=='aarch64'    aarch64
-    ...  ELSE    armv7   
-Disconnect from c8y        #Disconnects from Cumulocity IoT if connected
+Set File Name    # Setting the file name for download
+    IF    '${ARCH}'=='aarch64'    aarch64    ELSE    armv7
+
+Disconnect from c8y    # Disconnects from Cumulocity IoT if connected
     Execute Command    sudo tedge disconnect c8y
+
 Uninstall tedge with purge
     Execute Command    wget https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/uninstall-thin-edge_io.sh
     Execute Command    chmod a+x uninstall-thin-edge_io.sh
     Execute Command    ./uninstall-thin-edge_io.sh purge
+
 Clear previous downloaded files if any
     Execute Command    rm *.deb | rm *.zip | rm *.sh*
+
 Download the Build Package
     New Context    acceptDownloads=True
-    New Page    ${url_dow} 
+    New Page    ${url_dow}
     Click    //a[normalize-space()='Sign in']
     Fill Text    //input[@id='login_field']    ${user_git}
     Fill Text    //input[@id='password']    ${pass_git}
     Click    //input[@name='commit']
-    Fill Text    //input[@data-hotkey='Control+/,Meta+/']    workflow:build-workflow is:success 
-    Keyboard Key    press    Enter   
+    Fill Text    //input[@data-hotkey='Control+/,Meta+/']    workflow:build-workflow is:success
+    Keyboard Key    press    Enter
     Sleep    5s
     Wait For Elements State    //*[contains(@aria-label, '${BUILD}')]    visible
     Click    //*[contains(@aria-label, '${BUILD}')]
     Sleep    5s
-    Wait For Elements State     //a[normalize-space()='${FILENAME}']    visible
-    ${dl_promise}          Promise To Wait For Download    ${DIRECTORY}${FILENAME}.zip
+    Wait For Elements State    //a[normalize-space()='${FILENAME}']    visible
+    ${dl_promise}=    Promise To Wait For Download    ${DIRECTORY}${FILENAME}.zip
     Click    //a[normalize-space()='${FILENAME}']
-    ${file_obj}=    Wait For  ${dl_promise}
+    ${file_obj}=    Wait For    ${dl_promise}
     Sleep    5s
+
 Copy File to Device
     Put File    ${download_dir}${FILENAME}.zip
+
 Unpack the File
     ${rc}=    Execute Command    unzip ${FILENAME}.zip    return_stdout=False    return_rc=True
     Should Be Equal    ${rc}    ${0}
+
 Install Mosquitto
     ${rc}=    Execute Command    sudo apt-get --assume-yes install mosquitto    return_stdout=False    return_rc=True
     Should Be Equal    ${rc}    ${0}
+
 Install Libmosquitto1
-    ${rc}=    Execute Command    sudo apt-get --assume-yes install libmosquitto1    return_stdout=False    return_rc=True
+    ${rc}=    Execute Command
+    ...    sudo apt-get --assume-yes install libmosquitto1
+    ...    return_stdout=False
+    ...    return_rc=True
     Should Be Equal    ${rc}    ${0}
+
 Install Collectd-core
-    ${rc}=    Execute Command    sudo apt-get --assume-yes install collectd-core    return_stdout=False    return_rc=True
+    ${rc}=    Execute Command
+    ...    sudo apt-get --assume-yes install collectd-core
+    ...    return_stdout=False
+    ...    return_rc=True
     Should Be Equal    ${rc}    ${0}
+
 thin-edge.io installation
     ${rc}=    Execute Command    sudo dpkg -i ./tedge_${Version}_arm*.deb    return_stdout=False    return_rc=True
     Should Be Equal    ${rc}    ${0}
+
 Install Tedge mapper
-    ${rc}=    Execute Command    sudo dpkg -i ./tedge-mapper_${Version}_arm*.deb    return_stdout=False    return_rc=True
+    ${rc}=    Execute Command
+    ...    sudo dpkg -i ./tedge-mapper_${Version}_arm*.deb
+    ...    return_stdout=False
+    ...    return_rc=True
     Should Be Equal    ${rc}    ${0}
+
 Install Tedge agent
-    ${rc}=    Execute Command    sudo dpkg -i ./tedge-agent_${Version}_arm*.deb    return_stdout=False    return_rc=True
+    ${rc}=    Execute Command
+    ...    sudo dpkg -i ./tedge-agent_${Version}_arm*.deb
+    ...    return_stdout=False
+    ...    return_rc=True
     Should Be Equal    ${rc}    ${0}
+
 Install tedge apt plugin
-   ${rc}=    Execute Command    sudo dpkg -i ./tedge-apt-plugin_${Version}_arm*.deb    return_stdout=False    return_rc=True
+    ${rc}=    Execute Command
+    ...    sudo dpkg -i ./tedge-apt-plugin_${Version}_arm*.deb
+    ...    return_stdout=False
+    ...    return_rc=True
     Should Be Equal    ${rc}    ${0}
+
 Install Watchdog
-    ${rc}=    Execute Command    sudo dpkg -i ./tedge-watchdog_${Version}_arm*.deb    return_stdout=False    return_rc=True
+    ${rc}=    Execute Command
+    ...    sudo dpkg -i ./tedge-watchdog_${Version}_arm*.deb
+    ...    return_stdout=False
+    ...    return_rc=True
     Should Be Equal    ${rc}    ${0}
+
 Executing Create self-signed certificate
-    ${rc}=    Execute Command    sudo tedge cert create --device-id ${DeviceID}    return_stdout=False    return_rc=True
+    ${rc}=    Execute Command
+    ...    sudo tedge cert create --device-id ${DeviceID}
+    ...    return_stdout=False
+    ...    return_rc=True
     Should Be Equal    ${rc}    ${0}
-    ${output}=    Execute Command    sudo tedge cert show    #You can then check the content of that certificate.
+    ${output}=    Execute Command    sudo tedge cert show    # You can then check the content of that certificate.
     Should Contain    ${output}    Device certificate: /etc/tedge/device-certs/tedge-certificate.pem
+
 Set c8y URL
-    ${rc}=    Execute Command    sudo tedge config set c8y.url ${url_tedge}    return_stdout=False    return_rc=True    #Set the URL of your Cumulocity IoT tenant
+    # Set the URL of your Cumulocity IoT tenant
+    ${rc}=    Execute Command
+    ...    sudo tedge config set c8y.url ${url_tedge}
+    ...    return_stdout=False
+    ...    return_rc=True
     Should Be Equal    ${rc}    ${0}
-Upload certificate    
-    Write   sudo tedge cert upload c8y --user ${user}
+
+Upload certificate
+    Write    sudo tedge cert upload c8y --user ${user}
     Write    ${pass}
     Sleep    60s
+
 Connect to c8y
-    ${output}=    Execute Command    sudo tedge connect c8y    #You can then check the content of that certificate.
+    ${output}=    Execute Command    sudo tedge connect c8y    # You can then check the content of that certificate.
     Sleep    3s
     Should Contain    ${output}    tedge-agent service successfully started and enabled!
     Execute Command    rm *.deb | rm *.zip | rm *.sh*
 
+
 *** Keywords ***
 Open Connection And Log In
-   Open Connection     ${HOST}
-   Login               ${USERNAME}        ${PASSWORD}
+    Open Connection    ${HOST}
+    Login    ${USERNAME}    ${PASSWORD}
+
 aarch64
     [Documentation]    Setting file name according architecture
-    ${FILENAME}    Set Variable    debian-packages-aarch64-unknown-linux-gnu
+    ${FILENAME}=    Set Variable    debian-packages-aarch64-unknown-linux-gnu
     Log    ${FILENAME}
     Set Global Variable    ${FILENAME}
+
 armv7
     [Documentation]    Setting file name according architecture
-    ${FILENAME}    Set Variable    debian-packages-armv7-unknown-linux-gnueabihf
+    ${FILENAME}=    Set Variable    debian-packages-armv7-unknown-linux-gnueabihf
     Log    ${FILENAME}
     Set Global Variable    ${FILENAME}

--- a/tests/RobotFramework/tasks/build_install_rpi.robot
+++ b/tests/RobotFramework/tasks/build_install_rpi.robot
@@ -3,10 +3,10 @@
 
 
 *** Settings ***
-Library             Browser
-Library             OperatingSystem
-Library             SSHLibrary
 Library             DateTime
+Library             OperatingSystem
+Library             Browser
+Library             SSHLibrary
 Library             CryptoLibrary    variable_decryption=True
 
 Suite Setup         Open Connection And Log In

--- a/tests/RobotFramework/tasks/debug.robot
+++ b/tests/RobotFramework/tasks/debug.robot
@@ -12,7 +12,7 @@ Library             Cumulocity
 Library             ThinEdgeIO    adapter=docker
 Library             DebugLibrary
 
-Test Teardown       Get Logs
+Task Teardown       Get Logs
 
 
 *** Variables ***

--- a/tests/RobotFramework/tasks/debug.robot
+++ b/tests/RobotFramework/tasks/debug.robot
@@ -1,56 +1,55 @@
+*** Comments ***
 ###############################################################################
 # Debugging Tasks which are meant to assist the developer by spawning a new
 # containerized device where they can quickly deploy a new build, or the last
 # official build to try to reproduce bugs.
 ###############################################################################
 
-*** Settings ***
-Resource    ../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO    adapter=docker
-Library    DebugLibrary
 
-Test Teardown    Get Logs
+*** Settings ***
+Resource            ../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO    adapter=docker
+Library             DebugLibrary
+
+Test Teardown       Get Logs
+
 
 *** Variables ***
-${DPKG_INSTALL_SCRIPT}   cd /setup \
-...                      && dpkg -i tedge_*.deb \
-...                      && dpkg -i tedge*mapper*.deb \
-...                      && dpkg -i tedge*agent*.deb \
-...                      && dpkg -i tedge*watchdog*.deb \
-...                      && dpkg -i tedge*apt*plugin*.deb
+${DPKG_INSTALL_SCRIPT}      cd /setup \
+...                         && dpkg -i tedge_*.deb \
+...                         && dpkg -i tedge*mapper*.deb \
+...                         && dpkg -i tedge*agent*.deb \
+...                         && dpkg -i tedge*watchdog*.deb \
+...                         && dpkg -i tedge*apt*plugin*.deb
 
 
 *** Tasks ***
-
 Debug device with latest official version
-    ${DEVICE_SN}=                            Setup
-    Device Should Exist                      ${DEVICE_SN}
+    ${DEVICE_SN}=    Setup
+    Device Should Exist    ${DEVICE_SN}
     Debug
 
-
 Debug device with locally built debian packages (upgrading from last official release)
-    ${DEVICE_SN}=                            Setup
-    Device Should Exist                      ${DEVICE_SN}
+    ${DEVICE_SN}=    Setup
+    Device Should Exist    ${DEVICE_SN}
     Install Locally Built Packages
     Log Device Info
     Debug
 
-
 Debug device with locally built debian packages (no upgrade)
-    ${DEVICE_SN}=                            Setup    skip_bootstrap=True
-    Install Locally Built Packages           connect=yes
-    Device Should Exist                      ${DEVICE_SN}
+    ${DEVICE_SN}=    Setup    skip_bootstrap=True
+    Install Locally Built Packages    connect=yes
+    Device Should Exist    ${DEVICE_SN}
     Debug
 
 
 *** Keywords ***
-
 Install Locally Built Packages
     [Arguments]    ${connect}=no
-    Transfer To Device                       target/x86_64-unknown-linux-musl/packages/*.deb    /setup/
-    Execute Command                          apt-get update && apt-get install -y --no-install-recommends mosquitto
-    Execute Command                          ${DPKG_INSTALL_SCRIPT}
+    Transfer To Device    target/x86_64-unknown-linux-musl/packages/*.deb    /setup/
+    Execute Command    apt-get update && apt-get install -y --no-install-recommends mosquitto
+    Execute Command    ${DPKG_INSTALL_SCRIPT}
     IF    "${connect}" == "yes"
-        Execute Command                      test -f ./bootstrap.sh && ./bootstrap.sh --no-install || true
+        Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-install || true
     END

--- a/tests/RobotFramework/tests/MQTT_health_check/MQTT_health_endpoints.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/MQTT_health_endpoints.robot
@@ -1,19 +1,24 @@
-#Command to execute:    robot -d \results --timestampoutputs --log inotify_crate.html --report NONE --variable HOST:192.168.1.130 /thin-edge.io/tests/RobotFramework/MQTT_health_check/MQTT_health_endpoints.robot
+*** Comments ***
+# Command to execute:    robot -d \results --timestampoutputs --log inotify_crate.html --report NONE --variable HOST:192.168.1.130 /thin-edge.io/tests/RobotFramework/MQTT_health_check/MQTT_health_endpoints.robot
+
 
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:monitoring    theme:mqtt
-Suite Setup       Setup
-Suite Teardown    Get Logs
+Suite Setup         Setup
+Suite Teardown      Get Logs
+
+Test Tags           theme:monitoring    theme:mqtt
 
 
 *** Test Cases ***
-
 tedge-agent health status
     ${pid}=    Service Should Be Running    tedge-agent
     Execute Command    sudo tedge mqtt pub 'te/device/main/service/tedge-agent/cmd/health/check' ''
-    ${messages}=    Should Have MQTT Messages    te/device/main/service/tedge-agent/status/health    minimum=1    maximum=2
+    ${messages}=    Should Have MQTT Messages
+    ...    te/device/main/service/tedge-agent/status/health
+    ...    minimum=1
+    ...    maximum=2
     Should Contain    ${messages[0]}    "pid":${pid}
     Should Contain    ${messages[0]}    "status":"up"

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-agent.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-agent.robot
@@ -1,16 +1,18 @@
-#Command to execute:    robot -d \results --timestampoutputs --log health_tedge-agent.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io-fork/tests/RobotFramework/MQTT_health_check/health_tedge-agent.robot
+*** Comments ***
+# Command to execute:    robot -d \results --timestampoutputs --log health_tedge-agent.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io-fork/tests/RobotFramework/MQTT_health_check/health_tedge-agent.robot
+
 
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:monitoring
-Suite Setup       Setup
-Suite Teardown    Get Logs
+Suite Setup         Setup
+Suite Teardown      Get Logs
+
+Test Tags           theme:monitoring
 
 
 *** Test Cases ***
-
 Stop tedge-agent
     Execute Command    sudo systemctl stop tedge-agent.service
 

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-aws.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-aws.robot
@@ -1,20 +1,21 @@
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:monitoring    theme:az
-Suite Setup       Setup
-Suite Teardown    Get Logs
+Suite Setup         Setup
+Suite Teardown      Get Logs
+
+Test Tags           theme:monitoring    theme:az
 
 
 *** Test Cases ***
-
 Watchdog does not kill mapper if it responds
     # Set the watchdog interval low so we don't have to wait long
     Execute Command    sudo systemctl stop tedge-mapper-aws.service
     Execute Command    sudo systemctl stop tedge-watchdog.service
     Execute Command    cmd=sudo sed -i '10iWatchdogSec=5' /lib/systemd/system/tedge-mapper-aws.service
-    Execute Command    cmd=sudo sed -i "s/\\\\[Service\\\\]/\\\\0\\\\nEnvironment=\"TEDGE_MQTT_BRIDGE_BUILT_IN=false\"/" /lib/systemd/system/tedge-mapper-aws.service
+    Execute Command
+    ...    cmd=sudo sed -i "s/\\\\[Service\\\\]/\\\\0\\\\nEnvironment=\"TEDGE_MQTT_BRIDGE_BUILT_IN=false\"/" /lib/systemd/system/tedge-mapper-aws.service
     Execute Command    sudo systemctl daemon-reload
     Execute Command    sudo systemctl start tedge-mapper-aws.service
     Execute Command    sudo systemctl start tedge-watchdog.service
@@ -24,7 +25,5 @@ Watchdog does not kill mapper if it responds
     Sleep    10s
     ${pid_after_healthcheck}=    Service Should Be Running    tedge-mapper-aws
 
-    Should Have MQTT Messages     topic=te/device/main/service/tedge-mapper-aws/cmd/health/check    minimum=1
-    Should Be Equal               ${pid_before_healthcheck}    ${pid_after_healthcheck}
-
-
+    Should Have MQTT Messages    topic=te/device/main/service/tedge-mapper-aws/cmd/health/check    minimum=1
+    Should Be Equal    ${pid_before_healthcheck}    ${pid_after_healthcheck}

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-az.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-az.robot
@@ -1,7 +1,3 @@
-*** Comments ***
-# Command to execute:    robot -d \results --timestampoutputs --log health_tedge-mapper-az.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io-fork/tests/RobotFramework/MQTT_health_check/health_tedge-mapper-az.robot
-
-
 *** Settings ***
 Resource            ../../resources/common.resource
 Library             ThinEdgeIO

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-az.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-az.robot
@@ -1,22 +1,25 @@
-#Command to execute:    robot -d \results --timestampoutputs --log health_tedge-mapper-az.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io-fork/tests/RobotFramework/MQTT_health_check/health_tedge-mapper-az.robot
+*** Comments ***
+# Command to execute:    robot -d \results --timestampoutputs --log health_tedge-mapper-az.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io-fork/tests/RobotFramework/MQTT_health_check/health_tedge-mapper-az.robot
+
 
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:monitoring    theme:az
-Suite Setup       Setup
-Suite Teardown    Get Logs
+Suite Setup         Setup
+Suite Teardown      Get Logs
+
+Test Tags           theme:monitoring    theme:az
 
 
 *** Test Cases ***
-
 Stop tedge-mapper-az
     Execute Command    sudo systemctl stop tedge-mapper-az.service
 
 Update the service file
     Execute Command    cmd=sudo sed -i '10iWatchdogSec=30' /lib/systemd/system/tedge-mapper-az.service
-    Execute Command    cmd=sudo sed -i "s/\\\\[Service\\\\]/\\\\0\\\\nEnvironment=\"TEDGE_MQTT_BRIDGE_BUILT_IN=false\"/" /lib/systemd/system/tedge-mapper-az.service
+    Execute Command
+    ...    cmd=sudo sed -i "s/\\\\[Service\\\\]/\\\\0\\\\nEnvironment=\"TEDGE_MQTT_BRIDGE_BUILT_IN=false\"/" /lib/systemd/system/tedge-mapper-az.service
 
 Reload systemd files
     Execute Command    sudo systemctl daemon-reload
@@ -28,6 +31,7 @@ Start watchdog service
     Execute Command    sudo systemctl start tedge-watchdog.service
 
     Sleep    10s
+
 Check PID of tedge-mapper-az
     ${pid}=    Service Should Be Running    tedge-mapper-az
     Set Suite Variable    ${pid}
@@ -62,6 +66,5 @@ Watchdog does not kill mapper if it responds
     Sleep    10s
     ${pid_after_healthcheck}=    Service Should Be Running    tedge-mapper-az
 
-    Should Have MQTT Messages     topic=te/device/main/service/tedge-mapper-az/cmd/health/check    minimum=1
-    Should Be Equal               ${pid_before_healthcheck}    ${pid_after_healthcheck}
-
+    Should Have MQTT Messages    topic=te/device/main/service/tedge-mapper-az/cmd/health/check    minimum=1
+    Should Be Equal    ${pid_before_healthcheck}    ${pid_after_healthcheck}

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-collectd.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-collectd.robot
@@ -1,7 +1,3 @@
-*** Comments ***
-# Command to execute:    robot -d \results --timestampoutputs --log health_tedge-mapper-collectd.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io-fork/tests/RobotFramework/MQTT_health_check/health_tedge-mapper-collectd.robot
-
-
 *** Settings ***
 Resource            ../../resources/common.resource
 Library             ThinEdgeIO

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-collectd.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge-mapper-collectd.robot
@@ -1,16 +1,18 @@
-#Command to execute:    robot -d \results --timestampoutputs --log health_tedge-mapper-collectd.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io-fork/tests/RobotFramework/MQTT_health_check/health_tedge-mapper-collectd.robot
+*** Comments ***
+# Command to execute:    robot -d \results --timestampoutputs --log health_tedge-mapper-collectd.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io-fork/tests/RobotFramework/MQTT_health_check/health_tedge-mapper-collectd.robot
+
 
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:monitoring
-Suite Setup       Setup
-Suite Teardown    Get Logs
+Suite Setup         Setup
+Suite Teardown      Get Logs
+
+Test Tags           theme:monitoring
 
 
 *** Test Cases ***
-
 Stop tedge-mapper-collectd
     Execute Command    sudo systemctl stop tedge-mapper-collectd.service
 
@@ -51,9 +53,12 @@ Remove entry from service file
 tedge-collectd-mapper health status
     Execute Command    sudo systemctl start tedge-mapper-collectd.service
 
-    Sleep    5s     reason=It fails without this! It needs a better way of queuing requests
+    Sleep    5s    reason=It fails without this! It needs a better way of queuing requests
     ${pid}=    Service Should Be Running    tedge-mapper-collectd
     Execute Command    sudo tedge mqtt pub 'te/device/main/service/tedge-mapper-collectd/cmd/health/check' ''
-    ${messages}=    Should Have MQTT Messages    te/device/main/service/tedge-mapper-collectd/status/health    minimum=1    maximum=2
+    ${messages}=    Should Have MQTT Messages
+    ...    te/device/main/service/tedge-mapper-collectd/status/health
+    ...    minimum=1
+    ...    maximum=2
     Should Contain    ${messages[0]}    "pid":${pid}
     Should Contain    ${messages[0]}    "status":"up"

--- a/tests/RobotFramework/tests/MQTT_health_check/health_tedge_mapper_c8y.robot
+++ b/tests/RobotFramework/tests/MQTT_health_check/health_tedge_mapper_c8y.robot
@@ -1,16 +1,18 @@
-#Command to execute:    robot -d \results --timestampoutputs --log health_tedge_mapper.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io-fork/tests/RobotFramework/MQTT_health_check/health_tedge_mapper.robot
+*** Comments ***
+# Command to execute:    robot -d \results --timestampoutputs --log health_tedge_mapper.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io-fork/tests/RobotFramework/MQTT_health_check/health_tedge_mapper.robot
+
 
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:monitoring    theme:c8y
-Suite Setup       Setup
-Suite Teardown    Get Logs
+Suite Setup         Setup
+Suite Teardown      Get Logs
+
+Test Tags           theme:monitoring    theme:c8y
 
 
 *** Test Cases ***
-
 Stop tedge-mapper
     Execute Command    sudo systemctl stop tedge-mapper-c8y.service
 
@@ -27,6 +29,7 @@ Start watchdog service
     Execute Command    sudo systemctl start tedge-watchdog.service
 
     Sleep    10s
+
 Check PID of tedge-mapper
     ${pid}=    Service Should Be Running    tedge-mapper-c8y
     Set Suite Variable    ${pid}
@@ -61,5 +64,5 @@ Watchdog does not kill mapper if it responds
     Sleep    10s
     ${pid_after_healthcheck}=    Service Should Be Running    tedge-mapper-c8y
 
-    Should Have MQTT Messages     topic=te/device/main/service/tedge-mapper-c8y/cmd/health/check    minimum=1
-    Should Be Equal               ${pid_before_healthcheck}    ${pid_after_healthcheck}
+    Should Have MQTT Messages    topic=te/device/main/service/tedge-mapper-c8y/cmd/health/check    minimum=1
+    Should Be Equal    ${pid_before_healthcheck}    ${pid_after_healthcheck}

--- a/tests/RobotFramework/tests/aws/aws_connect.robot
+++ b/tests/RobotFramework/tests/aws/aws_connect.robot
@@ -1,18 +1,17 @@
 *** Settings ***
 Documentation       Verify that thin-edge.io can successfully connect to AWS IoT Core
-    ...             The test assumes that the Just in Time Provisioning (JITP) is setup in AWS
+...                 The test assumes that the Just in Time Provisioning (JITP) is setup in AWS
 
 Resource            ../../resources/common.resource
 Library             ThinEdgeIO
 
-Test Setup         Custom Setup
-Test Teardown      Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
 
 Test Tags           theme:mqtt    theme:aws    test:on_demand
 
 
 *** Test Cases ***
-
 Connect to AWS using mosquitto bridge
     Execute Command    tedge config set mqtt.bridge.built_in false
     Execute Command    sudo tedge config set aws.url ${AWS_CONFIG.host}
@@ -21,17 +20,17 @@ Connect to AWS using mosquitto bridge
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-aws
     Should Have MQTT Messages    te/device/main/service/mosquitto-aws-bridge/status/health    message_pattern=^1$
 
-
 Connect to AWS using built-in bridge
     Execute Command    tedge config set mqtt.bridge.built_in true
     Execute Command    sudo tedge config set aws.url ${AWS_CONFIG.host}
     ${stdout}=    Execute Command    sudo tedge connect aws    retries=0
     Should Not Contain    ${stdout}    Warning: Bridge has been configured, but Aws connection check failed
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-aws
-    Should Have MQTT Messages    te/device/main/service/tedge-mapper-bridge-aws/status/health    message_contains="status":"up"
+    Should Have MQTT Messages
+    ...    te/device/main/service/tedge-mapper-bridge-aws/status/health
+    ...    message_contains="status":"up"
 
 
 *** Keywords ***
-
 Custom Setup
     Setup

--- a/tests/RobotFramework/tests/aws/aws_telemetry.robot
+++ b/tests/RobotFramework/tests/aws/aws_telemetry.robot
@@ -12,52 +12,92 @@ Test Tags           theme:mqtt    theme:aws
 
 *** Test Cases ***
 Publish measurements to te measurement topic
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/main///m/ '{"temperature": 10}'
-    Should Have MQTT Messages    aws/td/device:main/m/    message_contains="temperature"    date_from=${timestamp}   minimum=1    maximum=1
+    Should Have MQTT Messages
+    ...    aws/td/device:main/m/
+    ...    message_contains="temperature"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish measurements to te measurement topic with measurement type
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/main///m/test-type '{"temperature": 10}'
-    Should Have MQTT Messages    aws/td/device:main/m/test-type   message_contains="temperature"    date_from=${timestamp}   minimum=1    maximum=1
+    Should Have MQTT Messages
+    ...    aws/td/device:main/m/test-type
+    ...    message_contains="temperature"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish service measurements to te measurement topic with measurement type
-    ${timestamp}=        Get Unix Timestamp  
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/main/service/test_service/m/test-type '{"temperature": 10}'
-    Should Have MQTT Messages    aws/td/device:main:service:test_service/m/test-type   message_contains="temperature"    date_from=${timestamp}   minimum=1    maximum=1
+    Should Have MQTT Messages
+    ...    aws/td/device:main:service:test_service/m/test-type
+    ...    message_contains="temperature"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish child measurements to te measurement topic with measurement type
-    ${timestamp}=        Get Unix Timestamp   
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/child///m/test-type '{"temperature": 10}'
-    Should Have MQTT Messages    aws/td/device:child/m/test-type   message_contains="temperature"    date_from=${timestamp}   minimum=1    maximum=1
-
+    Should Have MQTT Messages
+    ...    aws/td/device:child/m/test-type
+    ...    message_contains="temperature"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish main device event to te event topic with event type
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/main///e/event-type '{"text": "someone logged-in"}'
-    Should Have MQTT Messages    aws/td/device:main/e/event-type   message_contains="someone logged-in"    date_from=${timestamp}   minimum=1    maximum=1     
-
+    Should Have MQTT Messages
+    ...    aws/td/device:main/e/event-type
+    ...    message_contains="someone logged-in"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish child device event to te event topic with event type
-    ${timestamp}=        Get Unix Timestamp  
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/child///e/event-type '{"text": "someone logged-in"}'
-    Should Have MQTT Messages    aws/td/device:child/e/event-type   message_contains="someone logged-in"    date_from=${timestamp}   minimum=1    maximum=1
-
+    Should Have MQTT Messages
+    ...    aws/td/device:child/e/event-type
+    ...    message_contains="someone logged-in"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish main device alarm to te alarm topic with alarm type
-    ${timestamp}=        Get Unix Timestamp
-    Execute Command    tedge mqtt pub te/device/main///a/alarm-type '{"severity":"critical","text": "someone logged-in"}'
-    Should Have MQTT Messages    aws/td/device:main/a/alarm-type   message_contains="critical"    date_from=${timestamp}   minimum=1    maximum=1     
-
+    ${timestamp}=    Get Unix Timestamp
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/alarm-type '{"severity":"critical","text": "someone logged-in"}'
+    Should Have MQTT Messages
+    ...    aws/td/device:main/a/alarm-type
+    ...    message_contains="critical"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish child device alarm to te alarm topic with alarm type
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/child///a/alarm-type '{"severity":"major","text": "someone logged-in"}'
-    Should Have MQTT Messages    aws/td/device:child/a/alarm-type   message_contains="major"    date_from=${timestamp}   minimum=1    maximum=1
+    Should Have MQTT Messages
+    ...    aws/td/device:child/a/alarm-type
+    ...    message_contains="major"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish health status message for main device service
     Execute Command    tedge mqtt pub te/device/main/service/test-service/status/health '{"status":"up"}'
-    Should Have MQTT Messages    aws/td/device:main:service:test-service/status/health    message_contains="status":"up"
+    Should Have MQTT Messages
+    ...    aws/td/device:main:service:test-service/status/health
+    ...    message_contains="status":"up"
+
 
 *** Keywords ***
 Custom Setup

--- a/tests/RobotFramework/tests/azure/azure_telemetry.robot
+++ b/tests/RobotFramework/tests/azure/azure_telemetry.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation    Purpose of this test is to verify that tedge-mapper-az translates the messages that arrive on te topics
+Documentation       Purpose of this test is to verify that tedge-mapper-az translates the messages that arrive on te topics
 
 Resource            ../../resources/common.resource
 Library             ThinEdgeIO
@@ -11,65 +11,111 @@ Test Tags           theme:mqtt    theme:az
 
 
 *** Test Cases ***
-
 Publish measurements to te measurement topic with measurement type
-    ${timestamp}=        Get Unix Timestamp
-    Execute Command    tedge mqtt pub te/device/main///m/test-type '{"pressure": 10}'    
-    Should Have MQTT Messages    az/messages/events/#   message_contains="pressure"    date_from=${timestamp}   minimum=1    maximum=1
+    ${timestamp}=    Get Unix Timestamp
+    Execute Command    tedge mqtt pub te/device/main///m/test-type '{"pressure": 10}'
+    Should Have MQTT Messages
+    ...    az/messages/events/#
+    ...    message_contains="pressure"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish measurements to te measurement topic without measurement type
-    ${timestamp}=        Get Unix Timestamp
-    Execute Command    tedge mqtt pub te/device/main///m/ '{"windspeed": 10}'    
-    Should Have MQTT Messages    az/messages/events/#   message_contains="windspeed"    date_from=${timestamp}   minimum=1    maximum=1    
+    ${timestamp}=    Get Unix Timestamp
+    Execute Command    tedge mqtt pub te/device/main///m/ '{"windspeed": 10}'
+    Should Have MQTT Messages
+    ...    az/messages/events/#
+    ...    message_contains="windspeed"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish service measurements to te measurement topic with measurement type
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/main/service/test_service/m/test-type '{"temp": 10}'
-    Should Have MQTT Messages    az/messages/events/#   message_contains="temp"    date_from=${timestamp}   minimum=1    maximum=1
+    Should Have MQTT Messages
+    ...    az/messages/events/#
+    ...    message_contains="temp"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish child measurements to te measurement topic with measurement type
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/child///m/test-type '{"temperature_child": 10}'
-    Should Have MQTT Messages    az/messages/events/#   message_contains="temperature_child"    date_from=${timestamp}   minimum=1    maximum=1
-
+    Should Have MQTT Messages
+    ...    az/messages/events/#
+    ...    message_contains="temperature_child"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish main device event to te event topic with event type
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/main///e/event-type '{"text": "someone logged-in"}'
-    Should Have MQTT Messages    az/messages/events/#   message_contains="someone logged-in"    date_from=${timestamp}   minimum=1    maximum=1
-
+    Should Have MQTT Messages
+    ...    az/messages/events/#
+    ...    message_contains="someone logged-in"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish main device event to te event topic without event type
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/main///e/ '{"text": "someone logged-off"}'
-    Should Have MQTT Messages    az/messages/events/#   message_contains="someone logged-off"    date_from=${timestamp}   minimum=1    maximum=1
-
+    Should Have MQTT Messages
+    ...    az/messages/events/#
+    ...    message_contains="someone logged-off"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish child device event to te event topic with event type
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/child///e/event-type '{"text": "child_device event"}'
-    Should Have MQTT Messages    az/messages/events/#   message_contains="child_device event"    date_from=${timestamp}   minimum=1    maximum=1
-
+    Should Have MQTT Messages
+    ...    az/messages/events/#
+    ...    message_contains="child_device event"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish main device alarm to te alarm topic with alarm type
-    ${timestamp}=        Get Unix Timestamp   
-    Execute Command    tedge mqtt pub te/device/main///a/alarm-type '{"severity":"critical","text": "someone logged-in"}'
-    Should Have MQTT Messages    az/messages/events/#   message_contains="critical"    date_from=${timestamp}   minimum=1    maximum=1
+    ${timestamp}=    Get Unix Timestamp
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/alarm-type '{"severity":"critical","text": "someone logged-in"}'
+    Should Have MQTT Messages
+    ...    az/messages/events/#
+    ...    message_contains="critical"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish main device alarm to te alarm topic without alarm type
-    ${timestamp}=        Get Unix Timestamp   
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/main///a/ '{"severity":"major","text": "someone logged-in"}'
-    Should Have MQTT Messages    az/messages/events/#   message_contains="major"    date_from=${timestamp}   minimum=1    maximum=1 
-
+    Should Have MQTT Messages
+    ...    az/messages/events/#
+    ...    message_contains="major"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish child device alarm to te alarm topic with alarm type
-    ${timestamp}=        Get Unix Timestamp   
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/child///a/alarm-type '{"severity":"minor","text": "someone logged-in"}'
-    Should Have MQTT Messages    az/messages/events/#   message_contains="minor"    date_from=${timestamp}   minimum=1    maximum=1
+    Should Have MQTT Messages
+    ...    az/messages/events/#
+    ...    message_contains="minor"
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
 
 Publish health status message for main device service
     Execute Command    tedge mqtt pub te/device/main/service/test-service/status/health '{"status":"up"}'
     Should Have MQTT Messages    az/messages/events/    message_contains="status":"up"
+
 
 *** Keywords ***
 Custom Setup

--- a/tests/RobotFramework/tests/config_management/inotify_crate.robot
+++ b/tests/RobotFramework/tests/config_management/inotify_crate.robot
@@ -1,26 +1,30 @@
-#Command to execute:    robot -d \results --timestampoutputs --log inotify_crate.html --report NONE --variable HOST:192.168.1.130 /thin-edge.io/tests/RobotFramework/config_management/inotify_crate.robot
+*** Comments ***
+# Command to execute:    robot -d \results --timestampoutputs --log inotify_crate.html --report NONE --variable HOST:192.168.1.130 /thin-edge.io/tests/RobotFramework/config_management/inotify_crate.robot
+
 
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
-Library    Cumulocity
-Library    Collections
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+Library             Cumulocity
+Library             Collections
 
-Test Tags    theme:configuration    theme:plugins
-Test Teardown    Get Logs
+Test Teardown       Get Logs
+
+Test Tags           theme:configuration    theme:plugins
+
 
 *** Variables ***
-${toml}    SEPARATOR=\n
-...       files = [
-...           { path = '/etc/tedge/tedge.toml', type = 'tedge.toml'},
-...           { path = '/etc/tedge/mosquitto-conf/c8y-bridge.conf', type = 'c8y-bridge.conf' },
-...           { path = '/etc/tedge/mosquitto-conf/tedge-mosquitto.conf', type = 'tedge-mosquitto.conf' },
-...           { path = '/etc/mosquitto/mosquitto.conf', type = 'mosquitto.conf' },
-...           { path = '/etc/tedge/c8y/example.txt', type = 'example', user = 'tedge', group = 'tedge', mode = 0o444 }
-...       ]
+${toml}     SEPARATOR=\n
+...         files = [
+...         { path = '/etc/tedge/tedge.toml', type = 'tedge.toml'},
+...         { path = '/etc/tedge/mosquitto-conf/c8y-bridge.conf', type = 'c8y-bridge.conf' },
+...         { path = '/etc/tedge/mosquitto-conf/tedge-mosquitto.conf', type = 'tedge-mosquitto.conf' },
+...         { path = '/etc/mosquitto/mosquitto.conf', type = 'mosquitto.conf' },
+...         { path = '/etc/tedge/c8y/example.txt', type = 'example', user = 'tedge', group = 'tedge', mode = 0o444 }
+...         ]
+
 
 *** Test Cases ***
-
 Configuration types should be detected on file change (without restarting service)
     ${DEVICE_SN}=    Setup    skip_bootstrap=True
     Execute Command    /setup/bootstrap.sh 2>&1
@@ -28,9 +32,15 @@ Configuration types should be detected on file change (without restarting servic
 
     ${supported_configs}=    Should Support Configurations    tedge-configuration-plugin    includes=True
     Should Not Contain    ${supported_configs}    example
-    
+
     Execute Command    sudo rm -f /etc/tedge/plugins/tedge-configuration-plugin.toml
     Execute Command    sudo printf '%s' "${toml}" > tedge-configuration-plugin.toml
     Execute Command    sudo mv tedge-configuration-plugin.toml /etc/tedge/plugins/
 
-    ${supported_configs}=    Should Support Configurations    c8y-bridge.conf    tedge-configuration-plugin    mosquitto.conf    tedge-mosquitto.conf    tedge.toml    example
+    ${supported_configs}=    Should Support Configurations
+    ...    c8y-bridge.conf
+    ...    tedge-configuration-plugin
+    ...    mosquitto.conf
+    ...    tedge-mosquitto.conf
+    ...    tedge.toml
+    ...    example

--- a/tests/RobotFramework/tests/config_management/inotify_crate.robot
+++ b/tests/RobotFramework/tests/config_management/inotify_crate.robot
@@ -4,9 +4,9 @@
 
 *** Settings ***
 Resource            ../../resources/common.resource
+Library             Collections
 Library             ThinEdgeIO
 Library             Cumulocity
-Library             Collections
 
 Test Teardown       Get Logs
 

--- a/tests/RobotFramework/tests/configuration/lock_file.robot
+++ b/tests/RobotFramework/tests/configuration/lock_file.robot
@@ -1,17 +1,18 @@
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:configuration
-Suite Setup    Setup
-Test Teardown   Get Logs
+Suite Setup         Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:configuration
+
 
 *** Test Cases ***
-
 Check lock file existence in default folder
-    [Documentation]    When deploying thin-edge components in single-process containers, 
-    ...    the lock file mechanism used by some components (e.g. tedge-agent, tedge-mapper) 
-    ...    do not makes sense as the container filesystem is isolated. 
+    [Documentation]    When deploying thin-edge components in single-process containers,
+    ...    the lock file mechanism used by some components (e.g. tedge-agent, tedge-mapper)
+    ...    do not makes sense as the container filesystem is isolated.
     ...    Having the lock file system just adds unnecessary dependencies on the /run/lock folder.
     File Should Exist    /run/lock/tedge-agent.lock
     File Should Exist    /run/lock/tedge-mapper-c8y.lock
@@ -26,8 +27,8 @@ Check PID number in lock file
     Should Be Equal As Integers    ${pid_mapper1}    ${pid_mapper_lock1}
 
 Check PID number in lock file after restarting the services
-    [Documentation]    Include the new pid generated after service restart 
-    ...  inside the existing lock files under /run/lock/
+    [Documentation]    Include the new pid generated after service restart
+    ...    inside the existing lock files under /run/lock/
     Stop/Start Service    tedge-agent
     Stop/Start Service    tedge-mapper-c8y
     ${pid_agent2}=    Service Should Be Running    tedge-agent
@@ -38,32 +39,32 @@ Check PID number in lock file after restarting the services
     Should Be Equal As Integers    ${pid_mapper2}    ${pid_mapper_lock2}
 
 Check starting same service twice
-    [Documentation]    This step is checking if same service can be started twice, 
+    [Documentation]    This step is checking if same service can be started twice,
     ...    expected is that this should not be the case
     Execute Command    sudo -u tedge tedge-agent    exp_exit_code=!0
     Execute Command    sudo -u tedge tedge-mapper c8y    exp_exit_code=!0
 
 Switch off lock file creation
-    [Documentation]    Add a new configuration option under the '[run]'' section to turn off the lock file generation logic. 
-    ...    '[run]' 
-    ...    'lock_files = false' 
-    ...    Having this configuration setting allows the user to set it using a common environment 
+    [Documentation]    Add a new configuration option under the '[run]'' section to turn off the lock file generation logic.
+    ...    '[run]'
+    ...    'lock_files = false'
+    ...    Having this configuration setting allows the user to set it using a common environment
     ...    setting when running the components in individual containers.
-    #Stop the running services
+    # Stop the running services
     Stop Service    tedge-mapper-c8y
     Stop Service    tedge-agent
-    #Remove the existing lock files (if they exist)
+    # Remove the existing lock files (if they exist)
     Execute Command    sudo rm -f /run/lock/ted*
     Execute Command    sudo tedge config set run.lock_files false
-    #Restart the stopped services
+    # Restart the stopped services
     Start Service    tedge-mapper-c8y
     Start Service    tedge-agent
-    #Check that no lock file is created
+    # Check that no lock file is created
     File Should Not Exist    /run/lock/tedge-agent.lock
     File Should Not Exist    /run/lock/tedge-mapper-c8y.lock
 
-*** Keywords ***
 
+*** Keywords ***
 Stop/Start Service
     [Arguments]    ${name}
     # Note: Use stop/start service rather than restart as 'systemctl restart <service>'

--- a/tests/RobotFramework/tests/configuration/tedge_configuration.robot
+++ b/tests/RobotFramework/tests/configuration/tedge_configuration.robot
@@ -1,30 +1,31 @@
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:configuration
 # Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Teardown       Get Logs
+
+Test Tags           theme:configuration
+
 
 *** Test Cases ***
-
 Startup with invalid system.toml
     [Tags]    known-issue
     Skip    msg=Known issue. tedge does not startup if the system.toml file contains invalid toml content
     Setup    skip_bootstrap=True
-    Execute Command           test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
-    ${DEVICE_SN}=    Execute Command           tedge config get device.id
-    Execute Command           cmd=echo -n "[new-section]\ntest = invalid" > /etc/tedge/system.toml
-    Execute Command           test -f ./bootstrap.sh && ./bootstrap.sh --no-install || true
-    Device Should Exist       ${DEVICE_SN}
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
+    ${DEVICE_SN}=    Execute Command    tedge config get device.id
+    Execute Command    cmd=echo -n "[new-section]\ntest = invalid" > /etc/tedge/system.toml
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-install || true
+    Device Should Exist    ${DEVICE_SN}
 
 Startup with invalid tedge.toml
     [Tags]    known-issue
     Skip    msg=Known issue. tedge does not startup if the tedge.toml file contains invalid toml content
     Setup    skip_bootstrap=True
-    Execute Command           test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
-    ${DEVICE_SN}=    Execute Command           tedge config get device.id
-    Execute Command           cmd=echo -n "[new-section]\ntest = invalid" > /etc/tedge/tedge.toml
-    Execute Command           test -f ./bootstrap.sh && ./bootstrap.sh --no-install || true
-    Device Should Exist       ${DEVICE_SN}
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
+    ${DEVICE_SN}=    Execute Command    tedge config get device.id
+    Execute Command    cmd=echo -n "[new-section]\ntest = invalid" > /etc/tedge/tedge.toml
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-install || true
+    Device Should Exist    ${DEVICE_SN}

--- a/tests/RobotFramework/tests/configuration/tedge_configuration.robot
+++ b/tests/RobotFramework/tests/configuration/tedge_configuration.robot
@@ -6,12 +6,11 @@ Library             ThinEdgeIO
 # Test Setup    Custom Setup
 Test Teardown       Get Logs
 
-Test Tags           theme:configuration
+Test Tags           theme:configuration    known-issue
 
 
 *** Test Cases ***
 Startup with invalid system.toml
-    [Tags]    known-issue
     Skip    msg=Known issue. tedge does not startup if the system.toml file contains invalid toml content
     Setup    skip_bootstrap=True
     Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
@@ -21,7 +20,6 @@ Startup with invalid system.toml
     Device Should Exist    ${DEVICE_SN}
 
 Startup with invalid tedge.toml
-    [Tags]    known-issue
     Skip    msg=Known issue. tedge does not startup if the tedge.toml file contains invalid toml content
     Setup    skip_bootstrap=True
     Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true

--- a/tests/RobotFramework/tests/cumulocity/availability/c8y_required_availability.robot
+++ b/tests/RobotFramework/tests/cumulocity/availability/c8y_required_availability.robot
@@ -1,14 +1,15 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:monitoring
-Test Setup    Test Setup
-Test Teardown    Get Logs
+Test Setup          Test Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:monitoring
+
 
 *** Test Cases ***
-
 c8y_RequiredAvailability is set by default to an hour
     Execute Command    ./bootstrap.sh
 
@@ -48,17 +49,17 @@ c8y_RequiredAvailability is not set when disabled
     Register child
     Managed Object Should Not Have Fragments    c8y_RequiredAvailability
 
+
 *** Keywords ***
 Test Setup
     ${DEVICE_SN}=    Setup    skip_bootstrap=True
-    Set Test Variable     $DEVICE_SN
+    Set Test Variable    $DEVICE_SN
 
     ${CHILD_SN}=    Get Random Name
     Set Test Variable    $CHILD_SN
     Set Test Variable    $CHILD_XID    ${DEVICE_SN}:device:${CHILD_SN}
 
 Register child
-    [Arguments]
     Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device"}'
     Set Device    ${CHILD_XID}
     Device Should Exist    ${CHILD_XID}

--- a/tests/RobotFramework/tests/cumulocity/availability/heartbeat.robot
+++ b/tests/RobotFramework/tests/cumulocity/availability/heartbeat.robot
@@ -1,34 +1,43 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:monitoring
-Test Setup    Test Setup
-Test Teardown    Get Logs
+Test Setup          Test Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:monitoring
 
 
 *** Variables ***
+${INTERVAL_CHANGE_TIMEOUT}      180
+${CHECK_INTERVAL}               10
+${HEARTBEAT_INTERVAL}           60
 
-${INTERVAL_CHANGE_TIMEOUT}    180
-${CHECK_INTERVAL}             10
-${HEARTBEAT_INTERVAL}         60
 
 *** Test Cases ***
-
 ### Main Device ###
 Heartbeat is sent
     [Documentation]    Full end-to-end test which will check the Cumulocity IoT behaviour to sending the heartbeat signal
-        ...            The tests therefore relies on the backend availability service which then sets the c8y_Availability fragment
-        ...            based on the last received telemetry data.
-    Device Should Have Fragment Values    c8y_Availability.status\=AVAILABLE   timeout=${INTERVAL_CHANGE_TIMEOUT}    wait=${CHECK_INTERVAL}
+    ...    The tests therefore relies on the backend availability service which then sets the c8y_Availability fragment
+    ...    based on the last received telemetry data.
+    Device Should Have Fragment Values
+    ...    c8y_Availability.status\=AVAILABLE
+    ...    timeout=${INTERVAL_CHANGE_TIMEOUT}
+    ...    wait=${CHECK_INTERVAL}
     Stop Service    tedge-agent
     Service Health Status Should Be Down    tedge-agent
-    Device Should Have Fragment Values    c8y_Availability.status\=UNAVAILABLE   timeout=${INTERVAL_CHANGE_TIMEOUT}    wait=${CHECK_INTERVAL}
+    Device Should Have Fragment Values
+    ...    c8y_Availability.status\=UNAVAILABLE
+    ...    timeout=${INTERVAL_CHANGE_TIMEOUT}
+    ...    wait=${CHECK_INTERVAL}
 
     Start Service    tedge-agent
     Service Health Status Should Be Up    tedge-agent
-    Device Should Have Fragment Values    c8y_Availability.status\=AVAILABLE   timeout=${INTERVAL_CHANGE_TIMEOUT}    wait=${CHECK_INTERVAL}
+    Device Should Have Fragment Values
+    ...    c8y_Availability.status\=AVAILABLE
+    ...    timeout=${INTERVAL_CHANGE_TIMEOUT}
+    ...    wait=${CHECK_INTERVAL}
 
 #
 # Note about remaining test cases
@@ -40,17 +49,21 @@ Heartbeat is sent
 #
 
 Heartbeat is sent based on the custom health topic status
-    Execute Command    tedge mqtt pub --retain 'te/device/main//' '{"@type":"device","@health":"device/main/service/foo"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/main//' '{"@type":"device","@health":"device/main/service/foo"}'
     Execute Command    tedge mqtt pub --retain 'te/device/main/service/foo/status/health' '{"status":"up"}'
     ${existing_count}=    Should Have Heartbeat Message Count    ${DEVICE_SN}    minimum=1
 
     # Stop tedge-agent to make sure the heartbeat is not sent based on the tedge-agent status
     Stop Service    tedge-agent
     Service Health Status Should Be Down    tedge-agent
-    ${existing_count}=    Should Have Heartbeat Message Count    ${DEVICE_SN}    minimum=${existing_count + 1}    timeout=${HEARTBEAT_INTERVAL}
-
+    ${existing_count}=    Should Have Heartbeat Message Count
+    ...    ${DEVICE_SN}
+    ...    minimum=${existing_count + 1}
+    ...    timeout=${HEARTBEAT_INTERVAL}
 
 ### Child Device ###
+
 Child heartbeat is sent
     # Register a child device
     Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device"}'
@@ -60,12 +73,17 @@ Child heartbeat is sent
     ${existing_count}=    Should Have Heartbeat Message Count    ${CHILD_XID}    minimum=0    maximum=0
 
     # Fake tedge-agent status is up for the child device
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}/service/tedge-agent/status/health' '{"status":"up"}'
-    Should Have Heartbeat Message Count    ${CHILD_XID}    minimum=${existing_count + 1}    timeout=${HEARTBEAT_INTERVAL}
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}/service/tedge-agent/status/health' '{"status":"up"}'
+    Should Have Heartbeat Message Count
+    ...    ${CHILD_XID}
+    ...    minimum=${existing_count + 1}
+    ...    timeout=${HEARTBEAT_INTERVAL}
 
 Child heartbeat is sent based on the custom health topic status
     # Register a child device
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device", "@health":"device/${CHILD_SN}/service/bar"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device", "@health":"device/${CHILD_SN}/service/bar"}'
     Set Device    ${CHILD_XID}
     Device Should Exist    ${CHILD_XID}
 
@@ -73,15 +91,19 @@ Child heartbeat is sent based on the custom health topic status
 
     # The custom health endpoint is up but tedge-agent is down
     Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}/service/bar/status/health' '{"status":"up"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}/service/tedge-agent/status/health' '{"status":"down"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}/service/tedge-agent/status/health' '{"status":"down"}'
 
-    Should Have Heartbeat Message Count    ${CHILD_XID}    minimum=${existing_count + 1}    timeout=${HEARTBEAT_INTERVAL}
+    Should Have Heartbeat Message Count
+    ...    ${CHILD_XID}
+    ...    minimum=${existing_count + 1}
+    ...    timeout=${HEARTBEAT_INTERVAL}
 
 
 *** Keywords ***
 Test Setup
     ${DEVICE_SN}=    Setup    skip_bootstrap=True
-    Set Test Variable     $DEVICE_SN
+    Set Test Variable    $DEVICE_SN
 
     ${CHILD_SN}=    Get Random Name
     Set Test Variable    $CHILD_SN
@@ -96,6 +118,11 @@ Test Setup
 
 Should Have Heartbeat Message Count
     [Arguments]    ${SERIAL}    ${minimum}=${None}    ${maximum}=${None}    ${timeout}=30
-    ${messages}=    Should Have MQTT Messages    c8y/inventory/managedObjects/update/${SERIAL}    minimum=${minimum}    maximum=${maximum}    message_pattern=^\{\}$    timeout=${timeout}
+    ${messages}=    Should Have MQTT Messages
+    ...    c8y/inventory/managedObjects/update/${SERIAL}
+    ...    minimum=${minimum}
+    ...    maximum=${maximum}
+    ...    message_pattern=^\{\}$
+    ...    timeout=${timeout}
     ${count}=    Get Length    ${messages}
     RETURN    ${count}

--- a/tests/RobotFramework/tests/cumulocity/benchmarks/benchmarks.robot
+++ b/tests/RobotFramework/tests/cumulocity/benchmarks/benchmarks.robot
@@ -1,16 +1,16 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource        ../../../resources/common.resource
+Library         Cumulocity
+Library         ThinEdgeIO
 
-Test Tags    theme:c8y    theme:benchmarks    \#2326
-Suite Setup    Suite Setup
-Test Setup    Test Setup
+Suite Setup     Suite Setup
+Test Setup      Test Setup
 
+Test Tags       theme:c8y    theme:benchmarks    \#2326
 # Note: Don't get logs at the end of each test as the benchmarks cause too much noise
 
-*** Test Cases ***
 
+*** Test Cases ***
 Publish measurements varying period
     [Template]    Run Benchmark
     count=500    beats=100    beats_delay=0    period=0:25:100
@@ -30,14 +30,14 @@ Publish measurements varying beats_delay
 
 
 *** Keywords ***
-
 Suite Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist                      ${DEVICE_SN}
+    Device Should Exist    ${DEVICE_SN}
 
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/benchmark.py         /usr/bin/
-    Execute Command    sudo apt-get update && sudo apt-get install -y python3-minimal python3-paho-mqtt --no-install-recommends
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/benchmark.py    /usr/bin/
+    Execute Command
+    ...    sudo apt-get update && sudo apt-get install -y python3-minimal python3-paho-mqtt --no-install-recommends
     Execute Command    benchmark.py configure
 
 Test Setup
@@ -46,4 +46,5 @@ Test Setup
 
 Run Benchmark
     [Arguments]    ${count}    ${beats}    ${beats_delay}    ${period}
-    Execute Command    benchmark.py run --count ${count} --beats ${beats} --beats-delay ${beats_delay} --period ${period} --pretty --qos 0 --verbose
+    Execute Command
+    ...    benchmark.py run --count ${count} --beats ${beats} --beats-delay ${beats_delay} --period ${period} --pretty --qos 0 --verbose

--- a/tests/RobotFramework/tests/cumulocity/bootstrap.robot
+++ b/tests/RobotFramework/tests/cumulocity/bootstrap.robot
@@ -1,14 +1,13 @@
 *** Settings ***
-Resource    ../../resources/common.resource
+Resource            ../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+Library             DateTime
 
-Library    Cumulocity
-Library    ThinEdgeIO
-Library    DateTime
+Test Teardown       Get Logs
 
-Test Teardown    Get Logs
 
 *** Test Cases ***
-
 No unexpected child devices created with service autostart
     [Tags]    \#2584
     ${DEVICE_SN}=    Setup    skip_bootstrap=True
@@ -47,9 +46,11 @@ Mapper restart does not alter device hierarchy
     Device Should Exist    ${DEVICE_SN}
 
     ${child_level1}=    Get Random Name
-    Execute Command    tedge mqtt pub --retain 'te/device/${child_level1}//' '{"@id":"${child_level1}","@type":"child-device","@parent":"device/main//","name":"${child_level1}"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${child_level1}//' '{"@id":"${child_level1}","@type":"child-device","@parent":"device/main//","name":"${child_level1}"}'
     ${child_level2}=    Get Random Name
-    Execute Command    tedge mqtt pub --retain 'te/device/${child_level2}//' '{"@id":"${child_level2}","@type":"child-device","@parent":"device/${child_level1}//","name":"${child_level2}"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${child_level2}//' '{"@id":"${child_level2}","@type":"child-device","@parent":"device/${child_level1}//","name":"${child_level2}"}'
 
     Set Device    ${DEVICE_SN}
     Device Should Have A Child Devices    ${child_level1}
@@ -80,4 +81,3 @@ Mapper started early does not miss supported operations
     ...    c8y_UploadConfigFile
     ...    c8y_DownloadConfigFile
     ...    c8y_LogfileRequest
-

--- a/tests/RobotFramework/tests/cumulocity/bootstrap.robot
+++ b/tests/RobotFramework/tests/cumulocity/bootstrap.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource            ../../resources/common.resource
+Library             DateTime
 Library             Cumulocity
 Library             ThinEdgeIO
-Library             DateTime
 
 Test Teardown       Get Logs
 

--- a/tests/RobotFramework/tests/cumulocity/bridge_config/builtin_bridge.robot
+++ b/tests/RobotFramework/tests/cumulocity/bridge_config/builtin_bridge.robot
@@ -1,35 +1,35 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
 
 *** Test Cases ***
-
 Connection test
     [Documentation]    Repeatedly test the cloud connection
     FOR    ${attempt}    IN RANGE    0    10    1
         ${output}=    Execute Command    tedge connect c8y --test    timeout=10
-        Should Not Contain  ${output}    connection check failed
+        Should Not Contain    ${output}    connection check failed
     END
-
 
 Support publishing QoS 0 messages to c8y topic #2960
     [Documentation]    Verify the publishing of multiple QoS 0 message directly to the cloud connection
-    ...                Note 1: Since QoS 0 aren't guarenteed to be delivered, use a non-strict assertion on the exact event count in the cloud.
-    ...                        During testing the test would reliably fail if the expected count is less than 10 messages.
-    ...                Note 2: The bridge will automatically change the QoS from 0 when translating messages from te/# to c8y/#,
-    ...                we can't use the te/# topics in the test.
+    ...    Note 1: Since QoS 0 aren't guarenteed to be delivered, use a non-strict assertion on the exact event count in the cloud.
+    ...    During testing the test would reliably fail if the expected count is less than 10 messages.
+    ...    Note 2: The bridge will automatically change the QoS from 0 when translating messages from te/# to c8y/#,
+    ...    we can't use the te/# topics in the test.
     FOR    ${attempt}    IN RANGE    0    20    1
-        Execute Command    tedge mqtt pub -q 0 c8y/s/us '400,test_q0,Test event with qos 0 attempt ${attempt}'    timeout=10
+        Execute Command
+        ...    tedge mqtt pub -q 0 c8y/s/us '400,test_q0,Test event with qos 0 attempt ${attempt}'
+        ...    timeout=10
     END
     Cumulocity.Device Should Have Event/s    expected_text=Test event with qos 0.*    type=test_q0    minimum=10
 
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    ${DEVICE_SN}

--- a/tests/RobotFramework/tests/cumulocity/bridge_config/local_cleansession.robot
+++ b/tests/RobotFramework/tests/cumulocity/bridge_config/local_cleansession.robot
@@ -1,9 +1,8 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    ThinEdgeIO
+Resource        ../../../resources/common.resource
+Library         ThinEdgeIO
 
-Suite Setup    Suite Setup
-
+Suite Setup     Suite Setup
 #
 # Testing against older mosquitto versions is difficult as the there is not
 # an easy way to installed older versions without changing the whole operating system
@@ -13,8 +12,8 @@ Suite Setup    Suite Setup
 # default in Debian bullseye and newer
 #
 
-*** Test Cases ***
 
+*** Test Cases ***
 Default local_cleansession setting
     Configure and Verify local_cleansession setting    default    local_cleansession false
 
@@ -29,19 +28,21 @@ Force exclusion of local_cleansession
 
 
 *** Keywords ***
-
 Configure and Verify local_cleansession setting
     [Arguments]    ${value}    ${expected_value}=${EMPTY}
 
     IF    $value == "default"
         Execute Command    tedge config unset c8y.bridge.include.local_cleansession
     ELSE
-        Execute Command    tedge config set c8y.bridge.include.local_cleansession ${value}    
+        Execute Command    tedge config set c8y.bridge.include.local_cleansession ${value}
     END
-    
+
     Execute Command    tedge reconnect c8y
     Execute Command    grep "^cleansession true" /etc/tedge/mosquitto-conf/c8y-bridge.conf
-    ${local_cleansesion}=    Execute Command    grep "^local_cleansession " /etc/tedge/mosquitto-conf/c8y-bridge.conf    ignore_exit_code=${True}    strip=${True}
+    ${local_cleansesion}=    Execute Command
+    ...    grep "^local_cleansession " /etc/tedge/mosquitto-conf/c8y-bridge.conf
+    ...    ignore_exit_code=${True}
+    ...    strip=${True}
     Should Be Equal    ${local_cleansesion}    ${expected_value}
 
     # mosquitto should be running (to validate the configuration)

--- a/tests/RobotFramework/tests/cumulocity/configuration/backward_compatibility.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/backward_compatibility.robot
@@ -3,12 +3,12 @@ Resource            ../../../resources/common.resource
 Library             ThinEdgeIO
 Library             Cumulocity
 
-Test Teardown      Get Logs    name=${DEVICE_SN}
+Test Teardown       Get Logs    name=${DEVICE_SN}
 
-Test Tags          theme:configuration    theme:installation
+Test Tags           theme:configuration    theme:installation
+
 
 *** Test Cases ***
-
 Migrate Legacy Configuration Files
     ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
     Set Suite Variable    $DEVICE_SN
@@ -16,7 +16,7 @@ Migrate Legacy Configuration Files
     # Copy old c8y-configuration-plugin's config file before bootstrapping
     ThinEdgeIO.Execute Command    rm -f /etc/tedge/plugins/*
     ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y-configuration-plugin.toml    /etc/tedge/c8y/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/config1.json         /etc/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/config1.json    /etc/
 
     # Bootstrap the tedge-agent so that it picks up the old c8y-configuration-plugin.toml
     Execute Command    ./bootstrap.sh

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -270,6 +270,7 @@ Set Configuration from Device
     ...    ${ownership}
     ...    ${delete_file_before}=${true}
     ...    ${agent_as_root}=${false}
+    Log    Description: ${test_desc}
 
     IF    ${delete_file_before}
         ThinEdgeIO.Set Device Context    ${device}
@@ -364,6 +365,7 @@ Set Configuration from Device with tedge-write at another location
 
 Set Configuration from URL
     [Arguments]    ${test_desc}    ${device}    ${external_id}    ${config_type}    ${device_file}    ${config_url}
+    Log    Test Description: ${test_desc}
 
     ThinEdgeIO.Set Device Context    ${device}
     ${hash_before}=    Execute Command    md5sum ${device_file}
@@ -380,6 +382,7 @@ Set Configuration from URL
 
 Get Unknown Configuration Type From Device
     [Arguments]    ${test_desc}    ${external_id}    ${config_type}
+    Log    Test Description: ${test_desc}
     Cumulocity.Set Device    ${external_id}
     ${operation}=    Cumulocity.Get Configuration    ${config_type}
     Operation Should Be FAILED
@@ -388,6 +391,7 @@ Get Unknown Configuration Type From Device
 
 Get non existent configuration file From Device
     [Arguments]    ${test_desc}    ${device}    ${external_id}    ${config_type}    ${device_file}
+    Log    Test Description: ${test_desc}
     ThinEdgeIO.Set Device Context    ${device}
     ThinEdgeIO.Execute Command    rm -f ${device_file}
     Cumulocity.Set Device    ${external_id}
@@ -396,6 +400,7 @@ Get non existent configuration file From Device
 
 Get Configuration from Device
     [Arguments]    ${description}    ${device}    ${external_id}    ${config_type}    ${device_file}
+    Log    Test Description: ${description}
     Cumulocity.Set Device    ${external_id}
     ${operation}=    Cumulocity.Get Configuration    ${config_type}
     ${operation}=    Operation Should Be SUCCESSFUL    ${operation}    timeout=120
@@ -423,6 +428,7 @@ Get Configuration from Device
 
 Update configuration plugin config via cloud
     [Arguments]    ${test_desc}    ${external_id}
+    Log    Test Description: ${test_desc}
     Cumulocity.Set Device    ${external_id}
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
@@ -445,6 +451,7 @@ Update configuration plugin config via cloud
 
 Modify configuration plugin config via local filesystem modify inplace
     [Arguments]    ${test_desc}    ${device}    ${external_id}
+    Log    Test Description: ${test_desc}
     Cumulocity.Set Device    ${external_id}
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
@@ -465,6 +472,7 @@ Modify configuration plugin config via local filesystem modify inplace
 
 Modify configuration plugin config via local filesystem overwrite
     [Arguments]    ${test_desc}    ${device}    ${external_id}
+    Log    Test Description: ${test_desc}
     ThinEdgeIO.Set Device Context    ${device}
     Cumulocity.Set Device    ${external_id}
     Cumulocity.Should Support Configurations
@@ -487,6 +495,7 @@ Modify configuration plugin config via local filesystem overwrite
 
 Update configuration plugin config via local filesystem copy
     [Arguments]    ${test_desc}    ${device}    ${external_id}
+    Log    Test Description: ${test_desc}
     ThinEdgeIO.Set Device Context    ${device}
     Cumulocity.Set Device    ${external_id}
     Cumulocity.Should Support Configurations
@@ -509,6 +518,7 @@ Update configuration plugin config via local filesystem copy
 
 Update configuration plugin config via local filesystem move (different directory)
     [Arguments]    ${test_desc}    ${device}    ${external_id}
+    Log    Test Description: ${test_desc}
     ThinEdgeIO.Set Device Context    ${device}
     Cumulocity.Set Device    ${external_id}
     Cumulocity.Should Support Configurations
@@ -531,6 +541,7 @@ Update configuration plugin config via local filesystem move (different director
 
 Update configuration plugin config via local filesystem move (same directory)
     [Arguments]    ${test_desc}    ${device}    ${external_id}
+    Log    Test Description: ${test_desc}
     ThinEdgeIO.Set Device Context    ${device}
     Cumulocity.Set Device    ${external_id}
     Cumulocity.Should Support Configurations
@@ -666,25 +677,21 @@ Publish and Verify Local Command
     [Teardown]    Execute Command    tedge mqtt pub --retain '${topic}' ''
 
 Disable config update capability of tedge-agent
-    [Arguments]    ${device_sn}=${PARENT_SN}
     Execute Command    tedge config set agent.enable.config_update false
     ThinEdgeIO.Restart Service    tedge-agent
     ThinEdgeIO.Service Should Be Running    tedge-agent
 
 Enable config update capability of tedge-agent
-    [Arguments]    ${device_sn}=${PARENT_SN}
     Execute Command    tedge config set agent.enable.config_update true
     ThinEdgeIO.Restart Service    tedge-agent
     ThinEdgeIO.Service Should Be Running    tedge-agent
 
 Disable config snapshot capability of tedge-agent
-    [Arguments]    ${device_sn}=${PARENT_SN}
     Execute Command    tedge config set agent.enable.config_snapshot false
     ThinEdgeIO.Restart Service    tedge-agent
     ThinEdgeIO.Service Should Be Running    tedge-agent
 
 Enable config snapshot capability of tedge-agent
-    [Arguments]    ${device_sn}=${PARENT_SN}
     Execute Command    tedge config set agent.enable.config_snapshot true
     ThinEdgeIO.Restart Service    tedge-agent
     ThinEdgeIO.Service Should Be Running    tedge-agent

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -259,8 +259,7 @@ Default plugin configuration
 
 *** Keywords ***
 Set Configuration from Device
-    [Arguments]
-    ...    ${test_desc}
+    [Arguments]    ${test_desc}
     ...    ${device}
     ...    ${external_id}
     ...    ${config_type}
@@ -313,8 +312,7 @@ Set Configuration from Device with tedge-write at another location
     ...    to make sure that other location is in $PATH and that this new $PATH is inherited by tedge-agent, so for the
     ...    purposes of the test we change $PATH at the tedge-agent systemd service level. We also add a sudoers entry
     ...    with new path of tedge-write so sudo correcly elevates permissions.
-    [Arguments]
-    ...    ${test_desc}
+    [Arguments]    ${test_desc}
     ...    ${device}
     ...    ${external_id}
     ...    ${config_type}

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -21,30 +21,30 @@ ${CHILD_SN}     ${EMPTY}
 # Set configuration
 #
 Set Configuration when file does not exist
-    [Tags]    \#2318
-    [Template]    Set Configuration from Device
     [Documentation]    If the configuration file does not exist, it should be created, with owner and permissions
     ...    specified in `tedge-configuration-plugin.toml` file.
+    [Tags]    \#2318
+    [Template]    Set Configuration from Device
     Text file (Main Device)    ${PARENT_SN}    ${PARENT_SN}    CONFIG1    /etc/config1.json    ${CURDIR}/config1-version2.json    640    tedge:tedge    delete_file_before=${true}
     Binary file (Main Device)    ${PARENT_SN}    ${PARENT_SN}    CONFIG1_BINARY    /etc/binary-config1.tar.gz    ${CURDIR}/binary-config1.tar.gz    640    tedge:tedge    delete_file_before=${true}
     Text file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1    /etc/config1.json    ${CURDIR}/config1-version2.json    640    tedge:tedge    delete_file_before=${true}
     Binary file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1_BINARY    /etc/binary-config1.tar.gz    ${CURDIR}/binary-config1.tar.gz    640    tedge:tedge    delete_file_before=${true}
 
 Set Configuration when file exists and agent run normally
-    [Tags]    \#2972
-    [Template]    Set Configuration from Device
     [Documentation]    If the configuration file already exists, it should be overwritten, but owner and permissions
     ...    should remain unchanged.
+    [Tags]    \#2972
+    [Template]    Set Configuration from Device
     Text file (Main Device)    ${PARENT_SN}    ${PARENT_SN}    CONFIG1    /etc/config1.json    ${CURDIR}/config1-version2.json    664    root:root    delete_file_before=${false}
     Binary file (Main Device)    ${PARENT_SN}    ${PARENT_SN}    CONFIG1_BINARY    /etc/binary-config1.tar.gz    ${CURDIR}/binary-config1.tar.gz    664    root:root    delete_file_before=${false}
     Text file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1    /etc/config1.json    ${CURDIR}/config1-version2.json    664    root:root    delete_file_before=${false}
     Binary file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1_BINARY    /etc/binary-config1.tar.gz    ${CURDIR}/binary-config1.tar.gz    664    root:root    delete_file_before=${false}
 
 Set Configuration when file exists and tedge run by root
-    [Tags]    \#3073
-    [Template]    Set Configuration from Device
     [Documentation]    If the configuration file already exists, it should be overwritten, but owner and permissions
     ...    should remain unchanged. If tedge-agent is run as root, it should not use tedge-agent for privilege elevation
+    [Tags]    \#3073
+    [Template]    Set Configuration from Device
     Text file (Main Device)    ${PARENT_SN}    ${PARENT_SN}    CONFIG1    /etc/config1.json    ${CURDIR}/config1-version2.json    664    root:root    delete_file_before=${false}
     ...    agent_as_root=${true}
     Binary file (Main Device)    ${PARENT_SN}    ${PARENT_SN}    CONFIG1_BINARY    /etc/binary-config1.tar.gz    ${CURDIR}/binary-config1.tar.gz    664    root:root    delete_file_before=${false}
@@ -140,12 +140,12 @@ Trigger config_snapshot operation from another operation
     ...    payload={"status":"init","tedgeUrl":"http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/sub_config_snapshot/sub-1111","type":"tedge-configuration-plugin"}
     ...    expected_status=successful
     ...    c8y_fragment=c8y_UploadConfigFile
-    ${snapshot}    Execute Command    curl http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/sub_config_snapshot/sub-1111
-    ${config}      Get File    ${CURDIR}/tedge-configuration-plugin.toml
-    Should Be Equal    ${snapshot}     ${config}
+    ${snapshot}=    Execute Command
+    ...    curl http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/sub_config_snapshot/sub-1111
+    ${config}=    Get File    ${CURDIR}/tedge-configuration-plugin.toml
+    Should Be Equal    ${snapshot}    ${config}
 
 Trigger custom config_snapshot operation
-    [Teardown]    Restore config operations
     Set Device Context    ${PARENT_SN}
     Customize config operations
     Publish and Verify Local Command
@@ -153,9 +153,11 @@ Trigger custom config_snapshot operation
     ...    payload={"status":"init","tedgeUrl":"http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/config_snapshot/custom-1111","type":"tedge-configuration-plugin"}
     ...    expected_status=successful
     ...    c8y_fragment=c8y_UploadConfigFile
-    ${snapshot}    Execute Command    curl http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/config_snapshot/custom-1111
-    ${config}      Get File    ${CURDIR}/tedge-configuration-plugin.toml
-    Should Be Equal    ${snapshot}     ${config}
+    ${snapshot}=    Execute Command
+    ...    curl http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/config_snapshot/custom-1111
+    ${config}=    Get File    ${CURDIR}/tedge-configuration-plugin.toml
+    Should Be Equal    ${snapshot}    ${config}
+    [Teardown]    Restore config operations
 
 Config_snapshot operation request with the tedgeUrl created by agent
     Set Device Context    ${PARENT_SN}
@@ -171,7 +173,9 @@ Config_snapshot operation request with the tedgeUrl created by agent
     ...    message_contains=http://${PARENT_IP}:8000/tedge/file-transfer/main/config_snapshot/tedge-configuration-plugin-local-3333
     ...    date_from=${timestamp}
 
-    ${output}=    Execute Command    curl -sSLf "http://${PARENT_IP}:8000/tedge/file-transfer/main/config_snapshot/tedge-configuration-plugin-local-3333"    strip=${True}
+    ${output}=    Execute Command
+    ...    curl -sSLf "http://${PARENT_IP}:8000/tedge/file-transfer/main/config_snapshot/tedge-configuration-plugin-local-3333"
+    ...    strip=${True}
     Should Match Regexp    ${output}    pattern=files\\s*=\\s*\\[.*\\]    flags=DOTALL
 
 Manual config_update operation request
@@ -186,33 +190,34 @@ Manual config_update operation request
 Trigger config_update operation from another workflow
     Set Device Context    ${PARENT_SN}
 
-    Execute Command     curl -X PUT --data-binary 'new content for CONFIG1' "http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/sub_config_update/sub-2222"
+    Execute Command
+    ...    curl -X PUT --data-binary 'new content for CONFIG1' "http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/sub_config_update/sub-2222"
     Publish and Verify Local Command
     ...    topic=te/device/main///cmd/sub_config_update/sub-2222
     ...    payload={"status":"init","tedgeUrl":"http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/sub_config_update/sub-2222","remoteUrl":"","type":"CONFIG1"}
     ...    expected_status=successful
     ...    c8y_fragment=c8y_DownloadConfigFile
 
-    ${update}           Execute Command    cat /etc/config1.json
-    Should Be Equal     ${update}     new content for CONFIG1
+    ${update}=    Execute Command    cat /etc/config1.json
+    Should Be Equal    ${update}    new content for CONFIG1
 
 Trigger custom config_update operation
-    [Teardown]    Restore config operations
     Set Device Context    ${PARENT_SN}
     Customize config operations
 
-    Execute Command     curl -X PUT --data-binary 'updated config' "http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/config_update/custom-2222"
+    Execute Command
+    ...    curl -X PUT --data-binary 'updated config' "http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/config_update/custom-2222"
     Publish and Verify Local Command
     ...    topic=te/device/main///cmd/config_update/custom-2222
     ...    payload={"status":"init","tedgeUrl":"http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/config_update/custom-2222","remoteUrl":"","type":"/tmp/config_update_target"}
     ...    expected_status=successful
     ...    c8y_fragment=c8y_DownloadConfigFile
 
-    ${update}           Execute Command    cat /tmp/config_update_target
-    Should Be Equal     ${update}     updated config
+    ${update}=    Execute Command    cat /tmp/config_update_target
+    Should Be Equal    ${update}    updated config
+    [Teardown]    Restore config operations
 
 Config update request not processed when operation is disabled for tedge-agent
-    [Teardown]    Enable config update capability of tedge-agent
     Set Device Context    ${PARENT_SN}
     Disable config update capability of tedge-agent
     Publish and Verify Local Command
@@ -220,9 +225,9 @@ Config update request not processed when operation is disabled for tedge-agent
     ...    payload={"status":"init","tedgeUrl":"http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/config_update/local-2222","remoteUrl":"","type":"tedge-configuration-plugin"}
     ...    expected_status=init
     ...    c8y_fragment=c8y_DownloadConfigFile
+    [Teardown]    Enable config update capability of tedge-agent
 
 Config snapshot request not processed when operation is disabled for tedge-agent
-    [Teardown]    Enable config snapshot capability of tedge-agent
     Set Device Context    ${PARENT_SN}
     Disable config snapshot capability of tedge-agent
     Publish and Verify Local Command
@@ -230,6 +235,7 @@ Config snapshot request not processed when operation is disabled for tedge-agent
     ...    payload={"status":"init","tedgeUrl":"http://${PARENT_IP}:8000/tedge/file-transfer/${PARENT_SN}/config_snapshot/local-1111","type":"tedge-configuration-plugin"}
     ...    expected_status=init
     ...    c8y_fragment=c8y_UploadConfigFile
+    [Teardown]    Enable config snapshot capability of tedge-agent
 
 Default plugin configuration
     Set Device Context    ${PARENT_SN}
@@ -239,7 +245,7 @@ Default plugin configuration
 
     # Agent restart should recreate the default plugin configuration
     Stop Service    tedge-agent
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Start Service    tedge-agent
     Service Should Be Running    tedge-agent
     Should Have MQTT Messages    c8y/s/us    message_contains=119,    date_from=${timestamp}
@@ -290,7 +296,6 @@ Set Configuration from Device
         ThinEdgeIO.Set Device Context    ${device}
         File Checksum Should Be Equal    ${device_file}    ${file}
         Path Should Have Permissions    ${device_file}    ${permission}    ${ownership}
-
     FINALLY
         IF    ${agent_as_root} == ${true}
             ThinEdgeIO.Set Device Context    ${device}
@@ -317,14 +322,14 @@ Set Configuration from Device with tedge-write at another location
     ...    ${permission}
     ...    ${ownership}
     ...    ${delete_file_before}=${true}
-    [Setup]
-    [Teardown]
- 
+    [Setup]    NONE
+
     Set Device Context    ${device}
 
-    # Have /opt/tedge/bin in $PATH of tedge-agent 
+    # Have /opt/tedge/bin in $PATH of tedge-agent
     Execute Command    mkdir -p /etc/systemd/system/tedge-agent.service.d
-    Execute Command    cmd=echo "[Service]\nEnvironment=\\"PATH=/opt/tedge/bin:$PATH\\"" > /etc/systemd/system/tedge-agent.service.d/10-override-path.conf
+    Execute Command
+    ...    cmd=echo "[Service]\nEnvironment=\\"PATH=/opt/tedge/bin:$PATH\\"" > /etc/systemd/system/tedge-agent.service.d/10-override-path.conf
     Execute Command    systemctl daemon-reload
     Restart Service    tedge-agent
 
@@ -406,7 +411,9 @@ Get Configuration from Device
     ...    ${events[0]["id"]}
     ...    expected_md5=${expected_checksum}
 
-    ${event}=    Cumulocity.Event Attachment Should Have File Info    ${events[0]["id"]}    name=^${external_id}_[\\w\\W]+-c8y-mapper-\\d+$
+    ${event}=    Cumulocity.Event Attachment Should Have File Info
+    ...    ${events[0]["id"]}
+    ...    name=^${external_id}_[\\w\\W]+-c8y-mapper-\\d+$
 
     RETURN    ${contents}
 
@@ -617,10 +624,11 @@ Copy Configuration Files
     ThinEdgeIO.Transfer To Device    ${CURDIR}/binary-config1.tar.gz    /etc/
 
     # make sure initial files have the same permissions on systems with different umasks
-    Execute Command                  chmod 664 /etc/config1.json /etc/config2.json /etc/binary-config1.tar.gz
+    Execute Command    chmod 664 /etc/config1.json /etc/config2.json /etc/binary-config1.tar.gz
 
     # on a child device, user with uid 1000 doesn't exist, so make sure files we're testing on have a well defined user
-    Execute Command    chown root:root /etc/tedge/plugins/tedge-configuration-plugin.toml /etc/config1.json /etc/binary-config1.tar.gz
+    Execute Command
+    ...    chown root:root /etc/tedge/plugins/tedge-configuration-plugin.toml /etc/config1.json /etc/binary-config1.tar.gz
     ThinEdgeIO.Service Health Status Should Be Up    tedge-agent    device=${CHILD_SN}
 
 Customize Operation Workflows

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource            ../../../resources/common.resource
+Library             OperatingSystem
 Library             ThinEdgeIO
 Library             Cumulocity
-Library             OperatingSystem
 
 Suite Setup         Suite Setup
 Suite Teardown      Get Logs    name=${PARENT_SN}

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -395,7 +395,7 @@ Get non existent configuration file From Device
     Operation Should Be FAILED    ${operation}    failure_reason=.*No such file or directory.*
 
 Get Configuration from Device
-    [Arguments]    ${test_name}    ${device}    ${external_id}    ${config_type}    ${device_file}
+    [Arguments]    ${description}    ${device}    ${external_id}    ${config_type}    ${device_file}
     Cumulocity.Set Device    ${external_id}
     ${operation}=    Cumulocity.Get Configuration    ${config_type}
     ${operation}=    Operation Should Be SUCCESSFUL    ${operation}    timeout=120

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -279,7 +279,7 @@ Set Configuration from Device
     # we check that when `tedge` user has permissions to the configuration file's parent directory, tedge-write is not
     # used to deploy the configuration file but a normal write is used; we change path of tedge-write so that test fails
     # if its attempted to be used, the test fails
-    IF    ${agent_as_root} == ${true}
+    IF    ${agent_as_root}
         ThinEdgeIO.Set Device Context    ${device}
         Execute Command    sed 's/User\=tedge/User\=root/' -i /lib/systemd/system/tedge-agent.service
         Execute Command    systemctl daemon-reload
@@ -297,7 +297,7 @@ Set Configuration from Device
         File Checksum Should Be Equal    ${device_file}    ${file}
         Path Should Have Permissions    ${device_file}    ${permission}    ${ownership}
     FINALLY
-        IF    ${agent_as_root} == ${true}
+        IF    ${agent_as_root}
             ThinEdgeIO.Set Device Context    ${device}
             Execute Command    mv /usr/bin/tedge-write.bak /usr/bin/tedge-write
             Execute Command    sed 's/User\=root/User\=tedge/' -i /lib/systemd/system/tedge-agent.service

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -190,9 +190,9 @@ Re-enable HTTP Client Certificate for Mapper
     Execute Command    sudo systemctl restart tedge-mapper-c8y
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-c8y
 
-##
-## Setup
-##
+#
+# Setup
+#
 
 Suite Setup
     # Parent

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -260,8 +260,12 @@ Suite Teardown
     Get Logs    name=${CHILD_SN}
 
 Setup Child Device
-    [Arguments]    ${child_sn}    ${parent_ip}    ${install_package}    ${root_certificate}
-    ...    ${client_certificate}    ${client_key}
+    [Arguments]    ${child_sn}
+    ...    ${parent_ip}
+    ...    ${install_package}
+    ...    ${root_certificate}
+    ...    ${client_certificate}
+    ...    ${client_key}
 
     Set Device Context    ${CHILD_SN}
 
@@ -295,8 +299,11 @@ Setup Child Device
     RETURN    ${child_sn}
 
 Setup Main Device Agent
-    [Arguments]    ${root_certificate}    ${agent_certificate}    ${agent_key}
-    ...    ${client_certificate}    ${client_key}
+    [Arguments]    ${root_certificate}
+    ...    ${agent_certificate}
+    ...    ${agent_key}
+    ...    ${client_certificate}
+    ...    ${client_key}
     Set Device Context    ${FTS_SN}
 
     Execute Command    sudo dpkg -i packages/tedge_*.deb

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -62,11 +62,9 @@ Configuration operation fails when configuration-plugin does not supply client c
     Enable Certificate Authentication for File Transfer Service
     Disable HTTP Client Certificate for FTS client
     Get Configuration Should Fail
-    ...    device=${CHILD_SN}
     ...    failure_reason=config-manager failed uploading configuration snapshot:.+https://${FTS_IP}:8000/tedge/file-transfer/.+received fatal alert: CertificateRequired
     ...    external_id=${PARENT_SN}:device:${CHILD_SN}
     Update Configuration Should Fail
-    ...    device=${CHILD_SN}
     ...    failure_reason=config-manager failed downloading a file:.+https://${parent_ip}:8001/c8y/inventory/binaries/.+received fatal alert: CertificateRequired
     ...    external_id=${PARENT_SN}:device:${CHILD_SN}
 
@@ -75,7 +73,6 @@ Configuration snapshot fails when mapper does not supply client certificate
     Disable HTTP Client Certificate for Mapper
     Enable HTTP Client Certificate for FTS client
     Get Configuration Should Fail
-    ...    device=${CHILD_SN}
     ...    failure_reason=tedge-mapper-c8y failed to download configuration snapshot from file-transfer service:.+https://${FTS_IP}:8000/tedge/file-transfer/.+received fatal alert: CertificateRequired
     ...    external_id=${PARENT_SN}:device:${CHILD_SN}
     [Teardown]    Re-enable HTTP Client Certificate for Mapper
@@ -105,13 +102,13 @@ Get Configuration Should Succeed
     RETURN    ${contents}
 
 Get Configuration Should Fail
-    [Arguments]    ${failure_reason}    ${device}    ${external_id}
+    [Arguments]    ${failure_reason}    ${external_id}
     Cumulocity.Set Device    ${external_id}
     ${operation}=    Cumulocity.Get Configuration    tedge-configuration-plugin
     Operation Should Be FAILED    ${operation}    failure_reason=${failure_reason}    timeout=120
 
 Update Configuration Should Fail
-    [Arguments]    ${failure_reason}    ${device}    ${external_id}
+    [Arguments]    ${failure_reason}    ${external_id}
     Cumulocity.Set Device    ${external_id}
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
@@ -250,7 +247,6 @@ Suite Setup
     # Child
     Setup Child Device    ${child_sn}    parent_ip=${parent_ip}    install_package=tedge-agent
     ...    root_certificate=${root_certificate}
-    ...    agent_certificate=${agent_certificate}    agent_private_key=${agent_key}
     ...    client_certificate=${client_certificate}    client_key=${client_key}
 
     Setup Main Device Agent    ${root_certificate}    ${agent_certificate}    ${agent_key}
@@ -265,7 +261,6 @@ Suite Teardown
 
 Setup Child Device
     [Arguments]    ${child_sn}    ${parent_ip}    ${install_package}    ${root_certificate}
-    ...    ${agent_certificate}    ${agent_private_key}
     ...    ${client_certificate}    ${client_key}
 
     Set Device Context    ${CHILD_SN}

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -5,9 +5,9 @@ Documentation       This suite aims to test the configuration update and snapsho
 ...                 containers in total.
 
 Resource            ../../../resources/common.resource
+Library             OperatingSystem
 Library             ThinEdgeIO
 Library             Cumulocity
-Library             OperatingSystem
 
 Suite Setup         Suite Setup
 Suite Teardown      Suite Teardown

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray/operation_relay_array.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray/operation_relay_array.robot
@@ -1,26 +1,28 @@
 *** Settings ***
-Resource    ../../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:operation    theme:custom
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:operation    theme:custom
+
 
 *** Test Cases ***
-
 c8y_RelayArray operation
     Cumulocity.Should Contain Supported Operations    c8y_RelayArray
-    ${operation}=    Cumulocity.Create Operation    description=Set relays    fragments={"c8y_RelayArray":["OPEN", "CLOSED"]}
+    ${operation}=    Cumulocity.Create Operation
+    ...    description=Set relays
+    ...    fragments={"c8y_RelayArray":["OPEN", "CLOSED"]}
     Operation Should Be SUCCESSFUL    ${operation}
     Cumulocity.Managed Object Should Have Fragment Values    c8y_RelayArray\=["OPEN", "CLOSED"]
 
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist                      ${DEVICE_SN}
+    Device Should Exist    ${DEVICE_SN}
     ThinEdgeIO.Transfer To Device    ${CURDIR}/set_relay.sh    /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_RelayArray      /etc/tedge/operations/c8y/c8y_RelayArray
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_RelayArray    /etc/tedge/operations/c8y/c8y_RelayArray

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_reload/dynamically_reload_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_reload/dynamically_reload_operation.robot
@@ -1,31 +1,33 @@
 *** Settings ***
-Resource    ../../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:operation    theme:custom
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:operation    theme:custom
+
 
 *** Test Cases ***
 Update the custom operation dynamically
     # Add a new custom operation and trigger it.
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command_1     /etc/tedge/operations/c8y/c8y_Command  
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command_1    /etc/tedge/operations/c8y/c8y_Command
     ${operation}=    Cumulocity.Create Operation    description=do something    fragments={"c8y_Command":{"text":""}}
     Operation Should Be SUCCESSFUL    ${operation}
     Should Be Equal    ${operation.to_json()["c8y_Command"]["result"]}    command 1\n
 
     # Change the custom operation (c8y_Command) file, c8y mapper has to execute the new command when its triggered
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command_2     /etc/tedge/operations/c8y/c8y_Command  
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command_2    /etc/tedge/operations/c8y/c8y_Command
     ${operation}=    Cumulocity.Create Operation    description=do something    fragments={"c8y_Command":{"text":""}}
     Operation Should Be SUCCESSFUL    ${operation}
     Should Be Equal    ${operation.to_json()["c8y_Command"]["result"]}    command 2\n
-   
+
 
 *** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist                      ${DEVICE_SN}
+    Device Should Exist    ${DEVICE_SN}
     ThinEdgeIO.Transfer To Device    ${CURDIR}/command_*.sh    /etc/tedge/operations/
     Execute Command    chmod a+x /etc/tedge/operations/command_*.sh

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_timeout/custom_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_timeout/custom_operation.robot
@@ -1,33 +1,35 @@
 *** Settings ***
-Resource    ../../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:operation    theme:custom
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:operation    theme:custom
+
 
 *** Test Cases ***
-
 Custom operation successful
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command_Success      /etc/tedge/operations/c8y/c8y_Command    
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command_Success    /etc/tedge/operations/c8y/c8y_Command
     ThinEdgeIO.Restart Service    tedge-mapper-c8y
-    ${operation}=    Cumulocity.Create Operation    description=do something    fragments={"c8y_Command":{"text":"sleep 5"}}
+    ${operation}=    Cumulocity.Create Operation
+    ...    description=do something
+    ...    fragments={"c8y_Command":{"text":"sleep 5"}}
     Operation Should Be SUCCESSFUL    ${operation}
 
-
 Custom operation fails
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command_Fails      /etc/tedge/operations/c8y/c8y_Command   
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command_Fails    /etc/tedge/operations/c8y/c8y_Command
     ThinEdgeIO.Restart Service    tedge-mapper-c8y
-    ${operation}=    Cumulocity.Create Operation    description=do something    fragments={"c8y_Command":{"text":"sleep 20"}}
+    ${operation}=    Cumulocity.Create Operation
+    ...    description=do something
+    ...    fragments={"c8y_Command":{"text":"sleep 20"}}
     Operation Should Be FAILED    ${operation}    failure_reason=operation failed due to timeout: duration=10s
 
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist                      ${DEVICE_SN}
+    Device Should Exist    ${DEVICE_SN}
     ThinEdgeIO.Transfer To Device    ${CURDIR}/customop_handler.*    /etc/tedge/operations/
-

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation.robot
@@ -1,14 +1,15 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:firmware    theme:plugins
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:firmware    theme:plugins
+
 
 *** Test Cases ***
-
 Successful firmware operation
     ${operation}=    Cumulocity.Install Firmware    ubuntu    1.0.2    https://dummy.url/firmware.zip
     ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}    timeout=120
@@ -16,16 +17,18 @@ Successful firmware operation
 
 Install with empty firmware name
     ${operation}=    Cumulocity.Install Firmware    ${EMPTY}    1.0.2    https://dummy.url/firmware.zip
-    Operation Should Be FAILED    ${operation}    failure_reason=.*Invalid firmware name. Firmware name cannot be empty    timeout=120
+    Operation Should Be FAILED
+    ...    ${operation}
+    ...    failure_reason=.*Invalid firmware name. Firmware name cannot be empty
+    ...    timeout=120
 
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist                      ${DEVICE_SN}
+    Device Should Exist    ${DEVICE_SN}
     ThinEdgeIO.Transfer To Device    ${CURDIR}/firmware_handler.*    /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Firmware*         /etc/tedge/operations/c8y/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Firmware*    /etc/tedge/operations/c8y/
     ThinEdgeIO.Restart Service    tedge-agent
     ThinEdgeIO.Disconnect Then Connect Mapper    c8y

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
@@ -1,9 +1,9 @@
 *** Settings ***
 Resource            ../../../resources/common.resource
+Library             String
+Library             JSONLibrary
 Library             Cumulocity
 Library             ThinEdgeIO
-Library             JSONLibrary
-Library             String
 
 Suite Setup         Custom Setup
 Test Teardown       Get Logs    name=${PARENT_SN}

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device.robot
@@ -8,50 +8,50 @@ Library             String
 Suite Setup         Custom Setup
 Test Teardown       Get Logs    name=${PARENT_SN}
 
-Test Tags          theme:firmware    theme:childdevices
+Test Tags           theme:firmware    theme:childdevices
 
 
 *** Variables ***
-${PARENT_IP}
+${PARENT_IP}                ${EMPTY}
 ${HTTP_PORT}                8000
 
-${PARENT_SN}
-${CHILD_SN}
+${PARENT_SN}                ${EMPTY}
+${CHILD_SN}                 ${EMPTY}
 
-${op_id}
-${cache_key}
-${file_url}
-${file_transfer_url}
-${file_creation_time}
+${op_id}                    ${EMPTY}
+${cache_key}                ${EMPTY}
+${file_url}                 ${EMPTY}
+${file_transfer_url}        ${EMPTY}
+${file_creation_time}       ${EMPTY}
 
 
 *** Test Cases ***
 Prerequisite Parent
-    Set Device Context    ${PARENT_SN}    #Creates ssh connection to the parent device
+    Set Device Context    ${PARENT_SN}    # Creates ssh connection to the parent device
     Execute Command    sudo tedge disconnect c8y
 
-    Delete child related content    #Delete any previous created child related configuration files/folders on the parent device
-    Check for child related content    #Checks if folders that will trigger child device creation are existing
-    Set external MQTT bind address    #Setting external MQTT bind address which child will use for communication
-    Set external MQTT port    #Setting external MQTT port which child will use for communication Default:1883
+    Delete child related content    # Delete any previous created child related configuration files/folders on the parent device
+    Check for child related content    # Checks if folders that will trigger child device creation are existing
+    Set external MQTT bind address    # Setting external MQTT bind address which child will use for communication
+    Set external MQTT port    # Setting external MQTT port which child will use for communication Default:1883
 
     Sleep    3s
     Restart Service    tedge-agent
     Execute Command    sudo tedge connect c8y
-    Restart Firmware plugin    #Stop and Start c8y-firmware-plugin
+    Restart Firmware plugin    # Stop and Start c8y-firmware-plugin
     Cumulocity.Log Device Info
 
 Prerequisite Child
-    Child device delete firmware file    #Delete previous downloaded firmware file
-    Create child device    #Let mapper to create a child device
-    Validate child Name    #This is to check the existence of the bug: https://github.com/thin-edge/thin-edge.io/issues/1569
+    Child device delete firmware file    # Delete previous downloaded firmware file
+    Create child device    # Let mapper to create a child device
+    Validate child Name    # This is to check the existence of the bug: https://github.com/thin-edge/thin-edge.io/issues/1569
 
 Child device firmware update
     Upload binary to Cumulocity
     ${OPERATION_FILTER_DATE_FROM}=    ThinEdgeIO.Get Unix Timestamp
     Create c8y_Firmware operation
     Validate firmware update request    ${OPERATION_FILTER_DATE_FROM}
-    Child device response on update request    #Child device is sending 'executing' and 'successful' MQTT responses
+    Child device response on update request    # Child device is sending 'executing' and 'successful' MQTT responses
     Validate Cumulocity operation status and MO
 
 Child device firmware update with cache
@@ -59,15 +59,15 @@ Child device firmware update with cache
     ${OPERATION_FILTER_DATE_FROM}=    ThinEdgeIO.Get Unix Timestamp
     Create c8y_Firmware operation
     Validate firmware update request    ${OPERATION_FILTER_DATE_FROM}
-    Child device response on update request    #Child device is sending 'executing' and 'successful' MQTT responses
+    Child device response on update request    # Child device is sending 'executing' and 'successful' MQTT responses
     Validate Cumulocity operation status and MO
     Validate if file is not newly downloaded
 
 
 *** Keywords ***
 Delete child related content
-    Execute Command    sudo rm -rf /etc/tedge/operations/c8y/TST*    #if folder exists, child device will be created
-    Execute Command    sudo rm -rf /etc/tedge/c8y/TST*    #if folder exists, child device will be created
+    Execute Command    sudo rm -rf /etc/tedge/operations/c8y/TST*    # if folder exists, child device will be created
+    Execute Command    sudo rm -rf /etc/tedge/c8y/TST*    # if folder exists, child device will be created
     Execute Command    sudo rm -rf /var/tedge/file-transfer/*
     Execute Command    sudo rm -rf /var/tedge/cache/*
     Execute Command    sudo rm -rf /var/tedge/firmware/*

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device_retry.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device_retry.robot
@@ -1,14 +1,15 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:firmware
-Suite Setup    Custom Setup
-Test Teardown    Get Logs
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:firmware
+
 
 *** Test Cases ***
-
 Firmware plugin supports restart via service manager #1932
     ${binary_url}=    Cumulocity.Create Inventory Binary    firmware    binary    contents=content1
     Cumulocity.Set Device    ${CHILD_SN}
@@ -17,22 +18,28 @@ Firmware plugin supports restart via service manager #1932
     # Wait for first message to be sent
     ${operation_start}=    ThinEdgeIO.Get Unix Timestamp
     ThinEdgeIO.Set Device Context    ${DEVICE_SN}
-    ThinEdgeIO.Should Have MQTT Messages    topic=tedge/${CHILD_SN}/commands/req/firmware_update    date_from=${operation_start}    minimum=1    maximum=1
-    
+    ThinEdgeIO.Should Have MQTT Messages
+    ...    topic=tedge/${CHILD_SN}/commands/req/firmware_update
+    ...    date_from=${operation_start}
+    ...    minimum=1
+    ...    maximum=1
+
     # Restart firmware plugin
     ${restart_pre}=    ThinEdgeIO.Get Unix Timestamp
     Restart Service    c8y-firmware-plugin
     ${restart_post}=    ThinEdgeIO.Get Unix Timestamp
-    Should Be True    ${restart_post} - ${restart_pre} < 30    msg=Service should not timeout when trying to restart #1932
+    Should Be True
+    ...    ${restart_post} - ${restart_pre} < 30
+    ...    msg=Service should not timeout when trying to restart #1932
+
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
     Set Suite Variable    $CHILD_SN    ${DEVICE_SN}_child1
     Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_SN}"}'
-    Device Should Exist                      ${DEVICE_SN}
-    Device Should Exist                      ${CHILD_SN}
+    Device Should Exist    ${DEVICE_SN}
+    Device Should Exist    ${CHILD_SN}
 
     Service Health Status Should Be Up    tedge-mapper-c8y

--- a/tests/RobotFramework/tests/cumulocity/inventory/inventory_update.robot
+++ b/tests/RobotFramework/tests/cumulocity/inventory/inventory_update.robot
@@ -1,14 +1,15 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:telemetry
-Suite Setup    Custom Setup
-Test Teardown    Get Logs
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:telemetry
+
 
 *** Test Cases ***
-
 Update Inventory data via inventory.json
     ${mo}=    Cumulocity.Device Should Have Fragments    customData    types
     Should Be Equal    ${mo["customData"]["mode"]}    ACTIVE
@@ -20,15 +21,15 @@ Update Inventory data via inventory.json
 Inventory includes the agent fragment with version information
     ${expected_version}=    Execute Command    tedge-mapper --version | cut -d' ' -f2    strip=${True}
     ${mo}=    Cumulocity.Device Should Have Fragments    c8y_Agent
-    Should Be Equal    ${mo["c8y_Agent"]["name"]}        thin-edge.io
-    Should Be Equal    ${mo["c8y_Agent"]["version"]}     ${expected_version}
-    Should Be Equal    ${mo["c8y_Agent"]["url"]}         https://thin-edge.io
+    Should Be Equal    ${mo["c8y_Agent"]["name"]}    thin-edge.io
+    Should Be Equal    ${mo["c8y_Agent"]["version"]}    ${expected_version}
+    Should Be Equal    ${mo["c8y_Agent"]["url"]}    https://thin-edge.io
+
 
 *** Keywords ***
-
 Custom Setup
-    ${DEVICE_SN}=                    Setup
-    Set Suite Variable               $DEVICE_SN
-    Device Should Exist              ${DEVICE_SN}
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Device Should Exist    ${DEVICE_SN}
     ThinEdgeIO.Transfer To Device    ${CURDIR}/inventory.json    /etc/tedge/device/
     ThinEdgeIO.Disconnect Then Connect Mapper    c8y

--- a/tests/RobotFramework/tests/cumulocity/jwt/jwt_request.robot
+++ b/tests/RobotFramework/tests/cumulocity/jwt/jwt_request.robot
@@ -1,11 +1,13 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:tokens
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:tokens
+
 
 *** Test Cases ***
 Retrieve a JWT tokens
@@ -13,6 +15,7 @@ Retrieve a JWT tokens
     Execute Command    tedge mqtt pub c8y/s/uat ''
     ${messages}=    Should Have MQTT Messages    c8y/s/dat    maximum=1    date_from=${start_time}
     Should Contain    ${messages[0]}    71
+
 
 *** Keywords ***
 Custom Setup

--- a/tests/RobotFramework/tests/cumulocity/log/backward_compatibility.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/backward_compatibility.robot
@@ -3,12 +3,12 @@ Resource            ../../../resources/common.resource
 Library             ThinEdgeIO
 Library             Cumulocity
 
-Test Teardown      Get Logs    name=${DEVICE_SN}
+Test Teardown       Get Logs    name=${DEVICE_SN}
 
-Test Tags          theme:troubleshooting    theme:installation
+Test Tags           theme:troubleshooting    theme:installation
+
 
 *** Test Cases ***
-
 Migrate Legacy Configuration Files
     ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
     Set Suite Variable    $DEVICE_SN

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
@@ -201,8 +201,7 @@ Publish and Verify Local Command
     [Teardown]    Execute Command    tedge mqtt pub --retain '${topic}' ''
 
 Log File Contents Should Be Equal
-    [Arguments]
-    ...    ${operation}
+    [Arguments]    ${operation}
     ...    ${expected_contents}
     ...    ${encoding}=utf-8
     ...    ${expected_filename}=^${DEVICE_SN}_[\\w\\W]+-c8y-mapper-\\d+$
@@ -220,8 +219,7 @@ Log File Contents Should Be Equal
     RETURN    ${contents}
 
 Create Log Request Operation
-    [Arguments]
-    ...    ${start_timestamp}
+    [Arguments]    ${start_timestamp}
     ...    ${end_timestamp}
     ...    ${log_type}
     ...    ${search_text}=${EMPTY}

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
@@ -241,13 +241,11 @@ Log Operation Attachment File Contains
     ...    encoding=utf-8
 
 Disable log upload capability of tedge-agent
-    [Arguments]    ${device_sn}=${DEVICE_SN}
     Execute Command    tedge config set agent.enable.log_upload false
     ThinEdgeIO.Restart Service    tedge-agent
     ThinEdgeIO.Service Should Be Running    tedge-agent
 
 Enable log upload capability of tedge-agent
-    [Arguments]    ${device_sn}=${DEVICE_SN}
     Execute Command    tedge config set agent.enable.log_upload true
     ThinEdgeIO.Restart Service    tedge-agent
     ThinEdgeIO.Service Should Be Running    tedge-agent

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
@@ -13,7 +13,7 @@ Test Tags           theme:c8y    theme:log
 
 
 *** Test Cases ***
-Log operation ignore date range when log file has a static path   
+Log operation ignore date range when log file has a static path
     ${start_timestamp}=    Get Current Date    UTC    +10 seconds    result_format=%Y-%m-%dT%H:%M:%S+0000
     ${end_timestamp}=    Get Current Date    UTC    +60 seconds    result_format=%Y-%m-%dT%H:%M:%S+0000
     ${operation}=    Cumulocity.Create Operation
@@ -47,19 +47,21 @@ Trigger log_upload operation from another operation
     Publish and Verify Local Command
     ...    topic=te/device/main///cmd/sub_log_upload/example-1234
     ...    payload={"status":"init","tedgeUrl":"http://127.0.0.1:8000/tedge/file-transfer/${DEVICE_SN}/sub_log_upload/example-1234","type":"example","dateFrom":"${start_timestamp}","dateTo":"${end_timestamp}","searchText":"repeated","lines":3}
-    ${log_excerpt}     Execute Command    curl http://127.0.0.1:8000/tedge/file-transfer/${DEVICE_SN}/sub_log_upload/example-1234
-    Should Be Equal    ${log_excerpt}     filename: example.log\n13 repeated line\n14 repeated line\n15 repeated line\n
+    ${log_excerpt}=    Execute Command
+    ...    curl http://127.0.0.1:8000/tedge/file-transfer/${DEVICE_SN}/sub_log_upload/example-1234
+    Should Be Equal    ${log_excerpt}    filename: example.log\n13 repeated line\n14 repeated line\n15 repeated line\n
 
 Trigger custom log_upload operation
-    [Teardown]    Restore log_upload operation
     Customize log_upload operation
     Publish and Verify Local Command
     ...    topic=te/device/main///cmd/log_upload/custom-1234
     ...    payload={"status":"init","tedgeUrl":"http://127.0.0.1:8000/tedge/file-transfer/${DEVICE_SN}/log_upload/custom-1234","type":"example","searchText":"first","lines":10}
     ...    c8y_fragment=c8y_LogfileRequest
-    ${log_excerpt}     Execute Command    curl http://127.0.0.1:8000/tedge/file-transfer/${DEVICE_SN}/log_upload/custom-1234
-    ${expected_log}    Get File    ${CURDIR}/example.log
-    Should Be Equal    ${log_excerpt}     ${expected_log}
+    ${log_excerpt}=    Execute Command
+    ...    curl http://127.0.0.1:8000/tedge/file-transfer/${DEVICE_SN}/log_upload/custom-1234
+    ${expected_log}=    Get File    ${CURDIR}/example.log
+    Should Be Equal    ${log_excerpt}    ${expected_log}
+    [Teardown]    Restore log_upload operation
 
 Log file request limits maximum number of lines with text filter
     ${start_timestamp}=    Get Current Date    UTC    -24 hours    result_format=%Y-%m-%dT%H:%M:%S+0000
@@ -101,7 +103,6 @@ Log file request supports date/time filters and can search across multiple log f
     ...    filename: logfile.3.log\n${logfile3_contents}\nfilename: logfile.2.log\n${logfile2_contents}\n
 
 Log file request not processed if operation is disabled for tedge-agent
-    [Teardown]    Enable log upload capability of tedge-agent
     Disable log upload capability of tedge-agent
     ${start_timestamp}=    Get Current Date    UTC    -24 hours    result_format=%Y-%m-%dT%H:%M:%SZ
     ${end_timestamp}=    Get Current Date    UTC    +60 seconds    result_format=%Y-%m-%dT%H:%M:%SZ
@@ -110,6 +111,7 @@ Log file request not processed if operation is disabled for tedge-agent
     ...    payload={"status":"init","tedgeUrl":"http://127.0.0.1:8000/tedge/file-transfer/${DEVICE_SN}/log_upload/example-1234","type":"example","dateFrom":"${start_timestamp}","dateTo":"${end_timestamp}","searchText":"first","lines":10}
     ...    expected_status=init
     ...    c8y_fragment=c8y_LogfileRequest
+    [Teardown]    Enable log upload capability of tedge-agent
 
 Default plugin configuration
     Set Device Context    ${DEVICE_SN}
@@ -120,7 +122,7 @@ Default plugin configuration
     # Agent restart should recreate the default plugin configuration
     Stop Service    tedge-agent
     Service Should Be Stopped    tedge-agent
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Start Service    tedge-agent
     Service Should Be Running    tedge-agent
 
@@ -130,9 +132,13 @@ Default plugin configuration
 
     ${start_timestamp}=    Get Current Date    UTC    -24 hours    result_format=%Y-%m-%dT%H:%M:%S+0000
     ${end_timestamp}=    Get Current Date    UTC    +60 seconds    result_format=%Y-%m-%dT%H:%M:%S+0000
-    ${operation}=    Create Log Request Operation    ${start_timestamp}    ${end_timestamp}    log_type=software-management
+    ${operation}=    Create Log Request Operation
+    ...    ${start_timestamp}
+    ...    ${end_timestamp}
+    ...    log_type=software-management
     ${operation}=    Operation Should Be SUCCESSFUL    ${operation}    timeout=120
     Log Operation Attachment File Contains    ${operation}    expected_pattern=.*software_list @ successful
+
 
 *** Keywords ***
 Setup LogFiles
@@ -195,18 +201,31 @@ Publish and Verify Local Command
     [Teardown]    Execute Command    tedge mqtt pub --retain '${topic}' ''
 
 Log File Contents Should Be Equal
-    [Arguments]    ${operation}    ${expected_contents}    ${encoding}=utf-8    ${expected_filename}=^${DEVICE_SN}_[\\w\\W]+-c8y-mapper-\\d+$    ${expected_mime_type}=text/plain
+    [Arguments]
+    ...    ${operation}
+    ...    ${expected_contents}
+    ...    ${encoding}=utf-8
+    ...    ${expected_filename}=^${DEVICE_SN}_[\\w\\W]+-c8y-mapper-\\d+$
+    ...    ${expected_mime_type}=text/plain
     ${event_url_parts}=    Split String    ${operation["c8y_LogfileRequest"]["file"]}    separator=/
     ${event_id}=    Set Variable    ${event_url_parts}[-2]
     ${contents}=    Cumulocity.Event Should Have An Attachment
     ...    ${event_id}
     ...    expected_contents=${expected_contents}
     ...    encoding=${encoding}
-    ${event}=    Cumulocity.Event Attachment Should Have File Info    ${event_id}    name=${expected_filename}    mime_type=${expected_mime_type}
+    ${event}=    Cumulocity.Event Attachment Should Have File Info
+    ...    ${event_id}
+    ...    name=${expected_filename}
+    ...    mime_type=${expected_mime_type}
     RETURN    ${contents}
 
 Create Log Request Operation
-    [Arguments]    ${start_timestamp}    ${end_timestamp}    ${log_type}    ${search_text}=${EMPTY}    ${maximum_lines}=1000
+    [Arguments]
+    ...    ${start_timestamp}
+    ...    ${end_timestamp}
+    ...    ${log_type}
+    ...    ${search_text}=${EMPTY}
+    ...    ${maximum_lines}=1000
     ${start_timestamp}=    Get Current Date    UTC    -24 hours    result_format=%Y-%m-%dT%H:%M:%S+0000
     ${end_timestamp}=    Get Current Date    UTC    +60 seconds    result_format=%Y-%m-%dT%H:%M:%S+0000
     ${operation}=    Cumulocity.Create Operation
@@ -222,7 +241,6 @@ Log Operation Attachment File Contains
     ...    ${event_id}
     ...    expected_pattern=${expected_pattern}
     ...    encoding=utf-8
-
 
 Disable log upload capability of tedge-agent
     [Arguments]    ${device_sn}=${DEVICE_SN}

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
@@ -226,8 +226,6 @@ Create Log Request Operation
     ...    ${log_type}
     ...    ${search_text}=${EMPTY}
     ...    ${maximum_lines}=1000
-    ${start_timestamp}=    Get Current Date    UTC    -24 hours    result_format=%Y-%m-%dT%H:%M:%S+0000
-    ${end_timestamp}=    Get Current Date    UTC    +60 seconds    result_format=%Y-%m-%dT%H:%M:%S+0000
     ${operation}=    Cumulocity.Create Operation
     ...    description=Log file request
     ...    fragments={"c8y_LogfileRequest":{"dateFrom":"${start_timestamp}","dateTo":"${end_timestamp}","logFile":"${log_type}","searchText":"${search_text}","maximumLines":${maximum_lines}}}

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
@@ -1,10 +1,10 @@
 *** Settings ***
 Resource            ../../../resources/common.resource
-Library             Cumulocity
 Library             DateTime
-Library             ThinEdgeIO
 Library             String
 Library             OperatingSystem
+Library             Cumulocity
+Library             ThinEdgeIO
 
 Suite Setup         Custom Setup
 Test Teardown       Get Logs

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource            ../../../resources/common.resource
 Library             DateTime
-Library             String
 Library             OperatingSystem
+Library             String
 Library             Cumulocity
 Library             ThinEdgeIO
 

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
@@ -36,7 +36,8 @@ Setup Child Device
 
     ThinEdgeIO.Transfer To Device    ${CURDIR}/tedge-log-plugin.toml    /etc/tedge/plugins/tedge-log-plugin.toml
     ThinEdgeIO.Transfer To Device    ${CURDIR}/example.log    /var/log/example/
-    Execute Command    chown root:root /etc/tedge/plugins/tedge-log-plugin.toml /var/log/example/example.log && touch /var/log/example/example.log
+    Execute Command
+    ...    chown root:root /etc/tedge/plugins/tedge-log-plugin.toml /var/log/example/example.log && touch /var/log/example/example.log
 
     Enable Service    tedge-agent
     Start Service    tedge-agent
@@ -46,7 +47,7 @@ Custom Setup
     # Parent
     ${parent_sn}=    Setup    skip_bootstrap=${True}
     Set Suite Variable    $PARENT_SN    ${parent_sn}
-    Execute Command           test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
 
     ${parent_ip}=    Get IP Address
     Set Suite Variable    $PARENT_IP    ${parent_ip}
@@ -70,12 +71,20 @@ Custom Teardown
     Get Logs    ${CHILD_SN}
 
 Log File Contents Should Be Equal
-    [Arguments]    ${operation}    ${expected_contents}    ${encoding}=utf-8    ${expected_filename}=^${CHILD_XID}_[\\w\\W]+-c8y-mapper-\\d+$    ${expected_mime_type}=text/plain
+    [Arguments]
+    ...    ${operation}
+    ...    ${expected_contents}
+    ...    ${encoding}=utf-8
+    ...    ${expected_filename}=^${CHILD_XID}_[\\w\\W]+-c8y-mapper-\\d+$
+    ...    ${expected_mime_type}=text/plain
     ${event_url_parts}=    Split String    ${operation["c8y_LogfileRequest"]["file"]}    separator=/
     ${event_id}=    Set Variable    ${event_url_parts}[-2]
     ${contents}=    Cumulocity.Event Should Have An Attachment
     ...    ${event_id}
     ...    expected_contents=${expected_contents}
     ...    encoding=${encoding}
-    ${event}=    Cumulocity.Event Attachment Should Have File Info    ${event_id}    name=${expected_filename}    mime_type=${expected_mime_type}
+    ${event}=    Cumulocity.Event Attachment Should Have File Info
+    ...    ${event_id}
+    ...    name=${expected_filename}
+    ...    mime_type=${expected_mime_type}
     RETURN    ${contents}

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
@@ -1,9 +1,9 @@
 *** Settings ***
 Resource            ../../../resources/common.resource
-Library             Cumulocity
 Library             DateTime
-Library             ThinEdgeIO
 Library             String
+Library             Cumulocity
+Library             ThinEdgeIO
 
 Test Setup          Custom Setup
 Test Teardown       Custom Teardown

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_child.robot
@@ -71,8 +71,7 @@ Custom Teardown
     Get Logs    ${CHILD_SN}
 
 Log File Contents Should Be Equal
-    [Arguments]
-    ...    ${operation}
+    [Arguments]    ${operation}
     ...    ${expected_contents}
     ...    ${encoding}=utf-8
     ...    ${expected_filename}=^${CHILD_XID}_[\\w\\W]+-c8y-mapper-\\d+$

--- a/tests/RobotFramework/tests/cumulocity/log/workflow/log_workflow.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/workflow/log_workflow.robot
@@ -1,9 +1,9 @@
 *** Settings ***
 Resource            ../../../../resources/common.resource
-Library             Cumulocity
 Library             DateTime
-Library             ThinEdgeIO
 Library             String
+Library             Cumulocity
+Library             ThinEdgeIO
 
 Suite Setup         Custom Setup
 Test Teardown       Get Logs

--- a/tests/RobotFramework/tests/cumulocity/log/workflow/log_workflow.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/workflow/log_workflow.robot
@@ -10,24 +10,29 @@ Test Teardown       Get Logs
 
 Test Tags           theme:c8y    theme:log
 
-*** Test Cases ***
 
+*** Test Cases ***
 Custom log workflow with pre-processor
     [Documentation]    Use a custom log_upload workflow to support command based logs. It uses a custom preprocessor
-    ...   step to run a custom command (via the log_upload.sh script), which can be used to read logs from any source
-    ...   (sqlite in this example)
+    ...    step to run a custom command (via the log_upload.sh script), which can be used to read logs from any source
+    ...    (sqlite in this example)
     Cumulocity.Should Support Log File Types    sqlite    includes=${True}
 
     ${start_timestamp}=    Get Current Date    UTC    -24 hours    result_format=%Y-%m-%dT%H:%M:%S+0000
     ${end_timestamp}=    Get Current Date    UTC    +60 seconds    result_format=%Y-%m-%dT%H:%M:%S+0000
 
-    ${operation}=    Cumulocity.Get Log File    type=sqlite    date_from=${start_timestamp}    date_to=${end_timestamp}    maximum_lines=10
+    ${operation}=    Cumulocity.Get Log File
+    ...    type=sqlite
+    ...    date_from=${start_timestamp}
+    ...    date_to=${end_timestamp}
+    ...    maximum_lines=10
     ${operation}=    Operation Should Be SUCCESSFUL    ${operation}
-    Log File Contents Should Be Equal    operation=${operation}    expected_pattern=filename: sqlite.log\\nRunning some sqlite query...\\nParameters:\\n\\s+dateFrom=.+\\n\\s+dateTo=.+\\n
+    Log File Contents Should Be Equal
+    ...    operation=${operation}
+    ...    expected_pattern=filename: sqlite.log\\nRunning some sqlite query...\\nParameters:\\n\\s+dateFrom=.+\\n\\s+dateTo=.+\\n
 
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
@@ -46,14 +51,21 @@ Setup LogFiles
     ThinEdgeIO.Service Health Status Should Be Up    tedge-agent
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-c8y
 
-
 Log File Contents Should Be Equal
-    [Arguments]    ${operation}    ${expected_pattern}    ${encoding}=utf-8    ${expected_filename}=^${DEVICE_SN}_[\\w\\W]+-c8y-mapper-\\d+$    ${expected_mime_type}=text/plain
+    [Arguments]
+    ...    ${operation}
+    ...    ${expected_pattern}
+    ...    ${encoding}=utf-8
+    ...    ${expected_filename}=^${DEVICE_SN}_[\\w\\W]+-c8y-mapper-\\d+$
+    ...    ${expected_mime_type}=text/plain
     ${event_url_parts}=    Split String    ${operation["c8y_LogfileRequest"]["file"]}    separator=/
     ${event_id}=    Set Variable    ${event_url_parts}[-2]
     ${contents}=    Cumulocity.Event Should Have An Attachment
     ...    ${event_id}
     ...    expected_pattern=${expected_pattern}
     ...    encoding=${encoding}
-    ${event}=    Cumulocity.Event Attachment Should Have File Info    ${event_id}    name=${expected_filename}    mime_type=${expected_mime_type}
+    ${event}=    Cumulocity.Event Attachment Should Have File Info
+    ...    ${event_id}
+    ...    name=${expected_filename}
+    ...    mime_type=${expected_mime_type}
     RETURN    ${contents}

--- a/tests/RobotFramework/tests/cumulocity/log/workflow/log_workflow.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/workflow/log_workflow.robot
@@ -52,8 +52,7 @@ Setup LogFiles
     ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-c8y
 
 Log File Contents Should Be Equal
-    [Arguments]
-    ...    ${operation}
+    [Arguments]    ${operation}
     ...    ${expected_pattern}
     ...    ${encoding}=utf-8
     ...    ${expected_filename}=^${DEVICE_SN}_[\\w\\W]+-c8y-mapper-\\d+$

--- a/tests/RobotFramework/tests/cumulocity/mapper_recovery/recover_and_publish_software_update_message.robot
+++ b/tests/RobotFramework/tests/cumulocity/mapper_recovery/recover_and_publish_software_update_message.robot
@@ -6,7 +6,7 @@ Library             ThinEdgeIO
 Suite Setup         Custom Setup
 Test Teardown       Get Logs
 
-Test Tags           theme:c8y    theme:mapper recovery
+Test Tags           theme:c8y    theme:mapper_recovery
 
 
 *** Test Cases ***

--- a/tests/RobotFramework/tests/cumulocity/mapper_recovery/recover_and_publish_software_update_message.robot
+++ b/tests/RobotFramework/tests/cumulocity/mapper_recovery/recover_and_publish_software_update_message.robot
@@ -1,29 +1,37 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:mapper recovery 
-Suite Setup    Custom Setup
-Test Teardown    Get Logs
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:mapper recovery
+
 
 *** Test Cases ***
 Mapper recovers and processes output of ongoing software update request
-    [Documentation]    C8y-Mapper receives a software update request, 
-    ...                Delegates operation to tedge-agent and gets back `executing` status
-    ...                And then goes down (here purposefully stopped).
-    ...                Mean while the agent processes the update message and publishes the software update message
-    ...                After some time mapper recovers and pushes the result to c8y cloud
-    ...                Verify that the rolldice package is installed or not
-    ${timestamp}=        Get Unix Timestamp
-    ThinEdgeIO.Service Should Be Running    tedge-mapper-c8y    
+    [Documentation]    C8y-Mapper receives a software update request,
+    ...    Delegates operation to tedge-agent and gets back `executing` status
+    ...    And then goes down (here purposefully stopped).
+    ...    Mean while the agent processes the update message and publishes the software update message
+    ...    After some time mapper recovers and pushes the result to c8y cloud
+    ...    Verify that the rolldice package is installed or not
+    ${timestamp}=    Get Unix Timestamp
+    ThinEdgeIO.Service Should Be Running    tedge-mapper-c8y
     ${OPERATION}=    Install Software    rolldice,1.0.0::dummy
-    Should Have MQTT Messages    te/device/main///cmd/software_update/+    message_contains=executing    date_from=${timestamp}
-    ThinEdgeIO.Stop Service    tedge-mapper-c8y    
-    Should Have MQTT Messages    te/device/main///cmd/software_update/+    message_contains=successful    date_from=${timestamp}
+    Should Have MQTT Messages
+    ...    te/device/main///cmd/software_update/+
+    ...    message_contains=executing
+    ...    date_from=${timestamp}
+    ThinEdgeIO.Stop Service    tedge-mapper-c8y
+    Should Have MQTT Messages
+    ...    te/device/main///cmd/software_update/+
+    ...    message_contains=successful
+    ...    date_from=${timestamp}
     ThinEdgeIO.Start Service    tedge-mapper-c8y
     ThinEdgeIO.Service Should Be Running    tedge-mapper-c8y
-    Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
+    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
     Device Should Have Installed Software    rolldice
 
 Recovery from corrupt entity store file
@@ -34,12 +42,12 @@ Recovery from corrupt entity store file
     ${owner}=    Execute Command    stat -c "%U" /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl    strip="true"
     Should Be Equal    ${owner}    tedge
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup
-    Set Suite Variable    $DEVICE_SN 
-    Device Should Exist                      ${DEVICE_SN}
+    Set Suite Variable    $DEVICE_SN
+    Device Should Exist    ${DEVICE_SN}
     Service Health Status Should Be Up    tedge-mapper-c8y
     # This acts as a custom sm plugin
-    ThinEdgeIO.Transfer To Device     ${CURDIR}/custom_sw_plugin.sh    /etc/tedge/sm-plugins/dummy
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/custom_sw_plugin.sh    /etc/tedge/sm-plugins/dummy

--- a/tests/RobotFramework/tests/cumulocity/monitoring/monitor_device_collectd.robot
+++ b/tests/RobotFramework/tests/cumulocity/monitoring/monitor_device_collectd.robot
@@ -1,36 +1,35 @@
 *** Settings ***
-Documentation      With thin-edge.io device monitoring, you can collect metrics from your device 
-...                and forward these device metrics to IoT platforms in the cloud. Using these metrics, 
-...                you can monitor the health of devices and can proactively initiate actions in case the 
-...                device seems to malfunction. Additionally, the metrics can be used to help the customer 
-...                troubleshoot when problems with the device are reported. Thin-edge.io uses the open source 
-...                component collectd to collect the metrics from the device. Thin-edge.io translates the 
-...                collected metrics from their native format to the thin-edge.io JSON format and then into 
-...                the cloud-vendor specific format.
-...                Enabling monitoring on your device is a 3-steps process:
-...                1. Install collectd,
-...                2. Configure collectd,
-...                3. Enable thin-edge.io monitoring.
-...                Checking the grouping of measurements:
-...                Sending fake collectd measurements with stopped collectd and check that messages are
-...                published on te/device/main///m/ for that timestamp and grouping the two fake collectd measurements
-...                (i.e. the temperature and the pressure sent by the two fake measurements).
+Documentation       With thin-edge.io device monitoring, you can collect metrics from your device
+...                 and forward these device metrics to IoT platforms in the cloud. Using these metrics,
+...                 you can monitor the health of devices and can proactively initiate actions in case the
+...                 device seems to malfunction. Additionally, the metrics can be used to help the customer
+...                 troubleshoot when problems with the device are reported. Thin-edge.io uses the open source
+...                 component collectd to collect the metrics from the device. Thin-edge.io translates the
+...                 collected metrics from their native format to the thin-edge.io JSON format and then into
+...                 the cloud-vendor specific format.
+...                 Enabling monitoring on your device is a 3-steps process:
+...                 1. Install collectd,
+...                 2. Configure collectd,
+...                 3. Enable thin-edge.io monitoring.
+...                 Checking the grouping of measurements:
+...                 Sending fake collectd measurements with stopped collectd and check that messages are
+...                 published on te/device/main///m/ for that timestamp and grouping the two fake collectd measurements
+...                 (i.e. the temperature and the pressure sent by the two fake measurements).
 
+Resource            ../../../resources/common.resource
+Library             ThinEdgeIO
+Library             Cumulocity
 
-Resource        ../../../resources/common.resource
-Library         ThinEdgeIO
-Library         Cumulocity
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
 
-Suite Setup     Custom Setup
-Test Teardown    Get Logs
+Test Tags           theme:monitoring    theme:c8y    theme:collectd
 
-Test Tags      theme:monitoring    theme:c8y    theme:collectd
 
 *** Test Cases ***
-
 Check running collectd
     Service Should Be Running    collectd
-    
+
 Is collectd publishing MQTT messages?
     ${messages}=    Should Have MQTT Messages    topic=collectd/#    minimum=1    maximum=None
 
@@ -39,35 +38,52 @@ Check thin-edge monitoring
     Execute Command    sudo systemctl enable tedge-mapper-collectd
     Execute Command    sudo systemctl start tedge-mapper-collectd
     # Check thin-edge monitoring
-    ${tedge_messages}=    Should Have MQTT Messages    topic=te/device/main///m/    minimum=1    maximum=None    message_pattern=.*(memory|cpu|df-root).*
-    Should Contain    ${tedge_messages[0]}   "time"
-    ${c8y_messages}=    Should Have MQTT Messages    topic=c8y/measurement/measurements/create    minimum=1    maximum=None
+    ${tedge_messages}=    Should Have MQTT Messages
+    ...    topic=te/device/main///m/
+    ...    minimum=1
+    ...    maximum=None
+    ...    message_pattern=.*(memory|cpu|df-root).*
+    Should Contain    ${tedge_messages[0]}    "time"
+    ${c8y_messages}=    Should Have MQTT Messages
+    ...    topic=c8y/measurement/measurements/create
+    ...    minimum=1
+    ...    maximum=None
     Should Contain    ${c8y_messages[0]}    "type":"ThinEdgeMeasurement"
 
-Check grouping of measurements 
+Check grouping of measurements
     # This test step is only partially checking the grouping of the messages, because of the timeouts and the current design
     # if proper checks will be implemented this test would be failing from time to time
-    
+
     Execute Command    sudo systemctl stop collectd
     Sleep    5s    reason=Needed because of the batching
     ${start_time}=    Get Unix Timestamp
-    Execute Command    tedge mqtt pub collectd/localhost/temperature/temp1 "`date +%s.%N`:50" && tedge mqtt pub collectd/localhost/temperature/temp2 "`date +%s.%N`:40" && tedge mqtt pub collectd/localhost/pressure/pres1 "`date +%s.%N`:10" && tedge mqtt pub collectd/localhost/pressure/pres2 "`date +%s.%N`:20"
-    ${c8y_messages}    Should Have MQTT Messages    c8y/measurement/measurements/create    maximum=4    date_from=${start_time}
-    Should Contain Any   ${c8y_messages[0]}    "temp1":{"value":50.0}    "temp2":{"value":40.0}    "pres1":{"value":10.0}    "pres2":{"value":20.0}
+    Execute Command
+    ...    tedge mqtt pub collectd/localhost/temperature/temp1 "`date +%s.%N`:50" && tedge mqtt pub collectd/localhost/temperature/temp2 "`date +%s.%N`:40" && tedge mqtt pub collectd/localhost/pressure/pres1 "`date +%s.%N`:10" && tedge mqtt pub collectd/localhost/pressure/pres2 "`date +%s.%N`:20"
+    ${c8y_messages}=    Should Have MQTT Messages
+    ...    c8y/measurement/measurements/create
+    ...    maximum=4
+    ...    date_from=${start_time}
+    Should Contain Any
+    ...    ${c8y_messages[0]}
+    ...    "temp1":{"value":50.0}
+    ...    "temp2":{"value":40.0}
+    ...    "pres1":{"value":10.0}
+    ...    "pres2":{"value":20.0}
 
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup
     Device Should Exist    ${DEVICE_SN}
     # 1. Install collectd
     # 2. Configure collectd
-    Execute Command    sudo apt-get update && sudo apt-get install -y --no-install-recommends collectd-core libmosquitto1
+    Execute Command
+    ...    sudo apt-get update && sudo apt-get install -y --no-install-recommends collectd-core libmosquitto1
     Execute Command    sudo cp /etc/tedge/contrib/collectd/collectd.conf /etc/collectd/collectd.conf
 
     # Shorten the interval to 1 second so it is easier to test. This is technically not a documentation step,
     # but collectd does not support a manual trigger to publish metrics
-    Execute Command    sudo sed -iE 's/\\bInterval.*[0-9]\\+/Interval 1/g' /etc/collectd/collectd.conf && cat /etc/collectd/collectd.conf
+    Execute Command
+    ...    sudo sed -iE 's/\\bInterval.*[0-9]\\+/Interval 1/g' /etc/collectd/collectd.conf && cat /etc/collectd/collectd.conf
 
     Execute Command    sudo systemctl restart collectd

--- a/tests/RobotFramework/tests/cumulocity/registration/registration_lifecycle.robot
+++ b/tests/RobotFramework/tests/cumulocity/registration/registration_lifecycle.robot
@@ -1,29 +1,29 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:registration    theme:deregistration
-Test Setup    Custom Setup
-Test Teardown    Get Logs    ${DEVICE_SN}
+Test Setup          Custom Setup
+Test Teardown       Get Logs    ${DEVICE_SN}
+
+Test Tags           theme:c8y    theme:registration    theme:deregistration
+
 
 *** Test Cases ***
-
 Main device registration
-    ${mo}=    Device Should Exist              ${DEVICE_SN}
+    ${mo}=    Device Should Exist    ${DEVICE_SN}
     ${mo}=    Cumulocity.Device Should Have Fragment Values    name\=${DEVICE_SN}
     Should Be Equal    ${mo["owner"]}    device_${DEVICE_SN}
     Should Be Equal    ${mo["name"]}    ${DEVICE_SN}
-
 
 Child device registration
     Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_SN}"}'
 
     # Check registration
-    ${child_mo}=    Device Should Exist        ${CHILD_SN}
+    ${child_mo}=    Device Should Exist    ${CHILD_SN}
     ${child_mo}=    Cumulocity.Device Should Have Fragment Values    name\=${CHILD_SN}
     Should Be Equal    ${child_mo["owner"]}    device_${DEVICE_SN}    # The parent is the owner of the child
-    Should Be Equal    ${child_mo["name"]}     ${CHILD_SN}
+    Should Be Equal    ${child_mo["name"]}    ${CHILD_SN}
 
     # Check child device relationship
     Cumulocity.Set Device    ${DEVICE_SN}
@@ -31,99 +31,194 @@ Child device registration
 
     # Deregister Child device
     Execute Command    mosquitto_sub --remove-retained -W 3 -t "te/device/${CHILD_SN}/+/+/#"    exp_exit_code=27
-    
+
     # Check if deregistration was successful
     Sleep    1s    reason=Allowing components to process messages
-    Should Have Retained Message Count    te/device/${CHILD_SN}/+/+/#    0     
+    Should Have Retained Message Count    te/device/${CHILD_SN}/+/+/#    0
 
     # Checking if child device will be recreated after mapper restart
-    Restart Service    tedge-mapper-c8y    
+    Restart Service    tedge-mapper-c8y
     Sleep    5s    reason=Allowing startup to complete
-    Should Have Retained Message Count    te/device/${CHILD_SN}/+/+/#    0  
+    Should Have Retained Message Count    te/device/${CHILD_SN}/+/+/#    0
 
 Register child device with defaults via MQTT
     Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device"}'
-    Should Have MQTT Messages    te/device/${CHILD_SN}//    message_contains="@id":"${CHILD_XID}"    message_contains="@type":"child-device"
-    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${CHILD_XID}    child_name=${CHILD_XID}    child_type=thin-edge.io-child
+    Should Have MQTT Messages
+    ...    te/device/${CHILD_SN}//
+    ...    message_contains="@id":"${CHILD_XID}"
+    ...    message_contains="@type":"child-device"
+    Check Child Device
+    ...    parent_sn=${DEVICE_SN}
+    ...    child_sn=${CHILD_XID}
+    ...    child_name=${CHILD_XID}
+    ...    child_type=thin-edge.io-child
 
 Register child device with custom name and type via MQTT
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","name":"${CHILD_SN}","type":"linux-device-Aböut"}'
-    Should Have MQTT Messages    te/device/${CHILD_SN}//    message_contains="@id":"${CHILD_XID}"    message_contains="@type":"child-device"
-    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${CHILD_XID}    child_name=${CHILD_SN}    child_type=linux-device-Aböut
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","name":"${CHILD_SN}","type":"linux-device-Aböut"}'
+    Should Have MQTT Messages
+    ...    te/device/${CHILD_SN}//
+    ...    message_contains="@id":"${CHILD_XID}"
+    ...    message_contains="@type":"child-device"
+    Check Child Device
+    ...    parent_sn=${DEVICE_SN}
+    ...    child_sn=${CHILD_XID}
+    ...    child_name=${CHILD_SN}
+    ...    child_type=linux-device-Aböut
 
 Register child device with custom id via MQTT
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"custom-${CHILD_XID}","name":"custom-${CHILD_SN}"}'
-    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=custom-${CHILD_XID}    child_name=custom-${CHILD_SN}    child_type=thin-edge.io-child
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"custom-${CHILD_XID}","name":"custom-${CHILD_SN}"}'
+    Check Child Device
+    ...    parent_sn=${DEVICE_SN}
+    ...    child_sn=custom-${CHILD_XID}
+    ...    child_name=custom-${CHILD_SN}
+    ...    child_type=thin-edge.io-child
 
 Register nested child device using default topic schema via MQTT
     ${child_level1}=    Get Random Name
     ${child_level2}=    Get Random Name
     ${child_level3}=    Get Random Name
 
-    Execute Command    tedge mqtt pub --retain 'te/device/${child_level1}//' '{"@type":"child-device","@parent":"device/main//"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${child_level2}//' '{"@type":"child-device","@parent":"device/${child_level1}//","name":"${child_level2}"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${child_level3}//' '{"@type":"child-device","@parent":"device/${child_level2}//","type":"child_level3"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${child_level3}/service/custom-app' '{"@type":"service","@parent":"device/${child_level3}//","name":"custom-app","type":"service-level3"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${child_level1}//' '{"@type":"child-device","@parent":"device/main//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${child_level2}//' '{"@type":"child-device","@parent":"device/${child_level1}//","name":"${child_level2}"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${child_level3}//' '{"@type":"child-device","@parent":"device/${child_level2}//","type":"child_level3"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${child_level3}/service/custom-app' '{"@type":"service","@parent":"device/${child_level3}//","name":"custom-app","type":"service-level3"}'
 
     # Level 1
-    Should Have MQTT Messages    te/device/${child_level1}//    message_contains="@id":"${DEVICE_SN}:device:${child_level1}"    message_contains="@type":"child-device"
-    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${DEVICE_SN}:device:${child_level1}    child_name=${DEVICE_SN}:device:${child_level1}    child_type=thin-edge.io-child
+    Should Have MQTT Messages
+    ...    te/device/${child_level1}//
+    ...    message_contains="@id":"${DEVICE_SN}:device:${child_level1}"
+    ...    message_contains="@type":"child-device"
+    Check Child Device
+    ...    parent_sn=${DEVICE_SN}
+    ...    child_sn=${DEVICE_SN}:device:${child_level1}
+    ...    child_name=${DEVICE_SN}:device:${child_level1}
+    ...    child_type=thin-edge.io-child
 
     # Level 2
-    Should Have MQTT Messages    te/device/${child_level2}//    message_contains="@id":"${DEVICE_SN}:device:${child_level2}"    message_contains="@type":"child-device"
-    Check Child Device    parent_sn=${DEVICE_SN}:device:${child_level1}    child_sn=${DEVICE_SN}:device:${child_level2}    child_name=${child_level2}    child_type=thin-edge.io-child
+    Should Have MQTT Messages
+    ...    te/device/${child_level2}//
+    ...    message_contains="@id":"${DEVICE_SN}:device:${child_level2}"
+    ...    message_contains="@type":"child-device"
+    Check Child Device
+    ...    parent_sn=${DEVICE_SN}:device:${child_level1}
+    ...    child_sn=${DEVICE_SN}:device:${child_level2}
+    ...    child_name=${child_level2}
+    ...    child_type=thin-edge.io-child
 
     # Level 3
-    Should Have MQTT Messages    te/device/${child_level3}//    message_contains="@id":"${DEVICE_SN}:device:${child_level3}"    message_contains="@type":"child-device"
-    Check Child Device    parent_sn=${DEVICE_SN}:device:${child_level2}    child_sn=${DEVICE_SN}:device:${child_level3}    child_name=${DEVICE_SN}:device:${child_level3}    child_type=child_level3
-    Should Have MQTT Messages    te/device/${child_level3}/service/custom-app    message_contains="@id":"${DEVICE_SN}:device:${child_level3}:service:custom-app"    message_contains="@type":"service"
-    Check Service    child_sn=${DEVICE_SN}:device:${child_level3}    service_sn=${DEVICE_SN}:device:${child_level3}:service:custom-app    service_name=custom-app    service_type=service-level3    service_status=up
-
+    Should Have MQTT Messages
+    ...    te/device/${child_level3}//
+    ...    message_contains="@id":"${DEVICE_SN}:device:${child_level3}"
+    ...    message_contains="@type":"child-device"
+    Check Child Device
+    ...    parent_sn=${DEVICE_SN}:device:${child_level2}
+    ...    child_sn=${DEVICE_SN}:device:${child_level3}
+    ...    child_name=${DEVICE_SN}:device:${child_level3}
+    ...    child_type=child_level3
+    Should Have MQTT Messages
+    ...    te/device/${child_level3}/service/custom-app
+    ...    message_contains="@id":"${DEVICE_SN}:device:${child_level3}:service:custom-app"
+    ...    message_contains="@type":"service"
+    Check Service
+    ...    child_sn=${DEVICE_SN}:device:${child_level3}
+    ...    service_sn=${DEVICE_SN}:device:${child_level3}:service:custom-app
+    ...    service_name=custom-app
+    ...    service_type=service-level3
+    ...    service_status=up
 
 Register service on a child device via MQTT
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","name":"${CHILD_SN}","type":"linux-device-Aböut"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}/service/custom-app' '{"@type":"service","@parent":"device/${CHILD_SN}//","name":"custom-app","type":"custom-type"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","name":"${CHILD_SN}","type":"linux-device-Aböut"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}/service/custom-app' '{"@type":"service","@parent":"device/${CHILD_SN}//","name":"custom-app","type":"custom-type"}'
 
     # Check child registration
-    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${CHILD_XID}    child_name=${CHILD_SN}    child_type=linux-device-Aböut
+    Check Child Device
+    ...    parent_sn=${DEVICE_SN}
+    ...    child_sn=${CHILD_XID}
+    ...    child_name=${CHILD_SN}
+    ...    child_type=linux-device-Aböut
 
     # Check service registration
-    Check Service    child_sn=${CHILD_XID}    service_sn=${CHILD_XID}:service:custom-app    service_name=custom-app    service_type=custom-type    service_status=up
+    Check Service
+    ...    child_sn=${CHILD_XID}
+    ...    service_sn=${CHILD_XID}:service:custom-app
+    ...    service_name=custom-app
+    ...    service_type=custom-type
+    ...    service_status=up
 
     # Deregister service on a child device
-    Execute Command    mosquitto_sub --remove-retained -W 3 -t 'te/device/${CHILD_SN}/service/custom-app/#'    exp_exit_code=27
+    Execute Command
+    ...    mosquitto_sub --remove-retained -W 3 -t 'te/device/${CHILD_SN}/service/custom-app/#'
+    ...    exp_exit_code=27
 
     # Check if deregistration was successful
     Sleep    1s    reason=Allowing components to process messages
-    Should Have Retained Message Count    te/device/${CHILD_SN}/service/custom-app/#    0   
+    Should Have Retained Message Count    te/device/${CHILD_SN}/service/custom-app/#    0
 
 Register devices using custom MQTT schema
     [Documentation]    Complex example showing how to use custom MQTT topics to register devices/services using
-        ...            custom identity schemas
+    ...    custom identity schemas
 
     Execute Command    tedge mqtt pub --retain 'te/base///' '{"@type":"device","name":"base","type":"te_gateway"}'
 
-    Execute Command    tedge mqtt pub --retain 'te/factory1/shop1/plc1/sensor1' '{"@type":"child-device","name":"sensor1","type":"SmartSensor"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory1/shop1/plc1/sensor2' '{"@type":"child-device","name":"sensor2","type":"SmartSensor"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory1/shop1/plc1/sensor1' '{"@type":"child-device","name":"sensor1","type":"SmartSensor"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory1/shop1/plc1/sensor2' '{"@type":"child-device","name":"sensor2","type":"SmartSensor"}'
 
     # Service of main device
-    Execute Command    tedge mqtt pub --retain 'te/factory1/shop1/plc1/metrics' '{"@type":"service","name":"metrics","type":"PLCApplication"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory1/shop1/plc1/metrics' '{"@type":"service","name":"metrics","type":"PLCApplication"}'
 
     # Service of child device
-    Execute Command    tedge mqtt pub --retain 'te/factory1/shop1/apps/sensor1' '{"@type":"service","@parent":"factory1/shop1/plc1/sensor1","name":"metrics","type":"PLCMonitorApplication"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory1/shop1/apps/sensor2' '{"@type":"service","@parent":"factory1/shop1/plc1/sensor2","name":"metrics","type":"PLCMonitorApplication"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory1/shop1/apps/sensor1' '{"@type":"service","@parent":"factory1/shop1/plc1/sensor1","name":"metrics","type":"PLCMonitorApplication"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory1/shop1/apps/sensor2' '{"@type":"service","@parent":"factory1/shop1/plc1/sensor2","name":"metrics","type":"PLCMonitorApplication"}'
 
-    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${DEVICE_SN}:factory1:shop1:plc1:sensor1    child_name=sensor1    child_type=SmartSensor
-    Check Child Device    parent_sn=${DEVICE_SN}    child_sn=${DEVICE_SN}:factory1:shop1:plc1:sensor2    child_name=sensor2    child_type=SmartSensor
-
+    Check Child Device
+    ...    parent_sn=${DEVICE_SN}
+    ...    child_sn=${DEVICE_SN}:factory1:shop1:plc1:sensor1
+    ...    child_name=sensor1
+    ...    child_type=SmartSensor
+    Check Child Device
+    ...    parent_sn=${DEVICE_SN}
+    ...    child_sn=${DEVICE_SN}:factory1:shop1:plc1:sensor2
+    ...    child_name=sensor2
+    ...    child_type=SmartSensor
 
     # Check if MQTT device/service representations contains @id
-    Should Have MQTT Messages    te/base///    message_contains="@id":"${DEVICE_SN}"    message_contains="@type":"device"
-    Should Have MQTT Messages    te/factory1/shop1/plc1/sensor1    message_contains="@id":"${DEVICE_SN}:factory1:shop1:plc1:sensor1"    message_contains="@type":"child-device"
-    Should Have MQTT Messages    te/factory1/shop1/plc1/sensor2    message_contains="@id":"${DEVICE_SN}:factory1:shop1:plc1:sensor2"    message_contains="@type":"child-device"
-    Should Have MQTT Messages    te/factory1/shop1/plc1/metrics    message_contains="@id":"${DEVICE_SN}:factory1:shop1:plc1:metrics"    message_contains="@type":"service"
-    Should Have MQTT Messages    te/factory1/shop1/apps/sensor1    message_contains="@id":"${DEVICE_SN}:factory1:shop1:apps:sensor1"    message_contains="@type":"service"
-    Should Have MQTT Messages    te/factory1/shop1/apps/sensor2    message_contains="@id":"${DEVICE_SN}:factory1:shop1:apps:sensor2"    message_contains="@type":"service"
+    Should Have MQTT Messages
+    ...    te/base///
+    ...    message_contains="@id":"${DEVICE_SN}"
+    ...    message_contains="@type":"device"
+    Should Have MQTT Messages
+    ...    te/factory1/shop1/plc1/sensor1
+    ...    message_contains="@id":"${DEVICE_SN}:factory1:shop1:plc1:sensor1"
+    ...    message_contains="@type":"child-device"
+    Should Have MQTT Messages
+    ...    te/factory1/shop1/plc1/sensor2
+    ...    message_contains="@id":"${DEVICE_SN}:factory1:shop1:plc1:sensor2"
+    ...    message_contains="@type":"child-device"
+    Should Have MQTT Messages
+    ...    te/factory1/shop1/plc1/metrics
+    ...    message_contains="@id":"${DEVICE_SN}:factory1:shop1:plc1:metrics"
+    ...    message_contains="@type":"service"
+    Should Have MQTT Messages
+    ...    te/factory1/shop1/apps/sensor1
+    ...    message_contains="@id":"${DEVICE_SN}:factory1:shop1:apps:sensor1"
+    ...    message_contains="@type":"service"
+    Should Have MQTT Messages
+    ...    te/factory1/shop1/apps/sensor2
+    ...    message_contains="@id":"${DEVICE_SN}:factory1:shop1:apps:sensor2"
+    ...    message_contains="@type":"service"
 
     # Check main device services
     Cumulocity.Set Device    ${DEVICE_SN}
@@ -141,10 +236,11 @@ Register devices using custom MQTT schema
     Cumulocity.Set Device    ${DEVICE_SN}
     Cumulocity.Device Should Have Measurements    type=gateway_stats    minimum=1    maximum=1
 
-
 Register tedge-agent when tedge-mapper-c8y is not running #2389
     Stop Service    tedge-mapper-c8y
-    Execute Command    cmd=timeout 5 env TEDGE_RUN_LOCK_FILES=false tedge-agent --mqtt-device-topic-id device/offlinechild1//    ignore_exit_code=${True}
+    Execute Command
+    ...    cmd=timeout 5 env TEDGE_RUN_LOCK_FILES=false tedge-agent --mqtt-device-topic-id device/offlinechild1//
+    ...    ignore_exit_code=${True}
     Start Service    tedge-mapper-c8y
     Service Health Status Should Be Up    tedge-mapper-c8y
 
@@ -157,7 +253,7 @@ Register tedge-agent when tedge-mapper-c8y is not running #2389
     Should Have MQTT Messages    te/device/offlinechild1///cmd/restart/+
 
 Early data messages cached and processed
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     ${prefix}=    Get Random Name
     Execute Command    sudo tedge config set c8y.entity_store.auto_register false
     Restart Service    tedge-mapper-c8y
@@ -169,23 +265,40 @@ Early data messages cached and processed
         Execute Command    sudo tedge mqtt pub 'te/device/${child}///twin/maintenance_mode' 'true'
     END
 
-    Execute Command    tedge mqtt pub --retain 'te/device/child000//' '{"@type":"child-device","@id":"${prefix}child000","@parent": "device/child00//"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/child00000//' '{"@type":"child-device","@id":"${prefix}child00000","@parent": "device/child0000//"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/child0000//' '{"@type":"child-device","@id":"${prefix}child0000","@parent": "device/child000//"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/child01//' '{"@type":"child-device","@id":"${prefix}child01","@parent": "device/child0//"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/child00//' '{"@type":"child-device","@id":"${prefix}child00","@parent": "device/child0//"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/child02//' '{"@type":"child-device","@parent": "device/child0//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/child000//' '{"@type":"child-device","@id":"${prefix}child000","@parent": "device/child00//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/child00000//' '{"@type":"child-device","@id":"${prefix}child00000","@parent": "device/child0000//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/child0000//' '{"@type":"child-device","@id":"${prefix}child0000","@parent": "device/child000//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/child01//' '{"@type":"child-device","@id":"${prefix}child01","@parent": "device/child0//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/child00//' '{"@type":"child-device","@id":"${prefix}child00","@parent": "device/child0//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/child02//' '{"@type":"child-device","@parent": "device/child0//"}'
     Execute Command    tedge mqtt pub --retain 'te/device/child0//' '{"@type":"child-device","@id":"${prefix}child0"}'
 
     Check Child Device    ${DEVICE_SN}    ${prefix}child0    ${prefix}child0    thin-edge.io-child
     Check Child Device    ${prefix}child0    ${prefix}child00    ${prefix}child00    thin-edge.io-child
     Check Child Device    ${prefix}child0    ${prefix}child01    ${prefix}child01    thin-edge.io-child
-    Check Child Device    ${prefix}child0    ${DEVICE_SN}:device:child02    ${DEVICE_SN}:device:child02    thin-edge.io-child
+    Check Child Device
+    ...    ${prefix}child0
+    ...    ${DEVICE_SN}:device:child02
+    ...    ${DEVICE_SN}:device:child02
+    ...    thin-edge.io-child
     Check Child Device    ${prefix}child00    ${prefix}child000    ${prefix}child000    thin-edge.io-child
     Check Child Device    ${prefix}child000    ${prefix}child0000    ${prefix}child0000    thin-edge.io-child
     Check Child Device    ${prefix}child0000    ${prefix}child00000    ${prefix}child00000    thin-edge.io-child
 
-    ${xids}=    Create List    ${prefix}child0    ${prefix}child00    ${prefix}child01    ${DEVICE_SN}:device:child02    ${prefix}child000    ${prefix}child0000    ${prefix}child00000
+    ${xids}=    Create List
+    ...    ${prefix}child0
+    ...    ${prefix}child00
+    ...    ${prefix}child01
+    ...    ${DEVICE_SN}:device:child02
+    ...    ${prefix}child000
+    ...    ${prefix}child0000
+    ...    ${prefix}child00000
     FOR    ${xid}    IN    @{xids}
         Cumulocity.Set Device    ${xid}
         Device Should Have Measurements    type=environment    minimum=1    maximum=1
@@ -201,8 +314,10 @@ Entities persisted and restored
 
     # without @id
     Execute Command    tedge mqtt pub --retain 'te/school/shop/plc1/' '{"@type":"child-device"}'
-    Execute Command    tedge mqtt pub --retain 'te/school/shop/plc1/sensor1' '{"@type":"child-device","@parent":"school/shop/plc1/"}'
-    Execute Command    tedge mqtt pub --retain 'te/school/shop/plc1/metrics' '{"@type":"service","@parent":"school/shop/plc1/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/school/shop/plc1/sensor1' '{"@type":"child-device","@parent":"school/shop/plc1/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/school/shop/plc1/metrics' '{"@type":"service","@parent":"school/shop/plc1/"}'
 
     External Identity Should Exist    ${DEVICE_SN}:school:shop:plc1
     External Identity Should Exist    ${DEVICE_SN}:school:shop:plc1:sensor1
@@ -211,11 +326,16 @@ Entities persisted and restored
     # with @id
     Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc1/' '{"@type":"child-device","@id":"${prefix}plc1"}'
     Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc2/' '{"@type":"child-device","@id":"${prefix}plc2"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc1/sensor1' '{"@type":"child-device","@id":"${prefix}plc1-sensor1","@parent":"factory/shop/plc1/"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc1/sensor2' '{"@type":"child-device","@id":"${prefix}plc1-sensor2","@parent":"factory/shop/plc1/"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc2/sensor1' '{"@type":"child-device","@id":"${prefix}plc2-sensor1","@parent":"factory/shop/plc2/"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc1/metrics' '{"@type":"service","@id":"${prefix}plc1-metrics","@parent":"factory/shop/plc1/"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc2/metrics' '{"@type":"service","@id":"${prefix}plc2-metrics","@parent":"factory/shop/plc2/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory/shop/plc1/sensor1' '{"@type":"child-device","@id":"${prefix}plc1-sensor1","@parent":"factory/shop/plc1/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory/shop/plc1/sensor2' '{"@type":"child-device","@id":"${prefix}plc1-sensor2","@parent":"factory/shop/plc1/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory/shop/plc2/sensor1' '{"@type":"child-device","@id":"${prefix}plc2-sensor1","@parent":"factory/shop/plc2/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory/shop/plc1/metrics' '{"@type":"service","@id":"${prefix}plc1-metrics","@parent":"factory/shop/plc1/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory/shop/plc2/metrics' '{"@type":"service","@id":"${prefix}plc2-metrics","@parent":"factory/shop/plc2/"}'
 
     External Identity Should Exist    ${prefix}plc1
     External Identity Should Exist    ${prefix}plc2
@@ -238,14 +358,54 @@ Entities persisted and restored
         Should Be Equal    ${last_modified_time}    ${original_last_modified_time}
 
         # Assert that the restored entities are not converted again
-        Should Have MQTT Messages    c8y/s/us    message_contains=101    date_from=${timestamp}    minimum=0    maximum=0
-        Should Have MQTT Messages    c8y/s/us/${DEVICE_SN}:school:shop:plc1    message_contains=101    date_from=${timestamp}    minimum=0    maximum=0
-        Should Have MQTT Messages    c8y/s/us/${DEVICE_SN}:school:shop:plc1:sensor1    message_contains=102    date_from=${timestamp}    minimum=0    maximum=0
-        Should Have MQTT Messages    c8y/s/us/${DEVICE_SN}:school:shop:plc1:metrics    message_contains=102    date_from=${timestamp}    minimum=0    maximum=0
-        Should Have MQTT Messages    c8y/s/us/${prefix}plc1    message_contains=101    date_from=${timestamp}    minimum=0    maximum=0
-        Should Have MQTT Messages    c8y/s/us/${prefix}plc2    message_contains=101    date_from=${timestamp}    minimum=0    maximum=0
-        Should Have MQTT Messages    c8y/s/us/${prefix}plc1    message_contains=102    date_from=${timestamp}    minimum=0    maximum=0
-        Should Have MQTT Messages    c8y/s/us/${prefix}plc2    message_contains=102    date_from=${timestamp}    minimum=0    maximum=0
+        Should Have MQTT Messages
+        ...    c8y/s/us
+        ...    message_contains=101
+        ...    date_from=${timestamp}
+        ...    minimum=0
+        ...    maximum=0
+        Should Have MQTT Messages
+        ...    c8y/s/us/${DEVICE_SN}:school:shop:plc1
+        ...    message_contains=101
+        ...    date_from=${timestamp}
+        ...    minimum=0
+        ...    maximum=0
+        Should Have MQTT Messages
+        ...    c8y/s/us/${DEVICE_SN}:school:shop:plc1:sensor1
+        ...    message_contains=102
+        ...    date_from=${timestamp}
+        ...    minimum=0
+        ...    maximum=0
+        Should Have MQTT Messages
+        ...    c8y/s/us/${DEVICE_SN}:school:shop:plc1:metrics
+        ...    message_contains=102
+        ...    date_from=${timestamp}
+        ...    minimum=0
+        ...    maximum=0
+        Should Have MQTT Messages
+        ...    c8y/s/us/${prefix}plc1
+        ...    message_contains=101
+        ...    date_from=${timestamp}
+        ...    minimum=0
+        ...    maximum=0
+        Should Have MQTT Messages
+        ...    c8y/s/us/${prefix}plc2
+        ...    message_contains=101
+        ...    date_from=${timestamp}
+        ...    minimum=0
+        ...    maximum=0
+        Should Have MQTT Messages
+        ...    c8y/s/us/${prefix}plc1
+        ...    message_contains=102
+        ...    date_from=${timestamp}
+        ...    minimum=0
+        ...    maximum=0
+        Should Have MQTT Messages
+        ...    c8y/s/us/${prefix}plc2
+        ...    message_contains=102
+        ...    date_from=${timestamp}
+        ...    minimum=0
+        ...    maximum=0
     END
 
 Entities send to cloud on restart
@@ -253,11 +413,16 @@ Entities send to cloud on restart
 
     Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc1/' '{"@type":"child-device","@id":"${prefix}plc1"}'
     Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc2/' '{"@type":"child-device","@id":"${prefix}plc2"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc1/sensor1' '{"@type":"child-device","@id":"${prefix}plc1-sensor1","@parent":"factory/shop/plc1/"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc1/sensor2' '{"@type":"child-device","@id":"${prefix}plc1-sensor2","@parent":"factory/shop/plc1/"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc2/sensor1' '{"@type":"child-device","@id":"${prefix}plc2-sensor1","@parent":"factory/shop/plc2/"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc1/metrics' '{"@type":"service","@id":"${prefix}plc1-metrics","@parent":"factory/shop/plc1/"}'
-    Execute Command    tedge mqtt pub --retain 'te/factory/shop/plc2/metrics' '{"@type":"service","@id":"${prefix}plc2-metrics","@parent":"factory/shop/plc2/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory/shop/plc1/sensor1' '{"@type":"child-device","@id":"${prefix}plc1-sensor1","@parent":"factory/shop/plc1/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory/shop/plc1/sensor2' '{"@type":"child-device","@id":"${prefix}plc1-sensor2","@parent":"factory/shop/plc1/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory/shop/plc2/sensor1' '{"@type":"child-device","@id":"${prefix}plc2-sensor1","@parent":"factory/shop/plc2/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory/shop/plc1/metrics' '{"@type":"service","@id":"${prefix}plc1-metrics","@parent":"factory/shop/plc1/"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/factory/shop/plc2/metrics' '{"@type":"service","@id":"${prefix}plc2-metrics","@parent":"factory/shop/plc2/"}'
 
     External Identity Should Exist    ${prefix}plc1
     External Identity Should Exist    ${prefix}plc2
@@ -267,36 +432,76 @@ Entities send to cloud on restart
     External Identity Should Exist    ${prefix}plc1-metrics
     External Identity Should Exist    ${prefix}plc2-metrics
 
-    Sleep    1s    reason=Provide sufficient gap after the last published messages so that the timestamp in the next step is higher than when the first messages published
+    Sleep
+    ...    1s
+    ...    reason=Provide sufficient gap after the last published messages so that the timestamp in the next step is higher than when the first messages published
 
     ${timestamp}=    Get Unix Timestamp
     Restart Service    tedge-mapper-c8y
     Service Health Status Should Be Up    tedge-mapper-c8y
-        
+
     # Assert that entities are sent to cloud again
-    Should Have MQTT Messages    c8y/s/us    message_contains=101,${prefix}plc1    date_from=${timestamp}    minimum=1    maximum=1
-    Should Have MQTT Messages    c8y/s/us    message_contains=101,${prefix}plc2    date_from=${timestamp}    minimum=1    maximum=1
-    Should Have MQTT Messages    c8y/s/us/${prefix}plc1    message_contains=101,${prefix}plc1-sensor1    date_from=${timestamp}    minimum=1    maximum=1
-    Should Have MQTT Messages    c8y/s/us/${prefix}plc1    message_contains=101,${prefix}plc1-sensor2    date_from=${timestamp}    minimum=1    maximum=1
-    Should Have MQTT Messages    c8y/s/us/${prefix}plc2    message_contains=101,${prefix}plc2-sensor1    date_from=${timestamp}    minimum=1    maximum=1
-    Should Have MQTT Messages    c8y/s/us/${prefix}plc1    message_contains=102,${prefix}plc1-metrics    date_from=${timestamp}    minimum=1    maximum=1
-    Should Have MQTT Messages    c8y/s/us/${prefix}plc2    message_contains=102,${prefix}plc2-metrics    date_from=${timestamp}    minimum=1    maximum=1
+    Should Have MQTT Messages
+    ...    c8y/s/us
+    ...    message_contains=101,${prefix}plc1
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
+    Should Have MQTT Messages
+    ...    c8y/s/us
+    ...    message_contains=101,${prefix}plc2
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
+    Should Have MQTT Messages
+    ...    c8y/s/us/${prefix}plc1
+    ...    message_contains=101,${prefix}plc1-sensor1
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
+    Should Have MQTT Messages
+    ...    c8y/s/us/${prefix}plc1
+    ...    message_contains=101,${prefix}plc1-sensor2
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
+    Should Have MQTT Messages
+    ...    c8y/s/us/${prefix}plc2
+    ...    message_contains=101,${prefix}plc2-sensor1
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
+    Should Have MQTT Messages
+    ...    c8y/s/us/${prefix}plc1
+    ...    message_contains=102,${prefix}plc1-metrics
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
+    Should Have MQTT Messages
+    ...    c8y/s/us/${prefix}plc2
+    ...    message_contains=102,${prefix}plc2-metrics
+    ...    date_from=${timestamp}
+    ...    minimum=1
+    ...    maximum=1
+
 
 *** Keywords ***
-
 Should Have Retained Message Count
-    [Arguments]    ${topic}    ${exp_count}  
-    ${output}=    Execute Command    mosquitto_sub --retained-only -W 3 -t "${topic}" -v    exp_exit_code=27    return_stdout=True  
-    Length Should Be    ${output.splitlines()}    ${exp_count}  
+    [Arguments]    ${topic}    ${exp_count}
+    ${output}=    Execute Command
+    ...    mosquitto_sub --retained-only -W 3 -t "${topic}" -v
+    ...    exp_exit_code=27
+    ...    return_stdout=True
+    Length Should Be    ${output.splitlines()}    ${exp_count}
 
 Check Child Device
     [Arguments]    ${parent_sn}    ${child_sn}    ${child_name}    ${child_type}
-    ${child_mo}=    Device Should Exist        ${child_sn}
+    ${child_mo}=    Device Should Exist    ${child_sn}
 
     ${child_mo}=    Cumulocity.Device Should Have Fragment Values    name\=${child_name}
     Should Be Equal    ${child_mo["owner"]}    device_${DEVICE_SN}
-    Should Be Equal    ${child_mo["name"]}     ${child_name}
-    Should Be Equal    ${child_mo["type"]}     ${child_type}
+    Should Be Equal    ${child_mo["name"]}    ${child_name}
+    Should Be Equal    ${child_mo["type"]}    ${child_type}
 
     # Check child device relationship
     Cumulocity.Device Should Exist    ${parent_sn}
@@ -309,8 +514,8 @@ Check Service
     Should Have Services    name=${service_name}    service_type=${service_type}    status=${service_status}
 
 Custom Setup
-    ${DEVICE_SN}=                    Setup
-    Set Test Variable               $DEVICE_SN
+    ${DEVICE_SN}=    Setup
+    Set Test Variable    $DEVICE_SN
 
     ${CHILD_SN}=    Get Random Name
     Set Test Variable    $CHILD_SN

--- a/tests/RobotFramework/tests/cumulocity/registration/registration_lifecycle.robot
+++ b/tests/RobotFramework/tests/cumulocity/registration/registration_lifecycle.robot
@@ -11,7 +11,7 @@ Test Tags           theme:c8y    theme:registration    theme:deregistration
 
 *** Test Cases ***
 Main device registration
-    ${mo}=    Device Should Exist    ${DEVICE_SN}
+    Device Should Exist    ${DEVICE_SN}
     ${mo}=    Cumulocity.Device Should Have Fragment Values    name\=${DEVICE_SN}
     Should Be Equal    ${mo["owner"]}    device_${DEVICE_SN}
     Should Be Equal    ${mo["name"]}    ${DEVICE_SN}
@@ -20,7 +20,7 @@ Child device registration
     Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_SN}"}'
 
     # Check registration
-    ${child_mo}=    Device Should Exist    ${CHILD_SN}
+    Device Should Exist    ${CHILD_SN}
     ${child_mo}=    Cumulocity.Device Should Have Fragment Values    name\=${CHILD_SN}
     Should Be Equal    ${child_mo["owner"]}    device_${DEVICE_SN}    # The parent is the owner of the child
     Should Be Equal    ${child_mo["name"]}    ${CHILD_SN}
@@ -496,7 +496,7 @@ Should Have Retained Message Count
 
 Check Child Device
     [Arguments]    ${parent_sn}    ${child_sn}    ${child_name}    ${child_type}
-    ${child_mo}=    Device Should Exist    ${child_sn}
+    Device Should Exist    ${child_sn}
 
     ${child_mo}=    Cumulocity.Device Should Have Fragment Values    name\=${child_name}
     Should Be Equal    ${child_mo["owner"]}    device_${DEVICE_SN}

--- a/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
+++ b/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
@@ -1,20 +1,24 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:troubleshooting    theme:plugins
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:troubleshooting    theme:plugins
+
 
 *** Test Cases ***
-
 Install/uninstall c8y-remote-access-plugin
     Device Should Have Installed Software    c8y-remote-access-plugin
     File Should Exist    /etc/tedge/operations/c8y/c8y_RemoteAccessConnect
 
     # Check that a command is used instead of an explicit path #3111
-    ${executable}=    Execute Command    cmd=grep "^command" /etc/tedge/operations/c8y/c8y_RemoteAccessConnect | cut -d= -f2-    strip=${True}    timeout=5
+    ${executable}=    Execute Command
+    ...    cmd=grep "^command" /etc/tedge/operations/c8y/c8y_RemoteAccessConnect | cut -d= -f2-
+    ...    strip=${True}
+    ...    timeout=5
     Should Match Regexp    ${executable}    pattern=^"c8y-remote-access-plugin\\b
 
     Execute Command    dpkg -r c8y-remote-access-plugin
@@ -23,7 +27,11 @@ Install/uninstall c8y-remote-access-plugin
 Execute ssh command using PASSTHROUGH
     ${KEY_FILE}=    Configure SSH
     Add Remote Access Passthrough Configuration
-    ${stdout}=    Execute Remote Access Command    command=tedge --version    exp_exit_code=0    user=root    key_file=${KEY_FILE}
+    ${stdout}=    Execute Remote Access Command
+    ...    command=tedge --version
+    ...    exp_exit_code=0
+    ...    user=root
+    ...    key_file=${KEY_FILE}
     Should Match Regexp    ${stdout}    tedge .+
 
 Remote access session is independent from mapper (when using socket activation)
@@ -31,7 +39,11 @@ Remote access session is independent from mapper (when using socket activation)
     Add Remote Access Passthrough Configuration
 
     # Restart mapper via tedge reconnect
-    ${stdout}=    Execute Remote Access Command    command=tedge reconnect c8y    exp_exit_code=0    user=root    key_file=${KEY_FILE}
+    ${stdout}=    Execute Remote Access Command
+    ...    command=tedge reconnect c8y
+    ...    exp_exit_code=0
+    ...    user=root
+    ...    key_file=${KEY_FILE}
     Should Contain    ${stdout}    tedge-agent service successfully started and enabled
     Cumulocity.Should Only Have Completed Operations
 
@@ -39,7 +51,11 @@ Remote access session is independent from mapper (when using socket activation)
     Transfer To Device    ${CURDIR}/restart-service.sh    /usr/local/share/tests/
 
     # Restart agent
-    ${stdout}=    Execute Remote Access Command    command=/usr/local/share/tests/restart-service.sh "tedge-agent" "restarted-tedge-agent"     exp_exit_code=0    user=root    key_file=${KEY_FILE}
+    ${stdout}=    Execute Remote Access Command
+    ...    command=/usr/local/share/tests/restart-service.sh "tedge-agent" "restarted-tedge-agent"
+    ...    exp_exit_code=0
+    ...    user=root
+    ...    key_file=${KEY_FILE}
     Should Contain    ${stdout}    restarted-tedge-agent
     Cumulocity.Should Only Have Completed Operations
 
@@ -51,16 +67,26 @@ Remote access session is not independent from mapper (when socket activation is 
     Execute Command    systemctl stop c8y-remote-access-plugin.socket
 
     # Check a command which won't stop the connection first
-    ${stdout}=    Execute Remote Access Command    command=tedge config get device.id    exp_exit_code=0    user=root    key_file=${KEY_FILE}
+    ${stdout}=    Execute Remote Access Command
+    ...    command=tedge config get device.id
+    ...    exp_exit_code=0
+    ...    user=root
+    ...    key_file=${KEY_FILE}
     Should Be Equal    ${stdout}    ${DEVICE_SN}    strip_spaces=${True}
 
-    ${stdout}=    Execute Remote Access Command    command=tedge reconnect c8y    exp_exit_code=255    user=root    key_file=${KEY_FILE}
-    Should Not Contain    ${stdout}    tedge-agent service successfully started and enabled
+    ${stdout}=    Execute Remote Access Command
+    ...    command=tedge reconnect c8y
+    ...    exp_exit_code=255
+    ...    user=root
+    ...    key_file=${KEY_FILE}
+    Should Not Contain
+    ...    ${stdout}
+    ...    tedge-agent service successfully started and enabled
     ...    msg=This message should not be present as the connection will be severed due to being a child process of the tedge-mapper-c8y
     Cumulocity.Should Only Have Completed Operations
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN

--- a/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access_custom_root_cert_path.robot
+++ b/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access_custom_root_cert_path.robot
@@ -1,22 +1,27 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:troubleshooting    theme:plugins    adapter:docker
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:troubleshooting    theme:plugins    adapter:docker
+
 
 *** Test Cases ***
-
 Execute ssh command with a custom root certificate path
     ${KEY_FILE}=    Configure SSH
     Add Remote Access Passthrough Configuration
-    ${stdout}=    Execute Remote Access Command    command=echo foobar    exp_exit_code=0    user=root    key_file=${KEY_FILE}
+    ${stdout}=    Execute Remote Access Command
+    ...    command=echo foobar
+    ...    exp_exit_code=0
+    ...    user=root
+    ...    key_file=${KEY_FILE}
     Should Contain    ${stdout}    foobar
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN

--- a/tests/RobotFramework/tests/cumulocity/restart/restart_device.robot
+++ b/tests/RobotFramework/tests/cumulocity/restart/restart_device.robot
@@ -1,14 +1,15 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:troubleshooting
-Test Setup    Custom Setup
-Test Teardown    Custom Teardown
+Test Setup          Custom Setup
+Test Teardown       Custom Teardown
+
+Test Tags           theme:c8y    theme:troubleshooting
+
 
 *** Test Cases ***
-
 Supports restarting the device
     [Documentation]    Use a longer timeout period to allow the device time to restart and allow the initial token fetching process to fail at least one (due to the 60 seconds retry window)
     Cumulocity.Should Contain Supported Operations    c8y_Restart
@@ -24,19 +25,20 @@ Supports restarting the device without sudo and running as root
 # Note: Sending an actual local restart operation to trigger a restart (e.g. status=init) is not feasible
 # as the assertion would fail due to the device/container being unresponsive during the actual restart.
 # Just checking that the messages do not trigger any c8y messages and does not clear the retained message
+
 tedge-mapper-c8y does not react to local restart operations transitions
     [Template]    Publish and Verify Local Command
-    topic=te/device/main///cmd/restart/local-1111    payload={"status":"executing"}     expected_status=executing     c8y_fragment=c8y_Restart
-    topic=te/device/main///cmd/restart/local-2222    payload={"status":"failed"}        expected_status=failed        c8y_fragment=c8y_Restart
+    topic=te/device/main///cmd/restart/local-1111    payload={"status":"executing"}    expected_status=executing    c8y_fragment=c8y_Restart
+    topic=te/device/main///cmd/restart/local-2222    payload={"status":"failed"}    expected_status=failed    c8y_fragment=c8y_Restart
     topic=te/device/main///cmd/restart/local-3333    payload={"status":"successful"}    expected_status=successful    c8y_fragment=c8y_Restart
 
 
 *** Keywords ***
-
 Set Service User
     [Arguments]    ${SERVICE_NAME}    ${SERVICE_USER}
     Execute Command    mkdir -p /etc/systemd/system/${SERVICE_NAME}.service.d/
-    Execute Command    cmd=printf "[Service]\nUser = ${SERVICE_USER}" | sudo tee /etc/systemd/system/${SERVICE_NAME}.service.d/10-user.conf
+    Execute Command
+    ...    cmd=printf "[Service]\nUser = ${SERVICE_USER}" | sudo tee /etc/systemd/system/${SERVICE_NAME}.service.d/10-user.conf
     Execute Command    systemctl daemon-reload
     Restart Service    ${SERVICE_NAME}
 
@@ -46,8 +48,10 @@ Custom Setup
     Device Should Exist    ${DEVICE_SN}
     Transfer To Device    ${CURDIR}/*.sh    /usr/bin/
     Transfer To Device    ${CURDIR}/*.service    /etc/systemd/system/
-    Execute Command    chmod a+x /usr/bin/*.sh && chmod 644 /etc/systemd/system/*.service && systemctl enable on_startup.service
-    Execute Command    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /usr/bin/on_shutdown.sh' > /etc/sudoers.d/tedge
+    Execute Command
+    ...    chmod a+x /usr/bin/*.sh && chmod 644 /etc/systemd/system/*.service && systemctl enable on_startup.service
+    Execute Command
+    ...    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /usr/bin/on_shutdown.sh' > /etc/sudoers.d/tedge
     Set Restart Command    ["/usr/bin/on_shutdown.sh"]
 
 Custom Teardown
@@ -57,15 +61,26 @@ Custom Teardown
 
 Publish and Verify Local Command
     [Arguments]    ${topic}    ${payload}    ${expected_status}=successful    ${c8y_fragment}=
-    [Teardown]    Execute Command    tedge mqtt pub --retain '${topic}' ''
     Execute Command    tedge mqtt pub --retain '${topic}' '${payload}'
-    ${messages}=    Should Have MQTT Messages    ${topic}    minimum=1    maximum=1    message_contains="status":"${expected_status}"
+    ${messages}=    Should Have MQTT Messages
+    ...    ${topic}
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains="status":"${expected_status}"
 
     Sleep    2s    reason=Given mapper a chance to react, if it does not react with 2 seconds it never will
-    ${retained_message}    Execute Command    timeout 1 tedge mqtt sub --no-topic '${topic}'    ignore_exit_code=${True}    strip=${True}
+    ${retained_message}=    Execute Command
+    ...    timeout 1 tedge mqtt sub --no-topic '${topic}'
+    ...    ignore_exit_code=${True}
+    ...    strip=${True}
     Should Be Equal    ${messages[0]}    ${retained_message}    msg=MQTT message should be unchanged
 
     IF    "${c8y_fragment}"
         # There should not be any c8y related operation transition messages sent: https://cumulocity.com/guides/reference/smartrest-two/#updating-operations
-        Should Have MQTT Messages    c8y/s/us    message_pattern=^(501|502|503|504|505|506),${c8y_fragment}.*    minimum=0    maximum=0
+        Should Have MQTT Messages
+        ...    c8y/s/us
+        ...    message_pattern=^(501|502|503|504|505|506),${c8y_fragment}.*
+        ...    minimum=0
+        ...    maximum=0
     END
+    [Teardown]    Execute Command    tedge mqtt pub --retain '${topic}' ''

--- a/tests/RobotFramework/tests/cumulocity/restart/restart_device_child.robot
+++ b/tests/RobotFramework/tests/cumulocity/restart/restart_device_child.robot
@@ -21,43 +21,59 @@ Restart operation should be set to failed when an non-existent command is config
     Set Restart Command    ["/usr/bin/on_shutdown_does_not_exist.sh"]
     Set Restart Timeout    60
     ${operation}=    Cumulocity.Restart Device
-    Operation Should Be FAILED    ${operation}    failure_reason=Restart Failed: Fail to trigger a restart.*    timeout=30
+    Operation Should Be FAILED
+    ...    ${operation}
+    ...    failure_reason=Restart Failed: Fail to trigger a restart.*
+    ...    timeout=30
 
 Restart operation should be set to failed when command is not allowed by sudo
     Set Restart Command    ["/sbin/reboot"]
     Set Restart Timeout    60
     ${operation}=    Cumulocity.Restart Device
-    Operation Should Be FAILED    ${operation}    failure_reason=Restart Failed: Fail to trigger a restart.*    timeout=30
+    Operation Should Be FAILED
+    ...    ${operation}
+    ...    failure_reason=Restart Failed: Fail to trigger a restart.*
+    ...    timeout=30
 
 Restart operation should be set to failed when the command does not restart the device
     Set Restart Command    ["/usr/bin/on_shutdown_no_reboot.sh"]
     Set Restart Timeout    30
     ${operation}=    Cumulocity.Restart Device
-    Operation Should Be FAILED    ${operation}    failure_reason=Restart Failed: No shutdown has been triggered.*    timeout=60
+    Operation Should Be FAILED
+    ...    ${operation}
+    ...    failure_reason=Restart Failed: No shutdown has been triggered.*
+    ...    timeout=60
 
 Restart operation should be set to failed if the restart command times out
     [Documentation]    tedge should protect against commands which don't finish within a given time period (protect against hanging scripts)
     Set Restart Command    ["/usr/bin/on_shutdown.sh", "300"]
     Set Restart Timeout    5
     ${operation}=    Cumulocity.Restart Device
-    Operation Should Be FAILED    ${operation}    failure_reason=Restart Failed: Restart command still running after 5 seconds    timeout=30
+    Operation Should Be FAILED
+    ...    ${operation}
+    ...    failure_reason=Restart Failed: Restart command still running after 5 seconds
+    ...    timeout=30
 
 Restart operation should be set to failed when the command has been killed by a signal
     [Documentation]    If the restart command is killed, assume it did trigger a restart, and wait for the restart. Only fail the
-        ...            the operation if the "wait for restart" logic does not detect a restart. This is because sometimes a shutdown
-        ...            can trigger the script to be killed before it has a chance to exit successfully.
+    ...    the operation if the "wait for restart" logic does not detect a restart. This is because sometimes a shutdown
+    ...    can trigger the script to be killed before it has a chance to exit successfully.
     Set Restart Command    ["/usr/bin/on_shutdown_signal_interrupt.sh"]
     Set Restart Timeout    30
     ${operation}=    Cumulocity.Restart Device
-    Operation Should Be FAILED    ${operation}    failure_reason=Restart Failed: No shutdown has been triggered    timeout=60
+    Operation Should Be FAILED
+    ...    ${operation}
+    ...    failure_reason=Restart Failed: No shutdown has been triggered
+    ...    timeout=60
 
 Default restart timeout supports the default 60 second delay of the linux shutdown command
     [Documentation]    The shutdown -r command performs a device restart 60 seconds after being called. thin-edge.io should
-        ...            support this setting out of the box
+    ...    support this setting out of the box
     Set Restart Command    ["shutdown", "-r"]
     Set Restart Timeout    default
     ${operation}=    Cumulocity.Restart Device
     Operation Should Be SUCCESSFUL    ${operation}    timeout=180
+
 
 *** Keywords ***
 Setup Child Device
@@ -76,8 +92,10 @@ Setup Child Device
 
     Transfer To Device    ${CURDIR}/*.sh    /usr/bin/
     Transfer To Device    ${CURDIR}/*.service    /etc/systemd/system/
-    Execute Command    cmd=chmod a+x /usr/bin/*.sh && chmod 644 /etc/systemd/system/*.service && systemctl enable on_startup.service
-    Execute Command    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /usr/bin/on_shutdown.sh, /usr/bin/on_shutdown_no_reboot.sh, /usr/bin/on_shutdown_does_not_exist.sh, /usr/bin/on_shutdown_does_not_exist.sh, /usr/bin/on_shutdown_signal_interrupt.sh, !/sbin/reboot' > /etc/sudoers.d/tedge
+    Execute Command
+    ...    cmd=chmod a+x /usr/bin/*.sh && chmod 644 /etc/systemd/system/*.service && systemctl enable on_startup.service
+    Execute Command
+    ...    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /usr/bin/on_shutdown.sh, /usr/bin/on_shutdown_no_reboot.sh, /usr/bin/on_shutdown_does_not_exist.sh, /usr/bin/on_shutdown_does_not_exist.sh, /usr/bin/on_shutdown_signal_interrupt.sh, !/sbin/reboot' > /etc/sudoers.d/tedge
     Set Restart Command    ["/usr/bin/on_shutdown.sh"]
     Set Restart Timeout    default
 
@@ -88,7 +106,7 @@ Custom Setup
     # Parent
     ${parent_sn}=    Setup    skip_bootstrap=${True}
     Set Suite Variable    $PARENT_SN    ${parent_sn}
-    Execute Command           test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
 
     ${parent_ip}=    Get IP Address
     Set Suite Variable    $PARENT_IP    ${parent_ip}

--- a/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
+++ b/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
@@ -43,13 +43,13 @@ Update tedge version from previous using Cumulocity
 
     # Install desired version
     Create Local Repository
-    ${OPERATION}=    Install Software
+    ${operation}=    Install Software
     ...    tedge,${NEW_VERSION}
     ...    tedge-mapper,${NEW_VERSION}
     ...    tedge-agent,${NEW_VERSION}
     ...    tedge-watchdog,${NEW_VERSION}
     ...    tedge-apt-plugin,${NEW_VERSION}
-    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=180
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=180
 
     # Software list reported by the former agent, which is still running
     # but formatted with by the c8y-mapper, which has just been installed

--- a/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
+++ b/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
@@ -1,37 +1,54 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
-Library    DateTime
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+Library             DateTime
 
-Test Tags    theme:c8y    theme:installation
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:installation
+
 
 *** Test Cases ***
-
 Update tedge version from previous using Cumulocity
     [Tags]    test:retry(1)    workaround
 
     ${PREV_VERSION}=    Set Variable    0.8.1
     # Install base version
-    Execute Command    curl -fsSL https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/get-thin-edge_io.sh | sudo sh -s ${PREV_VERSION}
+    Execute Command
+    ...    curl -fsSL https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/get-thin-edge_io.sh | sudo sh -s ${PREV_VERSION}
 
     # Disable service (as it was enabled by default in 0.8.1)
     Execute Command    systemctl stop tedge-mapper-az && systemctl disable tedge-mapper-az
 
     # Register device (using already installed version)
-    Execute Command    cmd=test -f ./bootstrap.sh && env DEVICE_ID=${DEVICE_SN} ./bootstrap.sh --no-install --no-secure || true
-    Device Should Exist                      ${DEVICE_SN}
+    Execute Command
+    ...    cmd=test -f ./bootstrap.sh && env DEVICE_ID=${DEVICE_SN} ./bootstrap.sh --no-install --no-secure || true
+    Device Should Exist    ${DEVICE_SN}
 
-    Restart Service    tedge-mapper-c8y    # WORKAROUND: #1731 Restart service to avoid suspected race condition causing software list message to be lost
+    # WORKAROUND: #1731 Restart service to avoid suspected race condition causing software list message to be lost
+    Restart Service
+    ...    tedge-mapper-c8y
 
     # Note: Software type is reported as a part of version in thin-edge 0.8.1
-    Device Should Have Installed Software    tedge,${PREV_VERSION}::apt    tedge_mapper,${PREV_VERSION}::apt    tedge_agent,${PREV_VERSION}::apt    tedge_watchdog,${PREV_VERSION}::apt    c8y_configuration_plugin,${PREV_VERSION}::apt    c8y_log_plugin,${PREV_VERSION}::apt    tedge_apt_plugin,${PREV_VERSION}::apt
+    Device Should Have Installed Software
+    ...    tedge,${PREV_VERSION}::apt
+    ...    tedge_mapper,${PREV_VERSION}::apt
+    ...    tedge_agent,${PREV_VERSION}::apt
+    ...    tedge_watchdog,${PREV_VERSION}::apt
+    ...    c8y_configuration_plugin,${PREV_VERSION}::apt
+    ...    c8y_log_plugin,${PREV_VERSION}::apt
+    ...    tedge_apt_plugin,${PREV_VERSION}::apt
 
     # Install desired version
     Create Local Repository
-    ${OPERATION}=    Install Software    tedge,${NEW_VERSION}    tedge-mapper,${NEW_VERSION}    tedge-agent,${NEW_VERSION}    tedge-watchdog,${NEW_VERSION}    tedge-apt-plugin,${NEW_VERSION}
+    ${OPERATION}=    Install Software
+    ...    tedge,${NEW_VERSION}
+    ...    tedge-mapper,${NEW_VERSION}
+    ...    tedge-agent,${NEW_VERSION}
+    ...    tedge-watchdog,${NEW_VERSION}
+    ...    tedge-apt-plugin,${NEW_VERSION}
     Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=180
 
     # Software list reported by the former agent, which is still running
@@ -56,9 +73,9 @@ Update tedge version from previous using Cumulocity
     ...    {"name": "tedge-apt-plugin", "softwareType": "apt", "version": "${NEW_VERSION_ESCAPED}"}
 
     # Check if services are still stopped and disabled
-    ${OUTPUT}    Execute Command    systemctl is-active tedge-mapper-az || exit 1    exp_exit_code=1    strip=True
+    ${OUTPUT}=    Execute Command    systemctl is-active tedge-mapper-az || exit 1    exp_exit_code=1    strip=True
     Should Be Equal    ${OUTPUT}    inactive    msg=Service should still be stopped
-    ${OUTPUT}    Execute Command    systemctl is-enabled tedge-mapper-az || exit 1    exp_exit_code=1    strip=True
+    ${OUTPUT}=    Execute Command    systemctl is-enabled tedge-mapper-az || exit 1    exp_exit_code=1    strip=True
     Should Be Equal    ${OUTPUT}    disabled    msg=Service should still be disabled
 
     # Check that the mapper is reacting to operations after the upgrade
@@ -71,37 +88,50 @@ Update tedge version from previous using Cumulocity
 Refreshes mosquitto bridge configuration
     ${PREV_VERSION}=    Set Variable    0.10.0
     # Install base version
-    Execute Command    curl -fsSL https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/get-thin-edge_io.sh | sudo sh -s ${PREV_VERSION}
+    Execute Command
+    ...    curl -fsSL https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/get-thin-edge_io.sh | sudo sh -s ${PREV_VERSION}
 
     # Register device (using already installed version)
-    Execute Command    cmd=test -f ./bootstrap.sh && env DEVICE_ID=${DEVICE_SN} ./bootstrap.sh --no-install --no-secure || true
-    Device Should Exist                      ${DEVICE_SN}
+    Execute Command
+    ...    cmd=test -f ./bootstrap.sh && env DEVICE_ID=${DEVICE_SN} ./bootstrap.sh --no-install --no-secure || true
+    Device Should Exist    ${DEVICE_SN}
 
     # get bridge modification time
-    ${before_upgrade_time}=    Execute Command      stat /etc/tedge/mosquitto-conf/c8y-bridge.conf -c %Y    strip=True
+    ${before_upgrade_time}=    Execute Command    stat /etc/tedge/mosquitto-conf/c8y-bridge.conf -c %Y    strip=True
 
     # Install newer version
     Create Local Repository
-    ${OPERATION}=    Install Software    tedge,${NEW_VERSION}    tedge-mapper,${NEW_VERSION}    tedge-agent,${NEW_VERSION}    tedge-watchdog,${NEW_VERSION}    tedge-apt-plugin,${NEW_VERSION}
+    ${OPERATION}=    Install Software
+    ...    tedge,${NEW_VERSION}
+    ...    tedge-mapper,${NEW_VERSION}
+    ...    tedge-agent,${NEW_VERSION}
+    ...    tedge-watchdog,${NEW_VERSION}
+    ...    tedge-apt-plugin,${NEW_VERSION}
     Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=180
 
     # TODO: check that this new configuration is actually used by mosquitto
-    ${c8y_bridge_mod_time}=    Execute Command      stat /etc/tedge/mosquitto-conf/c8y-bridge.conf -c %Y    strip=True
+    ${c8y_bridge_mod_time}=    Execute Command    stat /etc/tedge/mosquitto-conf/c8y-bridge.conf -c %Y    strip=True
     Should Not Be Equal    ${c8y_bridge_mod_time}    ${before_upgrade_time}
 
     # Mosquitto should be restarted with new bridge
-    Execute Command    cmd=sh -c '[ $(journalctl -u mosquitto | grep -c "Loading config file /etc/tedge/mosquitto-conf/c8y-bridge.conf") = 2 ]'
+    Execute Command
+    ...    cmd=sh -c '[ $(journalctl -u mosquitto | grep -c "Loading config file /etc/tedge/mosquitto-conf/c8y-bridge.conf") = 2 ]'
 
 Update tedge version from base to current using Cumulocity
     # Install base version (the latest official release) with self-update capability
     Execute Command    wget -O - thin-edge.io/install.sh | sh -s
     Execute Command    cd /setup && test -f ./bootstrap.sh && ./bootstrap.sh --no-install --no-secure
-    Device Should Exist                      ${DEVICE_SN}
+    Device Should Exist    ${DEVICE_SN}
     ${pid_before}=    Service Should Be Running    tedge-agent
 
     # Upgrade to current version
     Create Local Repository
-    ${OPERATION}=    Install Software    tedge,${NEW_VERSION}    tedge-mapper,${NEW_VERSION}    tedge-agent,${NEW_VERSION}    tedge-watchdog,${NEW_VERSION}    tedge-apt-plugin,${NEW_VERSION}
+    ${OPERATION}=    Install Software
+    ...    tedge,${NEW_VERSION}
+    ...    tedge-mapper,${NEW_VERSION}
+    ...    tedge-agent,${NEW_VERSION}
+    ...    tedge-watchdog,${NEW_VERSION}
+    ...    tedge-apt-plugin,${NEW_VERSION}
 
     Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=300
     Device Should Have Installed Software
@@ -114,24 +144,31 @@ Update tedge version from base to current using Cumulocity
     ${pid_after}=    Service Should Be Running    tedge-agent
     Should Not Be Equal    ${pid_before}    ${pid_after}
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup    skip_bootstrap=True
     Set Suite Variable    $DEVICE_SN
 
     # Cleanup
-    Execute Command    rm -f /etc/tedge/tedge.toml /etc/tedge/system.toml && sudo dpkg --configure -a && apt-get purge -y "tedge*" "c8y*"
-    Execute Command    cmd=rm -f /etc/apt/sources.list.d/thinedge*.list /etc/apt/sources.list.d/tedge*.list    # Remove any existing repositories (due to candidate bug in <= 0.8.1)
+    Execute Command
+    ...    rm -f /etc/tedge/tedge.toml /etc/tedge/system.toml && sudo dpkg --configure -a && apt-get purge -y "tedge*" "c8y*"
+    # Remove any existing repositories (due to candidate bug in <= 0.8.1)
+    Execute Command
+    ...    cmd=rm -f /etc/apt/sources.list.d/thinedge*.list /etc/apt/sources.list.d/tedge*.list
 
 Create Local Repository
     [Arguments]    ${packages_dir}=/setup/packages
     # Create local apt repo
     Execute Command    apt-get update && apt-get install -y --no-install-recommends dpkg-dev
-    Execute Command    mkdir -p /opt/repository/local && find ${packages_dir} -type f -name "*.deb" -exec cp {} /opt/repository/local \\;
-    ${NEW_VERSION}=    Execute Command    find ${packages_dir} -type f -name "tedge-mapper_*.deb" | sort -Vr | head -n1 | cut -d'_' -f 2    strip=True
+    Execute Command
+    ...    mkdir -p /opt/repository/local && find ${packages_dir} -type f -name "*.deb" -exec cp {} /opt/repository/local \\;
+    ${NEW_VERSION}=    Execute Command
+    ...    find ${packages_dir} -type f -name "tedge-mapper_*.deb" | sort -Vr | head -n1 | cut -d'_' -f 2
+    ...    strip=True
     Set Suite Variable    $NEW_VERSION
     ${NEW_VERSION_ESCAPED}=    Escape Pattern    ${NEW_VERSION}    is_json=${True}
     Set Suite Variable    $NEW_VERSION_ESCAPED
     Execute Command    cd /opt/repository/local && dpkg-scanpackages -m . > Packages
-    Execute Command    cmd=echo 'deb [trusted=yes] file:/opt/repository/local /' > /etc/apt/sources.list.d/tedge-local.list
+    Execute Command
+    ...    cmd=echo 'deb [trusted=yes] file:/opt/repository/local /' > /etc/apt/sources.list.d/tedge-local.list

--- a/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
+++ b/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource            ../../../resources/common.resource
+Library             DateTime
 Library             Cumulocity
 Library             ThinEdgeIO
-Library             DateTime
 
 Test Setup          Custom Setup
 Test Teardown       Get Logs

--- a/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
+++ b/tests/RobotFramework/tests/cumulocity/service_monitoring/service_monitoring.robot
@@ -1,13 +1,13 @@
 *** Settings ***
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+Library             DebugLibrary
 
-Resource    ../../../resources/common.resource
-Library     Cumulocity
-Library     ThinEdgeIO
-Library     DebugLibrary
+Test Setup          Custom Setup
+Test Teardown       Get Logs
 
-Test Tags    theme:c8y    theme:monitoring    theme:mqtt
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Tags           theme:c8y    theme:monitoring    theme:mqtt
 
 
 *** Variables ***
@@ -17,12 +17,12 @@ Test Teardown    Get Logs
 # seconds and mapper will reinitialize' error on startup, and then waits 60
 # seconds before trying again. The timeout should be larger than this interval
 # to give the service a chance to retry without failing the test
-${TIMEOUT}=    ${90}
+${TIMEOUT}=     ${90}
+
 
 *** Test Cases ***
-
 Test if all c8y services are up
-    [Template]     Check if a service is up
+    [Template]    Check if a service is up
     tedge-mapper-c8y
     tedge-agent
     c8y-firmware-plugin
@@ -30,67 +30,68 @@ Test if all c8y services are up
 Test bridge service status up
     ${SERVICE_NAME}=    Get Bridge Service Name    cloud=c8y
     External Identity Should Exist    ${DEVICE_SN}:device:main:service:${SERVICE_NAME}    show_info=False
-    Cumulocity.Managed Object Should Have Fragment Values    status\=up        timeout=${TIMEOUT}
+    Cumulocity.Managed Object Should Have Fragment Values    status\=up    timeout=${TIMEOUT}
 
 Test mosquitto bridge service status mapping
     Execute Command    tedge mqtt pub --retain te/device/main/service/mosquitto-xyz-bridge/status/health '0'
     External Identity Should Exist    ${DEVICE_SN}:device:main:service:mosquitto-xyz-bridge    show_info=False
-    Cumulocity.Managed Object Should Have Fragment Values    status\=down        timeout=${TIMEOUT}
+    Cumulocity.Managed Object Should Have Fragment Values    status\=down    timeout=${TIMEOUT}
 
     Execute Command    tedge mqtt pub --retain te/device/main/service/mosquitto-xyz-bridge/status/health '1'
-    Cumulocity.Managed Object Should Have Fragment Values    status\=up        timeout=${TIMEOUT}
+    Cumulocity.Managed Object Should Have Fragment Values    status\=up    timeout=${TIMEOUT}
 
-    Execute Command    tedge mqtt pub --retain te/device/main/service/mosquitto-xyz-bridge/status/health 'invalid payload'
-    Cumulocity.Managed Object Should Have Fragment Values    status\=unknown        timeout=${TIMEOUT}
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main/service/mosquitto-xyz-bridge/status/health 'invalid payload'
+    Cumulocity.Managed Object Should Have Fragment Values    status\=unknown    timeout=${TIMEOUT}
 
 Test non-mosquitto-bridge service status mapping
     Execute Command    tedge mqtt pub --retain te/device/main/service/some-service/status/health '{"status":"down"}'
     External Identity Should Exist    ${DEVICE_SN}:device:main:service:some-service    show_info=False
-    Cumulocity.Managed Object Should Have Fragment Values    status\=down        timeout=${TIMEOUT}
+    Cumulocity.Managed Object Should Have Fragment Values    status\=down    timeout=${TIMEOUT}
 
     Execute Command    tedge mqtt pub --retain te/device/main/service/some-service/status/health 'invalid payload'
-    Cumulocity.Managed Object Should Have Fragment Values    status\=unknown        timeout=${TIMEOUT}
+    Cumulocity.Managed Object Should Have Fragment Values    status\=unknown    timeout=${TIMEOUT}
 
     Execute Command    tedge mqtt pub --retain te/device/main/service/some-service/status/health '{"status":"up"}'
-    Cumulocity.Managed Object Should Have Fragment Values    status\=up        timeout=${TIMEOUT}
+    Cumulocity.Managed Object Should Have Fragment Values    status\=up    timeout=${TIMEOUT}
 
     Execute Command    tedge mqtt pub --retain te/device/main/service/some-service/status/health '{"status":"unknown"}'
-    Cumulocity.Managed Object Should Have Fragment Values    status\=unknown        timeout=${TIMEOUT}
+    Cumulocity.Managed Object Should Have Fragment Values    status\=unknown    timeout=${TIMEOUT}
 
 Test if all c8y services are down
-    [Template]     Check if a service is down
+    [Template]    Check if a service is down
     tedge-mapper-c8y
     tedge-agent
     c8y-firmware-plugin
 
 Test if all c8y services are using configured service type
-    [Template]     Check if a service using configured service type
+    [Template]    Check if a service using configured service type
     tedge-mapper-c8y
     tedge-agent
     c8y-firmware-plugin
 
 Test if all c8y services using default service type when service type configured as empty
-    [Template]     Check if a service using configured service type as empty
+    [Template]    Check if a service using configured service type as empty
     tedge-mapper-c8y
     tedge-agent
     c8y-firmware-plugin
 
 Check health status of tedge-mapper-c8y service on broker stop start
-    Device Should Exist                      ${DEVICE_SN}:device:main:service:tedge-mapper-c8y    show_info=False
+    Device Should Exist    ${DEVICE_SN}:device:main:service:tedge-mapper-c8y    show_info=False
     ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up
     Should Be Equal    ${SERVICE["name"]}    tedge-mapper-c8y
     Should Be Equal    ${SERVICE["status"]}    up
 
     ThinEdgeIO.Stop Service    mosquitto.service
-    ThinEdgeIO.Service Should Be Stopped  mosquitto.service
+    ThinEdgeIO.Service Should Be Stopped    mosquitto.service
 
-    Device Should Exist                      ${DEVICE_SN}:device:main:service:tedge-mapper-c8y    show_info=False
+    Device Should Exist    ${DEVICE_SN}:device:main:service:tedge-mapper-c8y    show_info=False
     ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=down
     Should Be Equal    ${SERVICE["name"]}    tedge-mapper-c8y
     Should Be Equal    ${SERVICE["status"]}    down
 
     ThinEdgeIO.Start Service    mosquitto.service
-    ThinEdgeIO.Service Should Be Running  mosquitto.service
+    ThinEdgeIO.Service Should Be Running    mosquitto.service
 
     ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up    timeout=${TIMEOUT}
     Should Be Equal    ${SERVICE["name"]}    tedge-mapper-c8y
@@ -99,16 +100,16 @@ Check health status of tedge-mapper-c8y service on broker stop start
 Check health status of tedge-mapper-c8y service on broker restart
     [Documentation]    Test tedge-mapper-c8y on mqtt broker restart
 
-    Device Should Exist                      ${DEVICE_SN}:device:main:service:tedge-mapper-c8y    show_info=False
+    Device Should Exist    ${DEVICE_SN}:device:main:service:tedge-mapper-c8y    show_info=False
     ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up    timeout=${TIMEOUT}
     Should Be Equal    ${SERVICE["name"]}    tedge-mapper-c8y
     Should Be Equal    ${SERVICE["status"]}    up
 
     ThinEdgeIO.Restart Service    mosquitto.service
-    ThinEdgeIO.Service Should Be Running  mosquitto.service
+    ThinEdgeIO.Service Should Be Running    mosquitto.service
 
     Sleep    5s    reason=Wait for any potential status changes to be sent to Cumulocity IoT
-    Device Should Exist                      ${DEVICE_SN}:device:main:service:tedge-mapper-c8y    show_info=False
+    Device Should Exist    ${DEVICE_SN}:device:main:service:tedge-mapper-c8y    show_info=False
     ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up    timeout=${TIMEOUT}
     Should Be Equal    ${SERVICE["name"]}    tedge-mapper-c8y
     Should Be Equal    ${SERVICE["status"]}    up
@@ -118,15 +119,16 @@ Check health status of child device service
     # Create the child device by sending the service status on te/device/<child-id>/service/<service-id
     # and relying on auto-registration mechanism to register the entity on the cloud
     # Verify if the service status is updated
-    Set Device         ${DEVICE_SN}
-    ${child_sn}=       Set Variable    ${DEVICE_SN}:device:external-sensor
-    ${child_name}=     Set Variable    external-sensor
-    Execute Command    tedge mqtt pub 'te/device/${child_name}/service/childservice/status/health' '{"status":"unknown"}'
+    Set Device    ${DEVICE_SN}
+    ${child_sn}=    Set Variable    ${DEVICE_SN}:device:external-sensor
+    ${child_name}=    Set Variable    external-sensor
+    Execute Command
+    ...    tedge mqtt pub 'te/device/${child_name}/service/childservice/status/health' '{"status":"unknown"}'
 
     Should Be A Child Device Of Device    ${child_sn}
 
     # Check created service entries
-    Device Should Exist                      ${child_sn}:service:childservice    show_info=False
+    Device Should Exist    ${child_sn}:service:childservice    show_info=False
     ${SERVICE}=    Device Should Have Fragment Values    status\=unknown
     Should Be Equal    ${SERVICE["name"]}    childservice
     Should Be Equal    ${SERVICE["serviceType"]}    service
@@ -135,18 +137,17 @@ Check health status of child device service
 
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist                      ${DEVICE_SN}
+    Device Should Exist    ${DEVICE_SN}
 
 Check if a service is up
     [Arguments]    ${service_name}
     ThinEdgeIO.Service Should Be Running    ${service_name}
 
-    Device Should Exist                      ${DEVICE_SN}:device:main:service:${service_name}    show_info=False
-    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up        timeout=${TIMEOUT}
+    Device Should Exist    ${DEVICE_SN}:device:main:service:${service_name}    show_info=False
+    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up    timeout=${TIMEOUT}
 
     Should Be Equal    ${SERVICE["name"]}    ${service_name}
     Should Be Equal    ${SERVICE["serviceType"]}    service
@@ -156,26 +157,29 @@ Check if a service is up
 
 Check if a service is down
     [Arguments]    ${service_name}
-    [Teardown]    ThinEdgeIO.Start Service    ${service_name}
     ThinEdgeIO.Start Service    ${service_name}
-    Device Should Exist                      ${DEVICE_SN}:device:main:service:${service_name}    show_info=False
+    Device Should Exist    ${DEVICE_SN}:device:main:service:${service_name}    show_info=False
     ThinEdgeIO.Stop Service    ${service_name}
-    ThinEdgeIO.Service Should Be Stopped  ${service_name}
+    ThinEdgeIO.Service Should Be Stopped    ${service_name}
 
-    Device Should Exist                      ${DEVICE_SN}:device:main:service:${service_name}    show_info=False
+    Device Should Exist    ${DEVICE_SN}:device:main:service:${service_name}    show_info=False
     ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=down
 
     Should Be Equal    ${SERVICE["name"]}    ${service_name}
     Should Be Equal    ${SERVICE["serviceType"]}    service
     Should Be Equal    ${SERVICE["status"]}    down
     Should Be Equal    ${SERVICE["type"]}    c8y_Service
+    [Teardown]    ThinEdgeIO.Start Service    ${service_name}
 
 Check if a service using configured service type
     [Arguments]    ${service_name}
     Execute Command    tedge config set service.type thinedge
     ThinEdgeIO.Restart Service    ${service_name}
-    Device Should Exist                      ${DEVICE_SN}:device:main:service:${service_name}    show_info=False
-    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up    serviceType\=thinedge        timeout=${TIMEOUT}
+    Device Should Exist    ${DEVICE_SN}:device:main:service:${service_name}    show_info=False
+    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values
+    ...    status\=up
+    ...    serviceType\=thinedge
+    ...    timeout=${TIMEOUT}
 
     Should Be Equal    ${SERVICE["name"]}    ${service_name}
     Should Be Equal    ${SERVICE["serviceType"]}    thinedge
@@ -186,8 +190,11 @@ Check if a service using configured service type as empty
     [Arguments]    ${service_name}
     Execute Command    tedge config set service.type ""
     ThinEdgeIO.Restart Service    ${service_name}
-    Device Should Exist                      ${DEVICE_SN}:device:main:service:${service_name}    show_info=False
-    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values    status\=up        serviceType\=service        timeout=${TIMEOUT}
+    Device Should Exist    ${DEVICE_SN}:device:main:service:${service_name}    show_info=False
+    ${SERVICE}=    Cumulocity.Device Should Have Fragment Values
+    ...    status\=up
+    ...    serviceType\=service
+    ...    timeout=${TIMEOUT}
 
     Should Be Equal    ${SERVICE["name"]}    ${service_name}
     Should Be Equal    ${SERVICE["serviceType"]}    service

--- a/tests/RobotFramework/tests/cumulocity/shell/shell_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/shell/shell_operation.robot
@@ -1,14 +1,15 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:troubleshooting    theme:plugins
-Suite Setup    Custom Setup
-Test Teardown    Get Logs
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:troubleshooting    theme:plugins
+
 
 *** Test Cases ***
-
 Successful shell command with output
     ${operation}=    Cumulocity.Execute Shell Command    echo helloworld
     Operation Should Be SUCCESSFUL    ${operation}
@@ -30,12 +31,11 @@ Failed shell command
 
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist                      ${DEVICE_SN}
+    Device Should Exist    ${DEVICE_SN}
     ThinEdgeIO.Transfer To Device    ${CURDIR}/command_handler.*    /etc/tedge/operations/command
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command*         /etc/tedge/operations/c8y/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command*    /etc/tedge/operations/c8y/
     ThinEdgeIO.Restart Service    tedge-agent
     ThinEdgeIO.Disconnect Then Connect Mapper    c8y

--- a/tests/RobotFramework/tests/cumulocity/shell/shell_operation_built-in_bridge.robot
+++ b/tests/RobotFramework/tests/cumulocity/shell/shell_operation_built-in_bridge.robot
@@ -1,14 +1,15 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:troubleshooting    theme:plugins
-Suite Setup    Custom Setup
-Test Teardown    Get Logs
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:troubleshooting    theme:plugins
+
 
 *** Test Cases ***
-
 Successful shell command with output
     ${operation}=    Cumulocity.Execute Shell Command    echo helloworld
     Operation Should Be SUCCESSFUL    ${operation}
@@ -30,14 +31,13 @@ Failed shell command
 
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist                      ${DEVICE_SN}
-    ThinEdgeIO.Execute Command      tedge config set mqtt.bridge.built_in true
-    ThinEdgeIO.Execute Command      tedge config set c8y.bridge.topic_prefix custom-c8y
+    Device Should Exist    ${DEVICE_SN}
+    ThinEdgeIO.Execute Command    tedge config set mqtt.bridge.built_in true
+    ThinEdgeIO.Execute Command    tedge config set c8y.bridge.topic_prefix custom-c8y
     ThinEdgeIO.Transfer To Device    ${CURDIR}/command_handler.*    /etc/tedge/operations/command
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command*         /etc/tedge/operations/c8y/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command*    /etc/tedge/operations/c8y/
     ThinEdgeIO.Restart Service    tedge-agent
-    ThinEdgeIO.Execute Command      tedge reconnect c8y
+    ThinEdgeIO.Execute Command    tedge reconnect c8y

--- a/tests/RobotFramework/tests/cumulocity/software_management/sm-plugin.robot
+++ b/tests/RobotFramework/tests/cumulocity/software_management/sm-plugin.robot
@@ -1,20 +1,19 @@
 *** Settings ***
-
 Resource            ../../../resources/common.resource
 Library             ThinEdgeIO
 Library             Cumulocity
 Library             Collections
 
-Test Setup         Custom Setup
-Test Teardown      Custom Teardown
+Test Setup          Custom Setup
+Test Teardown       Custom Teardown
 
 Test Tags           theme:software
 
-*** Test Cases ***
 
+*** Test Cases ***
 Check max_packages default value
     [Documentation]    Don't put an explicit max value to make the test more flexible against future tweaks to the default value.
-    ...                The main point is to prevent accidentally using a small default value which is likely to truncate the packages unexpectedly
+    ...    The main point is to prevent accidentally using a small default value which is likely to truncate the packages unexpectedly
     Execute Command    sudo tedge config unset software.plugin.max_packages
     ${default_value}=    Execute Command    sudo tedge config get software.plugin.max_packages
     Should Be True    int(${default_value}) > 100
@@ -128,19 +127,21 @@ Software updates download software packages only once #3062
     ${OPERATION}=    Install Software    dummy-software,1.0.0::dummy1,${file_url}
     ${OPERATION}=    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
     ${op_id}=    Get From Dictionary    ${OPERATION}    id
-    ${count}=    Execute Command    grep Downloading /var/log/tedge/agent/workflow-software_update-c8y-mapper-${op_id}.log -c
+    ${count}=    Execute Command
+    ...    grep Downloading /var/log/tedge/agent/workflow-software_update-c8y-mapper-${op_id}.log -c
     Should Be Equal As Numbers    ${count}    1
+
 
 *** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
     Set Test Variable    $DEVICE_SN
-    Execute Command           test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
     # Remove any existing packages to allow for exact assertions
-    Execute Command       rm -f /etc/tedge/sm-plugins/*
+    Execute Command    rm -f /etc/tedge/sm-plugins/*
     Transfer To Device    ${CURDIR}/dummy-plugin.sh    /etc/tedge/sm-plugins/dummy1
     Transfer To Device    ${CURDIR}/dummy-plugin.sh    /etc/tedge/sm-plugins/dummy2
-    Transfer To Device    ${CURDIR}/dummy-plugin-2.sh  /etc/tedge/sm-plugins/dummy3
+    Transfer To Device    ${CURDIR}/dummy-plugin-2.sh    /etc/tedge/sm-plugins/dummy3
 
 Custom Teardown
     # Restore sudo in case if the tests are run on a device (and not in a container)
@@ -150,5 +151,6 @@ Custom Teardown
 Set Service User
     [Arguments]    ${SERVICE_NAME}    ${SERVICE_USER}
     Execute Command    mkdir -p /etc/systemd/system/${SERVICE_NAME}.service.d/
-    Execute Command    cmd=printf "[Service]\nUser = ${SERVICE_USER}" | sudo tee /etc/systemd/system/${SERVICE_NAME}.service.d/10-user.conf
+    Execute Command
+    ...    cmd=printf "[Service]\nUser = ${SERVICE_USER}" | sudo tee /etc/systemd/system/${SERVICE_NAME}.service.d/10-user.conf
     Execute Command    systemctl daemon-reload

--- a/tests/RobotFramework/tests/cumulocity/software_management/sm-plugin.robot
+++ b/tests/RobotFramework/tests/cumulocity/software_management/sm-plugin.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource            ../../../resources/common.resource
+Library             Collections
 Library             ThinEdgeIO
 Library             Cumulocity
-Library             Collections
 
 Test Setup          Custom Setup
 Test Teardown       Custom Teardown

--- a/tests/RobotFramework/tests/cumulocity/software_management/software-update-child.robot
+++ b/tests/RobotFramework/tests/cumulocity/software_management/software-update-child.robot
@@ -1,26 +1,35 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:software    theme:childdevices
-Test Setup       Custom Setup
-Test Teardown    Custom Teardown
+Test Setup          Custom Setup
+Test Teardown       Custom Teardown
+
+Test Tags           theme:c8y    theme:software    theme:childdevices
+
 
 *** Test Cases ***
 Supported software types should be declared during startup
-    [Documentation]    #2654 This test will be updated once advanced software management support is implemented
     ThinEdgeIO.Set Device Context    ${PARENT_SN}
-    Should Have MQTT Messages    topic=te/device/${CHILD_SN}///cmd/software_list    minimum=1    maximum=1    message_contains="types":["apt"]
-    Should Have MQTT Messages    topic=te/device/${CHILD_SN}///cmd/software_update    minimum=1    maximum=1    message_contains="types":["apt"]
+    Should Have MQTT Messages
+    ...    topic=te/device/${CHILD_SN}///cmd/software_list
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains="types":["apt"]
+    Should Have MQTT Messages
+    ...    topic=te/device/${CHILD_SN}///cmd/software_update
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains="types":["apt"]
 
 Software list should be populated during startup
     Cumulocity.Should Contain Supported Operations    c8y_SoftwareUpdate
     Device Should Have Installed Software    tedge    timeout=120
 
 Install software via Cumulocity
-    ${OPERATION}=    Install Software        rolldice
-    Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
+    ${OPERATION}=    Install Software    rolldice
+    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
     Device Should Have Installed Software    rolldice
 
 
@@ -47,7 +56,7 @@ Custom Setup
     # Parent
     ${parent_sn}=    Setup    skip_bootstrap=${True}
     Set Suite Variable    $PARENT_SN    ${parent_sn}
-    Execute Command           test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
 
     ${parent_ip}=    Get IP Address
     Set Suite Variable    $PARENT_IP    ${parent_ip}
@@ -68,4 +77,3 @@ Custom Setup
 Custom Teardown
     Get Logs    name=${PARENT_SN}
     Get Logs    name=${CHILD_SN}
-

--- a/tests/RobotFramework/tests/cumulocity/software_management/software.robot
+++ b/tests/RobotFramework/tests/cumulocity/software_management/software.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource            ../../../resources/common.resource
+Library             Collections
 Library             Cumulocity
 Library             ThinEdgeIO
-Library             Collections
 
 Test Setup          Custom Setup
 Test Teardown       Custom Teardown

--- a/tests/RobotFramework/tests/cumulocity/software_management/software.robot
+++ b/tests/RobotFramework/tests/cumulocity/software_management/software.robot
@@ -1,18 +1,28 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
-Library    Collections
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+Library             Collections
 
-Test Tags    theme:c8y    theme:software    theme:plugins
-Test Setup       Custom Setup
-Test Teardown    Custom Teardown
+Test Setup          Custom Setup
+Test Teardown       Custom Teardown
+
+Test Tags           theme:c8y    theme:software    theme:plugins
+
 
 *** Test Cases ***
 Supported software types should be declared during startup
     [Documentation]    c8y_SupportedSoftwareTypes should NOT be created by default #2654
-    Should Have MQTT Messages    topic=te/device/main///cmd/software_list    minimum=1    maximum=1    message_contains="types":["apt"]
-    Should Have MQTT Messages    topic=te/device/main///cmd/software_update    minimum=1    maximum=1    message_contains="types":["apt"]
+    Should Have MQTT Messages
+    ...    topic=te/device/main///cmd/software_list
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains="types":["apt"]
+    Should Have MQTT Messages
+    ...    topic=te/device/main///cmd/software_update
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains="types":["apt"]
     Run Keyword And Expect Error    *    Device Should Have Fragment Values    c8y_SupportedSoftwareTypes\=["apt"]
 
 Supported software types and c8y_SupportedSoftwareTypes should be declared during startup
@@ -33,19 +43,19 @@ Software list should be populated during startup with advanced software manageme
     Device Should Have Installed Software    tedge    timeout=120
 
 Install software via Cumulocity
-    ${OPERATION}=    Install Software        c8y-remote-access-plugin    # TODO: Use different package
-    Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
+    ${OPERATION}=    Install Software    c8y-remote-access-plugin    # TODO: Use different package
+    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
     Device Should Have Installed Software    c8y-remote-access-plugin
 
 tedge-agent should terminate on SIGINT while downloading file
     [Documentation]    The test uses a custom local http server with throttling applied to it to ensure
-    ...                the download does not complete before stopping the tedge-agent
+    ...    the download does not complete before stopping the tedge-agent
     ${start_time}=    Get Unix Timestamp
-    ${OPERATION}=    Install Software        test-very-large-software,1.0,http://localhost/speedlimit/10MB
+    ${OPERATION}=    Install Software    test-very-large-software,1.0,http://localhost/speedlimit/10MB
 
     # wait for the download to start by waiting for a specific marker to appear in the logs
     Logs Should Contain    text=download::download: Downloading file from url    date_from=${start_time}
-    Operation Should Not Be PENDING          ${OPERATION}
+    Operation Should Not Be PENDING    ${OPERATION}
 
     # Service should stop within 5s
     Stop tedge-agent
@@ -53,7 +63,9 @@ tedge-agent should terminate on SIGINT while downloading file
 Software list should only show currently installed software and not candidates
     ${EXPECTED_VERSION}=    Execute Command    dpkg -s tedge | grep "^Version: " | cut -d' ' -f2    strip=True
     ${VERSION}=    Escape Pattern    ${EXPECTED_VERSION}    is_json=${True}
-    Device Should Have Installed Software    {"name": "tedge", "softwareType": "apt", "version": "${VERSION}"}    timeout=120
+    Device Should Have Installed Software
+    ...    {"name": "tedge", "softwareType": "apt", "version": "${VERSION}"}
+    ...    timeout=120
 
 Manual software_list operation request
     # Note: There isn't a Cumulocity IoT operation related to getting the software list, so no need to check for operation transitions
@@ -82,8 +94,8 @@ Operation log uploaded automatically with default auto_log_upload setting as on-
     Should Be Equal    ${default_value}    on-failure
 
     # Validate that the operation log is NOT uploaded for a successful operation
-    ${OPERATION}=    Install Software        c8y-remote-access-plugin
-    Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
+    ${OPERATION}=    Install Software    c8y-remote-access-plugin
+    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
     Validate operation log not uploaded
 
     # Validate that the operation log is uploaded for a failed operation
@@ -96,8 +108,8 @@ Operation log uploaded automatically with auto_log_upload setting as always
     Restart Service    tedge-mapper-c8y
 
     # Validate that the operation log is uploaded for a successful operation as well
-    ${OPERATION}=    Install Software        c8y-remote-access-plugin
-    Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
+    ${OPERATION}=    Install Software    c8y-remote-access-plugin
+    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
     Validate operation log uploaded
 
     # Validate that the operation log is uploaded for a failed operation
@@ -110,8 +122,8 @@ Operation log uploaded automatically with auto_log_upload setting as never
     Restart Service    tedge-mapper-c8y
 
     # Validate that the operation log is NOT uploaded for a successful operation
-    ${OPERATION}=    Install Software        c8y-remote-access-plugin
-    Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
+    ${OPERATION}=    Install Software    c8y-remote-access-plugin
+    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
     Validate operation log not uploaded
 
     # Validate that the operation log is NOT uploaded for a failed operation either
@@ -120,51 +132,57 @@ Operation log uploaded automatically with auto_log_upload setting as never
     Validate operation log not uploaded
 
 Workflow log includes plugin output
-    ${OPERATION}=    Install Software        c8y-remote-access-plugin
-    Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
-    ${operation_log_file}=    Execute Command    ls -t /var/log/tedge/agent/workflow-software_update-* | head -n 1    strip=${True}
-    ${log_output}=     Execute Command    cat ${operation_log_file}
+    ${OPERATION}=    Install Software    c8y-remote-access-plugin
+    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
+    ${operation_log_file}=    Execute Command
+    ...    ls -t /var/log/tedge/agent/workflow-software_update-* | head -n 1
+    ...    strip=${True}
+    ${log_output}=    Execute Command    cat ${operation_log_file}
     Should Contain    ${log_output}    Executing command: "apt-get" "--quiet" "--yes" "update"
 
 Backward compatibility using 501-503 templates to update status
     Execute Command    tedge config set c8y.smartrest.use_operation_id false
     Restart Service    tedge-mapper-c8y
     Service Health Status Should Be Up    tedge-mapper-c8y
-    ${OPERATION}=    Install Software        c8y-remote-access-plugin
-    Operation Should Be SUCCESSFUL           ${OPERATION}    timeout=60
+    ${OPERATION}=    Install Software    c8y-remote-access-plugin
+    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
     Device Should Have Installed Software    c8y-remote-access-plugin
     Should Have MQTT Messages    c8y/s/us    message_pattern=^(501|502|503),c8y_SoftwareUpdate.*    minimum=1
 
 Operation gets updated regardless of the order of the creation time
     Stop Service    tedge-agent
-    ${OPERATION1}=    Install Software        non-existent-package1
-    ${OPERATION2}=    Install Software        non-existent-package2
+    ${OPERATION1}=    Install Software    non-existent-package1
+    ${OPERATION2}=    Install Software    non-existent-package2
     ${op1dict}=    Operation Should Be PENDING    ${OPERATION1}
     ${op2dict}=    Operation Should Be PENDING    ${OPERATION2}
     ${op_id1}=    Get From Dictionary    ${op1dict}    id
     ${op_id2}=    Get From Dictionary    ${op2dict}    id
-    Execute Command    tedge mqtt pub -r te/device/main///cmd/software_update/c8y-mapper-${op_id2} '{"status":"executing","updateList":[{"type":"default","modules":[{"name":"non-existent-package2","action":"install"}]}]}'
+    Execute Command
+    ...    tedge mqtt pub -r te/device/main///cmd/software_update/c8y-mapper-${op_id2} '{"status":"executing","updateList":[{"type":"default","modules":[{"name":"non-existent-package2","action":"install"}]}]}'
     Operation Should Be PENDING    ${OPERATION1}    timeout=60    # The older operation status shouldn't be updated
     Operation Should Be EXECUTING    ${OPERATION2}    timeout=60
-    Execute Command    tedge mqtt pub -r te/device/main///cmd/software_update/c8y-mapper-${op_id2} '{"status":"successful","updateList":[{"type":"default","modules":[{"name":"non-existent-package2","action":"install"}]}]}'
+    Execute Command
+    ...    tedge mqtt pub -r te/device/main///cmd/software_update/c8y-mapper-${op_id2} '{"status":"successful","updateList":[{"type":"default","modules":[{"name":"non-existent-package2","action":"install"}]}]}'
     Operation Should Be SUCCESSFUL    ${OPERATION2}    timeout=60
-    Execute Command    tedge mqtt pub -r te/device/main///cmd/software_update/c8y-mapper-${op_id1} '{"status":"executing","updateList":[{"type":"default","modules":[{"name":"non-existent-package1","action":"install"}]}]}'
+    Execute Command
+    ...    tedge mqtt pub -r te/device/main///cmd/software_update/c8y-mapper-${op_id1} '{"status":"executing","updateList":[{"type":"default","modules":[{"name":"non-existent-package1","action":"install"}]}]}'
     Operation Should Be EXECUTING    ${OPERATION1}    timeout=60
-    Execute Command    tedge mqtt pub -r te/device/main///cmd/software_update/c8y-mapper-${op_id1} '{"status":"successful","updateList":[{"type":"default","modules":[{"name":"non-existent-package1","action":"install"}]}]}'
+    Execute Command
+    ...    tedge mqtt pub -r te/device/main///cmd/software_update/c8y-mapper-${op_id1} '{"status":"successful","updateList":[{"type":"default","modules":[{"name":"non-existent-package1","action":"install"}]}]}'
     Operation Should Be SUCCESSFUL    ${OPERATION1}    timeout=60
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
-    ${DEVICE_SN}=                            Setup
-    Device Should Exist                      ${DEVICE_SN}
+    ${DEVICE_SN}=    Setup
+    Device Should Exist    ${DEVICE_SN}
     Set Test Variable    $DEVICE_SN
     Should Have MQTT Messages    te/device/main/service/tedge-mapper-c8y/status/health
     Execute Command    sudo start-http-server.sh
 
 Stop tedge-agent
-    [Timeout]                                5 seconds
-    Stop Service                             tedge-agent
+    [Timeout]    5 seconds
+    Stop Service    tedge-agent
 
 Custom Teardown
     Execute Command    sudo stop-http-server.sh
@@ -172,22 +190,35 @@ Custom Teardown
 
 Publish and Verify Local Command
     [Arguments]    ${topic}    ${payload}    ${expected_status}=successful    ${c8y_fragment}=
-    [Teardown]    Execute Command    tedge mqtt pub --retain '${topic}' ''
     Execute Command    tedge mqtt pub --retain '${topic}' '${payload}'
-    ${messages}=    Should Have MQTT Messages    ${topic}    minimum=1    maximum=1    message_contains="status":"${expected_status}"
+    ${messages}=    Should Have MQTT Messages
+    ...    ${topic}
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains="status":"${expected_status}"
 
     Sleep    5s    reason=Given mapper a chance to react, if it does not react with 5 seconds it never will
-    ${retained_message}    Execute Command    timeout 1 tedge mqtt sub --no-topic '${topic}'    ignore_exit_code=${True}    strip=${True}
+    ${retained_message}=    Execute Command
+    ...    timeout 1 tedge mqtt sub --no-topic '${topic}'
+    ...    ignore_exit_code=${True}
+    ...    strip=${True}
     Should Be Equal    ${messages[0]}    ${retained_message}    msg=MQTT message should be unchanged
 
     IF    "${c8y_fragment}"
         # There should not be any c8y related operation transition messages sent: https://cumulocity.com/guides/reference/smartrest-two/#updating-operations
-        Should Have MQTT Messages    c8y/s/us    message_pattern=^(501|502|503|504|505|506),${c8y_fragment}.*    minimum=0    maximum=0
+        Should Have MQTT Messages
+        ...    c8y/s/us
+        ...    message_pattern=^(501|502|503|504|505|506),${c8y_fragment}.*
+        ...    minimum=0
+        ...    maximum=0
     END
+    [Teardown]    Execute Command    tedge mqtt pub --retain '${topic}' ''
 
 Validate operation log uploaded
     # Find the latest workflow log for software update operation
-    ${operation_log_file}=    Execute Command    ls -t /var/log/tedge/agent/workflow-software_update-* | head -n 1    strip=${True}
+    ${operation_log_file}=    Execute Command
+    ...    ls -t /var/log/tedge/agent/workflow-software_update-* | head -n 1
+    ...    strip=${True}
     ${log_checksum}=    Execute Command    md5sum '${operation_log_file}' | cut -d' ' -f1    strip=${True}
     ${events}=    Cumulocity.Device Should Have Event/s
     ...    minimum=1

--- a/tests/RobotFramework/tests/cumulocity/supported_operations/mapper-publishing-agent-supported-ops.robot
+++ b/tests/RobotFramework/tests/cumulocity/supported_operations/mapper-publishing-agent-supported-ops.robot
@@ -1,33 +1,41 @@
 *** Settings ***
-Resource    ../../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:operation    theme:tedge-agent
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:operation    theme:tedge-agent
+
 
 *** Test Cases ***
-
 Full supported operations message has no duplicates
-    Should Have MQTT Messages    c8y/s/us    message_pattern=114,c8y_DeviceProfile,c8y_DownloadConfigFile,c8y_LogfileRequest,c8y_RemoteAccessConnect,c8y_Restart,c8y_SoftwareUpdate,c8y_UploadConfigFile    minimum=1    maximum=1
+    Should Have MQTT Messages
+    ...    c8y/s/us
+    ...    message_pattern=114,c8y_DeviceProfile,c8y_DownloadConfigFile,c8y_LogfileRequest,c8y_RemoteAccessConnect,c8y_Restart,c8y_SoftwareUpdate,c8y_UploadConfigFile
+    ...    minimum=1
+    ...    maximum=1
 
 Create and publish the tedge agent supported operations on mapper restart
     # stop mapper and remove the supported operations
-    ThinEdgeIO.Stop Service     tedge-mapper-c8y
+    ThinEdgeIO.Stop Service    tedge-mapper-c8y
     Execute Command    sudo rm -rf /etc/tedge/operations/c8y/*
-  
+
     # the operation files must not exist
     ThinEdgeIO.File Should Not Exist    /etc/tedge/operations/c8y/c8y_SoftwareUpdate
     ThinEdgeIO.File Should Not Exist    /etc/tedge/operations/c8y/c8y_Restart
 
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     # now restart the mapper
     ThinEdgeIO.start Service    tedge-mapper-c8y
-    Should Have MQTT Messages    te/device/main/service/tedge-mapper-c8y/status/health     message_contains=up    date_from=${timestamp}
+    Should Have MQTT Messages
+    ...    te/device/main/service/tedge-mapper-c8y/status/health
+    ...    message_contains=up
+    ...    date_from=${timestamp}
     # After receiving the health status `up` from tege-agent, the mapper creates supported operations and will publish to c8y
-    Should Have MQTT Messages    te/device/main/service/tedge-agent/status/health     message_contains=up
-    
+    Should Have MQTT Messages    te/device/main/service/tedge-agent/status/health    message_contains=up
+
     # Check if the `c8y_SoftwareUpdate` and `c8y_Restart` ops files exists in `/etc/tedge/operations/c8y` directory
     ThinEdgeIO.File Should Exist    /etc/tedge/operations/c8y/c8y_SoftwareUpdate
     ThinEdgeIO.File Should Exist    /etc/tedge/operations/c8y/c8y_Restart
@@ -35,19 +43,23 @@ Create and publish the tedge agent supported operations on mapper restart
     # Check if the tedge-agent supported operations exists in c8y cloud
     Cumulocity.Should Contain Supported Operations    c8y_Restart    c8y_SoftwareUpdate
 
-
 Agent gets the software list request once it comes up
-    ${timestamp}=        Get Unix Timestamp    
+    ${timestamp}=    Get Unix Timestamp
     ThinEdgeIO.restart Service    tedge-agent
     # wait till there is up status on tedge-agent health
-    Should Have MQTT Messages    te/device/main/service/tedge-agent/status/health    message_contains=up    date_from=${timestamp}
+    Should Have MQTT Messages
+    ...    te/device/main/service/tedge-agent/status/health
+    ...    message_contains=up
+    ...    date_from=${timestamp}
     # now there should be a new list request
-    Should Have MQTT Messages    te/device/main///cmd/software_list/+   message_contains=status    date_from=${timestamp}
-   
+    Should Have MQTT Messages
+    ...    te/device/main///cmd/software_list/+
+    ...    message_contains=status
+    ...    date_from=${timestamp}
+
 
 *** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist                      ${DEVICE_SN}
-   
+    Device Should Exist    ${DEVICE_SN}

--- a/tests/RobotFramework/tests/cumulocity/telemetry/c8y_child_alarms_rpi.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/c8y_child_alarms_rpi.robot
@@ -39,11 +39,11 @@ Normal case when the child device does not exist on c8y cloud
     ...    severity=CRITICAL
 
 Normal case when the child device already exists
-# Sending child alarm again
+    # Sending child alarm again
     Execute Command
     ...    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-02T05:30:45+00:00" }' -q 2 -r
 
-# Check created second alarm
+    # Check created second alarm
     ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    updated_after=2021-01-02
     ${alarms}=    Device Should Have Alarm/s
     ...    minimum=1

--- a/tests/RobotFramework/tests/cumulocity/telemetry/c8y_child_alarms_rpi.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/c8y_child_alarms_rpi.robot
@@ -1,30 +1,29 @@
 *** Settings ***
+Resource            ../../../resources/common.resource
+Library             ThinEdgeIO
+Library             Cumulocity
 
-Resource    ../../../resources/common.resource
-Library    ThinEdgeIO
-Library    Cumulocity
+Suite Setup         Custom Setup
+Suite Teardown      Get Logs
 
-Test Tags    theme:telemetry    theme:childdevices
-Suite Setup            Custom Setup
-Suite Teardown         Get Logs
+Test Tags           theme:telemetry    theme:childdevices
 
 
 *** Variables ***
-
-${DEVICE_SN}
-${CHILD_SN}
-${CHILD_XID}
+${DEVICE_SN}    ${EMPTY}
+${CHILD_SN}     ${EMPTY}
+${CHILD_XID}    ${EMPTY}
 
 
 *** Test Cases ***
-
 Define Child device 1 ID
     Set Suite Variable    $CHILD_SN    child01
     Set Suite Variable    $CHILD_XID    ${DEVICE_SN}:device:${CHILD_SN}
 
 Normal case when the child device does not exist on c8y cloud
     # Sending child alarm
-    Execute Command    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-01T05:30:45+00:00" }' -q 2 -r
+    Execute Command
+    ...    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-01T05:30:45+00:00" }' -q 2 -r
     # Check Child device creation
     Set Device    ${DEVICE_SN}
     Should Be A Child Device Of Device    ${CHILD_XID}
@@ -32,24 +31,43 @@ Normal case when the child device does not exist on c8y cloud
     # Check created alarm
     Set Device    ${CHILD_XID}
     ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    # Should be the only alarm there
-    ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    expected_text=Temperature is very high    type=temperature_high    severity=CRITICAL
+    ${alarms}=    Device Should Have Alarm/s
+    ...    minimum=1
+    ...    maximum=1
+    ...    expected_text=Temperature is very high
+    ...    type=temperature_high
+    ...    severity=CRITICAL
 
 Normal case when the child device already exists
-#Sending child alarm again
-    Execute Command    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-02T05:30:45+00:00" }' -q 2 -r
+# Sending child alarm again
+    Execute Command
+    ...    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-02T05:30:45+00:00" }' -q 2 -r
 
-#Check created second alarm
+# Check created second alarm
     ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    updated_after=2021-01-02
-    ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    expected_text=Temperature is very high    type=temperature_high    severity=CRITICAL    updated_after=2021-01-02
+    ${alarms}=    Device Should Have Alarm/s
+    ...    minimum=1
+    ...    maximum=1
+    ...    expected_text=Temperature is very high
+    ...    type=temperature_high
+    ...    severity=CRITICAL
+    ...    updated_after=2021-01-02
 
 Reconciliation when the new alarm message arrives, restart the mapper
     Execute Command    sudo systemctl stop tedge-mapper-c8y.service
-    Execute Command    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-03T05:30:45+00:00" }' -q 2 -r
+    Execute Command
+    ...    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-03T05:30:45+00:00" }' -q 2 -r
     Execute Command    sudo systemctl start tedge-mapper-c8y.service
 
     # Check created second alarm
     ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    updated_after=2021-01-03
-    ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    expected_text=Temperature is very high    type=temperature_high    severity=CRITICAL    updated_after=2021-01-03
+    ${alarms}=    Device Should Have Alarm/s
+    ...    minimum=1
+    ...    maximum=1
+    ...    expected_text=Temperature is very high
+    ...    type=temperature_high
+    ...    severity=CRITICAL
+    ...    updated_after=2021-01-03
 
 Reconciliation when the alarm that is cleared
     Execute Command    sudo systemctl stop tedge-mapper-c8y.service
@@ -59,7 +77,6 @@ Reconciliation when the alarm that is cleared
 
 
 *** Keywords ***
-
 Custom Setup
     ${device_sn}=    Setup
     Set Suite Variable    $DEVICE_SN    ${device_sn}

--- a/tests/RobotFramework/tests/cumulocity/telemetry/c8y_child_alarms_rpi.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/c8y_child_alarms_rpi.robot
@@ -30,7 +30,7 @@ Normal case when the child device does not exist on c8y cloud
 
     # Check created alarm
     Set Device    ${CHILD_XID}
-    ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    # Should be the only alarm there
+    Device Should Have Alarm/s    minimum=1    maximum=1    # Should be the only alarm there
     ${alarms}=    Device Should Have Alarm/s
     ...    minimum=1
     ...    maximum=1
@@ -44,7 +44,7 @@ Normal case when the child device already exists
     ...    sudo tedge mqtt pub 'te/device/${CHILD_SN}///a/temperature_high' '{ "severity": "critical", "text": "Temperature is very high", "time": "2021-01-02T05:30:45+00:00" }' -q 2 -r
 
     # Check created second alarm
-    ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    updated_after=2021-01-02
+    Device Should Have Alarm/s    minimum=1    maximum=1    updated_after=2021-01-02
     ${alarms}=    Device Should Have Alarm/s
     ...    minimum=1
     ...    maximum=1
@@ -60,7 +60,7 @@ Reconciliation when the new alarm message arrives, restart the mapper
     Execute Command    sudo systemctl start tedge-mapper-c8y.service
 
     # Check created second alarm
-    ${alarms}=    Device Should Have Alarm/s    minimum=1    maximum=1    updated_after=2021-01-03
+    Device Should Have Alarm/s    minimum=1    maximum=1    updated_after=2021-01-03
     ${alarms}=    Device Should Have Alarm/s
     ...    minimum=1
     ...    maximum=1

--- a/tests/RobotFramework/tests/cumulocity/telemetry/child_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/child_device_telemetry.robot
@@ -1,82 +1,137 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:telemetry
-Suite Setup    Custom Setup
-Test Teardown    Get Logs
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:telemetry
+
 
 *** Test Cases ***
 Child devices support sending simple measurements
     Execute Command    tedge mqtt pub te/device/${CHILD_SN}///m/ '{ "temperature": 25 }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=ThinEdgeMeasurement    value=temperature    series=temperature
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=ThinEdgeMeasurement
+    ...    value=temperature
+    ...    series=temperature
     Log    ${measurements}
 
 Child devices support sending simple measurements with custom type in topic
     Execute Command    tedge mqtt pub te/device/${CHILD_SN}///m/CustomType_topic '{ "temperature": 25 }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomType_topic    value=temperature    series=temperature
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=CustomType_topic
+    ...    value=temperature
+    ...    series=temperature
     Log    ${measurements}
 
-
 Child devices support sending simple measurements with custom type in payload
-    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///m/CustomType_topic '{ "type":"CustomType_payload","temperature": 25 }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomType_payload    value=temperature    series=temperature
+    Execute Command
+    ...    tedge mqtt pub te/device/${CHILD_SN}///m/CustomType_topic '{ "type":"CustomType_payload","temperature": 25 }'
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=CustomType_payload
+    ...    value=temperature
+    ...    series=temperature
     Log    ${measurements}
 
 Child devices support sending custom measurements
     Execute Command    tedge mqtt pub te/device/${CHILD_SN}///m/ '{ "current": {"L1": 9.5, "L2": 1.3} }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=ThinEdgeMeasurement    value=current    series=L1
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=ThinEdgeMeasurement
+    ...    value=current
+    ...    series=L1
     Log    ${measurements}
 
-
 Child devices support sending custom events
-    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///e/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=myCustomType1    fragment=someOtherCustomFragment
+    Execute Command
+    ...    tedge mqtt pub te/device/${CHILD_SN}///e/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Some test event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomType1
+    ...    fragment=someOtherCustomFragment
     Log    ${events}
-
 
 Child devices support sending custom events overriding the type
-    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///e/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=otherType    fragment=someOtherCustomFragment
+    Execute Command
+    ...    tedge mqtt pub te/device/${CHILD_SN}///e/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Some test event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=otherType
+    ...    fragment=someOtherCustomFragment
     Log    ${events}
-
 
  Child devices support sending custom events without type in topic
-    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///e/ '{"text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=ThinEdgeEvent    fragment=someOtherCustomFragment
+    Execute Command
+    ...    tedge mqtt pub te/device/${CHILD_SN}///e/ '{"text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Some test event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=ThinEdgeEvent
+    ...    fragment=someOtherCustomFragment
     Log    ${events}
 
-
 Child devices support sending large events
-    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///e/largeEvent "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(yes "x" | head -n 100000 | tr -d '\n')")"
-    ${events}=    Device Should Have Event/s    expected_text=Large event    with_attachment=False    minimum=1    maximum=1    type=largeEvent    fragment=large_text_field
+    Execute Command
+    ...    tedge mqtt pub te/device/${CHILD_SN}///e/largeEvent "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(yes "x" | head -n 100000 | tr -d '\n')")"
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Large event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=largeEvent
+    ...    fragment=large_text_field
     Length Should Be    ${events[0]["large_text_field"]}    100000
     Log    ${events}
 
-
 Child devices support sending custom alarms #1699
     [Tags]    \#1699
-    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=CRITICAL    minimum=1    maximum=1    type=myCustomAlarmType
+    Execute Command
+    ...    tedge mqtt pub te/device/${CHILD_SN}///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=CRITICAL
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomAlarmType
     Should Be Equal    ${alarms[0]["someOtherCustomFragment"]["nested"]["value"]}    extra info
     Log    ${alarms}
 
-
 Child devices support sending alarms using text fragment
-    Execute Command    tedge mqtt pub te/device/${CHILD_SN}///a/childAlarmType1 '{ "severity": "critical", "text": "Some test alarm" }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=CRITICAL    minimum=1    maximum=1    type=childAlarmType1
+    Execute Command
+    ...    tedge mqtt pub te/device/${CHILD_SN}///a/childAlarmType1 '{ "severity": "critical", "text": "Some test alarm" }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=CRITICAL
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=childAlarmType1
     Log    ${alarms}
-
 
 Child devices support sending inventory data via c8y topic
     Execute Command    tedge mqtt pub "c8y/inventory/managedObjects/update/${CHILD_SN}" '{"custom":{"fragment":"yes"}}'
     ${mo}=    Device Should Have Fragments    custom
     Should Be Equal    ${mo["custom"]["fragment"]}    yes
 
-
 Child devices support sending inventory data via tedge topic with type
-    Execute Command    tedge mqtt pub --retain "te/device/${CHILD_SN}///twin/device_OS" '{"family":"Debian","version":11,"complex":[1,"2",3],"object":{"foo":"bar"}}'
+    Execute Command
+    ...    tedge mqtt pub --retain "te/device/${CHILD_SN}///twin/device_OS" '{"family":"Debian","version":11,"complex":[1,"2",3],"object":{"foo":"bar"}}'
     Cumulocity.Set Device    ${CHILD_SN}
     ${mo}=    Device Should Have Fragments    device_OS
     Should Be Equal    ${mo["device_OS"]["family"]}    Debian
@@ -90,7 +145,6 @@ Child devices support sending inventory data via tedge topic with type
     # Validate clearing of fragments
     Execute Command    tedge mqtt pub --retain "te/device/${CHILD_SN}///twin/device_OS" ''
     Managed Object Should Not Have Fragments    device_OS
-
 
 Child devices supports sending inventory data via tedge topic to root fragments
     Execute Command    tedge mqtt pub --retain "te/device/${CHILD_SN}///twin/subtype" '"LinuxDeviceA"'
@@ -113,20 +167,27 @@ Child devices supports sending inventory data via tedge topic to root fragments
     Should Be Equal    ${mo["type"]}    thin-edge.io-child
     Should Be Equal    ${mo["name"]}    ${CHILD_SN}
 
-
 Child device supports sending custom child device measurements directly to c8y
-    Execute Command    tedge mqtt pub "c8y/measurement/measurements/create" '{"time":"2023-03-20T08:03:56.940907Z","externalSource":{"externalId":"${CHILD_SN}","type":"c8y_Serial"},"environment":{"temperature":{"value":29.9,"unit":"°C"}},"type":"10min_average","meta":{"sensorLocation":"Brisbane, Australia"}}'
+    Execute Command
+    ...    tedge mqtt pub "c8y/measurement/measurements/create" '{"time":"2023-03-20T08:03:56.940907Z","externalSource":{"externalId":"${CHILD_SN}","type":"c8y_Serial"},"environment":{"temperature":{"value":29.9,"unit":"°C"}},"type":"10min_average","meta":{"sensorLocation":"Brisbane, Australia"}}'
     Cumulocity.Set Device    ${CHILD_SN}
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    value=environment    series=temperature    type=10min_average
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    value=environment
+    ...    series=temperature
+    ...    type=10min_average
     Should Be Equal As Numbers    ${measurements[0]["environment"]["temperature"]["value"]}    29.9
     Should Be Equal    ${measurements[0]["meta"]["sensorLocation"]}    Brisbane, Australia
     Should Be Equal    ${measurements[0]["type"]}    10min_average
 
 Nested child devices support sending inventory data via tedge topic
     ${nested_child}=    Get Random Name
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
 
-    Execute Command    tedge mqtt pub --retain "te/device/${nested_child}///twin/device_OS" '{"family":"Debian","version":11}'
+    Execute Command
+    ...    tedge mqtt pub --retain "te/device/${nested_child}///twin/device_OS" '{"family":"Debian","version":11}'
     Execute Command    tedge mqtt pub --retain "te/device/${nested_child}///twin/subtype" '"LinuxDeviceB"'
     Execute Command    tedge mqtt pub --retain "te/device/${nested_child}///twin/type" '"ShouldBeIgnored"'
     Execute Command    tedge mqtt pub --retain "te/device/${nested_child}///twin/name" '"ShouldBeIgnored"'
@@ -153,11 +214,11 @@ Nested child devices support sending inventory data via tedge topic
     Should Be Equal    ${mo["type"]}    thin-edge.io-child
     Should Be Equal    ${mo["name"]}    ${nested_child}
 
-
 #
 # Services
 #
 # measurements
+
 Send measurements to an unregistered child service
     Execute Command    tedge mqtt pub te/device/${CHILD_SN}/service/app1/m/m_type '{"temperature": 30.1}'
     Cumulocity.Device Should Exist    ${CHILD_SN}
@@ -165,23 +226,26 @@ Send measurements to an unregistered child service
 
     Cumulocity.Device Should Exist    ${DEVICE_SN}:device:${CHILD_SN}:service:app1
     ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=m_type
-    Should Be Equal    ${measurements[0]["type"]}   m_type
+    Should Be Equal    ${measurements[0]["type"]}    m_type
     Should Be Equal As Numbers    ${measurements[0]["temperature"]["temperature"]["value"]}    30.1
 
 Send measurements to a registered child service
-    Execute Command    tedge mqtt pub --retain te/device/${CHILD_SN}/service/app2 '{"@type":"service","@parent":"device/${CHILD_SN}//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/${CHILD_SN}/service/app2 '{"@type":"service","@parent":"device/${CHILD_SN}//"}'
     Cumulocity.Device Should Exist    ${CHILD_SN}
     Cumulocity.Should Have Services    name=app2    min_count=1    max_count=1
-    
+
     Execute Command    tedge mqtt pub te/device/${CHILD_SN}/service/app2/m/m_type '{"temperature": 30.1}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}:device:${CHILD_SN}:service:app2
     ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=m_type
     Should Be Equal    ${measurements[0]["type"]}    m_type
-    Should Be Equal As Numbers    ${measurements[0]["temperature"]["temperature"]["value"]}    30.1    
+    Should Be Equal As Numbers    ${measurements[0]["temperature"]["temperature"]["value"]}    30.1
 
 # alarms
+
 Send alarms to an unregistered child service
-    Execute Command    tedge mqtt pub te/device/${CHILD_SN}/service/app3/a/alarm_001 '{"text": "test alarm","severity":"major"}'
+    Execute Command
+    ...    tedge mqtt pub te/device/${CHILD_SN}/service/app3/a/alarm_001 '{"text": "test alarm","severity":"major"}'
     Cumulocity.Device Should Exist    ${CHILD_SN}
     Cumulocity.Should Have Services    min_count=1    max_count=1    name=app3
 
@@ -191,7 +255,8 @@ Send alarms to an unregistered child service
     Should Be Equal    ${alarms[0]["severity"]}    MAJOR
 
 Send alarms to a registered child service
-    Execute Command    tedge mqtt pub --retain te/device/${CHILD_SN}/service/app4 '{"@type":"service","@parent":"device/${CHILD_SN}//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/${CHILD_SN}/service/app4 '{"@type":"service","@parent":"device/${CHILD_SN}//"}'
     Cumulocity.Device Should Exist    ${CHILD_SN}
     Cumulocity.Should Have Services    name=app4    min_count=1    max_count=1
 
@@ -201,6 +266,7 @@ Send alarms to a registered child service
     Should Be Equal    ${alarms[0]["type"]}    alarm_002
 
 # events
+
 Send events to an unregistered child service
     Execute Command    tedge mqtt pub te/device/${CHILD_SN}/service/app5/e/event_001 '{"text": "test event"}'
     Cumulocity.Device Should Exist    ${CHILD_SN}
@@ -210,48 +276,67 @@ Send events to an unregistered child service
     Device Should Have Event/s    expected_text=test event    type=event_001    minimum=1    maximum=1
 
 Send events to a registered child service
-    Execute Command    tedge mqtt pub --retain te/device/${CHILD_SN}/service/app6 '{"@type":"service","@parent":"device/${CHILD_SN}//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/${CHILD_SN}/service/app6 '{"@type":"service","@parent":"device/${CHILD_SN}//"}'
     Cumulocity.Device Should Exist    ${CHILD_SN}
     Cumulocity.Should Have Services    name=app6    min_count=1    max_count=1
     Cumulocity.Device Should Exist    ${DEVICE_SN}:device:${CHILD_SN}:service:app6
     Execute Command    tedge mqtt pub te/device/${CHILD_SN}/service/app6/e/event_002 '{"text": "test event"}'
     Device Should Have Event/s    expected_text=test event    type=event_002    minimum=1    maximum=1
-  
+
 # Nested child devices
+
 Nested child devices support sending measurement
     ${nested_child}=    Get Random Name
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
     Execute Command    tedge mqtt pub te/device/${nested_child}///m/ '{ "temperature": 25 }'
     Cumulocity.Device Should Exist    ${nested_child}
-    ${measurements}=    Device Should Have Measurements     type=ThinEdgeMeasurement    value=temperature    series=temperature       minimum=1    maximum=1
+    ${measurements}=    Device Should Have Measurements
+    ...    type=ThinEdgeMeasurement
+    ...    value=temperature
+    ...    series=temperature
+    ...    minimum=1
+    ...    maximum=1
     Log    ${measurements}
-
 
 Nested child devices support sending alarm
     ${nested_child}=    Get Random Name
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
-    Execute Command    tedge mqtt pub te/device/${nested_child}///a/test_alarm '{ "severity":"critical","text":"temperature alarm" }'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
+    Execute Command
+    ...    tedge mqtt pub te/device/${nested_child}///a/test_alarm '{ "severity":"critical","text":"temperature alarm" }'
     Cumulocity.Device Should Exist    ${nested_child}
-    ${alarm}=    Device Should Have Alarm/s    type=test_alarm    expected_text=temperature alarm   severity=CRITICAL    minimum=1    maximum=1  
+    ${alarm}=    Device Should Have Alarm/s
+    ...    type=test_alarm
+    ...    expected_text=temperature alarm
+    ...    severity=CRITICAL
+    ...    minimum=1
+    ...    maximum=1
     Log    ${alarm}
 
 Nested child devices support sending event
     ${nested_child}=    Get Random Name
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
     Execute Command    tedge mqtt pub te/device/${nested_child}///e/event_nested '{ "text":"nested child event" }'
     Cumulocity.Device Should Exist    ${nested_child}
     Device Should Have Event/s    expected_text=nested child event    type=event_nested    minimum=1    maximum=1
- 
-# Nested child device services 
+
+# Nested child device services
+
 Nested child device service support sending simple measurements
     ${nested_child}=    Get Random Name
     ${service_name}=    Get Random Name
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}/service/${service_name}' '{"@type":"service","@parent":"device/${nested_child}//","@id":"${service_name}"}'
-    Execute Command    tedge mqtt pub te/device/${nested_child}/service/${service_name}/m/m_type '{ "temperature": 30.1 }'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${nested_child}/service/${service_name}' '{"@type":"service","@parent":"device/${nested_child}//","@id":"${service_name}"}'
+    Execute Command
+    ...    tedge mqtt pub te/device/${nested_child}/service/${service_name}/m/m_type '{ "temperature": 30.1 }'
     Cumulocity.Device Should Exist    ${nested_child}
-    Cumulocity.Should Have Services    name=${service_name}    min_count=1    max_count=1  
-    Cumulocity.Device Should Exist   ${service_name}
+    Cumulocity.Should Have Services    name=${service_name}    min_count=1    max_count=1
+    Cumulocity.Device Should Exist    ${service_name}
     ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1
     Should Be Equal    ${measurements[0]["type"]}    m_type
     Should Be Equal As Numbers    ${measurements[0]["temperature"]["temperature"]["value"]}    30.1
@@ -260,24 +345,35 @@ Nested child device service support sending simple measurements
 Nested child device service support sending events
     ${nested_child}=    Get Random Name
     ${service_name}=    Get Random Name
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}/service/${service_name}' '{"@type":"service","@parent":"device/${nested_child}//","@id":"${service_name}"}'
-    Execute Command    tedge mqtt pub te/device/${nested_child}/service/${service_name}/e/e_type '{ "text": "nested device service started" }'
-    Cumulocity.Device Should Exist    ${nested_child}    
-    Cumulocity.Should Have Services    name=${service_name}    min_count=1    max_count=1  
-    Cumulocity.Device Should Exist   ${service_name}
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${nested_child}/service/${service_name}' '{"@type":"service","@parent":"device/${nested_child}//","@id":"${service_name}"}'
+    Execute Command
+    ...    tedge mqtt pub te/device/${nested_child}/service/${service_name}/e/e_type '{ "text": "nested device service started" }'
+    Cumulocity.Device Should Exist    ${nested_child}
+    Cumulocity.Should Have Services    name=${service_name}    min_count=1    max_count=1
+    Cumulocity.Device Should Exist    ${service_name}
     Device Should Have Event/s    expected_text=nested device service started    type=e_type    minimum=1    maximum=1
-   
+
 Nested child device service support sending alarm
     ${nested_child}=    Get Random Name
     ${service_name}=    Get Random Name
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
-    Execute Command    tedge mqtt pub --retain 'te/device/${nested_child}/service/${service_name}' '{"@type":"service","@parent":"device/${nested_child}//","@id":"${service_name}"}'
-    Execute Command    tedge mqtt pub te/device/${nested_child}/service/${service_name}/a/test_alarm '{ "severity":"critical","text":"temperature alarm" }'
-    Cumulocity.Device Should Exist    ${nested_child}    
-    Cumulocity.Should Have Services    name=${service_name}    min_count=1    max_count=1  
-    Cumulocity.Device Should Exist   ${service_name}
-    ${alarm}=    Device Should Have Alarm/s    type=test_alarm    expected_text=temperature alarm   severity=CRITICAL    minimum=1    maximum=1  
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${nested_child}//' '{"@type":"child-device","@parent":"device/${CHILD_SN}//","@id":"${nested_child}"}'
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${nested_child}/service/${service_name}' '{"@type":"service","@parent":"device/${nested_child}//","@id":"${service_name}"}'
+    Execute Command
+    ...    tedge mqtt pub te/device/${nested_child}/service/${service_name}/a/test_alarm '{ "severity":"critical","text":"temperature alarm" }'
+    Cumulocity.Device Should Exist    ${nested_child}
+    Cumulocity.Should Have Services    name=${service_name}    min_count=1    max_count=1
+    Cumulocity.Device Should Exist    ${service_name}
+    ${alarm}=    Device Should Have Alarm/s
+    ...    type=test_alarm
+    ...    expected_text=temperature alarm
+    ...    severity=CRITICAL
+    ...    minimum=1
+    ...    maximum=1
     Log    ${alarm}
 
 Child device registered even on bad input
@@ -288,14 +384,14 @@ Child device registered even on bad input
     Execute Command    tedge mqtt pub te/device/${nested_child}///e/event_001 '{"text": "test event"}'
     Device Should Have Event/s    expected_text=test event    type=event_001    minimum=1    maximum=1
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
     Set Suite Variable    $CHILD_SN    ${DEVICE_SN}_child1
     Execute Command    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_SN}"}'
-    Device Should Exist                      ${DEVICE_SN}
-    Device Should Exist                      ${CHILD_SN}
+    Device Should Exist    ${DEVICE_SN}
+    Device Should Exist    ${CHILD_SN}
 
     Service Health Status Should Be Up    tedge-mapper-c8y

--- a/tests/RobotFramework/tests/cumulocity/telemetry/raise_alarms.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/raise_alarms.robot
@@ -1,12 +1,12 @@
 *** Settings ***
-Resource        ../../../resources/common.resource
-Library         ThinEdgeIO
-Library         Cumulocity
+Resource            ../../../resources/common.resource
+Library             ThinEdgeIO
+Library             Cumulocity
 
-Test Setup     Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
 
-Test Tags      theme:telemetry    theme:c8y    theme:alarms
+Test Tags           theme:telemetry    theme:c8y    theme:alarms
 
 
 *** Test Cases ***
@@ -17,8 +17,8 @@ Check retained alarms
     minor
     warning
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup
     Device Should Exist    ${DEVICE_SN}
@@ -26,14 +26,25 @@ Custom Setup
 Send retained Alarm
     [Documentation]    https://github.com/thin-edge/thin-edge.io/blob/main/docs/src/start/raise-alarm.md
     [Arguments]    ${severity}
-    ${timestamp}    ThinEdgeIO.Get Test Start Time
-    #Raising alarms + adding custom fragment
+    ${timestamp}=    ThinEdgeIO.Get Test Start Time
+    # Raising alarms + adding custom fragment
     Stop Service    tedge-mapper-c8y
-    Execute Command    sudo tedge mqtt pub 'tedge/alarms/${severity}/temperature_${severity}' '{ "text": "Temperature is ${severity}", "details": "A custom alarm info ${severity}" }' -q 2 -r
+    Execute Command
+    ...    sudo tedge mqtt pub 'tedge/alarms/${severity}/temperature_${severity}' '{ "text": "Temperature is ${severity}", "details": "A custom alarm info ${severity}" }' -q 2 -r
     Device Should Not Have Alarm/s    type=temperature_${severity}
     Start Service    tedge-mapper-c8y
-    Device Should Have Alarm/s    minimum=0    maximum=1    expected_text=Temperature is ${severity}    type=temperature_${severity}    severity=${severity}
-    Device Should Have Alarm/s    minimum=0    maximum=1    expected_text=A custom alarm info ${severity}    type=temperature_${severity}    severity=${severity}     
-    #Clearing alarms
+    Device Should Have Alarm/s
+    ...    minimum=0
+    ...    maximum=1
+    ...    expected_text=Temperature is ${severity}
+    ...    type=temperature_${severity}
+    ...    severity=${severity}
+    Device Should Have Alarm/s
+    ...    minimum=0
+    ...    maximum=1
+    ...    expected_text=A custom alarm info ${severity}
+    ...    type=temperature_${severity}
+    ...    severity=${severity}
+    # Clearing alarms
     Execute Command    sudo tedge mqtt pub tedge/alarms/${severity}/temperature_${severity} "" -q 2 -r
     Device Should Not Have Alarm/s    type=temperature_${severity}

--- a/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry.robot
@@ -1,139 +1,233 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:telemetry
-Suite Setup    Custom Setup
-Test Teardown    Get Logs
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:telemetry
+
 
 *** Test Cases ***
 Thin-edge devices support sending simple measurements
     Execute Command    tedge mqtt pub te/device/main///m/ '{ "temperature": 25 }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=ThinEdgeMeasurement    value=temperature    series=temperature
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=ThinEdgeMeasurement
+    ...    value=temperature
+    ...    series=temperature
     Log    ${measurements}
-
 
 Thin-edge devices support sending simple measurements with custom type
     Execute Command    tedge mqtt pub te/device/main///m/ '{ "type":"CustomType", "temperature": 25 }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomType    value=temperature    series=temperature
-    Log    ${measurements}    
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=CustomType
+    ...    value=temperature
+    ...    series=temperature
+    Log    ${measurements}
 
 Thin-edge devices support sending simple measurements with custom type in topic
     Execute Command    tedge mqtt pub te/device/main///m/CustomType_topic '{ "temperature": 25 }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomType_topic    value=temperature    series=temperature
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=CustomType_topic
+    ...    value=temperature
+    ...    series=temperature
     Log    ${measurements}
 
-
 Thin-edge devices support sending simple measurements with custom type in payload
-    Execute Command    tedge mqtt pub te/device/main///m/CustomType_topic '{ "type":"CustomType_payload","temperature": 25 }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomType_payload    value=temperature    series=temperature
-    Log    ${measurements}    
+    Execute Command
+    ...    tedge mqtt pub te/device/main///m/CustomType_topic '{ "type":"CustomType_payload","temperature": 25 }'
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=CustomType_payload
+    ...    value=temperature
+    ...    series=temperature
+    Log    ${measurements}
 
 Thin-edge devices support sending custom measurements
     Execute Command    tedge mqtt pub te/device/main///m/ '{ "current": {"L1": 9.5, "L2": 1.3} }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=ThinEdgeMeasurement    value=current    series=L1
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=ThinEdgeMeasurement
+    ...    value=current
+    ...    series=L1
     Log    ${measurements}
 
-
 Thin-edge devices support sending custom events
-    Execute Command    tedge mqtt pub te/device/main///e/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=myCustomType1    fragment=someOtherCustomFragment
+    Execute Command
+    ...    tedge mqtt pub te/device/main///e/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Some test event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomType1
+    ...    fragment=someOtherCustomFragment
     Log    ${events}
-
 
 Thin-edge devices support sending large events
-    Execute Command    tedge mqtt pub te/device/main///e/largeEvent "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(yes "x" | head -n 100000 | tr -d '\n')")"
-    ${events}=    Device Should Have Event/s    expected_text=Large event    with_attachment=False    minimum=1    maximum=1    type=largeEvent    fragment=large_text_field
+    Execute Command
+    ...    tedge mqtt pub te/device/main///e/largeEvent "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(yes "x" | head -n 100000 | tr -d '\n')")"
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Large event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=largeEvent
+    ...    fragment=large_text_field
     Length Should Be    ${events[0]["large_text_field"]}    100000
     Log    ${events}
-
 
 Thin-edge devices support sending large events using legacy api
     [Tags]    legacy
-    Execute Command    tedge mqtt pub tedge/events/largeEvent2 "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(yes "x" | head -n 100000 | tr -d '\n')")"
-    ${events}=    Device Should Have Event/s    expected_text=Large event    with_attachment=False    minimum=1    maximum=1    type=largeEvent2    fragment=large_text_field
+    Execute Command
+    ...    tedge mqtt pub tedge/events/largeEvent2 "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(yes "x" | head -n 100000 | tr -d '\n')")"
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Large event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=largeEvent2
+    ...    fragment=large_text_field
     Length Should Be    ${events[0]["large_text_field"]}    100000
     Log    ${events}
 
-
 Thin-edge devices support sending custom events overriding the type
-    Execute Command    tedge mqtt pub te/device/main///e/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=otherType    fragment=someOtherCustomFragment
+    Execute Command
+    ...    tedge mqtt pub te/device/main///e/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Some test event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=otherType
+    ...    fragment=someOtherCustomFragment
     Log    ${events}
-
 
 Thin-edge devices support sending custom events without type in topic
-    Execute Command    tedge mqtt pub te/device/main///e/ '{"text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=ThinEdgeEvent    fragment=someOtherCustomFragment
+    Execute Command
+    ...    tedge mqtt pub te/device/main///e/ '{"text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Some test event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=ThinEdgeEvent
+    ...    fragment=someOtherCustomFragment
     Log    ${events}
-
 
 Thin-edge devices support sending custom alarms #1699
     [Tags]    \#1699
-    Execute Command    tedge mqtt pub te/device/main///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=CRITICAL    minimum=1    maximum=1    type=myCustomAlarmType
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=CRITICAL
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomAlarmType
     Should Be Equal    ${alarms[0]["someOtherCustomFragment"]["nested"]["value"]}    extra info
     Log    ${alarms}
 
-
 Thin-edge devices support sending custom alarms overriding the type
-    Execute Command    tedge mqtt pub te/device/main///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "type": "otherType", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=CRITICAL    minimum=1    maximum=1    type=otherType
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "type": "otherType", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=CRITICAL
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=otherType
     Log    ${alarms}
-
 
 Thin-edge devices support sending custom alarms without type in topic
-    Execute Command    tedge mqtt pub te/device/main///a/ '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=CRITICAL    minimum=1    maximum=1    type=ThinEdgeAlarm
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/ '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=CRITICAL
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=ThinEdgeAlarm
     Log    ${alarms}
-
 
 Thin-edge devices support sending custom alarms without severity in payload
     Execute Command    tedge mqtt pub te/device/main///a/myCustomAlarmType2 '{ "text": "Some test alarm" }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=MINOR    minimum=1    maximum=1    type=myCustomAlarmType2
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=MINOR
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomAlarmType2
     Log    ${alarms}
-
 
 Thin-edge devices support sending custom alarms with unknown severity in payload
-    Execute Command    tedge mqtt pub te/device/main///a/myCustomAlarmType3 '{ "severity": "invalid", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=MINOR    minimum=1    maximum=1    type=myCustomAlarmType3
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/myCustomAlarmType3 '{ "severity": "invalid", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=MINOR
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomAlarmType3
     Log    ${alarms}
-
-
 
 Thin-edge devices support sending custom alarms without text in payload
-    Execute Command    tedge mqtt pub te/device/main///a/myCustomAlarmType4 '{ "severity": "major", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=myCustomAlarmType4    severity=MAJOR    minimum=1    maximum=1    type=myCustomAlarmType4
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/myCustomAlarmType4 '{ "severity": "major", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=myCustomAlarmType4
+    ...    severity=MAJOR
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomAlarmType4
     Log    ${alarms}
-
 
 Thin-edge devices support sending alarms using text fragment
-    Execute Command    tedge mqtt pub te/device/main///a/parentAlarmType1 '{ "severity": "minor", "text": "Some test alarm" }'
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/parentAlarmType1 '{ "severity": "minor", "text": "Some test alarm" }'
     Cumulocity.Set Device    ${DEVICE_SN}
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=MINOR    minimum=1    maximum=1    type=parentAlarmType1
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=MINOR
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=parentAlarmType1
     Log    ${alarms}
 
-
 Thin-edge device supports sending custom Thin-edge device measurements directly to c8y
-    Execute Command    tedge mqtt pub "c8y/measurement/measurements/create" '{"time":"2023-03-20T08:03:56.940907Z","environment":{"temperature":{"value":29.9,"unit":"°C"}},"type":"10min_average","meta":{"sensorLocation":"Brisbane, Australia"}}'
+    Execute Command
+    ...    tedge mqtt pub "c8y/measurement/measurements/create" '{"time":"2023-03-20T08:03:56.940907Z","environment":{"temperature":{"value":29.9,"unit":"°C"}},"type":"10min_average","meta":{"sensorLocation":"Brisbane, Australia"}}'
     Cumulocity.Set Device    ${DEVICE_SN}
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    value=environment    series=temperature    type=10min_average
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    value=environment
+    ...    series=temperature
+    ...    type=10min_average
     Should Be Equal As Numbers    ${measurements[0]["environment"]["temperature"]["value"]}    29.9
     Should Be Equal    ${measurements[0]["meta"]["sensorLocation"]}    Brisbane, Australia
     Should Be Equal    ${measurements[0]["type"]}    10min_average
 
-
 Thin-edge device support sending inventory data via c8y topic
-    Execute Command    tedge mqtt pub "c8y/inventory/managedObjects/update/${DEVICE_SN}" '{"parentInfo":{"nested":{"name":"complex"}},"subType":"customType"}'
+    Execute Command
+    ...    tedge mqtt pub "c8y/inventory/managedObjects/update/${DEVICE_SN}" '{"parentInfo":{"nested":{"name":"complex"}},"subType":"customType"}'
     Cumulocity.Set Device    ${DEVICE_SN}
     ${mo}=    Device Should Have Fragments    parentInfo    subType
     Should Be Equal    ${mo["parentInfo"]["nested"]["name"]}    complex
     Should Be Equal    ${mo["subType"]}    customType
 
-
 Thin-edge device support sending inventory data via tedge topic
-    Execute Command    tedge mqtt pub --retain "te/device/main///twin/device_OS" '{"family":"Debian","version":11,"complex":[1,"2",3],"object":{"foo":"bar"}}'
+    Execute Command
+    ...    tedge mqtt pub --retain "te/device/main///twin/device_OS" '{"family":"Debian","version":11,"complex":[1,"2",3],"object":{"foo":"bar"}}'
     Cumulocity.Set Device    ${DEVICE_SN}
     ${mo}=    Device Should Have Fragments    device_OS
     Should Be Equal    ${mo["device_OS"]["family"]}    Debian
@@ -147,7 +241,6 @@ Thin-edge device support sending inventory data via tedge topic
     # Validate clearing of fragments
     Execute Command    tedge mqtt pub --retain "te/device/main///twin/device_OS" ''
     Managed Object Should Not Have Fragments    device_OS
-
 
 Thin-edge device supports sending inventory data via tedge topic to root fragments
     Execute Command    tedge mqtt pub --retain "te/device/main///twin/subtype" '"LinuxDeviceA"'
@@ -166,11 +259,12 @@ Thin-edge device supports sending inventory data via tedge topic to root fragmen
     # Validate `name` and `type` can't be cleared
     Execute Command    tedge mqtt pub --retain "te/device/main///twin/type" ''
     Execute Command    tedge mqtt pub --retain "te/device/main///twin/name" ''
-    Sleep     5s    reason=Wait a minimum period before checking that the fragment has not changed (as it was previously set)
+    Sleep
+    ...    5s
+    ...    reason=Wait a minimum period before checking that the fragment has not changed (as it was previously set)
     ${mo}=    Device Should Have Fragments    type
     Should Be Equal    ${mo["type"]}    thin-edge.io
     Should Be Equal    ${mo["name"]}    ${DEVICE_SN}
-
 
 Previously cleared property should be sent to cloud when set again #2365
     [Tags]    \#2365
@@ -192,6 +286,7 @@ Previously cleared property should be sent to cloud when set again #2365
 # Services
 #
 # measurements
+
 Send measurements to an unregistered service
     Execute Command    tedge mqtt pub te/device/main/service/app1/m/service_type001 '{"temperature": 30.1}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
@@ -203,10 +298,11 @@ Send measurements to an unregistered service
     Should Be Equal As Numbers    ${measurements[0]["temperature"]["temperature"]["value"]}    30.1
 
 Send measurements to a registered service
-    Execute Command    tedge mqtt pub --retain te/device/main/service/app2 '{"@type":"service","@parent":"device/main//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main/service/app2 '{"@type":"service","@parent":"device/main//"}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
     Cumulocity.Should Have Services    name=app2    min_count=1    max_count=1
-    
+
     Execute Command    tedge mqtt pub te/device/main/service/app2/m/service_type002 '{"temperature": 30.1}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}:device:main:service:app2
     ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=service_type002
@@ -214,8 +310,10 @@ Send measurements to a registered service
     Should Be Equal As Numbers    ${measurements[0]["temperature"]["temperature"]["value"]}    30.1
 
 # alarms
+
 Send alarms to an unregistered service
-    Execute Command    tedge mqtt pub te/device/main/service/app3/a/alarm_001 '{"text": "test alarm","severity":"major"}'
+    Execute Command
+    ...    tedge mqtt pub te/device/main/service/app3/a/alarm_001 '{"text": "test alarm","severity":"major"}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
     Cumulocity.Should Have Services    min_count=1    max_count=1    name=app3
 
@@ -225,7 +323,8 @@ Send alarms to an unregistered service
     Should Be Equal    ${alarms[0]["severity"]}    MAJOR
 
 Send alarms to a registered service
-    Execute Command    tedge mqtt pub --retain te/device/main/service/app4 '{"@type":"service","@parent":"device/main//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main/service/app4 '{"@type":"service","@parent":"device/main//"}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
     Cumulocity.Should Have Services    name=app4    min_count=1    max_count=1
 
@@ -235,6 +334,7 @@ Send alarms to a registered service
     Should Be Equal    ${alarms[0]["type"]}    alarm_002
 
 # events
+
 Send events to an unregistered service
     Execute Command    tedge mqtt pub te/device/main/service/app5/e/event_001 '{"text": "test event"}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
@@ -244,7 +344,8 @@ Send events to an unregistered service
     Device Should Have Event/s    expected_text=test event    type=event_001    minimum=1    maximum=1
 
 Send events to a registered service
-    Execute Command    tedge mqtt pub --retain te/device/main/service/app6 '{"@type":"service","@parent":"device/main//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main/service/app6 '{"@type":"service","@parent":"device/main//"}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
     Cumulocity.Should Have Services    name=app6    min_count=1    max_count=1
 
@@ -252,10 +353,10 @@ Send events to a registered service
     Execute Command    tedge mqtt pub te/device/main/service/app6/e/event_002 '{"text": "test event"}'
     Device Should Have Event/s    expected_text=test event    type=event_002    minimum=1    maximum=1
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup
-    Set Suite Variable    $DEVICE_SN 
-    Device Should Exist                      ${DEVICE_SN}
+    Set Suite Variable    $DEVICE_SN
+    Device Should Exist    ${DEVICE_SN}
     Service Health Status Should Be Up    tedge-mapper-c8y

--- a/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry_built-in_bridge.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry_built-in_bridge.robot
@@ -1,19 +1,27 @@
 *** Settings ***
-Resource    ../../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
 
-Test Tags    theme:c8y    theme:telemetry
-Suite Setup    Custom Setup
-Test Teardown    Get Logs
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:telemetry
+
 
 *** Variables ***
 ${C8Y_TOPIC_PREFIX}     custom-c8y-prefix
 
+
 *** Test Cases ***
 Thin-edge devices support sending simple measurements
     Execute Command    tedge mqtt pub te/device/main///m/ '{ "temperature": 25 }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=ThinEdgeMeasurement    value=temperature    series=temperature
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=ThinEdgeMeasurement
+    ...    value=temperature
+    ...    series=temperature
     Log    ${measurements}
 
 Built-in bridge reports health status
@@ -21,136 +29,232 @@ Built-in bridge reports health status
 
 Bridge stops if mapper stops running
     Execute Command    tedge mqtt pub ${C8Y_TOPIC_PREFIX}/s/us '200,CustomMeasurement,temperature,25'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomMeasurement    series=temperature
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=CustomMeasurement
+    ...    series=temperature
     Log    ${measurements}
     Execute Command    systemctl stop tedge-mapper-c8y
     Service Health Status Should Be Down    tedge-mapper-bridge-custom-c8y-prefix
     Service Health Status Should Be Down    tedge-mapper-custom-c8y-prefix
     Execute Command    tedge mqtt pub ${C8Y_TOPIC_PREFIX}/s/us '200,CustomMeasurement,temperature,25'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomMeasurement    series=temperature
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=CustomMeasurement
+    ...    series=temperature
     Log    ${measurements}
     Execute Command    systemctl start tedge-mapper-c8y
 
 Thin-edge devices support sending simple measurements with custom type
     Execute Command    tedge mqtt pub te/device/main///m/ '{ "type":"CustomType", "temperature": 25 }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomType    value=temperature    series=temperature
-    Log    ${measurements}    
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=CustomType
+    ...    value=temperature
+    ...    series=temperature
+    Log    ${measurements}
 
 Thin-edge devices support sending simple measurements with custom type in topic
     Execute Command    tedge mqtt pub te/device/main///m/CustomType_topic '{ "temperature": 25 }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomType_topic    value=temperature    series=temperature
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=CustomType_topic
+    ...    value=temperature
+    ...    series=temperature
     Log    ${measurements}
 
-
 Thin-edge devices support sending simple measurements with custom type in payload
-    Execute Command    tedge mqtt pub te/device/main///m/CustomType_topic '{ "type":"CustomType_payload","temperature": 25 }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=CustomType_payload    value=temperature    series=temperature
-    Log    ${measurements}    
+    Execute Command
+    ...    tedge mqtt pub te/device/main///m/CustomType_topic '{ "type":"CustomType_payload","temperature": 25 }'
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=CustomType_payload
+    ...    value=temperature
+    ...    series=temperature
+    Log    ${measurements}
 
 Thin-edge devices support sending custom measurements
     Execute Command    tedge mqtt pub te/device/main///m/ '{ "current": {"L1": 9.5, "L2": 1.3} }'
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=ThinEdgeMeasurement    value=current    series=L1
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=ThinEdgeMeasurement
+    ...    value=current
+    ...    series=L1
     Log    ${measurements}
 
-
 Thin-edge devices support sending custom events
-    Execute Command    tedge mqtt pub te/device/main///e/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=myCustomType1    fragment=someOtherCustomFragment
+    Execute Command
+    ...    tedge mqtt pub te/device/main///e/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Some test event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomType1
+    ...    fragment=someOtherCustomFragment
     Log    ${events}
-
 
 Thin-edge devices support sending large events
-    Execute Command    tedge mqtt pub te/device/main///e/largeEvent "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(yes "x" | head -n 100000 | tr -d '\n')")"
-    ${events}=    Device Should Have Event/s    expected_text=Large event    with_attachment=False    minimum=1    maximum=1    type=largeEvent    fragment=large_text_field
+    Execute Command
+    ...    tedge mqtt pub te/device/main///e/largeEvent "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(yes "x" | head -n 100000 | tr -d '\n')")"
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Large event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=largeEvent
+    ...    fragment=large_text_field
     Length Should Be    ${events[0]["large_text_field"]}    100000
     Log    ${events}
-
 
 Thin-edge devices support sending large events using legacy api
     [Tags]    legacy
-    Execute Command    tedge mqtt pub tedge/events/largeEvent2 "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(yes "x" | head -n 100000 | tr -d '\n')")"
-    ${events}=    Device Should Have Event/s    expected_text=Large event    with_attachment=False    minimum=1    maximum=1    type=largeEvent2    fragment=large_text_field
+    Execute Command
+    ...    tedge mqtt pub tedge/events/largeEvent2 "$(printf '{"text":"Large event","large_text_field":"%s"}' "$(yes "x" | head -n 100000 | tr -d '\n')")"
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Large event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=largeEvent2
+    ...    fragment=large_text_field
     Length Should Be    ${events[0]["large_text_field"]}    100000
     Log    ${events}
 
-
 Thin-edge devices support sending custom events overriding the type
-    Execute Command    tedge mqtt pub te/device/main///e/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=otherType    fragment=someOtherCustomFragment
+    Execute Command
+    ...    tedge mqtt pub te/device/main///e/myCustomType '{"type": "otherType", "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Some test event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=otherType
+    ...    fragment=someOtherCustomFragment
     Log    ${events}
-
 
 Thin-edge devices support sending custom events without type in topic
-    Execute Command    tedge mqtt pub te/device/main///e/ '{"text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${events}=    Device Should Have Event/s    expected_text=Some test event    with_attachment=False    minimum=1    maximum=1    type=ThinEdgeEvent    fragment=someOtherCustomFragment
+    Execute Command
+    ...    tedge mqtt pub te/device/main///e/ '{"text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${events}=    Device Should Have Event/s
+    ...    expected_text=Some test event
+    ...    with_attachment=False
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=ThinEdgeEvent
+    ...    fragment=someOtherCustomFragment
     Log    ${events}
-
 
 Thin-edge devices support sending custom alarms #1699
     [Tags]    \#1699
-    Execute Command    tedge mqtt pub te/device/main///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=CRITICAL    minimum=1    maximum=1    type=myCustomAlarmType
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=CRITICAL
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomAlarmType
     Should Be Equal    ${alarms[0]["someOtherCustomFragment"]["nested"]["value"]}    extra info
     Log    ${alarms}
 
-
 Thin-edge devices support sending custom alarms overriding the type
-    Execute Command    tedge mqtt pub te/device/main///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "type": "otherType", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=CRITICAL    minimum=1    maximum=1    type=otherType
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/myCustomAlarmType '{ "severity": "critical", "text": "Some test alarm", "type": "otherType", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=CRITICAL
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=otherType
     Log    ${alarms}
-
 
 Thin-edge devices support sending custom alarms without type in topic
-    Execute Command    tedge mqtt pub te/device/main///a/ '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=CRITICAL    minimum=1    maximum=1    type=ThinEdgeAlarm
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/ '{ "severity": "critical", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=CRITICAL
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=ThinEdgeAlarm
     Log    ${alarms}
-
 
 Thin-edge devices support sending custom alarms without severity in payload
     Execute Command    tedge mqtt pub te/device/main///a/myCustomAlarmType2 '{ "text": "Some test alarm" }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=MINOR    minimum=1    maximum=1    type=myCustomAlarmType2
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=MINOR
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomAlarmType2
     Log    ${alarms}
-
 
 Thin-edge devices support sending custom alarms with unknown severity in payload
-    Execute Command    tedge mqtt pub te/device/main///a/myCustomAlarmType3 '{ "severity": "invalid", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=MINOR    minimum=1    maximum=1    type=myCustomAlarmType3
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/myCustomAlarmType3 '{ "severity": "invalid", "text": "Some test alarm", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=MINOR
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomAlarmType3
     Log    ${alarms}
-
-
 
 Thin-edge devices support sending custom alarms without text in payload
-    Execute Command    tedge mqtt pub te/device/main///a/myCustomAlarmType4 '{ "severity": "major", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
-    ${alarms}=    Device Should Have Alarm/s    expected_text=myCustomAlarmType4    severity=MAJOR    minimum=1    maximum=1    type=myCustomAlarmType4
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/myCustomAlarmType4 '{ "severity": "major", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=myCustomAlarmType4
+    ...    severity=MAJOR
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=myCustomAlarmType4
     Log    ${alarms}
-
 
 Thin-edge devices support sending alarms using text fragment
-    Execute Command    tedge mqtt pub te/device/main///a/parentAlarmType1 '{ "severity": "minor", "text": "Some test alarm" }'
+    Execute Command
+    ...    tedge mqtt pub te/device/main///a/parentAlarmType1 '{ "severity": "minor", "text": "Some test alarm" }'
     Cumulocity.Set Device    ${DEVICE_SN}
-    ${alarms}=    Device Should Have Alarm/s    expected_text=Some test alarm    severity=MINOR    minimum=1    maximum=1    type=parentAlarmType1
+    ${alarms}=    Device Should Have Alarm/s
+    ...    expected_text=Some test alarm
+    ...    severity=MINOR
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=parentAlarmType1
     Log    ${alarms}
 
-
 Thin-edge device supports sending custom Thin-edge device measurements directly to c8y
-    Execute Command    tedge mqtt pub "${C8Y_TOPIC_PREFIX}/measurement/measurements/create" '{"time":"2023-03-20T08:03:56.940907Z","environment":{"temperature":{"value":29.9,"unit":"°C"}},"type":"10min_average","meta":{"sensorLocation":"Brisbane, Australia"}}'
+    Execute Command
+    ...    tedge mqtt pub "${C8Y_TOPIC_PREFIX}/measurement/measurements/create" '{"time":"2023-03-20T08:03:56.940907Z","environment":{"temperature":{"value":29.9,"unit":"°C"}},"type":"10min_average","meta":{"sensorLocation":"Brisbane, Australia"}}'
     Cumulocity.Set Device    ${DEVICE_SN}
-    ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    value=environment    series=temperature    type=10min_average
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    value=environment
+    ...    series=temperature
+    ...    type=10min_average
     Should Be Equal As Numbers    ${measurements[0]["environment"]["temperature"]["value"]}    29.9
     Should Be Equal    ${measurements[0]["meta"]["sensorLocation"]}    Brisbane, Australia
     Should Be Equal    ${measurements[0]["type"]}    10min_average
 
-
 Thin-edge device support sending inventory data via c8y topic
-    Execute Command    tedge mqtt pub "${C8Y_TOPIC_PREFIX}/inventory/managedObjects/update/${DEVICE_SN}" '{"parentInfo":{"nested":{"name":"complex"}},"subType":"customType"}'
+    Execute Command
+    ...    tedge mqtt pub "${C8Y_TOPIC_PREFIX}/inventory/managedObjects/update/${DEVICE_SN}" '{"parentInfo":{"nested":{"name":"complex"}},"subType":"customType"}'
     Cumulocity.Set Device    ${DEVICE_SN}
     ${mo}=    Device Should Have Fragments    parentInfo    subType
     Should Be Equal    ${mo["parentInfo"]["nested"]["name"]}    complex
     Should Be Equal    ${mo["subType"]}    customType
 
-
 Thin-edge device support sending inventory data via tedge topic
-    Execute Command    tedge mqtt pub --retain "te/device/main///twin/device_OS" '{"family":"Debian","version":11,"complex":[1,"2",3],"object":{"foo":"bar"}}'
+    Execute Command
+    ...    tedge mqtt pub --retain "te/device/main///twin/device_OS" '{"family":"Debian","version":11,"complex":[1,"2",3],"object":{"foo":"bar"}}'
     Cumulocity.Set Device    ${DEVICE_SN}
     ${mo}=    Device Should Have Fragments    device_OS
     Should Be Equal    ${mo["device_OS"]["family"]}    Debian
@@ -164,7 +268,6 @@ Thin-edge device support sending inventory data via tedge topic
     # Validate clearing of fragments
     Execute Command    tedge mqtt pub --retain "te/device/main///twin/device_OS" ''
     Managed Object Should Not Have Fragments    device_OS
-
 
 Thin-edge device supports sending inventory data via tedge topic to root fragments
     Execute Command    tedge mqtt pub --retain "te/device/main///twin/subtype" '"LinuxDeviceA"'
@@ -183,11 +286,12 @@ Thin-edge device supports sending inventory data via tedge topic to root fragmen
     # Validate `name` and `type` can't be cleared
     Execute Command    tedge mqtt pub --retain "te/device/main///twin/type" ''
     Execute Command    tedge mqtt pub --retain "te/device/main///twin/name" ''
-    Sleep     5s    reason=Wait a minimum period before checking that the fragment has not changed (as it was previously set)
+    Sleep
+    ...    5s
+    ...    reason=Wait a minimum period before checking that the fragment has not changed (as it was previously set)
     ${mo}=    Device Should Have Fragments    type
     Should Be Equal    ${mo["type"]}    thin-edge.io
     Should Be Equal    ${mo["name"]}    ${DEVICE_SN}
-
 
 Previously cleared property should be sent to cloud when set again #2365
     [Tags]    \#2365
@@ -209,6 +313,7 @@ Previously cleared property should be sent to cloud when set again #2365
 # Services
 #
 # measurements
+
 Send measurements to an unregistered service
     Execute Command    tedge mqtt pub te/device/main/service/app1/m/service_type001 '{"temperature": 30.1}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
@@ -220,10 +325,11 @@ Send measurements to an unregistered service
     Should Be Equal As Numbers    ${measurements[0]["temperature"]["temperature"]["value"]}    30.1
 
 Send measurements to a registered service
-    Execute Command    tedge mqtt pub --retain te/device/main/service/app2 '{"@type":"service","@parent":"device/main//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main/service/app2 '{"@type":"service","@parent":"device/main//"}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
     Cumulocity.Should Have Services    name=app2    min_count=1    max_count=1
-    
+
     Execute Command    tedge mqtt pub te/device/main/service/app2/m/service_type002 '{"temperature": 30.1}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}:device:main:service:app2
     ${measurements}=    Device Should Have Measurements    minimum=1    maximum=1    type=service_type002
@@ -231,8 +337,10 @@ Send measurements to a registered service
     Should Be Equal As Numbers    ${measurements[0]["temperature"]["temperature"]["value"]}    30.1
 
 # alarms
+
 Send alarms to an unregistered service
-    Execute Command    tedge mqtt pub te/device/main/service/app3/a/alarm_001 '{"text": "test alarm","severity":"major"}'
+    Execute Command
+    ...    tedge mqtt pub te/device/main/service/app3/a/alarm_001 '{"text": "test alarm","severity":"major"}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
     Cumulocity.Should Have Services    min_count=1    max_count=1    name=app3
 
@@ -242,7 +350,8 @@ Send alarms to an unregistered service
     Should Be Equal    ${alarms[0]["severity"]}    MAJOR
 
 Send alarms to a registered service
-    Execute Command    tedge mqtt pub --retain te/device/main/service/app4 '{"@type":"service","@parent":"device/main//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main/service/app4 '{"@type":"service","@parent":"device/main//"}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
     Cumulocity.Should Have Services    name=app4    min_count=1    max_count=1
 
@@ -252,6 +361,7 @@ Send alarms to a registered service
     Should Be Equal    ${alarms[0]["type"]}    alarm_002
 
 # events
+
 Send events to an unregistered service
     Execute Command    tedge mqtt pub te/device/main/service/app5/e/event_001 '{"text": "test event"}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
@@ -261,7 +371,8 @@ Send events to an unregistered service
     Device Should Have Event/s    expected_text=test event    type=event_001    minimum=1    maximum=1
 
 Send events to a registered service
-    Execute Command    tedge mqtt pub --retain te/device/main/service/app6 '{"@type":"service","@parent":"device/main//"}'
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main/service/app6 '{"@type":"service","@parent":"device/main//"}'
     Cumulocity.Device Should Exist    ${DEVICE_SN}
     Cumulocity.Should Have Services    name=app6    min_count=1    max_count=1
 
@@ -269,12 +380,12 @@ Send events to a registered service
     Execute Command    tedge mqtt pub te/device/main/service/app6/e/event_002 '{"text": "test event"}'
     Device Should Have Event/s    expected_text=test event    type=event_002    minimum=1    maximum=1
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup
-    Set Suite Variable    $DEVICE_SN 
-    Device Should Exist                      ${DEVICE_SN}
+    Set Suite Variable    $DEVICE_SN
+    Device Should Exist    ${DEVICE_SN}
     ThinEdgeIO.Execute Command    tedge config set mqtt.bridge.built_in true
     ThinEdgeIO.Execute Command    tedge config set c8y.bridge.topic_prefix custom-c8y-prefix
     ThinEdgeIO.Execute Command    tedge reconnect c8y

--- a/tests/RobotFramework/tests/customizing/config_dir.robot
+++ b/tests/RobotFramework/tests/customizing/config_dir.robot
@@ -15,14 +15,14 @@ thin-edge components support a custom config-dir location via flags
 
     ThinEdgeIO.Directory Should Not Exist    /etc/tedge
 
-    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-mapper --config-dir ${CONFIG_DIR} c8y
-    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-agent --config-dir ${CONFIG_DIR}
-    Should Not Contain Default Path    ${CONFIG_DIR}    c8y-firmware-plugin --config-dir ${CONFIG_DIR}
+    Should Not Contain Default Path    tedge-mapper --config-dir ${CONFIG_DIR} c8y
+    Should Not Contain Default Path    tedge-agent --config-dir ${CONFIG_DIR}
+    Should Not Contain Default Path    c8y-firmware-plugin --config-dir ${CONFIG_DIR}
 
-    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-log-plugin --config-dir ${CONFIG_DIR}
+    Should Not Contain Default Path    tedge-log-plugin --config-dir ${CONFIG_DIR}
     ThinEdgeIO.File Should Exist    ${CONFIG_DIR}/plugins/tedge-log-plugin.toml
 
-    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-configuration-plugin --config-dir ${CONFIG_DIR}
+    Should Not Contain Default Path    tedge-configuration-plugin --config-dir ${CONFIG_DIR}
     ThinEdgeIO.File Should Exist    ${CONFIG_DIR}/plugins/tedge-configuration-plugin.toml
 
 thin-edge components support a custom config-dir location via an environment variable
@@ -31,15 +31,14 @@ thin-edge components support a custom config-dir location via an environment var
 
     ThinEdgeIO.Directory Should Not Exist    /etc/tedge
 
-    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-mapper c8y    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
-    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-agent    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
-    Should Not Contain Default Path    ${CONFIG_DIR}    c8y-firmware-plugin    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    Should Not Contain Default Path    tedge-mapper c8y    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    Should Not Contain Default Path    tedge-agent    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    Should Not Contain Default Path    c8y-firmware-plugin    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
 
-    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-log-plugin    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    Should Not Contain Default Path    tedge-log-plugin    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
     ThinEdgeIO.File Should Exist    ${CONFIG_DIR}/plugins/tedge-log-plugin.toml
 
     Should Not Contain Default Path
-    ...    ${CONFIG_DIR}
     ...    tedge-configuration-plugin
     ...    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
     ThinEdgeIO.File Should Exist    ${CONFIG_DIR}/plugins/tedge-configuration-plugin.toml
@@ -88,7 +87,7 @@ Should Not Contain Default Path
     ...    path /etc/tedge
     ...    This is only a rough check, as there is not a clean way to check
     ...    the current configuration of a specific component
-    [Arguments]    ${CONFIG_DIR}    ${COMMAND}    ${env}=
+    [Arguments]    ${COMMAND}    ${env}=
 
     ${LOG_OUTPUT}=    Execute Command
     ...    ${env} timeout -s SIGKILL 5 ${COMMAND}

--- a/tests/RobotFramework/tests/customizing/config_dir.robot
+++ b/tests/RobotFramework/tests/customizing/config_dir.robot
@@ -1,13 +1,14 @@
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:cli    theme:configuration
-Suite Setup            Custom Suite Setup
-Suite Teardown         Get Logs
+Suite Setup         Custom Suite Setup
+Suite Teardown      Get Logs
+
+Test Tags           theme:cli    theme:configuration
+
 
 *** Test Cases ***
-
 thin-edge components support a custom config-dir location via flags
     ${CONFIG_DIR}=    Set Variable    /tmp/test_config_dir
     Create Config Dir    ${CONFIG_DIR}    ${DEVICE_SN}
@@ -19,10 +20,10 @@ thin-edge components support a custom config-dir location via flags
     Should Not Contain Default Path    ${CONFIG_DIR}    c8y-firmware-plugin --config-dir ${CONFIG_DIR}
 
     Should Not Contain Default Path    ${CONFIG_DIR}    tedge-log-plugin --config-dir ${CONFIG_DIR}
-    ThinEdgeIO.File Should Exist       ${CONFIG_DIR}/plugins/tedge-log-plugin.toml
+    ThinEdgeIO.File Should Exist    ${CONFIG_DIR}/plugins/tedge-log-plugin.toml
 
     Should Not Contain Default Path    ${CONFIG_DIR}    tedge-configuration-plugin --config-dir ${CONFIG_DIR}
-    ThinEdgeIO.File Should Exist       ${CONFIG_DIR}/plugins/tedge-configuration-plugin.toml
+    ThinEdgeIO.File Should Exist    ${CONFIG_DIR}/plugins/tedge-configuration-plugin.toml
 
 thin-edge components support a custom config-dir location via an environment variable
     ${CONFIG_DIR}=    Set Variable    /tmp/test_config_dir_from_env
@@ -30,21 +31,24 @@ thin-edge components support a custom config-dir location via an environment var
 
     ThinEdgeIO.Directory Should Not Exist    /etc/tedge
 
-    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-mapper c8y       env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
-    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-agent            env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-mapper c8y    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-agent    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
     Should Not Contain Default Path    ${CONFIG_DIR}    c8y-firmware-plugin    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
 
-    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-log-plugin       env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
-    ThinEdgeIO.File Should Exist       ${CONFIG_DIR}/plugins/tedge-log-plugin.toml
+    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-log-plugin    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    ThinEdgeIO.File Should Exist    ${CONFIG_DIR}/plugins/tedge-log-plugin.toml
 
-    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-configuration-plugin    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
-    ThinEdgeIO.File Should Exist       ${CONFIG_DIR}/plugins/tedge-configuration-plugin.toml
+    Should Not Contain Default Path
+    ...    ${CONFIG_DIR}
+    ...    tedge-configuration-plugin
+    ...    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    ThinEdgeIO.File Should Exist    ${CONFIG_DIR}/plugins/tedge-configuration-plugin.toml
 
 Ignore env variable by using an empty value
     [Documentation]    If the TEDGE_CONFIG_DIR setting has been set globally, then
-        ...    sometimes it is still useful to be able to override the value without having to unset it.
-        ...    A common way to do this is just to give an empty value to TEDGE_CONFIG_DIR before
-        ...    launching a binary
+    ...    sometimes it is still useful to be able to override the value without having to unset it.
+    ...    A common way to do this is just to give an empty value to TEDGE_CONFIG_DIR before
+    ...    launching a binary
     ${CONFIG_DIR}=    Set Variable    /tmp/test_config_dir_reset
     Create Config Dir    ${CONFIG_DIR}    ${DEVICE_SN}
 
@@ -52,13 +56,13 @@ Ignore env variable by using an empty value
     ThinEdgeIO.Directory Should Exist    ${CONFIG_DIR}
     ThinEdgeIO.Directory Should Not Exist    /etc/tedge
 
-    # Ignore the globally set TEDGE_CONFIG_DIR value (for the process), but 
+    # Ignore the globally set TEDGE_CONFIG_DIR value (for the process), but
     # setting an empty value in the shell, e.g. TEDGE_CONFIG_DIR=
     Execute Command    cmd=TEDGE_CONFIG_DIR=${CONFIG_DIR} sh -c 'TEDGE_CONFIG_DIR= tedge init'
     ThinEdgeIO.Directory Should Exist    /etc/tedge
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Suite Setup
     ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
     Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-bootstrap --no-connect || true
@@ -79,12 +83,17 @@ Create Config Dir
     Execute Command    tedge --config-dir ${CONFIG_DIR} config set c8y.url ${C8Y_CONFIG.host}
 
 Should Not Contain Default Path
-    [Documentation]    Check a thin-edge.io executable by running it for a short time (~5s), and 
-    ...                analyzing the standard error output for any signs of the default
-    ...                path /etc/tedge
-    ...                This is only a rough check, as there is not a clean way to check
-    ...                the current configuration of a specific component
-
+    [Documentation]    Check a thin-edge.io executable by running it for a short time (~5s), and
+    ...    analyzing the standard error output for any signs of the default
+    ...    path /etc/tedge
+    ...    This is only a rough check, as there is not a clean way to check
+    ...    the current configuration of a specific component
     [Arguments]    ${CONFIG_DIR}    ${COMMAND}    ${env}=
-    ${LOG_OUTPUT}=    Execute Command    ${env} timeout -s SIGKILL 5 ${COMMAND}    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
+
+    ${LOG_OUTPUT}=    Execute Command
+    ...    ${env} timeout -s SIGKILL 5 ${COMMAND}
+    ...    stderr=${True}
+    ...    stdout=${False}
+    ...    ignore_exit_code=${True}
+
     Should Not Contain    ${LOG_OUTPUT}    /etc/tedge

--- a/tests/RobotFramework/tests/customizing/data_path_config.robot
+++ b/tests/RobotFramework/tests/customizing/data_path_config.robot
@@ -4,11 +4,11 @@
 
 *** Settings ***
 Resource            ../../resources/common.resource
-Library             ThinEdgeIO
-Library             Cumulocity
-Library             JSONLibrary
 Library             String
 Library             DebugLibrary
+Library             JSONLibrary
+Library             ThinEdgeIO
+Library             Cumulocity
 
 Suite Setup         Custom Setup
 Suite Teardown      Get Logs

--- a/tests/RobotFramework/tests/customizing/data_path_config.robot
+++ b/tests/RobotFramework/tests/customizing/data_path_config.robot
@@ -1,5 +1,5 @@
 *** Comments ***
-#Command to execute:    robot -d \results --timestampoutputs --log data_path_config.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io/tests/RobotFramework/customizing/data_path_config.robot
+# Command to execute:    robot -d \results --timestampoutputs --log data_path_config.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io/tests/RobotFramework/customizing/data_path_config.robot
 
 
 *** Settings ***
@@ -13,7 +13,7 @@ Library             DebugLibrary
 Suite Setup         Custom Setup
 Suite Teardown      Get Logs
 
-Test Tags          theme:cli    theme:configuration
+Test Tags           theme:cli    theme:configuration
 
 
 *** Test Cases ***

--- a/tests/RobotFramework/tests/customizing/log_path_config.robot
+++ b/tests/RobotFramework/tests/customizing/log_path_config.robot
@@ -1,18 +1,23 @@
-#Command to execute:    robot -d \results --timestampoutputs --log log_path_config.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io/tests/RobotFramework/customizinglog_path_config.robot
+*** Comments ***
+# Command to execute:    robot -d \results --timestampoutputs --log log_path_config.html --report NONE --variable HOST:192.168.1.120 /thin-edge.io/tests/RobotFramework/customizinglog_path_config.robot
+
 
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:cli    theme:configuration
-Suite Setup            Custom Setup
-Suite Teardown         Custom Teardown
+Suite Setup         Custom Setup
+Suite Teardown      Custom Teardown
+
+Test Tags           theme:cli    theme:configuration
+
 
 *** Test Cases ***
 Validate updated log path used by tedge-agent
     Execute Command    sudo tedge config set logs.path /var/test
     Restart Service    tedge-agent
     Directory Should Exist    /var/test/agent
+
 
 *** Keywords ***
 Custom Setup

--- a/tests/RobotFramework/tests/customizing/tedge_init.robot
+++ b/tests/RobotFramework/tests/customizing/tedge_init.robot
@@ -1,13 +1,14 @@
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:cli    theme:configuration
-Suite Setup            Custom Setup
-Suite Teardown         Custom Teardown
+Suite Setup         Custom Setup
+Suite Teardown      Custom Teardown
+
+Test Tags           theme:cli    theme:configuration
+
 
 *** Test Cases ***
-
 Check existence of init directories
     [Documentation]    During Custom Setup these folders were removed
     ...    this test step is confirming the deletion of the folders
@@ -43,7 +44,7 @@ Check ownership of the folders
     Check Owner of Directory    /var/log/tedge    tedge:tedge
 
 Change user/group and check the change
-    [Documentation]    Running tedge init --user <user> --group <group>  is setting custom user/group
+    [Documentation]    Running tedge init --user <user> --group <group>    is setting custom user/group
     ...    this test step is confirming the custom values for user/group
     Execute Command    sudo tedge init --user petertest --group petertest
     Check Owner of Directory    /etc/tedge    petertest:petertest
@@ -66,8 +67,8 @@ Tedge init and check if default values are restored
     Check Owner of Directory    /var/tedge    tedge:tedge
     Check Owner of Directory    /var/log/tedge    tedge:tedge
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     Setup
     Execute Command    sudo rm -rf /etc/tedge

--- a/tests/RobotFramework/tests/installation/install_apt.robot
+++ b/tests/RobotFramework/tests/installation/install_apt.robot
@@ -1,43 +1,51 @@
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:installation
-Test Setup    Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:installation
+
 
 *** Variables ***
-${APT_INSTALL}    apt-get install -y \
-    ...    tedge \
-    ...    tedge-mapper \
-    ...    tedge-agent \
-    ...    tedge-apt-plugin \
-    ...    c8y-firmware-plugin \
-    ...    tedge-watchdog
+${APT_INSTALL}      apt-get install -y \
+...                 tedge \
+...                 tedge-mapper \
+...                 tedge-agent \
+...                 tedge-apt-plugin \
+...                 c8y-firmware-plugin \
+...                 tedge-watchdog
+
 
 *** Test Cases ***
-
 Install thin-edge via apt
     Execute Command    apt-get update
     Execute Command    ${APT_INSTALL}
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup    skip_bootstrap=True
     Set Suite Variable    $DEVICE_SN
 
     # Cleanup
     Execute Command    rm -rf /etc/tedge && sudo dpkg --configure -a && apt-get purge -y "tedge*" "c8y*"
-    Execute Command    cmd=rm -f /etc/apt/sources.list.d/thinedge*.list /etc/apt/sources.list.d/tedge*.list    # Remove any existing repositories (due to candidate bug in <= 0.8.1)
+    # Remove any existing repositories (due to candidate bug in <= 0.8.1)
+    Execute Command
+    ...    cmd=rm -f /etc/apt/sources.list.d/thinedge*.list /etc/apt/sources.list.d/tedge*.list
 
     # Create local apt repo
     Create Local Repository
 
 Create Local Repository
     Execute Command    apt-get update && apt-get install -y --no-install-recommends dpkg-dev
-    Execute Command    mkdir -p /opt/repository/local && find /setup -type f -name "*.deb" -exec cp {} /opt/repository/local \\;
-    ${NEW_VERSION}=    Execute Command    find /setup -type f -name "tedge-mapper_*.deb" | sort -Vr | head -n1 | cut -d'_' -f 2    strip=True
+    Execute Command
+    ...    mkdir -p /opt/repository/local && find /setup -type f -name "*.deb" -exec cp {} /opt/repository/local \\;
+    ${NEW_VERSION}=    Execute Command
+    ...    find /setup -type f -name "tedge-mapper_*.deb" | sort -Vr | head -n1 | cut -d'_' -f 2
+    ...    strip=True
     Set Suite Variable    $NEW_VERSION
     Execute Command    cd /opt/repository/local && dpkg-scanpackages -m . > Packages
-    Execute Command    cmd=echo 'deb [trusted=yes] file:/opt/repository/local /' > /etc/apt/sources.list.d/tedge-local.list
+    Execute Command
+    ...    cmd=echo 'deb [trusted=yes] file:/opt/repository/local /' > /etc/apt/sources.list.d/tedge-local.list

--- a/tests/RobotFramework/tests/installation/install_on_linux.robot
+++ b/tests/RobotFramework/tests/installation/install_on_linux.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Resource        ../../resources/common.resource
-Library         ThinEdgeIO
 Library         Collections
+Library         ThinEdgeIO
 
 Test Tags       theme:installation    test:on_demand
 

--- a/tests/RobotFramework/tests/installation/install_on_linux.robot
+++ b/tests/RobotFramework/tests/installation/install_on_linux.robot
@@ -1,47 +1,47 @@
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
-Library    Collections
+Resource        ../../resources/common.resource
+Library         ThinEdgeIO
+Library         Collections
 
-Test Tags    theme:installation    test:on_demand
+Test Tags       theme:installation    test:on_demand
+
 
 *** Variables ***
 # Debian
-${APT_SETUP}      apt-get update \
-    ...           && apt-get install -y sudo curl mosquitto \
-    ...           && curl -1sLf https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.deb.sh | sudo -E bash
-${APT_INSTALL}    apt-get install -y tedge-full
+${APT_SETUP}        apt-get update \
+...                 && apt-get install -y sudo curl mosquitto \
+...                 && curl -1sLf https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.deb.sh | sudo -E bash
+${APT_INSTALL}      apt-get install -y tedge-full
 
 # CentOS/RHEL
-${DNF_SETUP}      dnf install -y epel-release \
-    ...           && dnf install -y sudo mosquitto \
-    ...           && curl -1sLf "https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.rpm.sh" | sudo -E bash
-${DNF_INSTALL}    dnf install -y tedge-full
+${DNF_SETUP}        dnf install -y epel-release \
+...                 && dnf install -y sudo mosquitto \
+...                 && curl -1sLf "https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.rpm.sh" | sudo -E bash
+${DNF_INSTALL}      dnf install -y tedge-full
 
-${SUSE_SETUP}     zypper install -y sudo curl mosquitto \
-    ...           && curl -1sLf "https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.rpm.sh" | sudo -E version\=any-version codename\="" bash
-${SUSE_INSTALL}   zypper install -y tedge-full
-
+${SUSE_SETUP}
+...                 zypper install -y sudo curl mosquitto \
+...                 && curl -1sLf "https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.rpm.sh" | sudo -E version\=any-version codename\="" bash
+${SUSE_INSTALL}     zypper install -y tedge-full
 
 # DNF where the epel-release repo is not required (e.g. Fedora)
-${DNF2_SETUP}     dnf install -y sudo mosquitto \
-    ...           && curl -1sLf "https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.rpm.sh" | sudo -E bash
-${DNF2_INSTALL}   dnf install -y tedge-full
+${DNF2_SETUP}       dnf install -y sudo mosquitto \
+...                 && curl -1sLf "https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.rpm.sh" | sudo -E bash
+${DNF2_INSTALL}     dnf install -y tedge-full
 
 # Microdnf
-${MDNF_SETUP}     microdnf install -y epel-release \
-    ...           && microdnf install -y sudo tar mosquitto \
-    ...           && curl -1sLf "https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.rpm.sh" | sudo -E bash
-${MDNF_INSTALL}   microdnf install -y tedge-full
+${MDNF_SETUP}       microdnf install -y epel-release \
+...                 && microdnf install -y sudo tar mosquitto \
+...                 && curl -1sLf "https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.rpm.sh" | sudo -E bash
+${MDNF_INSTALL}     microdnf install -y tedge-full
 
 # Alpine linux
-${APK_SETUP}      apk add --no-cache sudo curl bash mosquitto \
-    ...           && curl -1sLf "https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.alpine.sh" | sudo -E bash
-${APK_INSTALL}    apk add --no-cache tedge-full
+${APK_SETUP}        apk add --no-cache sudo curl bash mosquitto \
+...                 && curl -1sLf "https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.alpine.sh" | sudo -E bash
+${APK_INSTALL}      apk add --no-cache tedge-full
 
 
 *** Test Cases ***
-
 Install on CentOS/RHEL based images
     [Template]    Install using dnf
     rockylinux:9
@@ -89,64 +89,64 @@ Install on any linux distribution
     rockylinux:8-minimal
     almalinux:9-minimal
     almalinux:8-minimal
-    debian:12-slim     install_args=--package-manager tarball
+    debian:12-slim    install_args=--package-manager tarball
+
 
 *** Keywords ***
-
 Install using dnf
     [Arguments]    ${IMAGE}
     Set To Dictionary    ${DOCKER_CONFIG}    image=${IMAGE}
-    ${DEVICE_ID}=        Setup    skip_bootstrap=${True}
-    Execute Command      ${DNF_SETUP}
-    Execute Command      ${DNF_INSTALL}
+    ${DEVICE_ID}=    Setup    skip_bootstrap=${True}
+    Execute Command    ${DNF_SETUP}
+    Execute Command    ${DNF_INSTALL}
 
 Install using microdnf
     [Arguments]    ${IMAGE}
     Set To Dictionary    ${DOCKER_CONFIG}    image=${IMAGE}
-    ${DEVICE_ID}=        Setup    skip_bootstrap=${True}
-    Execute Command      ${MDNF_SETUP}
-    Execute Command      ${MDNF_INSTALL}
+    ${DEVICE_ID}=    Setup    skip_bootstrap=${True}
+    Execute Command    ${MDNF_SETUP}
+    Execute Command    ${MDNF_INSTALL}
 
 Install using fedora dnf
     [Arguments]    ${IMAGE}
     Set To Dictionary    ${DOCKER_CONFIG}    image=${IMAGE}
-    ${DEVICE_ID}=        Setup    skip_bootstrap=${True}
-    Execute Command      ${DNF2_SETUP}
-    Execute Command      ${DNF2_INSTALL}
+    ${DEVICE_ID}=    Setup    skip_bootstrap=${True}
+    Execute Command    ${DNF2_SETUP}
+    Execute Command    ${DNF2_INSTALL}
 
 Install using apt
     [Arguments]    ${IMAGE}
     Set To Dictionary    ${DOCKER_CONFIG}    image=${IMAGE}
-    ${DEVICE_ID}=        Setup    skip_bootstrap=${True}
-    Execute Command      ${APT_SETUP}
-    Execute Command      ${APT_INSTALL}
+    ${DEVICE_ID}=    Setup    skip_bootstrap=${True}
+    Execute Command    ${APT_SETUP}
+    Execute Command    ${APT_INSTALL}
 
 Install using apk
     [Arguments]    ${IMAGE}
     Set To Dictionary    ${DOCKER_CONFIG}    image=${IMAGE}
-    ${DEVICE_ID}=        Setup    skip_bootstrap=${True}
-    Execute Command      ${APK_SETUP}    shell=${True}    sudo=${False}
-    Execute Command      ${APK_INSTALL}
+    ${DEVICE_ID}=    Setup    skip_bootstrap=${True}
+    Execute Command    ${APK_SETUP}    shell=${True}    sudo=${False}
+    Execute Command    ${APK_INSTALL}
 
 Install using zypper
     [Arguments]    ${IMAGE}
     Set To Dictionary    ${DOCKER_CONFIG}    image=${IMAGE}
-    ${DEVICE_ID}=        Setup    skip_bootstrap=${True}
-    Execute Command      ${SUSE_SETUP}    shell=${True}    sudo=${False}
-    Execute Command      ${SUSE_INSTALL}
+    ${DEVICE_ID}=    Setup    skip_bootstrap=${True}
+    Execute Command    ${SUSE_SETUP}    shell=${True}    sudo=${False}
+    Execute Command    ${SUSE_INSTALL}
 
 Install using script
     [Arguments]    ${image}    ${pre_install}=    ${install_args}=
     Set To Dictionary    ${DOCKER_CONFIG}    image=${image}
-    ${DEVICE_ID}=        Setup    skip_bootstrap=${True}
+    ${DEVICE_ID}=    Setup    skip_bootstrap=${True}
 
     IF    "${pre_install}" != ""
-        Execute Command      ${pre_install}    sudo=${False}    timeout=2
+        Execute Command    ${pre_install}    sudo=${False}    timeout=2
     END
 
     Transfer To Device    ${CURDIR}/../../../../install.sh    /setup/
-    Execute Command      chmod +x /setup/install.sh && /setup/install.sh ${install_args}    sudo=${False}    timeout=2
+    Execute Command    chmod +x /setup/install.sh && /setup/install.sh ${install_args}    sudo=${False}    timeout=2
     Validate Installation
 
 Validate Installation
-    Execute Command      timeout 2 tedge-agent || exit 0        timeout=2
+    Execute Command    timeout 2 tedge-agent || exit 0    timeout=2

--- a/tests/RobotFramework/tests/installation/install_tedge.robot
+++ b/tests/RobotFramework/tests/installation/install_tedge.robot
@@ -1,10 +1,12 @@
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:installation
-Test Setup       Custom Setup
-Test Teardown    Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:installation
+
 
 *** Test Cases ***
 Install latest via script (from current branch)
@@ -17,7 +19,7 @@ Install latest via script (from current branch)
 
 Install specific version via script (from current branch)
     [Documentation]    Remove the tedge.toml file as the software filter is not supported in older tedge versions
-    ...                and unknown configuration causes problems
+    ...    and unknown configuration causes problems
     # TODO: Remove reliance on the legacy get-thin-edge_io.sh script, however thin-edge.io/install.sh does not currently support installing a specific version
     Transfer To Device    ${CURDIR}/../../../../get-thin-edge_io.sh    /setup/
     Execute Command    [ -f /etc/tedge/tedge.toml ] && sed -i '/\\[software\\]/,/\\n/d' /etc/tedge/tedge.toml
@@ -43,11 +45,12 @@ Install then uninstall latest tedge via script (from main branch)
     Execute Command    dpkg -s c8y-remote-access-plugin
 
     # Uninstall
-    Execute Command    curl -sSL https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/uninstall-thin-edge_io.sh | sudo sh -s purge
+    Execute Command
+    ...    curl -sSL https://raw.githubusercontent.com/thin-edge/thin-edge.io/main/uninstall-thin-edge_io.sh | sudo sh -s purge
     Tedge Should Not Be Installed
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     Setup    skip_bootstrap=True
 

--- a/tests/RobotFramework/tests/library/service-control.robot
+++ b/tests/RobotFramework/tests/library/service-control.robot
@@ -1,17 +1,17 @@
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO
+Resource        ../../resources/common.resource
+Library         Cumulocity
+Library         ThinEdgeIO
 
-Test Tags    theme:testing
+Test Tags       theme:testing
+
 
 *** Test Cases ***
-
 Support starting and stopping services
-    ${DEVICE_SN}                     Setup
-    Device Should Exist              ${DEVICE_SN}
-    Process Should Be Running        tedge[_-]mapper c8y
-    Stop Service                     tedge-mapper-c8y
+    ${DEVICE_SN}    Setup
+    Device Should Exist    ${DEVICE_SN}
+    Process Should Be Running    tedge[_-]mapper c8y
+    Stop Service    tedge-mapper-c8y
     Process Should Not Be Running    tedge[_-]mapper c8y
-    Start Service                    tedge-mapper-c8y
-    Process Should Be Running        tedge[_-]mapper c8y
+    Start Service    tedge-mapper-c8y
+    Process Should Be Running    tedge[_-]mapper c8y

--- a/tests/RobotFramework/tests/library/test-commands.robot
+++ b/tests/RobotFramework/tests/library/test-commands.robot
@@ -1,31 +1,32 @@
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO    adapter=docker
+Resource            ../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO    adapter=docker
 
-Test Tags    theme:testing
-Test Teardown    Get Logs
+Test Teardown       Get Logs
+
+Test Tags           theme:testing
+
 
 *** Test Cases ***
-
 Supports a reconnect
-    ${DEVICE_SN}                         Setup
-    Device Should Exist                  ${DEVICE_SN}
-    Disconnect Then Connect Mapper       mapper=c8y    sleep=5
+    ${DEVICE_SN}    Setup
+    Device Should Exist    ${DEVICE_SN}
+    Disconnect Then Connect Mapper    mapper=c8y    sleep=5
 
 Supports disconnect then connect
-    ${DEVICE_SN}                         Setup
-    Device Should Exist                  ${DEVICE_SN}
+    ${DEVICE_SN}    Setup
+    Device Should Exist    ${DEVICE_SN}
     Disconnect Mapper
     Connect Mapper
 
 Update unknown setting
-    ${DEVICE_SN}                         Setup
-    Device Should Exist                  ${DEVICE_SN}
-    Execute Command                      tedge config set unknown.value 1    exp_exit_code=2
+    ${DEVICE_SN}    Setup
+    Device Should Exist    ${DEVICE_SN}
+    Execute Command    tedge config set unknown.value 1    exp_exit_code=2
 
 Update known setting
-    ${DEVICE_SN}                         Setup
-    Set Tedge Configuration Using CLI    device.type        mycustomtype
-    ${OUTPUT}=    Execute Command        tedge config get device.type
-    Should Match    ${OUTPUT}            mycustomtype\n
+    ${DEVICE_SN}    Setup
+    Set Tedge Configuration Using CLI    device.type    mycustomtype
+    ${OUTPUT}    Execute Command    tedge config get device.type
+    Should Match    ${OUTPUT}    mycustomtype\n

--- a/tests/RobotFramework/tests/library/test-mqtt.robot
+++ b/tests/RobotFramework/tests/library/test-mqtt.robot
@@ -1,17 +1,18 @@
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    Cumulocity
-Library    ThinEdgeIO    adapter=docker
+Resource            ../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO    adapter=docker
 
-Test Tags    theme:testing
-Test Setup    Setup
-Test Teardown    Get Logs
+Test Setup          Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:testing
+
 
 *** Test Cases ***
-
 It checks MQTT messages using a pattern
-    ${DEVICE_SN}                         Setup
-    Device Should Exist                  ${DEVICE_SN}
-    Execute Command            tedge mqtt pub 'custom/message' '{"status":"executing"}'
+    ${DEVICE_SN}    Setup
+    Device Should Exist    ${DEVICE_SN}
+    Execute Command    tedge mqtt pub 'custom/message' '{"status":"executing"}'
     Should Have MQTT Messages    custom/message    message_pattern=.*executing.*
     Should Have MQTT Messages    custom/message    message_contains=executing

--- a/tests/RobotFramework/tests/mqtt/basic_pub_sub.robot
+++ b/tests/RobotFramework/tests/mqtt/basic_pub_sub.robot
@@ -5,7 +5,7 @@ Library         OperatingSystem
 
 Suite Setup     Custom Setup
 
-Test Tags      theme:mqtt
+Test Tags       theme:mqtt
 
 
 *** Test Cases ***

--- a/tests/RobotFramework/tests/mqtt/basic_pub_sub.robot
+++ b/tests/RobotFramework/tests/mqtt/basic_pub_sub.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Resource        ../../resources/common.resource
-Library         ThinEdgeIO
 Library         OperatingSystem
+Library         ThinEdgeIO
 
 Suite Setup     Custom Setup
 

--- a/tests/RobotFramework/tests/mqtt/custom_sub_topics_tedge-mapper-aws.robot
+++ b/tests/RobotFramework/tests/mqtt/custom_sub_topics_tedge-mapper-aws.robot
@@ -11,14 +11,12 @@ Test Tags           theme:mqtt    theme:aws
 
 
 *** Test Cases ***
-
-
 Publish events to subscribed topic
-    ${timestamp}=        Get Unix Timestamp
+    ${timestamp}=    Get Unix Timestamp
     Execute Command    tedge mqtt pub te/device/main///e/event-type '{"text": "someone logged-in"}'
     Should Have MQTT Messages    aws/td/device:main/e/event-type
 
-Publish measurements to unsubscribed topic   
+Publish measurements to unsubscribed topic
     Execute Command    tedge mqtt pub te/device/main///m/measurement-type '{"temperature": 30}'
     Sleep    5s    reason=If a message is not published in 5s, it will never be published.
     Should Have MQTT Messages    aws/td/device:main/m/measurement-type    minimum=0    maximum=0

--- a/tests/RobotFramework/tests/mqtt/custom_sub_topics_tedge-mapper-az.robot
+++ b/tests/RobotFramework/tests/mqtt/custom_sub_topics_tedge-mapper-az.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation        Purpose of this test is to verify that tedge-mapper-az subscribes the topics that are configured as az.topics
+Documentation       Purpose of this test is to verify that tedge-mapper-az subscribes the topics that are configured as az.topics
 
 Resource            ../../resources/common.resource
 Library             ThinEdgeIO
@@ -18,7 +18,7 @@ Publish events to subscribed topic
 Publish measurements to unsubscribed topic
     Execute Command    tedge mqtt pub te/device/main///m/ '{"temperature": 10}'
     Sleep    5s    reason=If a message is not published in 5s, it will never be published.
-    Should Have MQTT Messages    az/messages/events/#   minimum=0    maximum=0    message_contains=temperature
+    Should Have MQTT Messages    az/messages/events/#    minimum=0    maximum=0    message_contains=temperature
 
 
 *** Keywords ***

--- a/tests/RobotFramework/tests/mqtt/disconnect_from_broker.robot
+++ b/tests/RobotFramework/tests/mqtt/disconnect_from_broker.robot
@@ -1,17 +1,16 @@
 *** Settings ***
-Resource        ../../resources/common.resource
-Library         ThinEdgeIO
-Library         OperatingSystem
-Library         String
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+Library             OperatingSystem
+Library             String
 
-Test Setup     Setup    skip_bootstrap=True
-Suite Teardown  Get Logs
+Suite Teardown      Get Logs
+Test Setup          Setup    skip_bootstrap=True
 
-Test Tags      theme:mqtt
+Test Tags           theme:mqtt
 
 
 *** Test Cases ***
-
 Publish Connection Closed after publish
     [Documentation]    Tests that the connection to the MQTT broker is closed after publishing.
     Execute Command    /setup/bootstrap.sh
@@ -28,7 +27,7 @@ Publish Connection Closed after publish and no error message with TLS
     Execute Command    tedge mqtt pub test/topic Hello
     ${MQTT_PUB}    Execute Command    journalctl -u mosquitto -n 30
     Should Contain    ${MQTT_PUB}    Received DISCONNECT from tedge-pub
-   
+
 Subscribe Connection Closed On Interruption
     [Documentation]    Tests that a subscribe connection to MQTT broker closes upon interruption.
     Execute Command    /setup/bootstrap.sh
@@ -39,13 +38,16 @@ Subscribe Connection Closed On Interruption
 Stop subscription on SIGINT even when broker is not available
     Execute Command    /setup/bootstrap.sh
     Execute Command    sudo systemctl stop mosquitto
-    ${output}=     Execute Command    cmd=timeout --signal=SIGINT 2 tedge mqtt sub '#'    timeout=5    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
+    ${output}    Execute Command
+    ...    cmd=timeout --signal=SIGINT 2 tedge mqtt sub '#'
+    ...    timeout=5
+    ...    stderr=${True}
+    ...    stdout=${False}
+    ...    ignore_exit_code=${True}
     Should Contain    ${output}    Connection refused
 
 
-
 *** Keywords ***
-
 Set up broker with server and client authentication
     Transfer To Device    ${CURDIR}/mosquitto-client-auth.conf    /etc/tedge/mosquitto-conf/mosquitto-client-auth.conf
     Execute Command

--- a/tests/RobotFramework/tests/mqtt/disconnect_from_broker.robot
+++ b/tests/RobotFramework/tests/mqtt/disconnect_from_broker.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Resource            ../../resources/common.resource
-Library             String
 Library             OperatingSystem
+Library             String
 Library             ThinEdgeIO
 
 Suite Teardown      Get Logs

--- a/tests/RobotFramework/tests/mqtt/disconnect_from_broker.robot
+++ b/tests/RobotFramework/tests/mqtt/disconnect_from_broker.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource            ../../resources/common.resource
-Library             ThinEdgeIO
-Library             OperatingSystem
 Library             String
+Library             OperatingSystem
+Library             ThinEdgeIO
 
 Suite Teardown      Get Logs
 Test Setup          Setup    skip_bootstrap=True

--- a/tests/RobotFramework/tests/mqtt/remote_mqtt_broker.robot
+++ b/tests/RobotFramework/tests/mqtt/remote_mqtt_broker.robot
@@ -6,12 +6,12 @@ Library             Cumulocity
 Suite Setup         Custom Setup
 Suite Teardown      Custom Teardown
 
-Test Tags          theme:mqtt    theme:c8y    adapter:docker
+Test Tags           theme:mqtt    theme:c8y    adapter:docker
 
 
 *** Variables ***
-${CONTAINER_1}
-${CONTAINER_2}
+${CONTAINER_1}      ${EMPTY}
+${CONTAINER_2}      ${EMPTY}
 
 
 *** Test Cases ***

--- a/tests/RobotFramework/tests/plugin_apt/filter_packages_list_output.robot
+++ b/tests/RobotFramework/tests/plugin_apt/filter_packages_list_output.robot
@@ -55,6 +55,6 @@ Both filters as empty string
 *** Keywords ***
 Custom Setup
     Setup
-    ${RAW_VERSION}=    Execute Command    tedge --version | cut -d' ' -f 2 | sed 's/-rc\./~rc./'   strip=${True}
+    ${RAW_VERSION}=    Execute Command    tedge --version | cut -d' ' -f 2 | sed 's/-rc\./~rc./'    strip=${True}
     ${VERSION}=    Regexp Escape    ${RAW_VERSION}
     Set Suite Variable    ${VERSION}

--- a/tests/RobotFramework/tests/plugin_apt/improve_tedge_apt_plugin_error_messages.robot
+++ b/tests/RobotFramework/tests/plugin_apt/improve_tedge_apt_plugin_error_messages.robot
@@ -1,7 +1,3 @@
-*** Comments ***
-# Command to execute:    robot -d \results --timestampoutputs --log improve_tedge_apt_plugin_error_messages.html --report NONE --variable HOST:192.168.1.130 /thin-edge.io-fork/tests/RobotFramework/plugin_apt/improve_tedge_apt_plugin_error_messages.robot
-
-
 *** Settings ***
 Resource            ../../resources/common.resource
 Library             ThinEdgeIO

--- a/tests/RobotFramework/tests/plugin_apt/improve_tedge_apt_plugin_error_messages.robot
+++ b/tests/RobotFramework/tests/plugin_apt/improve_tedge_apt_plugin_error_messages.robot
@@ -1,27 +1,52 @@
-#Command to execute:    robot -d \results --timestampoutputs --log improve_tedge_apt_plugin_error_messages.html --report NONE --variable HOST:192.168.1.130 /thin-edge.io-fork/tests/RobotFramework/plugin_apt/improve_tedge_apt_plugin_error_messages.robot
+*** Comments ***
+# Command to execute:    robot -d \results --timestampoutputs --log improve_tedge_apt_plugin_error_messages.html --report NONE --variable HOST:192.168.1.130 /thin-edge.io-fork/tests/RobotFramework/plugin_apt/improve_tedge_apt_plugin_error_messages.robot
+
 
 *** Settings ***
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:software    theme:plugins
-Suite Setup       Custom Setup
-Suite Teardown    Get Logs
+Suite Setup         Custom Setup
+Suite Teardown      Get Logs
+
+Test Tags           theme:software    theme:plugins
 
 
 *** Test Cases ***
 Wrong package name
-    ${wpn}=    Execute Command    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file "${DEB_FILE}"    exp_exit_code=5    stdout=${False}    stderr=${True}
-    Should Contain    ${wpn}    ERROR: Validation of ${DEB_FILE} metadata failed, expected value for the Package is  rolldice, but provided  thinml-3964
+    ${wpn}=    Execute Command
+    ...    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file "${DEB_FILE}"
+    ...    exp_exit_code=5
+    ...    stdout=${False}
+    ...    stderr=${True}
+    Should Contain
+    ...    ${wpn}
+    ...    ERROR: Validation of ${DEB_FILE} metadata failed, expected value for the Package is
+    ...    rolldice, but provided
+    ...    thinml-3964
 
 Wrong version
-    ${wv}=    Execute Command    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file "${DEB_FILE}" --module-version 1.0    exp_exit_code=5    stdout=${False}    stderr=${True}
-    Should Contain    ${wv}    ERROR: Validation of ${DEB_FILE} metadata failed, expected value for the Version is  1.16-1build1, but provided  1.0
+    ${wv}=    Execute Command
+    ...    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file "${DEB_FILE}" --module-version 1.0
+    ...    exp_exit_code=5
+    ...    stdout=${False}
+    ...    stderr=${True}
+    Should Contain
+    ...    ${wv}
+    ...    ERROR: Validation of ${DEB_FILE} metadata failed, expected value for the Version is
+    ...    1.16-1build1, but provided
+    ...    1.0
 
 Wrong type
     Execute Command    echo "Not a debian package" >/tmp/foo.deb
-    ${wv}=    Execute Command    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file /tmp/foo.deb    exp_exit_code=5    stdout=${False}    stderr=${True}
-    Should Contain    ${wv}    ERROR: Parsing Debian package failed for `/tmp/foo.deb`, Error: dpkg-deb: error: '/tmp/foo.deb' is not a Debian format archive
+    ${wv}=    Execute Command
+    ...    sudo /etc/tedge/sm-plugins/apt install thinml-3964 --file /tmp/foo.deb
+    ...    exp_exit_code=5
+    ...    stdout=${False}
+    ...    stderr=${True}
+    Should Contain
+    ...    ${wv}
+    ...    ERROR: Parsing Debian package failed for `/tmp/foo.deb`, Error: dpkg-deb: error: '/tmp/foo.deb' is not a Debian format archive
     Execute Command    rm /tmp/*.deb
 
 

--- a/tests/RobotFramework/tests/plugin_apt/install_overwrite_config_files.robot
+++ b/tests/RobotFramework/tests/plugin_apt/install_overwrite_config_files.robot
@@ -3,7 +3,7 @@ Resource            ../../resources/common.resource
 Library             ThinEdgeIO
 Library             Cumulocity
 
-Test Setup         Custom Setup
+Test Setup          Custom Setup
 Test Teardown       Get Logs
 
 Test Tags           theme:software    theme:plugins
@@ -13,14 +13,16 @@ Test Tags           theme:software    theme:plugins
 Install packages without overwriting config files
     Execute Command    tedge config set apt.dpk.options.config keepold
     # install package v1
-    ${OPERATION}=    Install Software    {"name": "sampledeb", "version": "1.0.0", "softwareType": "apt", "url": "${FILE_URL_1}"}
+    ${OPERATION}=    Install Software
+    ...    {"name": "sampledeb", "version": "1.0.0", "softwareType": "apt", "url": "${FILE_URL_1}"}
     ${OPERATION}=    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
 
     # Modify the config file
     Execute Command    echo "Updated the config" | sudo tee -a /etc/sampledeb.cfg
 
     # install package v2
-    ${OPERATION}=    Install Software    {"name": "sampledeb", "version": "1.0.0", "softwareType": "apt", "url": "${FILE_URL_1}"}
+    ${OPERATION}=    Install Software
+    ...    {"name": "sampledeb", "version": "1.0.0", "softwareType": "apt", "url": "${FILE_URL_1}"}
     ${OPERATION}=    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
 
     # Assert to make sure installation of newer version did not update the config file
@@ -31,27 +33,36 @@ Install packages without overwriting config files
 Install packages overwrite config files
     Execute Command    tedge config set apt.dpk.options.config keepnew
     # install package v1
-    ${OPERATION}=    Install Software    {"name": "sampledeb", "version": "1.0.0", "softwareType": "apt", "url": "${FILE_URL_1}"}
+    ${OPERATION}=    Install Software
+    ...    {"name": "sampledeb", "version": "1.0.0", "softwareType": "apt", "url": "${FILE_URL_1}"}
     ${OPERATION}=    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
 
     # Modify the config file
     Execute Command    echo "Updated the config" | sudo tee -a /etc/sampledeb.cfg
 
     # install package v2
-    ${OPERATION}=    Install Software    {"name": "sampledeb", "version": "2.0.0", "softwareType": "apt", "url": "${FILE_URL_2}"}
+    ${OPERATION}=    Install Software
+    ...    {"name": "sampledeb", "version": "2.0.0", "softwareType": "apt", "url": "${FILE_URL_2}"}
     ${OPERATION}=    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
 
     # Assert to make sure installation of newer version did not update the config file
     ${output}=    Execute Command    cat /etc/sampledeb.cfg
     Should Contain    ${output}    conf 2.0
 
+
 *** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup
     Device Should Exist    ${DEVICE_SN}
 
-    ${FILE_URL_1}=    Cumulocity.Create Inventory Binary    sampledeb    package    file=${CURDIR}/sampledeb_1.0.0_all.deb
+    ${FILE_URL_1}=    Cumulocity.Create Inventory Binary
+    ...    sampledeb
+    ...    package
+    ...    file=${CURDIR}/sampledeb_1.0.0_all.deb
     Set Test Variable    $FILE_URL_1
 
-    ${FILE_URL_2}=    Cumulocity.Create Inventory Binary    sampledeb    package    file=${CURDIR}/sampledeb_2.0.0_all.deb
+    ${FILE_URL_2}=    Cumulocity.Create Inventory Binary
+    ...    sampledeb
+    ...    package
+    ...    file=${CURDIR}/sampledeb_2.0.0_all.deb
     Set Test Variable    $FILE_URL_2

--- a/tests/RobotFramework/tests/plugin_apt/install_overwrite_config_files.robot
+++ b/tests/RobotFramework/tests/plugin_apt/install_overwrite_config_files.robot
@@ -15,7 +15,7 @@ Install packages without overwriting config files
     # install package v1
     ${OPERATION}=    Install Software
     ...    {"name": "sampledeb", "version": "1.0.0", "softwareType": "apt", "url": "${FILE_URL_1}"}
-    ${OPERATION}=    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
+    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
 
     # Modify the config file
     Execute Command    echo "Updated the config" | sudo tee -a /etc/sampledeb.cfg
@@ -35,7 +35,7 @@ Install packages overwrite config files
     # install package v1
     ${OPERATION}=    Install Software
     ...    {"name": "sampledeb", "version": "1.0.0", "softwareType": "apt", "url": "${FILE_URL_1}"}
-    ${OPERATION}=    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
+    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
 
     # Modify the config file
     Execute Command    echo "Updated the config" | sudo tee -a /etc/sampledeb.cfg

--- a/tests/RobotFramework/tests/plugin_apt/install_package_with_epoch.robot
+++ b/tests/RobotFramework/tests/plugin_apt/install_package_with_epoch.robot
@@ -3,20 +3,26 @@ Resource            ../../resources/common.resource
 Library             ThinEdgeIO
 Library             Cumulocity
 
-Test Setup         Custom Setup
+Test Setup          Custom Setup
 Test Teardown       Get Logs
 
 Test Tags           theme:software    theme:plugins
 
+
 *** Test Cases ***
 Install package with Epoch in version #2666
-    ${FILE_URL}=    Cumulocity.Create Inventory Binary    package-with-epoch    package    file=${CURDIR}/package-with-epoch_1.2.3_all.deb
-    ${OPERATION}=    Install Software    {"name": "package-with-epoch", "version": "2:1.2.3", "softwareType": "apt", "url": "${FILE_URL}"}
+    ${FILE_URL}=    Cumulocity.Create Inventory Binary
+    ...    package-with-epoch
+    ...    package
+    ...    file=${CURDIR}/package-with-epoch_1.2.3_all.deb
+    ${OPERATION}=    Install Software
+    ...    {"name": "package-with-epoch", "version": "2:1.2.3", "softwareType": "apt", "url": "${FILE_URL}"}
     ${OPERATION}=    Operation Should Be SUCCESSFUL    ${OPERATION}    timeout=60
-    Device Should Have Installed Software    {"name": "package-with-epoch", "version": "2:1.2.3", "softwareType": "apt"}
+    Device Should Have Installed Software
+    ...    {"name": "package-with-epoch", "version": "2:1.2.3", "softwareType": "apt"}
+
 
 *** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup
     Device Should Exist    ${DEVICE_SN}
-    

--- a/tests/RobotFramework/tests/tedge/call_tedge.robot
+++ b/tests/RobotFramework/tests/tedge/call_tedge.robot
@@ -5,8 +5,8 @@ Documentation       Purpose of this test is to verify that the proper version nu
 ...                 will be shown
 
 Resource            ../../resources/common.resource
-Library             ThinEdgeIO
 Library             String
+Library             ThinEdgeIO
 
 Suite Setup         Custom Setup
 Suite Teardown      Get Logs

--- a/tests/RobotFramework/tests/tedge/call_tedge.robot
+++ b/tests/RobotFramework/tests/tedge/call_tedge.robot
@@ -1,30 +1,39 @@
 *** Settings ***
-Documentation    Purpose of this test is to verify that the proper version number
-...              will be shown by using the tedge -V command.
-...              By executing the tedge -h command that Usage, Options and Commands
-...              will be shown
+Documentation       Purpose of this test is to verify that the proper version number
+...                 will be shown by using the tedge -V command.
+...                 By executing the tedge -h command that Usage, Options and Commands
+...                 will be shown
 
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
-Library    String
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+Library             String
 
-Test Tags    theme:cli
-Suite Setup            Custom Setup
-Suite Teardown         Get Logs
+Suite Setup         Custom Setup
+Suite Teardown      Get Logs
+
+Test Tags           theme:cli
+
 
 *** Variables ***
-${version}
+${version}      ${EMPTY}
+
 
 *** Test Cases ***
 Install thin-edge.io
-    ${output}=    Execute Command    curl -fsSL https://thin-edge.io/install.sh | sh -s    #running the script for installing latest version of tedge
+    # running the script for installing latest version of tedge
+    ${output}=    Execute Command
+    ...    curl -fsSL https://thin-edge.io/install.sh | sh -s
     # Use apt-cache policy to get the installed version as the script lets apt handle this
-    ${version}=    Execute Command    apt-cache policy tedge | grep "Installed:" | cut -d":" -f2 | sed 's/~rc\./-rc./' | xargs
+    ${version}=    Execute Command
+    ...    apt-cache policy tedge | grep "Installed:" | cut -d":" -f2 | sed 's/~rc\./-rc./' | xargs
     Set Suite Variable    ${version}
 
 call tedge -V
     ${output}=    Execute Command    tedge -V
-    Should Contain    ${output}    ${version}    # Check that the output of tedge -V returns the version which was installed
+    # Check that the output of tedge -V returns the version which was installed
+    Should Contain
+    ...    ${output}
+    ...    ${version}
 
 call tedge -h
     ${output}=    Execute Command    tedge -h
@@ -38,8 +47,8 @@ call tedge help
     Should Contain    ${output}    Options:
     Should Contain    ${output}    Commands:
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     Setup    skip_bootstrap=True
     Execute Command    rm -f /etc/tedge/system.toml

--- a/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
+++ b/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
@@ -264,7 +264,7 @@ set/unset mqtt.topic_root
     ${set}    Execute Command    tedge config list
     Should Contain    ${set}    mqtt.topic_root=tt
 
-# Undo the change by using the 'unset' command, value returns to default one
+    # Undo the change by using the 'unset' command, value returns to default one
     Execute Command    sudo tedge config unset mqtt.topic_root    # Changing mqtt.topic_root
     ${unset}    Execute Command    tedge config list
     Should Contain    ${unset}    mqtt.topic_root=te
@@ -274,7 +274,7 @@ set/unset mqtt.device_topic_id
     ${set}    Execute Command    tedge config list
     Should Contain    ${set}    mqtt.device_topic_id=device/device//
 
-# Undo the change by using the 'unset' command, value returns to default one
+    # Undo the change by using the 'unset' command, value returns to default one
     Execute Command    sudo tedge config unset mqtt.device_topic_id
     ${unset}    Execute Command    tedge config list
     Should Contain    ${unset}    mqtt.device_topic_id=device/main//

--- a/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
+++ b/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
@@ -25,7 +25,7 @@ Library             ThinEdgeIO
 Suite Setup         Setup
 Suite Teardown      Get Logs
 
-Test Tags          theme:cli    theme:configuration
+Test Tags           theme:cli    theme:configuration
 
 
 *** Test Cases ***
@@ -95,8 +95,10 @@ set/unset c8y.topics
     # Undo the change by using the 'unset' command, value returns to default one
     Execute Command    sudo tedge config unset c8y.topics
     ${unset}    Execute Command    tedge config list
-    Should Contain    ${unset}    c8y.topics=["te/+/+/+/+", "te/+/+/+/+/twin/+", "te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
-    
+    Should Contain
+    ...    ${unset}
+    ...    c8y.topics=["te/+/+/+/+", "te/+/+/+/+/twin/+", "te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
+
 set/unset c8y.proxy.bind.address
     Execute Command    sudo tedge config set c8y.proxy.bind.address 127.1.1.1    # Changing c8y.proxy.bind.address
     ${set}    Execute Command    tedge config list
@@ -139,7 +141,9 @@ set/unset c8y.proxy.client.port
 
 set/unset c8y.bridge.include.local_cleansession
     # Checking for true
-    Execute Command    sudo tedge config set c8y.bridge.include.local_cleansession true    # Changing c8y.bridge.include.local_cleansession
+    # Changing c8y.bridge.include.local_cleansession
+    Execute Command
+    ...    sudo tedge config set c8y.bridge.include.local_cleansession true
     ${set}    Execute Command    tedge config list
     Should Contain    ${set}    c8y.bridge.include.local_cleansession=true
 
@@ -149,7 +153,7 @@ set/unset c8y.bridge.include.local_cleansession
     Should Contain    ${set}    c8y.bridge.include.local_cleansession=false
 
     # Undo the change by using the 'unset' command, value returns to default one
-    Execute Command    sudo tedge config unset c8y.bridge.include.local_cleansession 
+    Execute Command    sudo tedge config unset c8y.bridge.include.local_cleansession
     ${unset}    Execute Command    tedge config list
     Should Contain    ${unset}    c8y.bridge.include.local_cleansession=auto
 
@@ -199,7 +203,9 @@ set/unset az.topics
     # Undo the change by using the 'unset' command, value returns to default one
     Execute Command    sudo tedge config unset az.topics
     ${unset}    Execute Command    tedge config list
-    Should Contain    ${unset}    az.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
+    Should Contain
+    ...    ${unset}
+    ...    az.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
 
 set/unset aws.topics
     Execute Command    sudo tedge config set aws.topics topic1,topic2    # Changing aws.topics
@@ -209,7 +215,9 @@ set/unset aws.topics
     # Undo the change by using the 'unset' command, value returns to default one
     Execute Command    sudo tedge config unset aws.topics
     ${unset}    Execute Command    tedge config list
-    Should Contain    ${unset}    aws.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
+    Should Contain
+    ...    ${unset}
+    ...    aws.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
 
 set/unset aws.url
     Execute Command    sudo tedge config set aws.url your-endpoint.amazonaws.com    # Changing aws.url
@@ -237,7 +245,7 @@ set/unset aws.mapper.timestamp
     Should Contain    ${set}    aws.mapper.timestamp=false
 
     # Undo the change by using the 'unset' command, value returns to default one
-        Execute Command    sudo tedge config unset aws.mapper.timestamp
+    Execute Command    sudo tedge config unset aws.mapper.timestamp
     ${unset}    Execute Command    tedge config list
     Should Contain    ${unset}    aws.mapper.timestamp=true
 
@@ -266,7 +274,7 @@ set/unset mqtt.device_topic_id
     ${set}    Execute Command    tedge config list
     Should Contain    ${set}    mqtt.device_topic_id=device/device//
 
-# Undo the change by using the 'unset' command, value returns to default one  
+# Undo the change by using the 'unset' command, value returns to default one
     Execute Command    sudo tedge config unset mqtt.device_topic_id
     ${unset}    Execute Command    tedge config list
     Should Contain    ${unset}    mqtt.device_topic_id=device/main//
@@ -360,7 +368,7 @@ set/unset software.plugin.max_packages
     Execute Command    sudo tedge config unset software.plugin.max_packages
     ${unset}    Execute Command    tedge config list
     Should Contain    ${unset}    software.plugin.max_packages=1000
-    
+
 set/unset tmp.path
     Execute Command    sudo tedge config set tmp.path /tmp1    # Changing tmp.path
     ${set}    Execute Command    tedge config list
@@ -444,12 +452,12 @@ set/unset mqtt.external.bind.port
 
 mqtt.external.bind.address
     # Changing mqtt.external.bind.address
-    Execute Command     sudo tedge config set mqtt.external.bind.address 0.0.0.0
+    Execute Command    sudo tedge config set mqtt.external.bind.address 0.0.0.0
     ${set}    Execute Command    tedge config list
     Should Contain    ${set}    mqtt.external.bind.address=0.0.0.0
 
     # Undo the change by using the 'unset' command, value returns to default one
-    Execute Command     sudo tedge config unset mqtt.external.bind.address
+    Execute Command    sudo tedge config unset mqtt.external.bind.address
     ${unset}    Execute Command    tedge config list
     Should Not Contain    ${unset}    mqtt.external.bind.address=
 

--- a/tests/RobotFramework/tests/tedge/http_file_transfer_api.robot
+++ b/tests/RobotFramework/tests/tedge/http_file_transfer_api.robot
@@ -1,5 +1,5 @@
 *** Comments ***
-#Command to execute:    robot -d \results --timestampoutputs --log http_file_transfer_api.html --report NONE -v BUILD:840 -v HOST:192.168.1.130 thin-edge.io/tests/RobotFramework/tedge/http_file_transfer_api.robot
+# Command to execute:    robot -d \results --timestampoutputs --log http_file_transfer_api.html --report NONE -v BUILD:840 -v HOST:192.168.1.130 thin-edge.io/tests/RobotFramework/tedge/http_file_transfer_api.robot
 
 
 *** Settings ***
@@ -9,12 +9,12 @@ Library             ThinEdgeIO
 Suite Setup         Custom Setup
 Suite Teardown      Custom Teardown
 
-Test Tags          theme:cli    theme:configuration    theme:childdevices
+Test Tags           theme:cli    theme:configuration    theme:childdevices
 
 
 *** Variables ***
-${DEVICE_SN}    # Parent device serial number
-${DEVICE_IP}    # Parent device host name which is reachable
+${DEVICE_SN}    ${EMPTY}    # Parent device serial number
+${DEVICE_IP}    ${EMPTY}    # Parent device host name which is reachable
 ${PORT}=        8000
 
 

--- a/tests/RobotFramework/tests/tedge/http_file_transfer_api.robot
+++ b/tests/RobotFramework/tests/tedge/http_file_transfer_api.robot
@@ -15,7 +15,7 @@ Test Tags           theme:cli    theme:configuration    theme:childdevices
 *** Variables ***
 ${DEVICE_SN}    ${EMPTY}    # Parent device serial number
 ${DEVICE_IP}    ${EMPTY}    # Parent device host name which is reachable
-${PORT}=        8000
+${PORT}         8000
 
 
 *** Test Cases ***

--- a/tests/RobotFramework/tests/tedge/parse_root_certificate.robot
+++ b/tests/RobotFramework/tests/tedge/parse_root_certificate.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Resource            ../../resources/common.resource
-Library             String
 Library             Collections
+Library             String
 Library             ThinEdgeIO
 
 Test Teardown       Get Logs

--- a/tests/RobotFramework/tests/tedge/parse_root_certificate.robot
+++ b/tests/RobotFramework/tests/tedge/parse_root_certificate.robot
@@ -10,7 +10,6 @@ Test Tags           theme:ca_certificates
 
 
 *** Test Cases ***
-
 Verify Single Certificate File
     [Setup]    Setup With Self-Signed Certificate
     ThinEdgeIO.File Should Exist    /etc/tedge/device-certs/tedge-certificate.pem
@@ -28,13 +27,15 @@ Verify Multiple Certificates in Directory
     ThinEdgeIO.File Should Exist    /etc/tedge/device-certs/tedge-certificate.pem
     ${dir_contents}=    Execute Command    ls /etc/tedge/device-certs
     Log    ${dir_contents}
-    
+
     # List .pem files and check the result
     ${cert_files}=    Execute Command    ls /etc/tedge/device-certs/*.pem
     ${cert_files_list}=    Split String    ${cert_files}    \n
     @{filtered_cert_files}=    Create List
     FOR    ${file}    IN    @{cert_files_list}
-        Run Keyword If    '${file}' != ''    Append To List    ${filtered_cert_files}    ${file}
+        IF    '${file}' != ''
+            Append To List    ${filtered_cert_files}    ${file}
+        END
     END
 
     ${cert_files_length}=    Get Length    ${filtered_cert_files}
@@ -66,6 +67,8 @@ Should Contain Any Line
     [Arguments]    ${text}    ${cert_file}
     ${cert_present}=    Run Keyword And Return Status    Should Contain    ${text}    -----BEGIN CERTIFICATE-----
     ${key_present}=    Run Keyword And Return Status    Should Contain    ${text}    -----BEGIN PRIVATE KEY-----
-    Run Keyword If    ${cert_present}    Log    Certificate found in ${cert_file}
-    Run Keyword If    ${key_present}    Log    Private key found in ${cert_file}
-    Run Keyword If    not ${cert_present} and not ${key_present}    Fail    The file ${cert_file} does not contain a valid certificate or private key.
+    IF    ${cert_present}    Log    Certificate found in ${cert_file}
+    IF    ${key_present}    Log    Private key found in ${cert_file}
+    IF    not ${cert_present} and not ${key_present}
+        Fail    The file ${cert_file} does not contain a valid certificate or private key.
+    END

--- a/tests/RobotFramework/tests/tedge/parse_root_certificate.robot
+++ b/tests/RobotFramework/tests/tedge/parse_root_certificate.robot
@@ -1,8 +1,8 @@
 *** Settings ***
 Resource            ../../resources/common.resource
-Library             ThinEdgeIO
 Library             String
 Library             Collections
+Library             ThinEdgeIO
 
 Test Teardown       Get Logs
 

--- a/tests/RobotFramework/tests/tedge/tedge_config_get.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_config_get.robot
@@ -5,7 +5,7 @@ Library             ThinEdgeIO
 Suite Setup         Custom Setup
 Suite Teardown      Get Logs
 
-Test Tags          theme:cli    theme:configuration
+Test Tags           theme:cli    theme:configuration
 
 
 *** Test Cases ***

--- a/tests/RobotFramework/tests/tedge/tedge_upload_cert.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_upload_cert.robot
@@ -1,18 +1,20 @@
 *** Settings ***
-Documentation    Run certificate upload test and fails to upload the cert because there is no root certificate directory,
-...              Then check the negative response in stderr              
+Documentation       Run certificate upload test and fails to upload the cert because there is no root certificate directory,
+...                 Then check the negative response in stderr
 
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:cli    theme:mqtt    theme:c8y
-Test Teardown         Get Logs
+Test Teardown       Get Logs
+
+Test Tags           theme:cli    theme:mqtt    theme:c8y
+
 
 *** Test Cases ***
 Create the certificate
     [Setup]    Setup With Self-Signed Certificate
-    #You can then check the content of that certificate.
-    ${output}=    Execute Command    sudo tedge cert show    #You can then check the content of that certificate.
+    # You can then check the content of that certificate.
+    ${output}=    Execute Command    sudo tedge cert show    # You can then check the content of that certificate.
     Should Contain    ${output}    Device certificate: /etc/tedge/device-certs/tedge-certificate.pem
     Should Contain    ${output}    Subject: CN=${DEVICE_SN}, O=Thin Edge, OU=Test Device
     Should Contain    ${output}    Issuer: CN=${DEVICE_SN}, O=Thin Edge, OU=Test Device
@@ -22,36 +24,64 @@ Create the certificate
 
 Renew the certificate
     [Setup]    Setup With Self-Signed Certificate
-    Execute Command    sudo tedge disconnect c8y 
-    ${output}=    Execute Command    sudo tedge cert renew    stderr=${True}    stdout=${False}    ignore_exit_code=${True}    
-    Should Contain    ${output}    Certificate was successfully renewed, for un-interrupted service, the certificate has to be uploaded to the cloud
-    Execute Command    sudo env C8YPASS\='${C8Y_CONFIG.password}' tedge cert upload c8y --user ${C8Y_CONFIG.username}      log_output=${False}
-    ${output}=    Execute Command    sudo tedge connect c8y    
+    Execute Command    sudo tedge disconnect c8y
+    ${output}=    Execute Command
+    ...    sudo tedge cert renew
+    ...    stderr=${True}
+    ...    stdout=${False}
+    ...    ignore_exit_code=${True}
+    Should Contain
+    ...    ${output}
+    ...    Certificate was successfully renewed, for un-interrupted service, the certificate has to be uploaded to the cloud
+    Execute Command
+    ...    sudo env C8YPASS\='${C8Y_CONFIG.password}' tedge cert upload c8y --user ${C8Y_CONFIG.username}
+    ...    log_output=${False}
+    ${output}=    Execute Command    sudo tedge connect c8y
     Should Contain    ${output}    Connection check is successful.
 
 Cert upload prompts for username (from stdin)
     # Note: Use bash process substitution to simulate user input from /dev/stdin
     [Setup]    Setup With Self-Signed Certificate
     Execute Command    sudo tedge disconnect c8y
-    ${output}=    Execute Command    sudo tedge cert renew    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
-    Should Contain    ${output}    Certificate was successfully renewed, for un-interrupted service, the certificate has to be uploaded to the cloud
-    Execute Command    cmd=sudo env --unset=C8Y_USER C8Y_PASSWORD='${C8Y_CONFIG.password}' bash -c "tedge cert upload c8y < <(echo '${C8Y_CONFIG.username}')"    log_output=${False}
+    ${output}=    Execute Command
+    ...    sudo tedge cert renew
+    ...    stderr=${True}
+    ...    stdout=${False}
+    ...    ignore_exit_code=${True}
+    Should Contain
+    ...    ${output}
+    ...    Certificate was successfully renewed, for un-interrupted service, the certificate has to be uploaded to the cloud
+    Execute Command
+    ...    cmd=sudo env --unset=C8Y_USER C8Y_PASSWORD='${C8Y_CONFIG.password}' bash -c "tedge cert upload c8y < <(echo '${C8Y_CONFIG.username}')"
+    ...    log_output=${False}
     ${output}=    Execute Command    sudo tedge connect c8y
     Should Contain    ${output}    Connection check is successful.
 
 Cert upload supports reading username/password from go-c8y-cli env variables
     [Setup]    Setup With Self-Signed Certificate
     Execute Command    sudo tedge disconnect c8y
-    ${output}=    Execute Command    sudo tedge cert renew    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
-    Should Contain    ${output}    Certificate was successfully renewed, for un-interrupted service, the certificate has to be uploaded to the cloud
-    Execute Command    cmd=sudo env C8Y_USER='${C8Y_CONFIG.username}' C8Y_PASSWORD='${C8Y_CONFIG.password}' tedge cert upload c8y   log_output=${False}
+    ${output}=    Execute Command
+    ...    sudo tedge cert renew
+    ...    stderr=${True}
+    ...    stdout=${False}
+    ...    ignore_exit_code=${True}
+    Should Contain
+    ...    ${output}
+    ...    Certificate was successfully renewed, for un-interrupted service, the certificate has to be uploaded to the cloud
+    Execute Command
+    ...    cmd=sudo env C8Y_USER='${C8Y_CONFIG.username}' C8Y_PASSWORD='${C8Y_CONFIG.password}' tedge cert upload c8y
+    ...    log_output=${False}
     ${output}=    Execute Command    sudo tedge connect c8y
     Should Contain    ${output}    Connection check is successful.
 
 Renew certificate fails
     [Setup]    Setup Without Certificate
-    Execute Command    sudo tedge cert remove    
-    ${output}=    Execute Command    sudo tedge cert renew    stderr=${True}    stdout=${False}    ignore_exit_code=${True}    
+    Execute Command    sudo tedge cert remove
+    ${output}=    Execute Command
+    ...    sudo tedge cert renew
+    ...    stderr=${True}
+    ...    stdout=${False}
+    ...    ignore_exit_code=${True}
     Should Contain    ${output}    Missing file: "/etc/tedge/device-certs/tedge-certificate.pem"
     # Restore the certificate
     Execute Command    sudo tedge cert create --device-id test-user
@@ -60,18 +90,25 @@ tedge cert upload c8y command fails
     [Setup]    Setup Without Certificate
     Execute Command    sudo tedge cert create --device-id test-user
     Execute Command    sudo tedge config set c8y.url example.c8y.com
-    Execute Command    tedge config set c8y.root_cert_path /etc/ssl/certs_test    
-    ${output}=    Execute Command    sudo env C8YPASS\='password' tedge cert upload c8y --user testuser    ignore_exit_code=${True}    stdout=${False}    stderr=${True}
+    Execute Command    tedge config set c8y.root_cert_path /etc/ssl/certs_test
+    ${output}=    Execute Command
+    ...    sudo env C8YPASS\='password' tedge cert upload c8y --user testuser
+    ...    ignore_exit_code=${True}
+    ...    stdout=${False}
+    ...    stderr=${True}
     Execute Command    tedge config unset c8y.root_cert_path
-    Should Contain    ${output}    Unable to read certificates from c8y.root_cert_path: failed to read from path "/etc/ssl/certs_test"
+    Should Contain
+    ...    ${output}
+    ...    Unable to read certificates from c8y.root_cert_path: failed to read from path "/etc/ssl/certs_test"
+
 
 *** Keywords ***
 Setup With Self-Signed Certificate
-    ${DEVICE_SN}=                    Setup    skip_bootstrap=${True}
-    Set Test Variable               $DEVICE_SN
-    Execute Command           test -f ./bootstrap.sh && ./bootstrap.sh --cert-method selfsigned
+    ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
+    Set Test Variable    $DEVICE_SN
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --cert-method selfsigned
 
 Setup Without Certificate
-    ${DEVICE_SN}=                    Setup    skip_bootstrap=${True}
-    Set Test Variable               $DEVICE_SN
-    Execute Command           test -f ./bootstrap.sh && ./bootstrap.sh --install --no-bootstrap --no-connect
+    ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
+    Set Test Variable    $DEVICE_SN
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --install --no-bootstrap --no-connect

--- a/tests/RobotFramework/tests/tedge/tedge_upload_cert_custom_root_cert_path.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_upload_cert_custom_root_cert_path.robot
@@ -1,27 +1,37 @@
 *** Settings ***
-Documentation    Run certificate upload test and fails to upload the cert because there is no root certificate directory,
-...              Then check the negative response in stderr              
+Documentation       Run certificate upload test and fails to upload the cert because there is no root certificate directory,
+...                 Then check the negative response in stderr
 
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:cli    theme:mqtt    theme:c8y    adapter:docker
-Test Teardown         Get Logs
+Test Teardown       Get Logs
+
+Test Tags           theme:cli    theme:mqtt    theme:c8y    adapter:docker
+
 
 *** Test Cases ***
 tedge cert upload c8y respects root cert path
     [Setup]    Setup With Self-Signed Certificate
     Execute Command    sudo tedge disconnect c8y
-    ${output}=    Execute Command    sudo tedge cert renew    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
-    Should Contain    ${output}    Certificate was successfully renewed, for un-interrupted service, the certificate has to be uploaded to the cloud
+    ${output}=    Execute Command
+    ...    sudo tedge cert renew
+    ...    stderr=${True}
+    ...    stdout=${False}
+    ...    ignore_exit_code=${True}
+    Should Contain
+    ...    ${output}
+    ...    Certificate was successfully renewed, for un-interrupted service, the certificate has to be uploaded to the cloud
     Execute Command    mv /etc/ssl/certs /etc/ssl/certs_test
     Execute Command    tedge config set c8y.root_cert_path /etc/ssl/certs_test
-    Execute Command    cmd=sudo env C8Y_USER='${C8Y_CONFIG.username}' C8Y_PASSWORD='${C8Y_CONFIG.password}' tedge cert upload c8y
+    Execute Command
+    ...    cmd=sudo env C8Y_USER='${C8Y_CONFIG.username}' C8Y_PASSWORD='${C8Y_CONFIG.password}' tedge cert upload c8y
     ${output}=    Execute Command    sudo tedge connect c8y
     Should Contain    ${output}    Connection check is successful.
 
+
 *** Keywords ***
 Setup With Self-Signed Certificate
-    ${DEVICE_SN}=                    Setup    skip_bootstrap=${True}
-    Set Test Variable               $DEVICE_SN
-    Execute Command           test -f ./bootstrap.sh && ./bootstrap.sh --cert-method selfsigned
+    ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
+    Set Test Variable    $DEVICE_SN
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --cert-method selfsigned

--- a/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_initialization.robot
+++ b/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_initialization.robot
@@ -3,19 +3,19 @@ Resource            ../../../resources/common.resource
 Library             ThinEdgeIO
 Library             Cumulocity
 
-Test Tags           theme:tedge_agent
 Test Setup          Custom Setup
 Test Teardown       Get Logs
 
-*** Test Cases ***
+Test Tags           theme:tedge_agent
 
+
+*** Test Cases ***
 Device profile is included in supported operations
     Should Have MQTT Messages    te/device/main///cmd/device_profile    message_pattern=^{}$
     Should Contain Supported Operations    c8y_DeviceProfile
 
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN

--- a/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
+++ b/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
@@ -1,9 +1,9 @@
 *** Settings ***
 Resource            ../../../resources/common.resource
+Library             Collections
+Library             OperatingSystem
 Library             ThinEdgeIO
 Library             Cumulocity
-Library             OperatingSystem
-Library             Collections
 
 Suite Setup         Custom Setup
 Test Setup          Custom Test Setup

--- a/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
+++ b/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
@@ -9,7 +9,7 @@ Suite Setup         Custom Setup
 Test Setup          Custom Test Setup
 Test Teardown       Get Logs
 
-Test Tags          theme:tedge_agent
+Test Tags           theme:tedge_agent
 
 
 *** Test Cases ***

--- a/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
+++ b/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
@@ -5,44 +5,48 @@ Library             Cumulocity
 Library             OperatingSystem
 Library             Collections
 
-Force Tags          theme:tedge_agent
 Suite Setup         Custom Setup
 Test Setup          Custom Test Setup
 Test Teardown       Get Logs
 
-*** Test Cases ***
+Force Tags          theme:tedge_agent
 
+
+*** Test Cases ***
 Send device profile operation from Cumulocity IoT
-    ${config_url}=    Create Inventory Binary    tedge-configuration-plugin    tedge-configuration-plugin    file=${CURDIR}/tedge-configuration-plugin.toml
+    ${config_url}=    Create Inventory Binary
+    ...    tedge-configuration-plugin
+    ...    tedge-configuration-plugin
+    ...    file=${CURDIR}/tedge-configuration-plugin.toml
 
     ${PROFILE_NAME}=    Set Variable    Test Profile
     ${PROFILE_PAYLOAD}=    Catenate    SEPARATOR=\n    {
-    ...        "firmware": {
-    ...            "name":"tedge-core",
-    ...            "version":"1.0.0",
-    ...            "url":"https://abc.com/some/firmware/url"
-    ...        },
-    ...        "software":[
-    ...            {
-    ...                "name":"jq",
-    ...                "action":"install",
-    ...                "version":"latest",
-    ...                "url":""
-    ...            },
-    ...            {
-    ...                "name":"tree",
-    ...                "action":"install",
-    ...                "version":"latest",
-    ...                "url":""
-    ...            }
-    ...        ],
-    ...        "configuration":[
-    ...            {
-    ...                "name":"tedge-configuration-plugin",
-    ...                "type":"tedge-configuration-plugin",
-    ...                "url":"${config_url}"
-    ...            }
-    ...        ]
+    ...    "firmware": {
+    ...    "name":"tedge-core",
+    ...    "version":"1.0.0",
+    ...    "url":"https://abc.com/some/firmware/url"
+    ...    },
+    ...    "software":[
+    ...    {
+    ...    "name":"jq",
+    ...    "action":"install",
+    ...    "version":"latest",
+    ...    "url":""
+    ...    },
+    ...    {
+    ...    "name":"tree",
+    ...    "action":"install",
+    ...    "version":"latest",
+    ...    "url":""
+    ...    }
+    ...    ],
+    ...    "configuration":[
+    ...    {
+    ...    "name":"tedge-configuration-plugin",
+    ...    "type":"tedge-configuration-plugin",
+    ...    "url":"${config_url}"
+    ...    }
+    ...    ]
     ...    }
 
     ${profile}=    Cumulocity.Create Device Profile    ${PROFILE_NAME}    ${PROFILE_PAYLOAD}
@@ -54,83 +58,87 @@ Send device profile operation from Cumulocity IoT
 Send device profile operation locally
     ${config_url}=    Set Variable    http://localhost:8000/tedge/file-transfer/main/config_update/robot-123
 
-    Execute Command     curl -X PUT --data-binary "bad toml" "${config_url}"
+    Execute Command    curl -X PUT --data-binary "bad toml" "${config_url}"
 
-    ${payload}=    Catenate    SEPARATOR=\n    
+    ${payload}=    Catenate    SEPARATOR=\n
     ...    {
-    ...      "status": "init",
-    ...      "name": "dev-profile",
-    ...      "version": "v2",
-    ...      "operations": [
-    ...        {
-    ...          "operation": "firmware_update",
-    ...          "skip": false,
-    ...          "payload": {
-    ...            "name": "tedge-core",
-    ...            "remoteUrl": "https://abc.com/some/firmware/url",
-    ...            "version": "1.0.0"
-    ...          }
-    ...        },
-    ...        {
-    ...          "operation": "software_update",
-    ...          "skip": false,
-    ...          "payload": {
-    ...            "updateList": [
-    ...              {
-    ...                "type": "apt",
-    ...                "modules": [
-    ...                  {
-    ...                    "name": "yq",
-    ...                    "version": "latest",
-    ...                    "action": "install"
-    ...                  },
-    ...                  {
-    ...                    "name": "jo",
-    ...                    "version": "latest",
-    ...                    "action": "install"
-    ...                  }
-    ...                ]
-    ...              }
-    ...            ]
-    ...          }
-    ...        },
-    ...        {
-    ...          "operation": "config_update",
-    ...          "skip": false,
-    ...          "payload": {
-    ...            "type": "tedge-configuration-plugin",
-    ...            "tedgeUrl": "${config_url}",
-    ...            "remoteUrl": ""
-    ...          }
-    ...        },
-    ...        {
-    ...          "operation": "restart",
-    ...          "skip": false,
-    ...          "payload": {}
-    ...        },
-    ...        {
-    ...          "operation": "software_update",
-    ...          "skip": false,
-    ...          "payload": {
-    ...            "updateList": [
-    ...              {
-    ...                "type": "apt",
-    ...                "modules": [
-    ...                  {
-    ...                    "name": "rolldice",
-    ...                    "version": "latest",
-    ...                    "action": "install"
-    ...                  }
-    ...                ]
-    ...              }
-    ...            ]
-    ...          }
-    ...        }
-    ...      ]
+    ...    "status": "init",
+    ...    "name": "dev-profile",
+    ...    "version": "v2",
+    ...    "operations": [
+    ...    {
+    ...    "operation": "firmware_update",
+    ...    "skip": false,
+    ...    "payload": {
+    ...    "name": "tedge-core",
+    ...    "remoteUrl": "https://abc.com/some/firmware/url",
+    ...    "version": "1.0.0"
+    ...    }
+    ...    },
+    ...    {
+    ...    "operation": "software_update",
+    ...    "skip": false,
+    ...    "payload": {
+    ...    "updateList": [
+    ...    {
+    ...    "type": "apt",
+    ...    "modules": [
+    ...    {
+    ...    "name": "yq",
+    ...    "version": "latest",
+    ...    "action": "install"
+    ...    },
+    ...    {
+    ...    "name": "jo",
+    ...    "version": "latest",
+    ...    "action": "install"
+    ...    }
+    ...    ]
+    ...    }
+    ...    ]
+    ...    }
+    ...    },
+    ...    {
+    ...    "operation": "config_update",
+    ...    "skip": false,
+    ...    "payload": {
+    ...    "type": "tedge-configuration-plugin",
+    ...    "tedgeUrl": "${config_url}",
+    ...    "remoteUrl": ""
+    ...    }
+    ...    },
+    ...    {
+    ...    "operation": "restart",
+    ...    "skip": false,
+    ...    "payload": {}
+    ...    },
+    ...    {
+    ...    "operation": "software_update",
+    ...    "skip": false,
+    ...    "payload": {
+    ...    "updateList": [
+    ...    {
+    ...    "type": "apt",
+    ...    "modules": [
+    ...    {
+    ...    "name": "rolldice",
+    ...    "version": "latest",
+    ...    "action": "install"
+    ...    }
+    ...    ]
+    ...    }
+    ...    ]
+    ...    }
+    ...    }
+    ...    ]
     ...    }
 
     Execute Command    tedge mqtt pub --retain 'te/device/main///cmd/device_profile/robot-123' '${payload}'
-    ${cmd_messages}    Should Have MQTT Messages    te/device/main///cmd/device_profile/robot-123    message_pattern=.*successful.*   maximum=1    timeout=60
+    ${cmd_messages}=    Should Have MQTT Messages
+    ...    te/device/main///cmd/device_profile/robot-123
+    ...    message_pattern=.*successful.*
+    ...    maximum=1
+    ...    timeout=60
 
     # Validate installed packages
     Execute Command    dpkg -l | grep rolldice
@@ -142,15 +150,16 @@ Send device profile operation locally
 
     [Teardown]    Execute Command    tedge mqtt pub --retain te/device/main///cmd/device_profile/robot-123 ''
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Test Setup
-    Execute Command    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/systemctl, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /usr/bin/on_shutdown.sh, /usr/bin/tedge-write /etc/*' > /etc/sudoers.d/tedge
+    Execute Command
+    ...    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/systemctl, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /usr/bin/on_shutdown.sh, /usr/bin/tedge-write /etc/*' > /etc/sudoers.d/tedge
 
 Custom Setup
     ${DEVICE_SN}=    Setup
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist                      ${DEVICE_SN}
+    Device Should Exist    ${DEVICE_SN}
 
     Copy Configuration Files
     Restart Service    tedge-agent
@@ -158,8 +167,7 @@ Custom Setup
     # setup repos so that packages can be installed from them
     Execute Command    curl -1sLf 'https://dl.cloudsmith.io/public/thinedge/tedge-main/setup.deb.sh' | sudo -E bash
     Execute Command    curl -1sLf 'https://dl.cloudsmith.io/public/thinedge/community/setup.deb.sh' | sudo -E bash
-    
 
 Copy Configuration Files
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/firmware_update.toml      /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/tedge_operator_helper.sh         /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/firmware_update.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/tedge_operator_helper.sh    /etc/tedge/operations/

--- a/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
+++ b/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
@@ -9,7 +9,7 @@ Suite Setup         Custom Setup
 Test Setup          Custom Test Setup
 Test Teardown       Get Logs
 
-Force Tags          theme:tedge_agent
+Test Tags          theme:tedge_agent
 
 
 *** Test Cases ***

--- a/tests/RobotFramework/tests/tedge_agent/main_tedge_agent.robot
+++ b/tests/RobotFramework/tests/tedge_agent/main_tedge_agent.robot
@@ -1,28 +1,32 @@
 *** Settings ***
 Resource            ../../resources/common.resource
-Library    ThinEdgeIO
+Library             ThinEdgeIO
 
-Test Tags           theme:tedge_agent
 Test Setup          Custom Setup
 Test Teardown       Get Logs
 
-*** Test Cases ***
+Test Tags           theme:tedge_agent
 
+
+*** Test Cases ***
 On start process all the pending operations
     [Tags]    \#2369
     Stop Service    tedge-agent
-    FOR  ${id}   IN RANGE    0   10
-         Execute Command    tedge mqtt pub --retain te/device/main///cmd/software_list/test-${id} '{"status":"init"}'
+    FOR    ${id}    IN RANGE    0    10
+        Execute Command    tedge mqtt pub --retain te/device/main///cmd/software_list/test-${id} '{"status":"init"}'
     END
     Start Service    tedge-agent
     Sleep    5s
-    FOR  ${id}   IN RANGE    0   10
-         Should Have MQTT Messages    te/device/main///cmd/software_list/test-${id}    message_pattern=.*successful.*    minimum=1
-         Execute Command    tedge mqtt pub --retain te/device/main///cmd/software_list/test-${id} ''
+    FOR    ${id}    IN RANGE    0    10
+        Should Have MQTT Messages
+        ...    te/device/main///cmd/software_list/test-${id}
+        ...    message_pattern=.*successful.*
+        ...    minimum=1
+        Execute Command    tedge mqtt pub --retain te/device/main///cmd/software_list/test-${id} ''
     END
 
-*** Keywords ***
 
+*** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup    skip_bootstrap=False
     Set Suite Variable    $DEVICE_SN

--- a/tests/RobotFramework/tests/tedge_agent/tedge_agent.robot
+++ b/tests/RobotFramework/tests/tedge_agent/tedge_agent.robot
@@ -1,7 +1,7 @@
 *** Comments ***
-#PRECONDITION:
-#Device CH_DEV_CONF_MGMT is existing on tenant, if not
-#use -v DeviceID:xxxxxxxxxxx in the command line to use your existing device
+# PRECONDITION:
+# Device CH_DEV_CONF_MGMT is existing on tenant, if not
+# use -v DeviceID:xxxxxxxxxxx in the command line to use your existing device
 
 
 *** Settings ***
@@ -14,33 +14,34 @@ Library             Collections
 Suite Setup         Custom Setup
 Suite Teardown      Get Logs    name=${PARENT_SN}
 
-Test Tags          theme:tedge_agent
+Test Tags           theme:tedge_agent
 
 
 *** Variables ***
-${PARENT_IP}
-${PARENT_SN}
-${CHILD_SN}
+${PARENT_IP}    ${EMPTY}
+${PARENT_SN}    ${EMPTY}
+${CHILD_SN}     ${EMPTY}
 
 
 *** Test Cases ***
-
 Converter and file transfer service are not running on a child device
     Set Device Context    ${CHILD_SN}
 
     # check that file transfer service is disabled
-    Execute Command    curl -X PUT -d '' http://127.0.0.1:8000/tedge/file-transfer/test-file    exp_exit_code=7    # 7 - Failed to connect to host
+    # 7 - Failed to connect to host
+    Execute Command
+    ...    curl -X PUT -d '' http://127.0.0.1:8000/tedge/file-transfer/test-file
+    ...    exp_exit_code=7
 
     # check that tedge-to-te-converter is not working while on a child device
     Execute Command    mosquitto_pub -t tedge/measurements -h ${PARENT_IP} -m ''
-    
+
     Set Device Context    ${PARENT_SN}
     # Only parent converter should convert the message
     Should Have MQTT Messages    te/device/main///m/    minimum=1    maximum=1
 
 
 *** Keywords ***
-
 Custom Setup
     # Parent
     ${parent_sn}=    Setup    skip_bootstrap=False
@@ -50,7 +51,7 @@ Custom Setup
     Set Suite Variable    $PARENT_IP    ${parent_ip}
 
     Set Device Context    ${PARENT_SN}
-    Execute Command    tedge config set mqtt.external.bind.address ${PARENT_IP} 
+    Execute Command    tedge config set mqtt.external.bind.address ${PARENT_IP}
     Execute Command    tedge config set mqtt.external.bind.port 1883
     Execute Command    tedge reconnect c8y
 
@@ -58,14 +59,14 @@ Custom Setup
     ${child_sn}=    Setup    skip_bootstrap=True
     Set Suite Variable    $CHILD_SN    ${child_sn}
     Set Device Context    ${CHILD_SN}
-    Execute Command       echo '[mqtt]' >> /etc/tedge/tedge.toml
-    Execute Command       echo 'device_topic_id \= "device/child1//"' >> /etc/tedge/tedge.toml
-    Execute Command       echo 'client.host \= "${PARENT_IP}"' >> /etc/tedge/tedge.toml
+    Execute Command    echo '[mqtt]' >> /etc/tedge/tedge.toml
+    Execute Command    echo 'device_topic_id \= "device/child1//"' >> /etc/tedge/tedge.toml
+    Execute Command    echo 'client.host \= "${PARENT_IP}"' >> /etc/tedge/tedge.toml
 
     # Install and start tedge-agent
     Execute Command    dpkg -i packages/tedge_*.deb
     Execute Command    dpkg -i packages/tedge-agent_*.deb
-    Start Service      tedge-agent
+    Start Service    tedge-agent
     # delay for tedge-agent to connect to parent device MQTT broker
     Sleep    3s
 

--- a/tests/RobotFramework/tests/tedge_agent/tedge_agent.robot
+++ b/tests/RobotFramework/tests/tedge_agent/tedge_agent.robot
@@ -6,10 +6,10 @@
 
 *** Settings ***
 Resource            ../../resources/common.resource
+Library             Collections
+Library             JSONLibrary
 Library             ThinEdgeIO
 Library             Cumulocity
-Library             JSONLibrary
-Library             Collections
 
 Suite Setup         Custom Setup
 Suite Teardown      Get Logs    name=${PARENT_SN}

--- a/tests/RobotFramework/tests/tedge_agent/tedge_agent_as_child.robot
+++ b/tests/RobotFramework/tests/tedge_agent/tedge_agent_as_child.robot
@@ -1,29 +1,33 @@
 *** Settings ***
 Resource            ../../resources/common.resource
-Library    ThinEdgeIO
+Library             ThinEdgeIO
 
-Test Tags           theme:tedge_agent
 Test Setup          Custom Setup
 Test Teardown       Get Logs
 
-*** Test Cases ***
+Test Tags           theme:tedge_agent
 
+
+*** Test Cases ***
 Run agent with a custom topic prefix #3031
     # Only run tedge-agent for a few seconds
-    ${output}=    Execute Command    timeout 5 tedge-agent --mqtt-topic-root "custom_root" --mqtt-device-topic-id "device/customname//" 2>&1    ignore_exit_code=${True}
+    ${output}=    Execute Command
+    ...    timeout 5 tedge-agent --mqtt-topic-root "custom_root" --mqtt-device-topic-id "device/customname//" 2>&1
+    ...    ignore_exit_code=${True}
     Should Not Contain    ${output}    te/
     Should Contain    ${output}    custom_root/device/customname//
 
 tedge-agent should not subscribe to legacy topics when running as a child device #3034
     # Only run tedge-agent for a few seconds
-    ${output}=    Execute Command    timeout 5 tedge-agent --mqtt-device-topic-id "device/pump//" 2>&1    ignore_exit_code=${True}
+    ${output}=    Execute Command
+    ...    timeout 5 tedge-agent --mqtt-device-topic-id "device/pump//" 2>&1
+    ...    ignore_exit_code=${True}
     Should Contain    ${output}    Running as a child device, tedge_to_te_converter and File Transfer Service disabled
     Should Not Contain    ${output}    item=${SPACE}tedge/
 
 
 *** Keywords ***
-
 Custom Setup
     ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
-     Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect
     Set Suite Variable    $DEVICE_SN

--- a/tests/RobotFramework/tests/tedge_agent/workflows/custom_operation.robot
+++ b/tests/RobotFramework/tests/tedge_agent/workflows/custom_operation.robot
@@ -1,9 +1,9 @@
 *** Settings ***
 Resource            ../../../resources/common.resource
-Library             ThinEdgeIO
-Library             Cumulocity
 Library             OperatingSystem
 Library             JSONLibrary
+Library             ThinEdgeIO
+Library             Cumulocity
 
 Suite Setup         Custom Setup
 Test Setup          Custom Test Setup

--- a/tests/RobotFramework/tests/tedge_agent/workflows/custom_operation.robot
+++ b/tests/RobotFramework/tests/tedge_agent/workflows/custom_operation.robot
@@ -5,104 +5,163 @@ Library             Cumulocity
 Library             OperatingSystem
 Library             JSONLibrary
 
-Test Tags          theme:tedge_agent
 Suite Setup         Custom Setup
 Test Setup          Custom Test Setup
 Test Teardown       Get Logs
 
-*** Test Cases ***
+Test Tags           theme:tedge_agent
 
+
+*** Test Cases ***
 Trigger Custom Download Operation
-    Execute Command    tedge mqtt pub --retain te/device/main///cmd/download/robot-123 '{"status":"init","url":"https://from/there","file":"/put/it/here"}'
-    ${cmd_messages}    Should Have MQTT Messages    te/device/main///cmd/download/robot-123    message_pattern=.*successful.*   maximum=1
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main///cmd/download/robot-123 '{"status":"init","url":"https://from/there","file":"/put/it/here"}'
+    ${cmd_messages}    Should Have MQTT Messages
+    ...    te/device/main///cmd/download/robot-123
+    ...    message_pattern=.*successful.*
+    ...    maximum=1
     Execute Command    tedge mqtt pub --retain te/device/main///cmd/download/robot-123 ''
-    ${actual_log}      Execute Command    cat /tmp/download-robot-123
+    ${actual_log}    Execute Command    cat /tmp/download-robot-123
     ${expected_log}    Get File    ${CURDIR}/download-command-expected.log
     Should Be Equal    ${actual_log}    ${expected_log}
 
 Override Built-In Operation
-    Execute Command     tedge mqtt pub --retain te/device/main///cmd/software_list/robot-456 '{"status":"init"}'
-    ${software_list}    Should Have MQTT Messages    te/device/main///cmd/software_list/robot-456    message_pattern=.*successful.*   maximum=1
-    Should Contain      ${software_list[0]}    "currentSoftwareList"
-    Should Contain      ${software_list[0]}    "mosquitto"
-    Should Contain      ${software_list[0]}    "tedge"
-    Execute Command     tedge mqtt pub --retain te/device/main///cmd/software_list/robot-456 ''
+    Execute Command    tedge mqtt pub --retain te/device/main///cmd/software_list/robot-456 '{"status":"init"}'
+    ${software_list}    Should Have MQTT Messages
+    ...    te/device/main///cmd/software_list/robot-456
+    ...    message_pattern=.*successful.*
+    ...    maximum=1
+    Should Contain    ${software_list[0]}    "currentSoftwareList"
+    Should Contain    ${software_list[0]}    "mosquitto"
+    Should Contain    ${software_list[0]}    "tedge"
+    Execute Command    tedge mqtt pub --retain te/device/main///cmd/software_list/robot-456 ''
 
 Trigger Device Restart Using A Sub-Command
     [Documentation]    To detect if the device has been rebooted, a marker file is created in the /run directory
-        ...            which should be deleted when the device is restarted
+    ...    which should be deleted when the device is restarted
     Execute Command    sudo touch /run/boot1
-    Execute Command     tedge mqtt pub --retain te/device/main///cmd/restart_sub_command/robot-314 '{"status":"init"}'
-    Should Have MQTT Messages    te/device/main///cmd/restart_sub_command/robot-314    message_pattern=.*successful.*   maximum=1    timeout=300
+    Execute Command    tedge mqtt pub --retain te/device/main///cmd/restart_sub_command/robot-314 '{"status":"init"}'
+    Should Have MQTT Messages
+    ...    te/device/main///cmd/restart_sub_command/robot-314
+    ...    message_pattern=.*successful.*
+    ...    maximum=1
+    ...    timeout=300
     ThinEdgeIO.File Should Not Exist    /run/boot1
 
 Timeout An Action
-    Execute Command     tedge mqtt pub --retain te/device/main///cmd/slow_operation/robot-1 '{"status":"init"}'
-    Should Have MQTT Messages    te/device/main///cmd/slow_operation/robot-1    message_pattern=.*timeout.*   maximum=1
+    Execute Command    tedge mqtt pub --retain te/device/main///cmd/slow_operation/robot-1 '{"status":"init"}'
+    Should Have MQTT Messages
+    ...    te/device/main///cmd/slow_operation/robot-1
+    ...    message_pattern=.*timeout.*
+    ...    maximum=1
 
 Trigger Agent Restart
-    ${pid_before}=  Execute Command    sudo systemctl show --property MainPID tedge-agent
-    Execute Command     tedge mqtt pub --retain te/device/main///cmd/restart-tedge-agent/robot-1 '{"status":"init"}'
-    Should Have MQTT Messages    te/device/main///cmd/restart-tedge-agent/robot-1    message_pattern=.*tedge-agent-restarted.*   minimum=1    timeout=300
-    ${pid_after}=  Execute Command    sudo systemctl show --property MainPID tedge-agent
+    ${pid_before}    Execute Command    sudo systemctl show --property MainPID tedge-agent
+    Execute Command    tedge mqtt pub --retain te/device/main///cmd/restart-tedge-agent/robot-1 '{"status":"init"}'
+    Should Have MQTT Messages
+    ...    te/device/main///cmd/restart-tedge-agent/robot-1
+    ...    message_pattern=.*tedge-agent-restarted.*
+    ...    minimum=1
+    ...    timeout=300
+    ${pid_after}    Execute Command    sudo systemctl show --property MainPID tedge-agent
     Should Not Be Equal    ${pid_before}    ${pid_after}    msg=tedge-agent should have been restarted
 
 Trigger native-reboot within workflow (on_success)
-    Execute Command    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/systemctl, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /usr/sbin/reboot, /usr/bin/on_shutdown.sh' > /etc/sudoers.d/tedge
-    ${pid_before}=  Execute Command    sudo systemctl show --property MainPID tedge-agent
-    Execute Command     tedge mqtt pub --retain te/device/main///cmd/native-reboot/robot-1 '{"status":"init"}'
-    Should Have MQTT Messages    te/device/main///cmd/native-reboot/robot-1    message_pattern=.*successful.*   maximum=1    timeout=300
-    ${pid_after}=  Execute Command    sudo systemctl show --property MainPID tedge-agent
+    Execute Command
+    ...    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/systemctl, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /usr/sbin/reboot, /usr/bin/on_shutdown.sh' > /etc/sudoers.d/tedge
+    ${pid_before}    Execute Command    sudo systemctl show --property MainPID tedge-agent
+    Execute Command    tedge mqtt pub --retain te/device/main///cmd/native-reboot/robot-1 '{"status":"init"}'
+    Should Have MQTT Messages
+    ...    te/device/main///cmd/native-reboot/robot-1
+    ...    message_pattern=.*successful.*
+    ...    maximum=1
+    ...    timeout=300
+    ${pid_after}    Execute Command    sudo systemctl show --property MainPID tedge-agent
     Should Not Be Equal    ${pid_before}    ${pid_after}    msg=tedge-agent should have been restarted
-    ${workflow_log}=  Execute Command    cat /var/log/tedge/agent/workflow-native-reboot-robot-1.log
-    Should Contain    ${workflow_log}    item=native-reboot @ restarted    msg=restarted state should have been executed
+    ${workflow_log}    Execute Command    cat /var/log/tedge/agent/workflow-native-reboot-robot-1.log
+    Should Contain
+    ...    ${workflow_log}
+    ...    item=native-reboot @ restarted
+    ...    msg=restarted state should have been executed
 
 Trigger native-reboot within workflow (on_error) - missing sudoers entry for reboot
-    Execute Command    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync' > /etc/sudoers.d/tedge
-    ${pid_before}=  Execute Command    sudo systemctl show --property MainPID tedge-agent
-    Execute Command     tedge mqtt pub --retain te/device/main///cmd/native-reboot/robot-2 '{"status":"init"}'
-    Should Have MQTT Messages    te/device/main///cmd/native-reboot/robot-2    message_pattern=.*failed.*   maximum=1    timeout=180
-    ${pid_after}=  Execute Command    sudo systemctl show --property MainPID tedge-agent
+    Execute Command
+    ...    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync' > /etc/sudoers.d/tedge
+    ${pid_before}    Execute Command    sudo systemctl show --property MainPID tedge-agent
+    Execute Command    tedge mqtt pub --retain te/device/main///cmd/native-reboot/robot-2 '{"status":"init"}'
+    Should Have MQTT Messages
+    ...    te/device/main///cmd/native-reboot/robot-2
+    ...    message_pattern=.*failed.*
+    ...    maximum=1
+    ...    timeout=180
+    ${pid_after}    Execute Command    sudo systemctl show --property MainPID tedge-agent
     Should Be Equal    ${pid_before}    ${pid_after}    msg=tedge-agent should not have been restarted
-    ${workflow_log}=  Execute Command    cat /var/log/tedge/agent/workflow-native-reboot-robot-2.log
-    Should Not Contain    ${workflow_log}    item=native-reboot @ restarted    msg=restarted state should not have been executed
+    ${workflow_log}    Execute Command    cat /var/log/tedge/agent/workflow-native-reboot-robot-2.log
+    Should Not Contain
+    ...    ${workflow_log}
+    ...    item=native-reboot @ restarted
+    ...    msg=restarted state should not have been executed
 
 Invoke sub-operation from a super-command operation
-    Execute Command    tedge mqtt pub --retain te/device/main///cmd/super_command/test-42 '{"status":"init", "output_file":"/tmp/test-42.json"}'
-    ${cmd_messages}    Should Have MQTT Messages    te/device/main///cmd/super_command/test-42    message_pattern=.*successful.*   maximum=1
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main///cmd/super_command/test-42 '{"status":"init", "output_file":"/tmp/test-42.json"}'
+    ${cmd_messages}    Should Have MQTT Messages
+    ...    te/device/main///cmd/super_command/test-42
+    ...    message_pattern=.*successful.*
+    ...    maximum=1
     Execute Command    tedge mqtt pub --retain te/device/main///cmd/super_command/test-42 ''
-    ${actual_log}      Execute Command    cat /tmp/test-42.json
+    ${actual_log}    Execute Command    cat /tmp/test-42.json
     ${expected_log}    Get File    ${CURDIR}/super-command-expected.log
     Should Be Equal    ${actual_log}    ${expected_log}
-    ${workflow_log}=  Execute Command    cat /var/log/tedge/agent/workflow-super_command-test-42.log
+    ${workflow_log}    Execute Command    cat /var/log/tedge/agent/workflow-super_command-test-42.log
     Should Contain    ${workflow_log}    item=super_command @ init
     Should Contain    ${workflow_log}    item=super_command @ executing
     Should Contain    ${workflow_log}    item=super_command @ awaiting_completion
-    Should Contain    ${workflow_log}    item=super_command > sub_command @ init                      msg=main command log should contain sub command steps
-    Should Contain    ${workflow_log}    item=super_command > sub_command @ executing                 msg=main command log should contain sub command steps
-    Should Contain    ${workflow_log}    item=super_command > sub_command @ successful                msg=main command log should contain sub command steps
+    Should Contain
+    ...    ${workflow_log}
+    ...    item=super_command > sub_command @ init
+    ...    msg=main command log should contain sub command steps
+    Should Contain
+    ...    ${workflow_log}
+    ...    item=super_command > sub_command @ executing
+    ...    msg=main command log should contain sub command steps
+    Should Contain
+    ...    ${workflow_log}
+    ...    item=super_command > sub_command @ successful
+    ...    msg=main command log should contain sub command steps
     Should Contain    ${workflow_log}    item=super_command @ successful
 
 Use scripts to create sub-operation init states
-    Execute Command    tedge mqtt pub --retain te/device/main///cmd/lite_device_profile/test-42 '{"status":"init", "logfile":"/tmp/profile-42.log", "profile":"/etc/tedge/operations/lite_device_profile.example.txt"}'
-    Should Have MQTT Messages    te/device/main///cmd/lite_device_profile/test-42    message_pattern=.*successful.*   maximum=1
-    ${actual_log}      Execute Command    cat /tmp/profile-42.log
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main///cmd/lite_device_profile/test-42 '{"status":"init", "logfile":"/tmp/profile-42.log", "profile":"/etc/tedge/operations/lite_device_profile.example.txt"}'
+    Should Have MQTT Messages
+    ...    te/device/main///cmd/lite_device_profile/test-42
+    ...    message_pattern=.*successful.*
+    ...    maximum=1
+    ${actual_log}    Execute Command    cat /tmp/profile-42.log
     ${expected_log}    Get File    ${CURDIR}/lite_device_profile.expected.log
     Should Be Equal    ${actual_log}    ${expected_log}
 
 Invoke sub-operation from a sub-operation
-    Execute Command    tedge mqtt pub --retain te/device/main///cmd/gp_command/test-sub-sub '{"status":"init", "sub_operation":"super_command", "output_file":"/tmp/test-sub-sub.json"}'
-    ${cmd_messages}    Should Have MQTT Messages    te/device/main///cmd/gp_command/test-sub-sub    message_pattern=.*successful.*   maximum=1
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main///cmd/gp_command/test-sub-sub '{"status":"init", "sub_operation":"super_command", "output_file":"/tmp/test-sub-sub.json"}'
+    ${cmd_messages}    Should Have MQTT Messages
+    ...    te/device/main///cmd/gp_command/test-sub-sub
+    ...    message_pattern=.*successful.*
+    ...    maximum=1
     Execute Command    tedge mqtt pub --retain te/device/main///cmd/gp_command/test-sub-sub ''
-    ${actual_log}      Execute Command    cat /tmp/test-sub-sub.json
+    ${actual_log}    Execute Command    cat /tmp/test-sub-sub.json
     ${expected_log}    Get File    ${CURDIR}/gp-command-expected.log
     Should Be Equal    ${actual_log}    ${expected_log}
 
 Command steps should not be executed twice
     Execute Command    tedge mqtt pub --retain te/device/main///cmd/issue-2896/test-1 '{"status":"init"}'
-    ${cmd_messages}    Should Have MQTT Messages    te/device/main///cmd/issue-2896/test-1    message_pattern=.*successful.*
+    ${cmd_messages}    Should Have MQTT Messages
+    ...    te/device/main///cmd/issue-2896/test-1
+    ...    message_pattern=.*successful.*
     Execute Command    tedge mqtt pub --retain te/device/main///cmd/issue-2896/test-1 ''
-    ${workflow_log}    Execute Command    grep '\\[ issue-2896' /var/log/tedge/agent/workflow-issue-2896-test-1.log | cut -d '|' -f 1 | sed 's/ $//'
+    ${workflow_log}    Execute Command
+    ...    grep '\\[ issue-2896' /var/log/tedge/agent/workflow-issue-2896-test-1.log | cut -d '|' -f 1 | sed 's/ $//'
     TRY
         # "issue-2896 @ await_restart" is resumed first
         ${expected_log}    Get File    ${CURDIR}/issue-2896-test-1.seq1.log
@@ -115,44 +174,47 @@ Command steps should not be executed twice
 
 Placeholder workflow created for ill-defined operations
     Execute Command    tedge mqtt pub --retain te/device/main///cmd/issue-3079/test-1 '{"status":"init"}'
-    ${cmd_messages}    Should Have MQTT Messages    te/device/main///cmd/issue-3079/test-1    message_pattern=.*Invalid operation workflow definition.*
+    ${cmd_messages}    Should Have MQTT Messages
+    ...    te/device/main///cmd/issue-3079/test-1
+    ...    message_pattern=.*Invalid operation workflow definition.*
     Execute Command    tedge mqtt pub --retain te/device/main///cmd/issue-3079/test-1 ''
-    ${workflow_log}=   Execute Command    cat /var/log/tedge/agent/workflow-issue-3079-test-1.log
-    Should Contain     ${workflow_log}    item=TOML parse error
+    ${workflow_log}    Execute Command    cat /var/log/tedge/agent/workflow-issue-3079-test-1.log
+    Should Contain    ${workflow_log}    item=TOML parse error
+
 
 *** Keywords ***
-
 Custom Test Setup
-    Execute Command    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/systemctl, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /usr/bin/on_shutdown.sh' > /etc/sudoers.d/tedge
+    Execute Command
+    ...    cmd=echo 'tedge ALL = (ALL) NOPASSWD: /usr/bin/tedge, /usr/bin/systemctl, /etc/tedge/sm-plugins/[a-zA-Z0-9]*, /bin/sync, /sbin/init, /sbin/shutdown, /usr/bin/on_shutdown.sh' > /etc/sudoers.d/tedge
 
 Custom Setup
-    ${DEVICE_SN}=    Setup
+    ${DEVICE_SN}    Setup
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist                      ${DEVICE_SN}
+    Device Should Exist    ${DEVICE_SN}
     Copy Configuration Files
     Restart Service    tedge-agent
 
 Copy Configuration Files
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/software_list.toml       /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/software_list.toml    /etc/tedge/operations/
     ThinEdgeIO.Transfer To Device    ${CURDIR}/init-software-list.sh    /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/custom-download.toml     /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/schedule-download.sh     /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/launch-download.sh       /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/check-download.sh        /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/slow-operation.toml      /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/custom-download.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/schedule-download.sh    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/launch-download.sh    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/check-download.sh    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/slow-operation.toml    /etc/tedge/operations/
     ThinEdgeIO.Transfer To Device    ${CURDIR}/restart-tedge-agent.toml    /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/tedge-agent-pid.sh       /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/native-reboot.toml       /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/gp_command.toml          /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/super_command.toml       /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/sub_command.toml       /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/echo-as-json.sh          /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/write-file.sh            /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/restart_sub_command.toml           /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/extract_updates.sh                 /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/lite_device_profile.toml           /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/lite_config_update.toml            /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/lite_software_update.toml          /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/tedge-agent-pid.sh    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/native-reboot.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/gp_command.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/super_command.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/sub_command.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/echo-as-json.sh    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/write-file.sh    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/restart_sub_command.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/extract_updates.sh    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/lite_device_profile.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/lite_config_update.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/lite_software_update.toml    /etc/tedge/operations/
     ThinEdgeIO.Transfer To Device    ${CURDIR}/lite_device_profile.example.txt    /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/issue-2896.toml                    /etc/tedge/operations/
-    ThinEdgeIO.Transfer To Device    ${CURDIR}/issue-3079.toml                    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/issue-2896.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/issue-3079.toml    /etc/tedge/operations/

--- a/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
+++ b/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
@@ -1,14 +1,16 @@
 *** Settings ***
-Documentation    Run connection test while being connected and check the positive response in stdout
-...              disconnect the device from cloud and check the negative message in stderr
-...              Run sudo tedge connect c8y and check 
+Documentation       Run connection test while being connected and check the positive response in stdout
+...                 disconnect the device from cloud and check the negative message in stderr
+...                 Run sudo tedge connect c8y and check
 
-Resource    ../../resources/common.resource
-Library    ThinEdgeIO
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
 
-Test Tags    theme:cli    theme:mqtt    theme:c8y
-Suite Setup            Suite Setup
-Suite Teardown         Get Logs
+Suite Setup         Suite Setup
+Suite Teardown      Get Logs
+
+Test Tags           theme:cli    theme:mqtt    theme:c8y
+
 
 *** Test Cases ***
 tedge_connect_test_positive
@@ -27,10 +29,13 @@ Non-root users should be able to read the mosquitto configuration files #2154
     # Reset things after running the test
     [Teardown]    Execute Command    sudo tedge config unset mqtt.bridge.built_in
 
-
 tedge_connect_test_negative
     Execute Command    sudo tedge disconnect c8y
-    ${output}=    Execute Command    sudo tedge connect c8y --test    exp_exit_code=1    stdout=${False}    stderr=${True}
+    ${output}=    Execute Command
+    ...    sudo tedge connect c8y --test
+    ...    exp_exit_code=1
+    ...    stdout=${False}
+    ...    stderr=${True}
     Should Contain    ${output}    Error: failed to test connection to Cumulocity cloud.
 
 tedge_connect_test_sm_services
@@ -38,7 +43,10 @@ tedge_connect_test_sm_services
     Should Contain    ${output}    Successfully created bridge connection!
     Should Contain    ${output}    tedge-agent service successfully started and enabled!
     Should Contain    ${output}    tedge-mapper-c8y service successfully started and enabled!
-    Should Not Contain  ${output}    Warning:    message=Warning should not be displayed if the port does not match. Issue #2863
+    Should Not Contain
+    ...    ${output}
+    ...    Warning:
+    ...    message=Warning should not be displayed if the port does not match. Issue #2863
 
 tedge_disconnect_test_sm_services
     ${output}=    Execute Command    sudo tedge disconnect c8y
@@ -47,25 +55,26 @@ tedge_disconnect_test_sm_services
     Should Contain    ${output}    tedge-mapper-c8y service successfully stopped and disabled!
 
 tedge reconnect does not restart agent
-    ${pid_before}=  Execute Command    sudo systemctl show --property MainPID tedge-agent
+    ${pid_before}=    Execute Command    sudo systemctl show --property MainPID tedge-agent
     ${output}=    Execute Command    sudo tedge reconnect c8y
-    ${pid_after}=  Execute Command    sudo systemctl show --property MainPID tedge-agent
+    ${pid_after}=    Execute Command    sudo systemctl show --property MainPID tedge-agent
     Should Be Equal    ${pid_before}    ${pid_after}
 
 tedge reconnect restarts mapper
-    ${pid_before}=  Execute Command    sudo systemctl show --property MainPID tedge-mapper-c8y
+    ${pid_before}=    Execute Command    sudo systemctl show --property MainPID tedge-mapper-c8y
     ${output}=    Execute Command    sudo tedge reconnect c8y
-    ${pid_after}=  Execute Command    sudo systemctl show --property MainPID tedge-mapper-c8y
+    ${pid_after}=    Execute Command    sudo systemctl show --property MainPID tedge-mapper-c8y
     Should Not Be Equal    ${pid_before}    ${pid_after}
 
 Check absence of OpenSSL Error messages #3024
     ${SuiteStart}=    Get Suite Start Time
     # Only checkout output if mosquitto is being used
-    ${output}=    Execute Command    systemctl is-active mosquitto && journalctl -u mosquitto -n 5000 --since "@${SuiteStartSeconds}" || true
+    ${output}=    Execute Command
+    ...    systemctl is-active mosquitto && journalctl -u mosquitto -n 5000 --since "@${SuiteStartSeconds}" || true
     Should Not Contain    ${output}    OpenSSL Error
 
-*** Keywords ***
 
+*** Keywords ***
 Suite Setup
     Setup
     ${SuiteStartSeconds}=    Get Unix Timestamp
@@ -74,4 +83,7 @@ Suite Setup
 Should Have File Permissions
     [Arguments]    ${file}    ${expected_permissions}
     ${FILE_MODE_OWNERSHIP}=    Execute Command    stat -c '%a %U:%G' ${file}    strip=${True}
-    Should Be Equal    ${FILE_MODE_OWNERSHIP}    ${expected_permissions}    msg=Unexpected file permissions/ownership of ${file}
+    Should Be Equal
+    ...    ${FILE_MODE_OWNERSHIP}
+    ...    ${expected_permissions}
+    ...    msg=Unexpected file permissions/ownership of ${file}

--- a/tests/RobotFramework/tests/tedge_to_te_converter/convert_tedge_topics_to_te_topics.robot
+++ b/tests/RobotFramework/tests/tedge_to_te_converter/convert_tedge_topics_to_te_topics.robot
@@ -10,80 +10,125 @@ Suite Teardown      Custom Teardown
 
 Test Tags           theme:mqtt    theme:tedge to te
 
+
 *** Test Cases ***
 Convert main device measurement topic
     Execute Command    tedge mqtt pub tedge/measurements ''
     ${messages_tedge}=    Should Have MQTT Messages    tedge/measurements    minimum=1    maximum=1
     ${messages_te}=    Should Have MQTT Messages    te/device/main///m/    minimum=1    maximum=1
-    Should Be Equal    ${messages_tedge}  ${messages_te}    
+    Should Be Equal    ${messages_tedge}    ${messages_te}
 
 Convert main device empty measurement topic
     Execute Command    tedge mqtt pub tedge/measurements '{"temperature":20}'
-    ${messages_tedge}=    Should Have MQTT Messages    tedge/measurements    minimum=1    maximum=1    message_contains=20
-    ${messages_te}=    Should Have MQTT Messages    te/device/main///m/    minimum=1    maximum=1   message_contains=20
-    Should Be Equal    ${messages_tedge}  ${messages_te}
+    ${messages_tedge}=    Should Have MQTT Messages
+    ...    tedge/measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains=20
+    ${messages_te}=    Should Have MQTT Messages
+    ...    te/device/main///m/
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains=20
+    Should Be Equal    ${messages_tedge}    ${messages_te}
     Should Have MQTT Messages    te/device/main///m/    message_pattern={"temperature":20}
-   
+
 Convert child device measurement topic
     Execute Command    tedge mqtt pub tedge/measurements/child '{"temperature":25}'
-    ${messages_tedge}=    Should Have MQTT Messages    tedge/measurements/child   minimum=1    maximum=1    message_contains=25
-    ${messages_te}=    Should Have MQTT Messages    te/device/child///m/    minimum=1    maximum=1    message_contains=25
-    Should Be Equal    ${messages_tedge}  ${messages_te}
+    ${messages_tedge}=    Should Have MQTT Messages
+    ...    tedge/measurements/child
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains=25
+    ${messages_te}=    Should Have MQTT Messages
+    ...    te/device/child///m/
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains=25
+    Should Be Equal    ${messages_tedge}    ${messages_te}
     Should Have MQTT Messages    te/device/child///m/    message_pattern={"temperature":25}
 
 Convert main device event topic
     Execute Command    tedge mqtt pub tedge/events/login_event '{"text":"someone loggedin"}'
-    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event   minimum=1    maximum=1    message_contains=someone loggedin
-    ${messages_te}=    Should Have MQTT Messages    te/device/main///e/login_event    minimum=1    maximum=1    message_contains=someone loggedin
-    Should Be Equal    ${messages_tedge}  ${messages_te}
+    ${messages_tedge}=    Should Have MQTT Messages
+    ...    tedge/events/login_event
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains=someone loggedin
+    ${messages_te}=    Should Have MQTT Messages
+    ...    te/device/main///e/login_event
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains=someone loggedin
+    Should Be Equal    ${messages_tedge}    ${messages_te}
     Should Have MQTT Messages    te/device/main///e/login_event    message_pattern={"text":"someone loggedin"}
 
 Convert main device empty event topic
     Execute Command    tedge mqtt pub tedge/events/login_event2 ''
-    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event2   minimum=1    maximum=1
+    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event2    minimum=1    maximum=1
     ${messages_te}=    Should Have MQTT Messages    te/device/main///e/login_event2    minimum=1    maximum=1
-    Should Be Equal    ${messages_tedge}  ${messages_te}      
+    Should Be Equal    ${messages_tedge}    ${messages_te}
 
 Convert child device event topic
     Execute Command    tedge mqtt pub tedge/events/login_event/child '{"text":"someone loggedin 2"}'
-    ${messages_tedge}=    Should Have MQTT Messages    tedge/events/login_event/child   minimum=1    maximum=1    message_contains="someone loggedin 2"
-    ${messages_te}=    Should Have MQTT Messages    te/device/child///e/login_event    minimum=1    maximum=1    message_contains="someone loggedin 2"
-    Should Be Equal    ${messages_tedge}  ${messages_te}
+    ${messages_tedge}=    Should Have MQTT Messages
+    ...    tedge/events/login_event/child
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains="someone loggedin 2"
+    ${messages_te}=    Should Have MQTT Messages
+    ...    te/device/child///e/login_event
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains="someone loggedin 2"
+    Should Be Equal    ${messages_tedge}    ${messages_te}
     Should Have MQTT Messages    te/device/child///e/login_event    message_pattern={"text":"someone loggedin 2"}
 
 Convert main device alarm topic
     Execute Command    tedge mqtt pub tedge/alarms/minor/test_alarm '{"text":"test alarm 1"}' -q 2 -r
-    ${messages}=    Should Have MQTT Messages    te/device/main///a/test_alarm    minimum=1    maximum=1    message_contains="test alarm 1"
+    ${messages}=    Should Have MQTT Messages
+    ...    te/device/main///a/test_alarm
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains="test alarm 1"
     ${message}=    Convert String To Json    ${messages[0]}
     Should Be Equal    ${message["severity"]}    minor
 
 Convert main device alarm topic and retain
     Execute Command    tedge mqtt pub tedge/alarms/minor/test_alarm '{"text":"test alarm 2"}' -q 2 -r
-    ${messages}=    Should Have MQTT Messages    te/device/main///a/test_alarm    minimum=1     maximum=1    message_contains="test alarm 2"
+    ${messages}=    Should Have MQTT Messages
+    ...    te/device/main///a/test_alarm
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains="test alarm 2"
     ${message}=    Convert String To Json    ${messages[0]}
     Should Be Equal    ${message["severity"]}    minor
     # Check if the retained message received with new client or not
-    ${result}=    Execute Command    tedge mqtt sub te/device/main///a/test_alarm & sleep 2s; kill $!   
+    ${result}=    Execute Command    tedge mqtt sub te/device/main///a/test_alarm & sleep 2s; kill $!
     Should Contain    ${result}    "severity":"minor"
 
 Convert child device alarm topic
     Execute Command    tedge mqtt pub tedge/alarms/major/test_alarm/child1 '{"text":"test alarm 3"}' -q 2 -r
-    ${messages}=    Should Have MQTT Messages    te/device/child1///a/test_alarm    minimum=1     maximum=1    message_contains="test alarm 3"
+    ${messages}=    Should Have MQTT Messages
+    ...    te/device/child1///a/test_alarm
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_contains="test alarm 3"
     ${message}=    Convert String To Json    ${messages[0]}
     Should Be Equal    ${message["severity"]}    major
-
 
 Convert clear alarm topic
     Execute Command    tedge mqtt pub tedge/alarms/major/test_alarm/child2 '' -q 2 -r
     ${messages_tedge}=    Should Have MQTT Messages    tedge/alarms/major/test_alarm/child2    minimum=1    maximum=1
     ${messages_te}=    Should Have MQTT Messages    te/device/child2///a/test_alarm    minimum=1    maximum=1
-    Should Be Equal    ${messages_tedge}  ${messages_te}
-    
+    Should Be Equal    ${messages_tedge}    ${messages_te}
+
 Convert empty alarm message
     Execute Command    tedge mqtt pub tedge/alarms/major/test_alarm/child3 {} -q 2 -r
-    ${messages}=    Should Have MQTT Messages    te/device/child3///a/test_alarm    minimum=1     maximum=1
+    ${messages}=    Should Have MQTT Messages    te/device/child3///a/test_alarm    minimum=1    maximum=1
     ${message}=    Convert String To Json    ${messages[0]}
     Should Be Equal    ${message["severity"]}    major
+
 
 *** Keywords ***
 Custom Setup

--- a/tests/RobotFramework/tests/tedge_to_te_converter/convert_tedge_topics_to_te_topics.robot
+++ b/tests/RobotFramework/tests/tedge_to_te_converter/convert_tedge_topics_to_te_topics.robot
@@ -8,7 +8,7 @@ Library             JSONLibrary
 Suite Setup         Custom Setup
 Suite Teardown      Custom Teardown
 
-Test Tags           theme:mqtt    theme:tedge to te
+Test Tags           theme:mqtt    theme:tedge_to_te
 
 
 *** Test Cases ***

--- a/tests/RobotFramework/tests/tedge_write.robot
+++ b/tests/RobotFramework/tests/tedge_write.robot
@@ -1,41 +1,40 @@
 *** Settings ***
+Documentation
+...                 This suite aims to check the correctness of tedge-write component which is used for privilege
+...                 elevation to allow tedge processes running under `tedge` user to write to configuration files
+...                 on the system tedge normally doesn't have permissions for.
+...
+...                 tedge-write must:
+...                 - write to files `tedge` have no permissions to (privilege elevation happens)
+...                 - preserve permissions for existing files and apply new permissions for files created
+...                 - handle permissions correcly on non-standard umasks
+...                 - not leave temporary files
+...
+...                 Tests for tedge-write need to be done in RobotFramework because we need to run as a `tedge`
+...                 user, and a sudoers entry that allows `tedge` to run `sudo tedge-write` without password
+...                 needs to be present. Additionally, we need to ensure `tedge-write` works well on system where
+...                 the default umask is different.
+...
+...                 Additionally, apart from the component itself, we need to test features that use it directly,
+...                 like config_update.
+
 Resource            ../resources/common.resource
 Library             ThinEdgeIO
 
-Documentation
-...    This suite aims to check the correctness of tedge-write component which is used for privilege
-...    elevation to allow tedge processes running under `tedge` user to write to configuration files
-...    on the system tedge normally doesn't have permissions for.
-...
-...    tedge-write must:
-...    - write to files `tedge` have no permissions to (privilege elevation happens)
-...    - preserve permissions for existing files and apply new permissions for files created
-...    - handle permissions correcly on non-standard umasks
-...    - not leave temporary files
-...
-...    Tests for tedge-write need to be done in RobotFramework because we need to run as a `tedge`
-...    user, and a sudoers entry that allows `tedge` to run `sudo tedge-write` without password
-...    needs to be present. Additionally, we need to ensure `tedge-write` works well on system where
-...    the default umask is different.
-...
-...    Additionally, apart from the component itself, we need to test features that use it directly,
-...    like config_update.
-
 Suite Setup         Custom Setup
 Suite Teardown      Get Logs
-
 Test Teardown       Remove temporary test directories
 
 Test Tags           adapter:docker    theme:tedge-write
 
 
 *** Variables ***
-${REGULAR_USER} =    user
+${REGULAR_USER}     user
 
 
 *** Test Cases ***
 Sudo elevates permissions when tedge-write writes to a root-owned file
-    ${dest_file} =    Create a temporary file
+    ${dest_file}=    Create a temporary file
     Make file inaccessible to regular users    ${dest_file}
 
     Write content to file using sudo tedge-write as user    tedge    ${dest_file}
@@ -43,7 +42,7 @@ Sudo elevates permissions when tedge-write writes to a root-owned file
     There should be no leftover temporary files    ${dest_file}
 
 Sudo doesn't elevate permissions when tedge-write is run by another user
-    ${dest_file} =    Create a temporary file
+    ${dest_file}=    Create a temporary file
     Make file inaccessible to regular users    ${dest_file}
 
     Write content to file using sudo tedge-write as user
@@ -79,13 +78,13 @@ Creates a destination file if it doesn't exist
     # process, and `Execute Command` starts a new shell process everytime
     Execute Command as user    tedge
     ...    umask ${umask} && echo abc | sudo tedge-write ${dest_filename}    strip=True
-    
+
     Path Should Have Permissions    ${dest_filename}    owner_group=root:root
 
     There should be no leftover temporary files    ${dest_filename}
 
 Changes permissions if a destination doesn't exist
-    [Arguments]          ${umask}
+    [Arguments]    ${umask}
 
     ${dest_filename}=    Create a temporary file    dry_run=${True}
     Execute Command as user    tedge
@@ -96,11 +95,11 @@ Changes permissions if a destination doesn't exist
     There should be no leftover temporary files    ${dest_filename}
 
 Preserves permissions if a destination exists
-    [Arguments]          ${umask}
+    [Arguments]    ${umask}
 
     ${dest_file}=    Create a temporary file
-    Execute Command      chown tedge:tedge ${dest_file}
-    Execute Command      chmod 666 ${dest_file}
+    Execute Command    chown tedge:tedge ${dest_file}
+    Execute Command    chmod 666 ${dest_file}
 
     Execute Command as user    tedge
     ...    umask ${umask} && echo abc | sudo tedge-write ${dest_file} --user root --group root --mode 700
@@ -116,12 +115,12 @@ Custom Setup
     Create a regular user
 
 Create a temporary file
-    [Arguments]    ${dry_run}=${False}
     [Documentation]
     ...    Creates a temporary directory and creates a temporary file in that directory. This is so we can check that
     ...    after writing there are no leftover temporary files in the destination file's parent directory.
-    ${dir}=     Execute Command    mktemp --tmpdir\=/tmp --directory    strip=True
-    ${path}=    Execute Command    mktemp --tmpdir\=${dir} ${{'--dry-run' if ${dry_run} is True else ''}}   strip=True
+    [Arguments]    ${dry_run}=${False}
+    ${dir}=    Execute Command    mktemp --tmpdir\=/tmp --directory    strip=True
+    ${path}=    Execute Command    mktemp --tmpdir\=${dir} ${{'--dry-run' if ${dry_run} is True else ''}}    strip=True
     RETURN    ${path}
 
 Remove temporary test directories
@@ -145,9 +144,9 @@ Execute Command as user
     Execute Command    sudo -n --user\=${user} bash -c '${command}'    &{named}
 
 There should be no leftover temporary files
-    [Arguments]    ${dest_file}
     [Documentation]    Assuming ${dest_file} was the only file in a temporary directory that was written to by
     ...    tedge-agent, check that there are no other files in the directory after using tedge-write.
+    [Arguments]    ${dest_file}
 
-    ${num_files} =    Execute Command    ls $(dirname ${dest_file}) | wc -l     strip=True
+    ${num_files}=    Execute Command    ls $(dirname ${dest_file}) | wc -l    strip=True
     Should Be Equal    ${num_files}    1


### PR DESCRIPTION
## Proposed changes

Reformat Robot Framework files with a standard Robot Framework formatter, [robotframework-tidy](https://robotidy.readthedocs.io/en/stable/index.html).

The motivation is for our Robot Framework test suite to be more readable and consistent, by having the formatting be consistent and adhere to [Robot Framework Style Guide](https://docs.robotframework.org/docs/style_guide).

Most of the team writes Robot Framework tests in tandem with features they're working on, so they most often just expand existing test suites and replicate whatever style is already present there, but sometimes new suites are still created, also with different styles. As all of these suites expand, the styles can gradually drift apart.

Eventually perhaps everybody would set up their development environment to format these files automatically and we could set up formatting checks as we have for Rust, but that would require some effort for everybody to set things up, for now we can do this one-time reformatting.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2521

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments


We could also use [Robocop](https://robocop.readthedocs.io/en/stable/), but even after reformatting with Robotidy, it finds a lot of warnings that would have to be resolved manually:

```
$ robocop --report rules_by_error_type

...

Found 1942 issues: 1754 WARNINGs, 188 INFOs.
```

It would perhaps also require a less trivial restructuring of the test suite, which would be a lot of manual work, and it also finds a lot of `Line is too long (203/120) (line-too-long)` warnings, which should be handled by robotidy but apparently weren't. But the option is there.