### PR TITLE
fix: builtin bridge disconnected when under heavy load

### DIFF
--- a/crates/extensions/tedge_mqtt_bridge/src/health.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/health.rs
@@ -1,5 +1,5 @@
 use crate::overall_status;
-use crate::BidirectionalChannelHalf;
+use crate::BridgeAsyncClient;
 use crate::BridgeMessage;
 use crate::Status;
 use futures::channel::mpsc;
@@ -27,7 +27,7 @@ pub struct BridgeHealthMonitor {
 impl BridgeHealthMonitor {
     pub(crate) fn new(
         topic: String,
-        bridge_half: &BidirectionalChannelHalf,
+        bridge_half: &BridgeAsyncClient,
     ) -> (mpsc::Sender<(&'static str, Status)>, Self) {
         let (tx, rx_status) = mpsc::channel(10);
         (

--- a/crates/extensions/tedge_mqtt_bridge/src/health.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/health.rs
@@ -20,13 +20,13 @@ use tracing::log::info;
 pub struct BridgeHealthMonitor<T> {
     topic: String,
     rx_status: mpsc::Receiver<(&'static str, Status)>,
-    companion_bridge_half: mpsc::UnboundedSender<(T, Option<T>)>,
+    companion_bridge_half: mpsc::UnboundedSender<(Option<String>, T)>,
 }
 
-impl BridgeHealthMonitor<(String, Publish)> {
+impl BridgeHealthMonitor<Publish> {
     pub(crate) fn new(
         topic: String,
-        bridge_half: &BidirectionalChannelHalf<(String, Publish)>,
+        bridge_half: &BidirectionalChannelHalf<Publish>,
     ) -> (mpsc::Sender<(&'static str, Status)>, Self) {
         let (tx, rx_status) = mpsc::channel(10);
         (
@@ -57,7 +57,7 @@ impl BridgeHealthMonitor<(String, Publish)> {
                 // Publish the health message over MQTT, but with no duplicate
                 // in order to maintain synchronisation between the two bridge halves
                 self.companion_bridge_half
-                    .send(((self.topic.clone(), health_msg), None))
+                    .send((None, health_msg))
                     .await
                     .unwrap();
             }

--- a/crates/extensions/tedge_mqtt_bridge/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/lib.rs
@@ -508,6 +508,10 @@ async fn half_bridge(
                     if let Some(topic) = transformer.convert_topic(&publish.topic) {
                         received += 1;
                         target.publish(topic.to_string(), publish).await;
+                    } else {
+                        // Being not forwarded to this bridge target
+                        // The message has to be acknowledged
+                        recv_client.ack(&publish).await.unwrap()
                     }
                 }
             }


### PR DESCRIPTION
## Proposed changes

When a large amount of messages has to be published from the device to the cloud (say after a network outage),
the builtin bridge fails to cope with the load and reaches a point where no more progress is made. After a while, the local  MQTT broker closes the builtin bridge connection, with an error:

```
1725524939: Client tedge-mapper-bridge-c8y has exceeded timeout, disconnecting.
```

The root cause is a dead lock inside the builtin bridge. The two main tasks (one publishing local messages to the remote MQTT endpoint, the other forwarding the remote message acknowledgements to the local broker) are blocked waiting for the other to make progress.

What makes the issue not so easy to fix is that the MQTT library used by thin-edge (`rumqttc`) provides no way to reduce the pressure. When a message is received from the local MQTT connection and delivered to the builtin bridge, then the bridge can only acknowledge the message (and this should be done only when properly published and acknowledged by the cloud endpoint) or drop it (by pretending it has been processed). The bridge has no way to tell `rumqttc` that a message cannot be processed right now. Until the message is properly acknowledged, the broker keeps sending the same message again and again to `rumqttc` but those retries are not forwarded to the bridge.

So, what is proposed here is hold in memory all the messages until they are properly processed (received from local, published to cloud, acknowledged by cloud, acknowledged to local). This is done using `mpsc::unbounded()`.

Notes:
- If the mapper is shutdown with pending messages, all those will be resent by the MQTT broker.
- Not only a unbounded channel has been introduced, but also a new background task is spawned.
  This is to ensure that the rumqtt channel and the half-bridge companion channel are in sync.  

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3083

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
