### PR TITLE
test: format robotframework system tests

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -551,7 +551,6 @@ Update configuration plugin config via local filesystem move (different director
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG-ROOT
-
     ...    Config@2.0.0
     ${operation}=    Cumulocity.Get Configuration    Config@2.0.0
     Operation Should Be SUCCESSFUL    ${operation}

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command/custom_operation_command.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command/custom_operation_command.robot
@@ -15,7 +15,7 @@ Run shell custom operation for main device and publish the status
     ${operation}=    Cumulocity.Create Operation
     ...    description=echo helloworld
     ...    fragments={"c8y_Command":{"text":"echo helloworld"}}
-    
+
     Operation Should Be SUCCESSFUL    ${operation}
     Should Be Equal    ${operation.to_json()["c8y_Command"]["result"]}    helloworld\n
     Should Have MQTT Messages
@@ -28,11 +28,11 @@ Run shell custom operation for main device and do not publish the status
     ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command_2    /etc/tedge/operations/c8y/c8y_Command
     Restart Service    tedge-mapper-c8y
     ${operation}=    Cumulocity.Create Operation
-    ...    description=echo helloworld    
+    ...    description=echo helloworld
     ...    fragments={"c8y_Command":{"text":"echo helloworld"}}
-    
+
     Operation Should Be PENDING    ${operation}
-    
+
     Should Have MQTT Messages
     ...    c8y/s/us
     ...    message_pattern=^(504|505|506),[0-9]+($|,\\"helloworld\n\\")

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation.robot
@@ -18,6 +18,7 @@ Send firmware update operation from Cumulocity IoT
     ${operation}=    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
     Cumulocity.Device Should Have Firmware    tedge-core    1.0.0    https://abc.com/some/firmware/url
 
+
 *** Keywords ***
 Custom Setup
     ${DEVICE_SN}=    Setup


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Format Robotframework system tests using robotframework-tidy.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

