### PR TITLE
Refactor: Simplify entity auto-registration

### DIFF
--- a/crates/core/tedge_api/src/mqtt_topics.rs
+++ b/crates/core/tedge_api/src/mqtt_topics.rs
@@ -367,11 +367,6 @@ impl EntityTopicId {
         !default_topic_schema::parse(self).is_empty()
     }
 
-    /// Returns `true` if it's the topic identifier of the child device in default topic scheme.
-    pub fn is_default_child_device(&self) -> bool {
-        matches!(self.segments(), ["device", device_name, "", ""] if device_name != "main" && !device_name.is_empty())
-    }
-
     /// Returns the device name when the entity topic identifier is using the `device/+/service/+` pattern.
     ///
     /// Returns None otherwise.
@@ -393,20 +388,6 @@ impl EntityTopicId {
         }
     }
 
-    /// Returns the topic identifier of the source device of an entity,
-    /// - for a service, this is the parent entity
-    /// - for a device, this is the device itself
-    ///
-    /// Returns None if the pattern doesn't apply.
-    pub fn default_source_device_identifier(&self) -> Option<Self> {
-        match self.0.split('/').collect::<Vec<&str>>()[..] {
-            ["device", parent_id, "", ""] => Some(parent_id),
-            ["device", parent_id, "service", _] => Some(parent_id),
-            _ => None,
-        }
-        .map(|parent_id| EntityTopicId(format!("device/{parent_id}//")))
-    }
-
     /// Returns the topic identifier of the parent of a service,
     /// assuming `self` is the topic identifier of a service `device/+/service/+`
     ///
@@ -422,11 +403,6 @@ impl EntityTopicId {
     /// Returns true if the current topic identifier matches that of the main device
     pub fn is_default_main_device(&self) -> bool {
         self == &Self::default_main_device()
-    }
-
-    /// Returns true if the current topic identifier matches that of the service
-    pub fn is_default_service(&self) -> bool {
-        self.default_service_name().is_some()
     }
 
     /// If `self` is a device topic id, return a service topic id under this


### PR DESCRIPTION
## Proposed changes

 Introduce a new function `mqtt_topic::default_topic_schema::parse()` taking an entity topic id and returning the registration messages matching the auto-registration behavior.
    
Using this `parse` function simplifies the auto-registration logic which has no more to parse again and again the entity topic id to extract registration info.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

