### PR TITLE
chore: fix typos

### DIFF
--- a/crates/common/tedge_config_macros/impl/src/reader.rs
+++ b/crates/common/tedge_config_macros/impl/src/reader.rs
@@ -442,7 +442,7 @@ fn parents_for(
                     new_parents.push(PathItem::Dynamic(*span));
                 }
             } else {
-                // This key has diverged from the currrent key's parents, so empty the list
+                // This key has diverged from the current key's parents, so empty the list
                 // This will prevent unwanted matches that aren't genuine
                 while parents.next().is_some() {}
             }

--- a/crates/core/c8y_api/src/smartrest/smartrest_serializer.rs
+++ b/crates/core/c8y_api/src/smartrest/smartrest_serializer.rs
@@ -35,11 +35,11 @@ pub fn fail_operation_with_id(op_id: &str, reason: &str) -> String {
 }
 
 fn fail_operation(template_id: &str, operation: &str, reason: &str) -> String {
-    // If the failure reason exceeds 500 bytes, trancuate it
+    // If the failure reason exceeds 500 bytes, truncate it
     if reason.len() <= 500 {
         fields_to_csv_string(&[template_id, operation, reason])
     } else {
-        warn!("Failure reason too long, message trancuated to 500 bytes");
+        warn!("Failure reason too long, message truncated to 500 bytes");
         fields_to_csv_string(&[template_id, operation, &reason[..500]])
     }
 }


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix some minor typos in the Rust source code (detected by running `typo` locally)

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

