### PR TITLE
fix: Trim `reason` field in "succeed custom operation" smartrest message

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/shell/shell_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/shell/shell_operation.robot
@@ -29,6 +29,13 @@ Failed shell command
     ${operation}=    Cumulocity.Execute Shell Command    exit 1
     Operation Should Be FAILED    ${operation}
 
+Shell command succeeds if output is too large
+    [Documentation]    Output should be trimmed by c8y mapper.
+    ${operation}=    Cumulocity.Execute Shell Command    yes 'hello"' | head -n 100000
+    Operation Should Be SUCCESSFUL    ${operation}
+    ${result}=    Set Variable    ${operation.to_json()["c8y_Command"]["result"]}
+    Should End With    ${result}    ...<trimmed>
+
 
 *** Keywords ***
 Custom Setup


### PR DESCRIPTION
## TODO
- [x] add test
- [x] consider how to trim CSV output
- [x] remove unwraps
- [x] Rust unit test to improve coverage

## Proposed changes

Trims `reason` field for sent "set operation to SUCCESSFUL" smartrest messages.

Additionally, `...<trimmed>` indicator is inserted at the end to let the user know that the output was trimmed.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- https://github.com/thin-edge/thin-edge.io/issues/3171

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This PR solves the issue for operation success message for `c8y_Command`, but may still possibly fail for other types of messages.
For a follow-up we should do a clean up and use types to verify that message is smaller than max limit. 

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

