### PR TITLE
fix: handle error when jwt token could not be retrieved

### DIFF
--- a/crates/extensions/c8y_auth_proxy/src/tokens.rs
+++ b/crates/extensions/c8y_auth_proxy/src/tokens.rs
@@ -10,7 +10,7 @@ impl SharedTokenManager {
     /// Returns a JWT that doesn't match the provided JWT
     ///
     /// This prevents needless token refreshes if multiple requests are made in parallel
-    pub async fn not_matching(&self, input: Option<&Arc<str>>) -> Arc<str> {
+    pub async fn not_matching(&self, input: Option<&Arc<str>>) -> Result<Arc<str>, anyhow::Error> {
         self.0.lock().await.not_matching(input).await
     }
 }
@@ -31,17 +31,17 @@ impl TokenManager {
 }
 
 impl TokenManager {
-    async fn not_matching(&mut self, input: Option<&Arc<str>>) -> Arc<str> {
+    async fn not_matching(&mut self, input: Option<&Arc<str>>) -> Result<Arc<str>, anyhow::Error> {
         match (self.cached.as_mut(), input) {
-            (Some(token), None) => token.clone(),
+            (Some(token), None) => Ok(token.clone()),
             // The token should have arisen from this TokenManager, so pointer equality is sufficient
-            (Some(token), Some(no_match)) if !Arc::ptr_eq(token, no_match) => token.clone(),
+            (Some(token), Some(no_match)) if !Arc::ptr_eq(token, no_match) => Ok(token.clone()),
             _ => self.refresh().await,
         }
     }
 
-    async fn refresh(&mut self) -> Arc<str> {
-        self.cached = Some(self.recv.await_response(()).await.unwrap().unwrap().into());
-        self.cached.as_ref().unwrap().clone()
+    async fn refresh(&mut self) -> Result<Arc<str>, anyhow::Error> {
+        self.cached = Some(self.recv.await_response(()).await??.into());
+        Ok(self.cached.as_ref().unwrap().clone())
     }
 }


### PR DESCRIPTION
## Proposed changes
This PR replace `unwrap()` with `anyhow` error handling when `c8y_auth_proxy` is trying to retrive JWT token.
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #3019 
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

