### PR TITLE
feat: support setting config dir via env variable

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config_location.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config_location.rs
@@ -13,13 +13,28 @@ use crate::TEdgeConfigReader;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use serde::Serialize;
+use std::path::PathBuf;
 use tedge_utils::file::PermissionEntry;
 use tedge_utils::fs::atomically_write_file_sync;
 use tracing::debug;
 use tracing::warn;
 
-pub const DEFAULT_TEDGE_CONFIG_PATH: &str = "/etc/tedge";
+const DEFAULT_TEDGE_CONFIG_PATH: &str = "/etc/tedge";
+const ENV_TEDGE_CONFIG_DIR: &str = "TEDGE_CONFIG_DIR";
 const TEDGE_CONFIG_FILE: &str = "tedge.toml";
+
+/// Get the location of the configuration directory
+///
+/// Check if the TEDGE_CONFIG_DIR env variable is set and only
+/// use the value if it is not empty, otherwise use the default
+/// location, /etc/tedge
+pub fn get_config_dir() -> PathBuf {
+    match std::env::var(ENV_TEDGE_CONFIG_DIR) {
+        Ok(s) if !s.is_empty() => PathBuf::from(s),
+        _ => PathBuf::from(DEFAULT_TEDGE_CONFIG_PATH),
+    }
+}
+
 /// Information about where `tedge.toml` is located.
 ///
 /// Broadly speaking, we distinguish two different locations:

--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -9,7 +9,7 @@ use c8y_firmware_plugin::FirmwarePluginOpt;
 use c8y_remote_access_plugin::C8yRemoteAccessPluginOpt;
 pub use connect::*;
 use tedge_agent::AgentOpt;
-use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
+use tedge_config::get_config_dir;
 use tedge_mapper::MapperOpt;
 use tedge_watchdog::WatchdogOpt;
 use tedge_write::bin::Args as TedgeWriteOpt;
@@ -40,7 +40,14 @@ pub enum TEdgeOptMulticall {
         #[clap(subcommand)]
         cmd: TEdgeOpt,
 
-        #[clap(long = "config-dir", default_value = DEFAULT_TEDGE_CONFIG_PATH, global = true)]
+        // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+        #[clap(
+            long = "config-dir",
+            default_value = get_config_dir().into_os_string(),
+            hide_env_values = true,
+            hide_default_value = true,
+            global = true,
+        )]
         config_dir: PathBuf,
     },
 

--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -40,7 +40,7 @@ pub enum TEdgeOptMulticall {
         #[clap(subcommand)]
         cmd: TEdgeOpt,
 
-        // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+        /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
         #[clap(
             long = "config-dir",
             default_value = get_config_dir().into_os_string(),

--- a/crates/core/tedge_agent/src/lib.rs
+++ b/crates/core/tedge_agent/src/lib.rs
@@ -15,9 +15,9 @@ use std::sync::Arc;
 
 use agent::AgentConfig;
 use camino::Utf8PathBuf;
+use tedge_config::get_config_dir;
 use tedge_config::system_services::get_log_level;
 use tedge_config::system_services::set_log_level;
-use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 use tracing::log::warn;
 
 mod agent;
@@ -50,8 +50,13 @@ pub struct AgentOpt {
 
     /// Start the agent from custom path
     ///
-    /// WARNING: This is mostly used in testing.
-    #[clap(long = "config-dir", default_value = DEFAULT_TEDGE_CONFIG_PATH)]
+    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    #[clap(
+        long = "config-dir",
+        default_value = get_config_dir().into_os_string(),
+        hide_env_values = true,
+        hide_default_value = true,
+    )]
     pub config_dir: Utf8PathBuf,
 
     /// The device MQTT topic identifier

--- a/crates/core/tedge_agent/src/lib.rs
+++ b/crates/core/tedge_agent/src/lib.rs
@@ -50,7 +50,7 @@ pub struct AgentOpt {
 
     /// Start the agent from custom path
     ///
-    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
     #[clap(
         long = "config-dir",
         default_value = get_config_dir().into_os_string(),

--- a/crates/core/tedge_mapper/src/lib.rs
+++ b/crates/core/tedge_mapper/src/lib.rs
@@ -56,7 +56,7 @@ pub struct MapperOpt {
 
     /// Start the mapper from custom path
     ///
-    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
     #[clap(
         long = "config-dir",
         default_value = get_config_dir().into_os_string(),

--- a/crates/core/tedge_mapper/src/lib.rs
+++ b/crates/core/tedge_mapper/src/lib.rs
@@ -6,10 +6,10 @@ use crate::core::component::TEdgeComponent;
 use clap::Parser;
 use flockfile::check_another_instance_is_not_running;
 use std::fmt;
+use tedge_config::get_config_dir;
 use tedge_config::system_services::get_log_level;
 use tedge_config::system_services::set_log_level;
 use tedge_config::PathBuf;
-use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 use tracing::log::warn;
 
 mod aws;
@@ -56,8 +56,13 @@ pub struct MapperOpt {
 
     /// Start the mapper from custom path
     ///
-    /// WARNING: This is mostly used in testing.
-    #[clap(long = "config-dir", default_value = DEFAULT_TEDGE_CONFIG_PATH)]
+    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    #[clap(
+        long = "config-dir",
+        default_value = get_config_dir().into_os_string(),
+        hide_env_values = true,
+        hide_default_value = true,
+    )]
     pub config_dir: PathBuf,
 }
 

--- a/crates/core/tedge_watchdog/src/lib.rs
+++ b/crates/core/tedge_watchdog/src/lib.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
+use tedge_config::get_config_dir;
 use tedge_config::system_services::*;
-use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 
 // on linux, we use systemd
 #[cfg(target_os = "linux")]
@@ -32,8 +32,13 @@ pub struct WatchdogOpt {
 
     /// Start the watchdog from custom path
     ///
-    /// WARNING: This is mostly used in testing.
-    #[clap(long = "config-dir", default_value = DEFAULT_TEDGE_CONFIG_PATH)]
+    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    #[clap(
+        long = "config-dir",
+        default_value = get_config_dir().into_os_string(),
+        hide_env_values = true,
+        hide_default_value = true,
+    )]
     pub config_dir: PathBuf,
 }
 

--- a/crates/core/tedge_watchdog/src/lib.rs
+++ b/crates/core/tedge_watchdog/src/lib.rs
@@ -32,7 +32,7 @@ pub struct WatchdogOpt {
 
     /// Start the watchdog from custom path
     ///
-    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
     #[clap(
         long = "config-dir",
         default_value = get_config_dir().into_os_string(),

--- a/docs/src/legacy/child-device-firmware-management.md
+++ b/docs/src/legacy/child-device-firmware-management.md
@@ -86,7 +86,7 @@ USAGE:
 
 OPTIONS:
         --config-dir <CONFIG_DIR>
-            [default: /etc/tedge]
+            [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
 
         --debug
             Turn-on the debug log level.

--- a/docs/src/operate/configuration/index.md
+++ b/docs/src/operate/configuration/index.md
@@ -107,9 +107,23 @@ sudo systemctl restart tedge-agent
 
 `/etc/tedge/tedge.toml` is the default location for %%te%% configuration.
 
-This can be changed by passing an explicit `--config-dir` to all the %%te%% command invocations.
+This can be changed either by setting the `TEDGE_CONFIG_DIR` environment variable, or by passing an explicit `--config-dir` to all the %%te%% command invocations.
 
-For instance, the following uses `/tmp/tedge.toml` to set the `c8y.url` and launch the Cumulocity mapper.
+For instance, the following uses the `TEDGE_CONFIG_DIR` environment variable to change the default configuration directory so that all binaries will the new path.
+
+```sh
+export TEDGE_CONFIG_DIR=/tmp
+tedge config set c8y.url mytenant.cumulocity.com
+tedge-mapper c8y
+
+# Revert back to the default config dir for once-off commands (e.g. /etc/tedge)
+TEDGE_CONFIG_DIR= tedge-mapper c8y
+
+# Or unset the environment variable
+unset TEDGE_CONFIG_DIR
+```
+
+Alternatively, the following sample shows how to use the `--config-dir` flag to change the configuration directory, where the `/tmp/tedge.toml` configuration file will be used to set the `c8y.url` and launch the Cumulocity mapper.
 
 ```sh
 tedge --config-dir /tmp config set c8y.url mytenant.cumulocity.com

--- a/docs/src/references/cli/index.md
+++ b/docs/src/references/cli/index.md
@@ -13,7 +13,7 @@ USAGE:
     tedge [OPTIONS] [SUBCOMMAND]
 
 OPTIONS:
-        --config-dir <CONFIG_DIR>    [default: /etc/tedge]
+        --config-dir <CONFIG_DIR>    [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
     -h, --help                       Print help information
         --init                       Initialize the tedge
     -V, --version                    Print version information

--- a/docs/src/references/cli/tedge-cert.md
+++ b/docs/src/references/cli/tedge-cert.md
@@ -49,7 +49,7 @@ Usage: tedge cert create-csr [OPTIONS]
 Options:
       --device-id <ID>           The device identifier to be used as the common name for the certificate
       --output-path <OUTPUT_PATH>  Path where a Certificate signing request will be stored
-      --config-dir <CONFIG_DIR>  [default: /etc/tedge]
+      --config-dir <CONFIG_DIR>  [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
   -h, --help                     Print help
 ```
 

--- a/docs/src/references/cli/tedge-config.md
+++ b/docs/src/references/cli/tedge-config.md
@@ -102,7 +102,7 @@ Arguments:
   <VALUE>  Configuration value
 
 Options:
-      --config-dir <CONFIG_DIR>  [default: /etc/tedge]
+      --config-dir <CONFIG_DIR>  [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
   -h, --help                     Print help
 ```
 
@@ -118,6 +118,6 @@ Arguments:
   <VALUE>  Configuration value
 
 Options:
-      --config-dir <CONFIG_DIR>  [default: /etc/tedge]
+      --config-dir <CONFIG_DIR>  [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
   -h, --help                     Print help
 ```

--- a/docs/src/start/getting-started.md
+++ b/docs/src/start/getting-started.md
@@ -94,7 +94,7 @@ USAGE:
     tedge [OPTIONS] [SUBCOMMAND]
 
 OPTIONS:
-        --config-dir <CONFIG_DIR>    [default: /etc/tedge]
+        --config-dir <CONFIG_DIR>    [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
     -h, --help                       Print help information
         --init                       Initialize the tedge
     -V, --version                    Print version information

--- a/plugins/c8y_firmware_plugin/src/lib.rs
+++ b/plugins/c8y_firmware_plugin/src/lib.rs
@@ -8,10 +8,10 @@ use tedge_api::mqtt_topics::DeviceTopicId;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
 use tedge_api::mqtt_topics::Service;
+use tedge_config::get_config_dir;
 use tedge_config::system_services::get_log_level;
 use tedge_config::system_services::set_log_level;
 use tedge_config::TEdgeConfig;
-use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 use tedge_downloader_ext::DownloaderActor;
 use tedge_health_ext::HealthMonitorBuilder;
 use tedge_mqtt_ext::MqttActorBuilder;
@@ -49,7 +49,13 @@ pub struct FirmwarePluginOpt {
     #[clap(short, long)]
     pub init: bool,
 
-    #[clap(long = "config-dir", default_value = DEFAULT_TEDGE_CONFIG_PATH)]
+    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    #[clap(
+        long = "config-dir",
+        default_value = get_config_dir().into_os_string(),
+        hide_env_values = true,
+        hide_default_value = true,
+    )]
     pub config_dir: PathBuf,
 }
 

--- a/plugins/c8y_firmware_plugin/src/lib.rs
+++ b/plugins/c8y_firmware_plugin/src/lib.rs
@@ -49,7 +49,7 @@ pub struct FirmwarePluginOpt {
     #[clap(short, long)]
     pub init: bool,
 
-    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
     #[clap(
         long = "config-dir",
         default_value = get_config_dir().into_os_string(),

--- a/plugins/c8y_remote_access_plugin/src/input.rs
+++ b/plugins/c8y_remote_access_plugin/src/input.rs
@@ -7,9 +7,9 @@ use serde::Deserialize;
 use std::io::stdin;
 use std::io::BufRead;
 use std::path::PathBuf;
+use tedge_config::get_config_dir;
 use tedge_config::Path;
 use tedge_config::TEdgeConfigLocation;
-use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 
 use crate::csv::deserialize_csv_record;
 use crate::UNIX_SOCKFILE;
@@ -31,7 +31,13 @@ about = clap::crate_description!(),
 arg_required_else_help(true),
 )]
 pub struct C8yRemoteAccessPluginOpt {
-    #[arg(long = "config-dir", default_value = DEFAULT_TEDGE_CONFIG_PATH)]
+    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    #[clap(
+        long = "config-dir",
+        default_value = get_config_dir().into_os_string(),
+        hide_env_values = true,
+        hide_default_value = true,
+    )]
     config_dir: PathBuf,
 
     #[arg(long)]

--- a/plugins/c8y_remote_access_plugin/src/input.rs
+++ b/plugins/c8y_remote_access_plugin/src/input.rs
@@ -31,7 +31,7 @@ about = clap::crate_description!(),
 arg_required_else_help(true),
 )]
 pub struct C8yRemoteAccessPluginOpt {
-    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
     #[clap(
         long = "config-dir",
         default_value = get_config_dir().into_os_string(),

--- a/plugins/tedge_apt_plugin/src/lib.rs
+++ b/plugins/tedge_apt_plugin/src/lib.rs
@@ -11,10 +11,10 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::process::ExitStatus;
 use std::process::Stdio;
+use tedge_config::get_config_dir;
 use tedge_config::AptConfig;
 use tedge_config::TEdgeConfig;
 use tedge_config::TEdgeConfigLocation;
-use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
 
 #[derive(clap::Parser, Debug)]
 #[clap(
@@ -24,7 +24,13 @@ use tedge_config::DEFAULT_TEDGE_CONFIG_PATH;
     arg_required_else_help(true)
 )]
 pub struct AptCli {
-    #[clap(long = "config-dir", default_value = DEFAULT_TEDGE_CONFIG_PATH)]
+    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    #[clap(
+        long = "config-dir",
+        default_value = get_config_dir().into_os_string(),
+        hide_env_values = true,
+        hide_default_value = true,
+    )]
     config_dir: PathBuf,
 
     #[clap(subcommand)]

--- a/plugins/tedge_apt_plugin/src/lib.rs
+++ b/plugins/tedge_apt_plugin/src/lib.rs
@@ -24,7 +24,7 @@ use tedge_config::TEdgeConfigLocation;
     arg_required_else_help(true)
 )]
 pub struct AptCli {
-    // [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
     #[clap(
         long = "config-dir",
         default_value = get_config_dir().into_os_string(),

--- a/tests/RobotFramework/tests/customizing/config_dir.robot
+++ b/tests/RobotFramework/tests/customizing/config_dir.robot
@@ -24,6 +24,39 @@ thin-edge components support a custom config-dir location via flags
     Should Not Contain Default Path    ${CONFIG_DIR}    tedge-configuration-plugin --config-dir ${CONFIG_DIR}
     ThinEdgeIO.File Should Exist       ${CONFIG_DIR}/plugins/tedge-configuration-plugin.toml
 
+thin-edge components support a custom config-dir location via an environment variable
+    ${CONFIG_DIR}=    Set Variable    /tmp/test_config_dir_from_env
+    Create Config Dir    ${CONFIG_DIR}    ${DEVICE_SN}
+
+    ThinEdgeIO.Directory Should Not Exist    /etc/tedge
+
+    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-mapper c8y       env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-agent            env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    Should Not Contain Default Path    ${CONFIG_DIR}    c8y-firmware-plugin    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+
+    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-log-plugin       env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    ThinEdgeIO.File Should Exist       ${CONFIG_DIR}/plugins/tedge-log-plugin.toml
+
+    Should Not Contain Default Path    ${CONFIG_DIR}    tedge-configuration-plugin    env=TEDGE_CONFIG_DIR=${CONFIG_DIR}
+    ThinEdgeIO.File Should Exist       ${CONFIG_DIR}/plugins/tedge-configuration-plugin.toml
+
+Ignore env variable by using an empty value
+    [Documentation]    If the TEDGE_CONFIG_DIR setting has been set globally, then
+        ...    sometimes it is still useful to be able to override the value without having to unset it.
+        ...    A common way to do this is just to give an empty value to TEDGE_CONFIG_DIR before
+        ...    launching a binary
+    ${CONFIG_DIR}=    Set Variable    /tmp/test_config_dir_reset
+    Create Config Dir    ${CONFIG_DIR}    ${DEVICE_SN}
+
+    Execute Command    cmd=TEDGE_CONFIG_DIR=${CONFIG_DIR} sh -c 'tedge init'
+    ThinEdgeIO.Directory Should Exist    ${CONFIG_DIR}
+    ThinEdgeIO.Directory Should Not Exist    /etc/tedge
+
+    # Ignore the globally set TEDGE_CONFIG_DIR value (for the process), but 
+    # setting an empty value in the shell, e.g. TEDGE_CONFIG_DIR=
+    Execute Command    cmd=TEDGE_CONFIG_DIR=${CONFIG_DIR} sh -c 'TEDGE_CONFIG_DIR= tedge init'
+    ThinEdgeIO.Directory Should Exist    /etc/tedge
+
 *** Keywords ***
 
 Custom Suite Setup
@@ -52,6 +85,6 @@ Should Not Contain Default Path
     ...                This is only a rough check, as there is not a clean way to check
     ...                the current configuration of a specific component
 
-    [Arguments]    ${CONFIG_DIR}    ${COMMAND}
-    ${LOG_OUTPUT}=    Execute Command    timeout -s SIGKILL 5 ${COMMAND}    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
+    [Arguments]    ${CONFIG_DIR}    ${COMMAND}    ${env}=
+    ${LOG_OUTPUT}=    Execute Command    ${env} timeout -s SIGKILL 5 ${COMMAND}    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
     Should Not Contain    ${LOG_OUTPUT}    /etc/tedge


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Support setting the tedge `--config-dir` flag via an environment variable, `TEDGE_CONFIG_DIR`

This makes it much easier for users which are installing thin-edge.io in custom locations, as they can just set an environment variable and all of the binaries will respect the config dir path without having to add `--config-dir` everywhere.

**Implementation Note:** Clap's `.env(key)` function as it does not ignore empty environment variables, e.g. if an empty env variable is defined`export TEDGE_CONFIG_DIR=''`, then clap's logic will set the value to an empty string instead of falling back to the default value. Hence why the `default_value` logic was used instead, but that has a downside that the doc string needs to be manually provided (since the .env and .default_value functions are not used).

**Note:** @jarhodes314 Already add the `TEDGE_CONFIG_DIR` exception in the configuration parsing logic in 716e330 (`ignore(&["CONFIG_DIR"])`), so that the variable does not register as an "unknown configuration property".

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/1794

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

