### PR TITLE
Use `tempfile` in config-manager and downloader to ensure tmpfiles are always deleted

### DIFF
--- a/crates/common/download/Cargo.toml
+++ b/crates/common/download/Cargo.toml
@@ -22,6 +22,7 @@ rustls = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tedge_utils = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 url = { workspace = true }
@@ -29,7 +30,6 @@ url = { workspace = true }
 [dev-dependencies]
 mockito = { workspace = true }
 regex = { workspace = true }
-tempfile = { workspace = true }
 test-case = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/crates/common/download/src/download.rs
+++ b/crates/common/download/src/download.rs
@@ -25,9 +25,7 @@ use std::os::unix::prelude::AsRawFd;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
-use tedge_utils::file::move_file;
 use tedge_utils::file::FileError;
-use tedge_utils::file::PermissionEntry;
 
 #[cfg(target_os = "linux")]
 use nix::fcntl::fallocate;
@@ -106,7 +104,6 @@ impl Auth {
 #[derive(Debug)]
 pub struct Downloader {
     target_filename: PathBuf,
-    target_permission: PermissionEntry,
     backoff: ExponentialBackoff,
     client: Client,
 }
@@ -126,28 +123,6 @@ impl Downloader {
         let client = client_builder.build().expect("Client builder is valid");
         Self {
             target_filename: target_path,
-            target_permission: PermissionEntry::default(),
-            backoff: default_backoff(),
-            client,
-        }
-    }
-
-    /// Creates a new downloader which downloads to a target directory and sets
-    /// specified permissions the downloaded file.
-    pub fn with_permission(
-        target_path: PathBuf,
-        target_permission: PermissionEntry,
-        identity: Option<Identity>,
-        cloud_root_certs: CloudRootCerts,
-    ) -> Self {
-        let mut client_builder = cloud_root_certs.client_builder();
-        if let Some(identity) = identity {
-            client_builder = client_builder.identity(identity);
-        }
-        let client = client_builder.build().expect("Client builder is valid");
-        Self {
-            target_filename: target_path,
-            target_permission,
             backoff: default_backoff(),
             client,
         }

--- a/crates/extensions/c8y_http_proxy/src/actor.rs
+++ b/crates/extensions/c8y_http_proxy/src/actor.rs
@@ -513,9 +513,8 @@ impl C8YHttpProxyActor {
         }
 
         info!(target: self.name(), "Downloading from: {:?}", download_info.url());
-        let downloader: Downloader = Downloader::with_permission(
+        let downloader: Downloader = Downloader::new(
             request.file_path,
-            request.file_permissions,
             self.config.identity.clone(),
             self.config.cloud_root_certs.clone(),
         );

--- a/crates/extensions/c8y_http_proxy/src/handle.rs
+++ b/crates/extensions/c8y_http_proxy/src/handle.rs
@@ -13,7 +13,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use tedge_actors::ClientMessageBox;
 use tedge_actors::Service;
-use tedge_utils::file::PermissionEntry;
 
 use super::messages::DownloadFile;
 
@@ -112,12 +111,10 @@ impl C8YHttpProxy {
         &mut self,
         download_url: &str,
         file_path: PathBuf,
-        file_permissions: PermissionEntry,
     ) -> Result<(), C8YRestError> {
         let request: C8YRestRequest = DownloadFile {
             download_url: download_url.into(),
             file_path,
-            file_permissions,
         }
         .into();
         match self.c8y.await_response(request).await? {

--- a/crates/extensions/c8y_http_proxy/src/messages.rs
+++ b/crates/extensions/c8y_http_proxy/src/messages.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use tedge_actors::fan_in_message_type;
 use tedge_actors::ChannelError;
 use tedge_http_ext::HttpError;
-use tedge_utils::file::PermissionEntry;
 
 fan_in_message_type!(C8YRestRequest[GetJwtToken, GetFreshJwtToken, CreateEvent, SoftwareListResponse, UploadLogBinary, UploadFile, DownloadFile]: Debug, PartialEq, Eq);
 //HIPPO Rename EventId to String as there could be many other String responses as well and this macro doesn't allow another String variant
@@ -90,7 +89,6 @@ pub struct UploadFile {
 pub struct DownloadFile {
     pub download_url: String,
     pub file_path: PathBuf,
-    pub file_permissions: PermissionEntry,
 }
 
 pub type EventId = String;

--- a/crates/extensions/tedge_downloader_ext/src/actor.rs
+++ b/crates/extensions/tedge_downloader_ext/src/actor.rs
@@ -118,20 +118,11 @@ impl<T: Message> Server for DownloaderActor<T> {
             DownloadInfo::new(&request.url)
         };
 
-        let downloader = if let Some(permission) = request.permission {
-            Downloader::with_permission(
-                request.file_path.clone(),
-                permission,
-                self.identity.clone(),
-                self.cloud_root_certs.clone(),
-            )
-        } else {
-            Downloader::new(
-                request.file_path.clone(),
-                self.identity.clone(),
-                self.cloud_root_certs.clone(),
-            )
-        };
+        let downloader = Downloader::new(
+            request.file_path.clone(),
+            self.identity.clone(),
+            self.cloud_root_certs.clone(),
+        );
 
         info!(
             "Downloading from url {} to location {}",


### PR DESCRIPTION
## Proposed changes

Replace manually created tempfiles with `.tmp` suffixes that didn't properly get clean up on errors with `tempfile` which delete on drop.

Downloader and config manager should no longer leave temporary files if respective functions did not complete successfully.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

