### PR TITLE
fix: Stop chowning in tedge-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,7 +4023,6 @@ dependencies = [
  "tedge_utils",
  "tokio",
  "uzers",
- "whoami",
 ]
 
 [[package]]

--- a/crates/extensions/tedge_config_manager/src/actor.rs
+++ b/crates/extensions/tedge_config_manager/src/actor.rs
@@ -335,8 +335,7 @@ impl ConfigManagerWorker {
             return Err(anyhow::anyhow!("tedge_url not present in config update payload").into());
         };
 
-        let download_request = DownloadRequest::new(tedge_url, temp_path.as_std_path())
-            .with_permission(file_entry.file_permissions.to_owned());
+        let download_request = DownloadRequest::new(tedge_url, temp_path.as_std_path());
 
         info!(
             "Awaiting download for config type: {} from url: {}",

--- a/crates/extensions/tedge_downloader_ext/Cargo.toml
+++ b/crates/extensions/tedge_downloader_ext/Cargo.toml
@@ -24,7 +24,6 @@ mockito = { workspace = true }
 tedge_test_utils = { workspace = true }
 tokio = { workspace = true, default_features = false, features = ["time"] }
 uzers = { workspace = true }
-whoami = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/extensions/tedge_downloader_ext/src/actor.rs
+++ b/crates/extensions/tedge_downloader_ext/src/actor.rs
@@ -40,13 +40,6 @@ impl DownloadRequest {
             ..self
         }
     }
-
-    pub fn with_permission(self, permission: PermissionEntry) -> Self {
-        Self {
-            permission: Some(permission),
-            ..self
-        }
-    }
 }
 
 pub type DownloadResult = Result<DownloadResponse, DownloadError>;

--- a/crates/extensions/tedge_downloader_ext/src/tests.rs
+++ b/crates/extensions/tedge_downloader_ext/src/tests.rs
@@ -4,7 +4,6 @@ use download::Auth;
 use std::time::Duration;
 use tedge_actors::ClientMessageBox;
 use tedge_test_utils::fs::TempTedgeDir;
-use tedge_utils::file::PermissionEntry;
 use tokio::time::timeout;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(5);
@@ -55,43 +54,6 @@ async fn download_with_auth() {
     let server_url = server.url();
     let download_request =
         DownloadRequest::new(&server_url, &target_path).with_auth(Auth::Bearer("token".into()));
-
-    let mut requester = spawn_downloader_actor().await;
-
-    let (id, response) = timeout(
-        TEST_TIMEOUT,
-        requester.await_response(("id".to_string(), download_request)),
-    )
-    .await
-    .expect("timeout")
-    .expect("channel error");
-
-    assert_eq!(id.as_str(), "id");
-    assert_eq!(response.as_ref().unwrap().file_path, target_path.as_path());
-    assert_eq!(response.as_ref().unwrap().url, server_url);
-}
-
-#[tokio::test]
-async fn download_with_permission() {
-    let ttd = TempTedgeDir::new();
-    let mut server = mockito::Server::new();
-    let _mock = server
-        .mock("GET", "/")
-        .with_status(200)
-        .with_header("content-type", "text/plain")
-        .with_body("without auth")
-        .create();
-
-    let target_path = ttd.path().join("downloaded_file");
-    let server_url = server.url();
-    let user = whoami::username();
-    let group = uzers::get_current_groupname()
-        .unwrap()
-        .into_string()
-        .unwrap();
-
-    let download_request = DownloadRequest::new(&server_url, &target_path)
-        .with_permission(PermissionEntry::new(Some(user), Some(group), Some(0o775)));
 
     let mut requester = spawn_downloader_actor().await;
 

--- a/tests/RobotFramework/tests/cumulocity/configuration/config-root.json
+++ b/tests/RobotFramework/tests/cumulocity/configuration/config-root.json
@@ -1,0 +1,1 @@
+{"name":"configuration1"}

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -29,6 +29,8 @@ Set Configuration when file does not exist
     Binary file (Main Device)    ${PARENT_SN}    ${PARENT_SN}    CONFIG1_BINARY    /etc/binary-config1.tar.gz    ${CURDIR}/binary-config1.tar.gz    640    tedge:tedge    delete_file_before=${true}
     Text file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1    /etc/config1.json    ${CURDIR}/config1-version2.json    640    tedge:tedge    delete_file_before=${true}
     Binary file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1_BINARY    /etc/binary-config1.tar.gz    ${CURDIR}/binary-config1.tar.gz    640    tedge:tedge    delete_file_before=${true}
+    Root-owned file (Main Device)    ${PARENT_SN}    ${PARENT_SN}    CONFIG-ROOT    /etc/config-root.json    ${CURDIR}/config-root.json    600    root:root    delete_file_before=${true}
+    Root-owned file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG-ROOT    /etc/config-root.json    ${CURDIR}/config-root.json    600    root:root    delete_file_before=${true}
 
 Set Configuration when file exists and agent run normally
     [Documentation]    If the configuration file already exists, it should be overwritten, but owner and permissions
@@ -39,6 +41,8 @@ Set Configuration when file exists and agent run normally
     Binary file (Main Device)    ${PARENT_SN}    ${PARENT_SN}    CONFIG1_BINARY    /etc/binary-config1.tar.gz    ${CURDIR}/binary-config1.tar.gz    664    root:root    delete_file_before=${false}
     Text file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1    /etc/config1.json    ${CURDIR}/config1-version2.json    664    root:root    delete_file_before=${false}
     Binary file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1_BINARY    /etc/binary-config1.tar.gz    ${CURDIR}/binary-config1.tar.gz    664    root:root    delete_file_before=${false}
+    Root-owned file (Main Device)    ${PARENT_SN}    ${PARENT_SN}    CONFIG-ROOT    /etc/config-root.json    ${CURDIR}/config-root.json    600    root:root    delete_file_before=${false}
+    Root-owned file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG-ROOT    /etc/config-root.json    ${CURDIR}/config-root.json    600    root:root    delete_file_before=${true}
 
 Set Configuration when file exists and tedge run by root
     [Documentation]    If the configuration file already exists, it should be overwritten, but owner and permissions
@@ -52,6 +56,10 @@ Set Configuration when file exists and tedge run by root
     Text file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1    /etc/config1.json    ${CURDIR}/config1-version2.json    664    root:root    delete_file_before=${false}
     ...    agent_as_root=${true}
     Binary file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1_BINARY    /etc/binary-config1.tar.gz    ${CURDIR}/binary-config1.tar.gz    664    root:root    delete_file_before=${false}
+    ...    agent_as_root=${true}
+    Root-owned file (Main Device)    ${PARENT_SN}    ${PARENT_SN}    CONFIG-ROOT    /etc/config-root.json    ${CURDIR}/config-root.json    600    root:root    delete_file_before=${true}
+    ...    agent_as_root=${true}
+    Root-owned file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG-ROOT    /etc/config-root.json    ${CURDIR}/config-root.json    600    root:root    delete_file_before=${true}
     ...    agent_as_root=${true}
 
 Set Configuration when tedge-write is in another location
@@ -433,6 +441,7 @@ Update configuration plugin config via cloud
     ...    /etc/tedge/tedge.toml
     ...    system.toml
     ...    CONFIG1
+    ...    CONFIG-ROOT
     ...    CONFIG1_BINARY
     ${config_url}=    Cumulocity.Create Inventory Binary
     ...    tedge-configuration-plugin
@@ -445,6 +454,7 @@ Update configuration plugin config via cloud
     ...    /etc/tedge/tedge.toml
     ...    system.toml
     ...    CONFIG1
+    ...    CONFIG-ROOT
     ...    Config@2.0.0
 
 Modify configuration plugin config via local filesystem modify inplace
@@ -456,6 +466,7 @@ Modify configuration plugin config via local filesystem modify inplace
     ...    /etc/tedge/tedge.toml
     ...    system.toml
     ...    CONFIG1
+    ...    CONFIG-ROOT
     ...    CONFIG1_BINARY
     ThinEdgeIO.Set Device Context    ${device}
     ThinEdgeIO.Execute Command    sed -i 's/CONFIG1/CONFIG3/g' /etc/tedge/plugins/tedge-configuration-plugin.toml
@@ -465,6 +476,7 @@ Modify configuration plugin config via local filesystem modify inplace
     ...    system.toml
     ...    CONFIG3
     ...    CONFIG3_BINARY
+    ...    CONFIG-ROOT
     ${operation}=    Cumulocity.Get Configuration    CONFIG3
     Operation Should Be SUCCESSFUL    ${operation}
 
@@ -479,6 +491,7 @@ Modify configuration plugin config via local filesystem overwrite
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY
+    ...    CONFIG-ROOT
     ${NEW_CONFIG}=    ThinEdgeIO.Execute Command
     ...    sed 's/CONFIG1/CONFIG3/g' /etc/tedge/plugins/tedge-configuration-plugin.toml
     ThinEdgeIO.Execute Command    echo "${NEW_CONFIG}" > /etc/tedge/plugins/tedge-configuration-plugin.toml
@@ -488,6 +501,7 @@ Modify configuration plugin config via local filesystem overwrite
     ...    system.toml
     ...    CONFIG3
     ...    CONFIG3_BINARY
+    ...    CONFIG-ROOT
     ${operation}=    Cumulocity.Get Configuration    CONFIG3
     Operation Should Be SUCCESSFUL    ${operation}
 
@@ -502,6 +516,7 @@ Update configuration plugin config via local filesystem copy
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY
+    ...    CONFIG-ROOT
     Transfer To Device    ${CURDIR}/tedge-configuration-plugin-updated.toml    /etc/tedge/plugins/
     Execute Command
     ...    cp /etc/tedge/plugins/tedge-configuration-plugin-updated.toml /etc/tedge/plugins/tedge-configuration-plugin.toml
@@ -511,6 +526,7 @@ Update configuration plugin config via local filesystem copy
     ...    system.toml
     ...    CONFIG1
     ...    Config@2.0.0
+    ...    CONFIG-ROOT
     ${operation}=    Cumulocity.Get Configuration    Config@2.0.0
     Operation Should Be SUCCESSFUL    ${operation}
 
@@ -524,6 +540,7 @@ Update configuration plugin config via local filesystem move (different director
     ...    /etc/tedge/tedge.toml
     ...    system.toml
     ...    CONFIG1
+    ...    CONFIG-ROOT
     ...    CONFIG1_BINARY
     Transfer To Device    ${CURDIR}/tedge-configuration-plugin-updated.toml    /etc/
     Execute Command
@@ -533,6 +550,8 @@ Update configuration plugin config via local filesystem move (different director
     ...    /etc/tedge/tedge.toml
     ...    system.toml
     ...    CONFIG1
+    ...    CONFIG-ROOT
+
     ...    Config@2.0.0
     ${operation}=    Cumulocity.Get Configuration    Config@2.0.0
     Operation Should Be SUCCESSFUL    ${operation}
@@ -547,6 +566,7 @@ Update configuration plugin config via local filesystem move (same directory)
     ...    /etc/tedge/tedge.toml
     ...    system.toml
     ...    CONFIG1
+    ...    CONFIG-ROOT
     ...    CONFIG1_BINARY
     Transfer To Device    ${CURDIR}/tedge-configuration-plugin-updated.toml    /etc/tedge/plugins/
     Execute Command
@@ -556,6 +576,7 @@ Update configuration plugin config via local filesystem move (same directory)
     ...    /etc/tedge/tedge.toml
     ...    system.toml
     ...    CONFIG1
+    ...    CONFIG-ROOT
     ...    Config@2.0.0
     ${operation}=    Cumulocity.Get Configuration    Config@2.0.0
     Operation Should Be SUCCESSFUL    ${operation}

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -116,6 +116,7 @@ Update Configuration Should Fail
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY
+    ...    CONFIG-ROOT
     ${config_url}=    Cumulocity.Create Inventory Binary
     ...    tedge-configuration-plugin
     ...    tedge-configuration-plugin
@@ -128,6 +129,7 @@ Update Configuration Should Fail
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY
+    ...    CONFIG-ROOT
 
 Update Configuration Should Succeed
     [Arguments]    ${external_id}
@@ -138,6 +140,7 @@ Update Configuration Should Succeed
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY
+    ...    CONFIG-ROOT
     ${config_url}=    Cumulocity.Create Inventory Binary
     ...    tedge-configuration-plugin
     ...    tedge-configuration-plugin
@@ -149,6 +152,7 @@ Update Configuration Should Succeed
     ...    /etc/tedge/tedge.toml
     ...    system.toml
     ...    CONFIG1
+    ...    CONFIG-ROOT
     ...    Config@2.0.0
 
 Enable Certificate Authentication for File Transfer Service

--- a/tests/RobotFramework/tests/cumulocity/configuration/tedge-configuration-plugin-updated.toml
+++ b/tests/RobotFramework/tests/cumulocity/configuration/tedge-configuration-plugin-updated.toml
@@ -3,4 +3,5 @@ files = [
     { path = '/etc/tedge/system.toml', type = 'system.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
     { path = '/etc/config1.json', type = 'CONFIG1', user = 'tedge', group = 'tedge', mode = 0o444 },
     { path = '/etc/config2.json', type = 'Config@2.0.0', user = 'tedge', group = 'tedge', mode = 0o444 },
+    { path = '/etc/config-root.json', type = 'CONFIG-ROOT', user = 'root', group = 'root', mode = 0o600 },
 ]

--- a/tests/RobotFramework/tests/cumulocity/configuration/tedge-configuration-plugin.toml
+++ b/tests/RobotFramework/tests/cumulocity/configuration/tedge-configuration-plugin.toml
@@ -3,4 +3,5 @@ files = [
     { path = '/etc/tedge/system.toml', type = 'system.toml', user = 'tedge', group = 'tedge', mode = 0o444 },
     { path = '/etc/config1.json', type = 'CONFIG1', user = 'tedge', group = 'tedge', mode = 0o640 },
     { path = '/etc/binary-config1.tar.gz', type = 'CONFIG1_BINARY', user = 'tedge', group = 'tedge', mode = 0o640 },
+    { path = '/etc/config-root.json', type = 'CONFIG-ROOT', user = 'root', group = 'root', mode = 0o600 },
 ]


### PR DESCRIPTION
## Proposed changes

Stop setting file ownership in tedge-agent, which runs as `tedge` user. Also added a missing test for a case when a file is owned by root.

Setting file ownership is a privileged operation, which should be done by tedge-write. It's also unnecessary to change permissions on a temporary file which is atomically moved into destination by config-manager anyway.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- #3143

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This change should resolve the issue and is small, so it'd be good to merge it ASAP. It resolves first 2 points of https://github.com/thin-edge/thin-edge.io/issues/3143#issuecomment-2383833471, i.e. adds missing test case and removes the usage of `chown` while running as `tedge`.

We still unnecessarily leave temporary files, but that will be done in a follow-up PR.

