### PR TITLE
test: check publishing of telemetry data whilst mapper is down

### DIFF
--- a/tests/RobotFramework/tests/mqtt/offline_publishing.robot
+++ b/tests/RobotFramework/tests/mqtt/offline_publishing.robot
@@ -1,0 +1,24 @@
+*** Settings ***
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+Library             Cumulocity
+
+Test Setup          Setup Test
+Test Teardown       Get Logs
+
+
+*** Test Cases ***
+Publish event whilst mapper is down
+    [Documentation]    The mapper should publish the event to the cloud when it comes back online
+    ${event_type}=    Get Random Name
+    Stop Service    tedge-mapper-c8y
+    Execute Command    tedge mqtt pub -q 1 te/device/main///e/${event_type} '{"text":"test message"}'
+    Start Service    tedge-mapper-c8y
+    Cumulocity.Device Should Have Event/s    type=${event_type}    expected_text=test message
+
+
+*** Keywords ***
+Setup Test
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Device Should Exist    ${DEVICE_SN}

--- a/tests/images/debian-systemd/debian-systemd.dockerfile
+++ b/tests/images/debian-systemd/debian-systemd.dockerfile
@@ -20,17 +20,24 @@ RUN apt-get -y update \
     net-tools \
     # json tools (for tests)
     jq \
-    jo
+    jo \
+    # mosquitto (default version used by Debian, see below for more details)
+    mosquitto \
+    mosquitto-clients
 
+# Note: Avoid using mosquitto 2.0.18 due to a session persistence bug when using `per_listener_settings true
+# Only comment out the custom install logic to make it easier to re-enable once the bug is resolved
+# See https://github.com/thin-edge/thin-edge.io/issues/3185 for more details
 # Install more recent version of mosquitto >= 2.0.18 from debian backports to avoid mosquitto following bugs:
 # The mosquitto repo can't be used as it does not included builds for arm64/aarch64 (only amd64 and armhf)
 # * https://github.com/eclipse/mosquitto/issues/2604 (2.0.11)
 # * https://github.com/eclipse/mosquitto/issues/2634 (2.0.15)
-RUN sh -c "echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian bookworm-backports main' > /etc/apt/sources.list.d/debian-bookworm-backports.list" \
-    && apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install -t bookworm-backports \
-        mosquitto \
-        mosquitto-clients
+# * https://github.com/eclipse/mosquitto/issues/2618 (2.0.18)
+#RUN sh -c "echo 'deb [signed-by=/usr/share/keyrings/debian-archive-keyring.gpg] http://deb.debian.org/debian bookworm-backports main' > /etc/apt/sources.list.d/debian-bookworm-backports.list" \
+#    && apt-get update \
+#    && DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install -t bookworm-backports \
+#        mosquitto \
+#        mosquitto-clients
 
 # Remove unnecessary systemd services
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \


### PR DESCRIPTION
This PR adds a new test case to validate the behavior of ThinEdge.io when the tedge-mapper-c8y service is down, and events are published during the downtime. The test ensures that events sent via MQTT while the mapper is offline are published to Cumulocity when the service is restored.

Test Flow:

1.	Stop the tedge-mapper-c8y service.
2.	Publish an MQTT event with a random event type and a test message.
3.	Restart the tedge-mapper-c8y service.
4.	Assert that the event is correctly received and processed by Cumulocity, verifying both the event type and message content.

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3185
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

