### PR TITLE
fix: Ignore extra HealthStatus fields in service monitor (maintain single `HealthStatus`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,13 @@ c8y_mapper_ext = { path = "crates/extensions/c8y_mapper_ext" }
 camino = "1.1"
 cap = "0.1"
 certificate = { path = "crates/common/certificate" }
-clap = { version = "4.4", features = ["cargo", "derive"] }
+clap = { version = "4.4", features = [
+    "cargo",
+    "derive",
+    "string",
+    "env",
+    "unstable-styles",
+] }
 clock = { path = "crates/common/clock" }
 collectd_ext = { path = "crates/extensions/collectd_ext" }
 csv = "1.1"

--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -19,13 +19,7 @@ c8y-remote-access-plugin = { workspace = true }
 camino = { workspace = true }
 cap = { workspace = true }
 certificate = { workspace = true, features = ["reqwest-blocking"] }
-clap = { workspace = true, features = [
-    "cargo",
-    "derive",
-    "env",
-    "string",
-    "unstable-styles",
-] }
+clap = { workspace = true }
 doku = { workspace = true }
 hyper = { workspace = true, default-features = false }
 nix = { workspace = true }

--- a/crates/core/tedge_api/src/health/health_status.rs
+++ b/crates/core/tedge_api/src/health/health_status.rs
@@ -1,0 +1,131 @@
+use std::collections::HashMap;
+
+use crate::mqtt_topics::Channel;
+use crate::mqtt_topics::MqttSchema;
+use crate::Status;
+use mqtt_channel::MqttMessage;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+
+use super::HealthTopicError;
+
+/// Payload of the health status message.
+///
+/// https://thin-edge.github.io/thin-edge.io/operate/troubleshooting/monitoring-service-health/
+#[derive(Deserialize, Serialize, Debug, Default)]
+#[serde(from = "HealthStatusImp")]
+pub struct HealthStatus {
+    /// Current status of the service, synced by the mapper to the cloud
+    pub status: Status,
+
+    /// Used by the watchdog to monitor restarts of services.
+    ///
+    /// None if value not present or could not be deserialized successfully.
+    pub pid: Option<u32>,
+
+    pub time: Option<JsonValue>,
+
+    #[serde(flatten)]
+    pub extra: HashMap<String, JsonValue>,
+}
+
+impl HealthStatus {
+    pub fn try_from_health_status_message(
+        message: &MqttMessage,
+        mqtt_schema: &MqttSchema,
+    ) -> Result<Self, HealthTopicError> {
+        if let Ok((topic_id, Channel::Health)) = mqtt_schema.entity_channel_of(&message.topic) {
+            let health_status = if super::entity_is_mosquitto_bridge_service(&topic_id) {
+                let status = match message.payload_str() {
+                    Ok("1") => Status::Up,
+                    Ok("0") => Status::Down,
+                    _ => Status::default(),
+                };
+                HealthStatus {
+                    status,
+                    pid: None,
+                    time: None,
+                    extra: HashMap::new(),
+                }
+            } else {
+                serde_json::from_slice(message.payload()).unwrap_or_default()
+            };
+            Ok(health_status)
+        } else {
+            Err(HealthTopicError)
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.status == Status::Up || self.status == Status::Down
+    }
+}
+
+/// Provide customised Serialize/Deserialize implementations while exposing simple structure for tedge_api consumers.
+#[derive(Deserialize, Serialize, Debug)]
+struct HealthStatusImp {
+    status: Status,
+    pid: NoneIfErr<u32>,
+    time: Option<JsonValue>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, JsonValue>,
+}
+
+impl From<HealthStatusImp> for HealthStatus {
+    fn from(value: HealthStatusImp) -> Self {
+        HealthStatus {
+            status: value.status,
+            pid: value.pid.0,
+            time: value.time,
+            extra: value.extra,
+        }
+    }
+}
+
+/// Deserialize to `None` if deserialization fails.
+///
+/// We want to be able to use required fields like `status` even if there are errors when serializing some other
+/// optional fields (e.g. PID).
+#[derive(Serialize, Debug, Default)]
+#[serde(transparent)]
+struct NoneIfErr<T>(Option<T>);
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for NoneIfErr<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(NoneIfErr(T::deserialize(deserializer).ok()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_json::json;
+
+    #[test]
+    fn pid_none_when_missing() {
+        let health_status =
+            serde_json::from_value::<HealthStatus>(json!({"status": "up"})).unwrap();
+        assert_eq!(health_status.pid, None);
+    }
+
+    #[test]
+    fn pid_some_when_correct_type() {
+        let health_status =
+            serde_json::from_value::<HealthStatus>(json!({"status": "up", "pid": 2137})).unwrap();
+        assert_eq!(health_status.pid, Some(2137));
+    }
+
+    #[test]
+    fn pid_none_when_incorrect_type() {
+        let health_status =
+            serde_json::from_value::<HealthStatus>(json!({"status": "up", "pid": "invalid type"}))
+                .unwrap();
+        assert_eq!(health_status.pid, None);
+    }
+}

--- a/crates/core/tedge_watchdog/src/systemd_watchdog.rs
+++ b/crates/core/tedge_watchdog/src/systemd_watchdog.rs
@@ -1,4 +1,3 @@
-use crate::error::WatchdogError;
 use anyhow::Context;
 use freedesktop_entry_parser::parse_entry;
 use futures::channel::mpsc;
@@ -20,7 +19,6 @@ use tedge_api::mqtt_topics::Channel;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
 use tedge_api::mqtt_topics::OperationType;
-use tedge_api::HealthStatus;
 use tedge_config::TEdgeConfigLocation;
 use tedge_utils::timestamp::IsoOrUnix;
 use time::OffsetDateTime;
@@ -28,6 +26,9 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
+
+use crate::error::WatchdogError;
+use tedge_api::HealthStatus;
 
 const SERVICE_NAME: &str = "tedge-watchdog";
 
@@ -128,7 +129,6 @@ async fn start_watchdog_for_tedge_services(tedge_config_dir: PathBuf) {
 
                 let tedge_config_location = tedge_config_location.clone();
                 watchdog_tasks.push(tokio::spawn(async move {
-                    //
                     let interval = Duration::from_secs((interval / NOTIFY_SEND_FREQ_RATIO).max(1));
                     monitor_tedge_service(
                         tedge_config_location,

--- a/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
@@ -32,11 +32,8 @@ pub fn convert_health_status_message(
         return vec![];
     }
 
-    let HealthStatus {
-        status,
-        pid: _,
-        time: _,
-    } = HealthStatus::try_from_health_status_message(message, mqtt_schema).unwrap();
+    let HealthStatus { status, .. } =
+        HealthStatus::try_from_health_status_message(message, mqtt_schema).unwrap();
 
     let display_name = entity
         .other
@@ -82,6 +79,15 @@ mod tests {
         "c8y/s/us",
         r#"102,test_device:device:main:service:tedge-mapper-c8y,service,tedge-mapper-c8y,up"#;
         "service-monitoring-thin-edge-device"
+    )]
+    // If there are any problems with fields other than `status`, we want to ignore them and still send status update
+    #[test_case(
+        "test_device",
+        "te/device/main/service/tedge-mapper-c8y/status/health",
+        r#"{"unrecognised_field": [42], "time": "not a valid timestamp", "pid":"not a valid pid","status":"up"}"#,
+        "c8y/s/us",
+        r#"102,test_device:device:main:service:tedge-mapper-c8y,service,tedge-mapper-c8y,up"#;
+        "service-monitoring-thin-edge-device-optional-fields-invalid"
     )]
     #[test_case(
         "test_device",

--- a/plugins/tedge_apt_plugin/Cargo.toml
+++ b/plugins/tedge_apt_plugin/Cargo.toml
@@ -10,7 +10,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true }
 csv = { workspace = true }
 log = { workspace = true }
 regex = { workspace = true }


### PR DESCRIPTION
## Proposed changes

This is an alternative fix to #3132. It contains the same test, but differs in the approach to how we should deserialize `HealthStatus`.

In #3132, we use separate structs in `tedge_api` and `tedge_watchdog`. This allows each component to deserialize only mapper and watchdog to deserialize only fields they require, but could be argued duplicates structs and makes it harder to see what are possible fields for this type of message because they're spread out.

In this PR, an alternative approach is taken where we use a single `tedge_api::HealthStatus` struct which just fills in a fallback `None` on deserialization errors for other fields. Here we keep all the fields in a single place but ignore errors, which is not desirable. I thought it's going to be more complex but it turned out simpler than I anticipated.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #3128

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

