### PR TITLE
fix: c8y mapper panics on unexpected registration message

### DIFF
--- a/crates/core/tedge_api/src/entity_store.rs
+++ b/crates/core/tedge_api/src/entity_store.rs
@@ -496,7 +496,7 @@ impl EntityStore {
             EntityType::Service => message
                 .parent
                 .clone()
-                .or_else(|| topic_id.default_parent_identifier())
+                .or_else(|| topic_id.default_service_parent_identifier())
                 .or_else(|| Some(self.main_device.clone())),
         };
 
@@ -610,7 +610,7 @@ impl EntityStore {
             let mut register_messages = vec![];
 
             let parent_device_id = entity_topic_id
-                .default_parent_identifier()
+                .default_source_device_identifier()
                 .expect("device id must be present as the topic id follows the default scheme");
 
             if !parent_device_id.is_default_main_device() && self.get(&parent_device_id).is_none() {

--- a/crates/core/tedge_api/src/mqtt_topics.rs
+++ b/crates/core/tedge_api/src/mqtt_topics.rs
@@ -395,14 +395,26 @@ impl EntityTopicId {
         }
     }
 
-    /// Returns the topic identifier of the parent of a service,
-    /// assuming `self` is the topic identifier of a device `device/+//
-    /// or a service `device/+/service/+`
+    /// Returns the topic identifier of the source device of an entity,
+    /// - for a service, this is the parent entity
+    /// - for a device, this is the device itself
     ///
-    /// Returns None if this is not a service or if the pattern doesn't apply.
-    pub fn default_parent_identifier(&self) -> Option<Self> {
+    /// Returns None if the pattern doesn't apply.
+    pub fn default_source_device_identifier(&self) -> Option<Self> {
         match self.0.split('/').collect::<Vec<&str>>()[..] {
             ["device", parent_id, "", ""] => Some(parent_id),
+            ["device", parent_id, "service", _] => Some(parent_id),
+            _ => None,
+        }
+        .map(|parent_id| EntityTopicId(format!("device/{parent_id}//")))
+    }
+
+    /// Returns the topic identifier of the parent of a service,
+    /// assuming `self` is the topic identifier of a service `device/+/service/+`
+    ///
+    /// Returns None if this is not a service or if the pattern doesn't apply.
+    pub fn default_service_parent_identifier(&self) -> Option<Self> {
+        match self.0.split('/').collect::<Vec<&str>>()[..] {
             ["device", parent_id, "service", _] => Some(parent_id),
             _ => None,
         }

--- a/tests/RobotFramework/tests/cumulocity/registration/registration_lifecycle.robot
+++ b/tests/RobotFramework/tests/cumulocity/registration/registration_lifecycle.robot
@@ -484,6 +484,18 @@ Entities send to cloud on restart
     ...    minimum=1
     ...    maximum=1
 
+Unexpected message doesn't cause a panic #3134
+    # Register a service on a device topic
+    Execute Command    tedge mqtt pub --retain 'te/device/child1//' '{"@type":"service"}'
+    External Identity Should Exist    ${DEVICE_SN}:device:child1    show_info=False
+    Cumulocity.Managed Object Should Have Fragment Values    status\=up
+    Service Health Status Should Be Up    tedge-mapper-c8y
+
+    # Register a child device on a service topic
+    Execute Command    tedge mqtt pub --retain 'te/device/child2/service/foo' '{"@type":"child-device"}'
+    Device Should Exist    ${DEVICE_SN}:device:child2:service:foo
+    Service Health Status Should Be Up    tedge-mapper-c8y
+
 
 *** Keywords ***
 Should Have Retained Message Count


### PR DESCRIPTION
The mapper panics when receiving a registration message such as `'te/device/child02//' '{"@type":"service"}'`.

The issue is that:

- the entity is seen as a child device i.e. matching `device/+//`
- but its registration message pretends that this is a service.
- the mapper tries then to register the entity as its own parent.

## Proposed changes

When the type of entity is explicitly set to be a service, but the topic id is attached to a child device (according to the default scheme), then this entity must be considered as non-following the default scheme.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2986

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

