### PR TITLE
feat: allow to init remote access plugin with non-standard user/group

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
+++ b/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
@@ -16,13 +16,23 @@ Install/uninstall c8y-remote-access-plugin
 
     # Check that a command is used instead of an explicit path #3111
     ${executable}=    Execute Command
-    ...    cmd=grep "^command" /etc/tedge/operations/c8y/c8y_RemoteAccessConnect | cut -d= -f2-
+    ...    cmd=grep "command" /etc/tedge/operations/c8y/c8y_RemoteAccessConnect | cut -d= -f2-
     ...    strip=${True}
     ...    timeout=5
     Should Match Regexp    ${executable}    pattern=^"c8y-remote-access-plugin\\b
 
     Execute Command    dpkg -r c8y-remote-access-plugin
     File Should Not Exist    /etc/tedge/operations/c8y/c8y_RemoteAccessConnect
+
+Init c8y-remote-access-plugin with the custom user and group
+    Device Should Have Installed Software    c8y-remote-access-plugin
+
+    Execute Command    sudo c8y-remote-access-plugin --init --user petertest --group petertest
+    Path Should Have Permissions    /etc/tedge/operations/c8y    mode=755    owner_group=petertest:petertest
+    Path Should Have Permissions
+    ...    /etc/tedge/operations/c8y/c8y_RemoteAccessConnect
+    ...    mode=644
+    ...    owner_group=petertest:petertest
 
 Execute ssh command using PASSTHROUGH
     ${KEY_FILE}=    Configure SSH


### PR DESCRIPTION
## Proposed changes
This PR add two new flags to `c8y-remote-access-plugin`: `--user` and `--group` that can be used only with `--init` flag. Plugin will now create directory with custom permissions provided by user or change the permissions if file/directory already exists.
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #2886
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

