### PR TITLE
Improve validation of SmartREST payloads

### DIFF
--- a/crates/core/c8y_api/Cargo.toml
+++ b/crates/core/c8y_api/Cargo.toml
@@ -9,6 +9,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
 clock = { workspace = true }
 csv = { workspace = true }
 download = { workspace = true }
@@ -27,7 +28,6 @@ toml = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-anyhow = { workspace = true }
 assert-json-diff = { workspace = true }
 assert_matches = { workspace = true }
 maplit = { workspace = true }

--- a/crates/core/c8y_api/src/smartrest/csv.rs
+++ b/crates/core/c8y_api/src/smartrest/csv.rs
@@ -1,4 +1,7 @@
-pub fn fields_to_csv_string(record: &[&str]) -> String {
+pub fn fields_to_csv_string<T>(record: impl IntoIterator<Item = T>) -> String
+where
+    T: AsRef<str> + AsRef<[u8]>,
+{
     let mut writer = csv::Writer::from_writer(vec![]);
     writer
         .write_record(record)
@@ -14,12 +17,12 @@ mod tests {
 
     #[test]
     fn normal_fields_containing_commas_are_quoted() {
-        assert_eq!(fields_to_csv_string(&["503", "test,me"]), "503,\"test,me\"");
+        assert_eq!(fields_to_csv_string(["503", "test,me"]), "503,\"test,me\"");
     }
 
     #[test]
     fn normal_fields_containing_quotes_are_quoted() {
-        let rcd = fields_to_csv_string(&["503", r#"A value"with" quotes"#, "field"]);
+        let rcd = fields_to_csv_string(["503", r#"A value"with" quotes"#, "field"]);
         assert_eq!(rcd, r#"503,"A value""with"" quotes",field"#);
     }
 }

--- a/crates/core/c8y_api/src/smartrest/inventory.rs
+++ b/crates/core/c8y_api/src/smartrest/inventory.rs
@@ -16,6 +16,8 @@ use mqtt_channel::MqttMessage;
 use std::time::Duration;
 use tedge_config::TopicPrefix;
 
+use super::payload::SmartrestPayload;
+
 /// Create a SmartREST message for creating a child device under the given ancestors.
 ///
 /// The provided ancestors list must contain all the parents of the given device
@@ -46,15 +48,17 @@ pub fn child_device_creation_message(
         });
     }
 
+    let payload = SmartrestPayload::serialize((
+        101,
+        child_id,
+        device_name.unwrap_or(child_id),
+        device_type.unwrap_or("thin-edge.io-child"),
+    ))
+    .expect("child_id, device_name, device_type should not increase payload size over the limit");
+
     Ok(MqttMessage::new(
         &publish_topic_from_ancestors(ancestors, prefix),
-        // XXX: if any arguments contain commas, output will be wrong
-        format!(
-            "101,{},{},{}",
-            child_id,
-            device_name.unwrap_or(child_id),
-            device_type.unwrap_or("thin-edge.io-child")
-        ),
+        payload.into_inner(),
     ))
 }
 
@@ -71,7 +75,8 @@ pub fn service_creation_message(
 ) -> Result<MqttMessage, InvalidValueError> {
     Ok(MqttMessage::new(
         &publish_topic_from_ancestors(ancestors, prefix),
-        service_creation_message_payload(service_id, service_name, service_type, service_status)?,
+        service_creation_message_payload(service_id, service_name, service_type, service_status)?
+            .into_inner(),
     ))
 }
 
@@ -83,7 +88,7 @@ pub fn service_creation_message_payload(
     service_name: &str,
     service_type: &str,
     service_status: &str,
-) -> Result<String, InvalidValueError> {
+) -> Result<SmartrestPayload, InvalidValueError> {
     // TODO: most of this noise can be eliminated by implementing `Serialize`/`Deserialize` for smartrest format
     if service_id.is_empty() {
         return Err(InvalidValueError {
@@ -110,13 +115,13 @@ pub fn service_creation_message_payload(
         });
     }
 
-    Ok(fields_to_csv_string(&[
-        "102",
-        service_id,
-        service_type,
-        service_name,
-        service_status,
-    ]))
+    let payload =
+        SmartrestPayload::serialize((102, service_id, service_type, service_name, service_status))
+            .expect(
+            "TODO: message can get over the limit but none of the fields can be reasonably trimmed",
+        );
+
+    Ok(payload)
 }
 
 /// Create a SmartREST message to set a response interval for c8y_RequiredAvailability.
@@ -135,10 +140,9 @@ impl From<C8ySmartRestSetInterval117> for MqttMessage {
     fn from(value: C8ySmartRestSetInterval117) -> Self {
         let topic = value.c8y_topic.to_topic(&value.prefix).unwrap();
         let interval_in_minutes = value.interval.as_secs() / 60;
-        MqttMessage::new(
-            &topic,
-            fields_to_csv_string(&["117", &interval_in_minutes.to_string()]),
-        )
+        let payload = SmartrestPayload::serialize((117, &interval_in_minutes))
+            .expect("interval should not increase size over the limit");
+        MqttMessage::new(&topic, payload.into_inner())
     }
 }
 
@@ -149,7 +153,7 @@ impl From<C8ySmartRestSetInterval117> for MqttMessage {
 /// update and configuration update), the `profile_executed` field should be set
 /// to `true`, otherwise it should be `false`.
 pub fn set_c8y_profile_target_payload(profile_executed: bool) -> String {
-    fields_to_csv_string(&["121", &profile_executed.to_string()])
+    fields_to_csv_string(["121", &profile_executed.to_string()])
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/core/c8y_api/src/smartrest/mod.rs
+++ b/crates/core/c8y_api/src/smartrest/mod.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod inventory;
 pub mod message;
 pub mod operations;
+pub mod payload;
 pub mod smartrest_deserializer;
 pub mod smartrest_serializer;
 pub mod topic;

--- a/crates/core/c8y_api/src/smartrest/operations.rs
+++ b/crates/core/c8y_api/src/smartrest/operations.rs
@@ -10,6 +10,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 use tracing::warn;
 
+use super::payload::SmartrestPayload;
+
 const DEFAULT_GRACEFUL_TIMEOUT: Duration = Duration::from_secs(3600);
 const DEFAULT_FORCEFUL_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -71,7 +73,7 @@ impl Operations {
             .collect::<HashSet<String>>()
     }
 
-    pub fn create_smartrest_ops_message(&self) -> String {
+    pub fn create_smartrest_ops_message(&self) -> SmartrestPayload {
         let mut ops = self.get_operations_list();
         ops.sort();
         let ops = ops.iter().map(|op| op.as_str()).collect::<Vec<_>>();

--- a/crates/core/c8y_api/src/smartrest/payload.rs
+++ b/crates/core/c8y_api/src/smartrest/payload.rs
@@ -1,0 +1,99 @@
+use std::fmt::Display;
+
+use serde::Serialize;
+use tracing::error;
+
+use super::message::MAX_PAYLOAD_LIMIT_IN_BYTES;
+
+/// A Cumulocity SmartREST message payload.
+///
+/// A SmartREST message is either an HTTP request or an MQTT message that contains SmartREST topic and payload. The
+/// payload is a CSV-like format that is backed by templates, either static or registered by the user. This struct
+/// represents that payload, and should be used as such in SmartREST 1.0 and 2.0 message implementations.
+///
+/// # Example
+///
+/// ```text
+/// 503,c8y_Command,"This is a ""Set operation to SUCCESSFUL (503)"" message payload; it has a template id (503),
+/// operation fragment (c8y_Command), and optional parameters."
+/// ```
+///
+/// # Reference
+///
+/// - https://cumulocity.com/docs/smartrest/smartrest-introduction/
+#[derive(Debug, Clone, PartialEq, Eq)]
+// TODO: pub(crate) for now so it can be constructed manually in serializer::succeed_operation, need to figure out a
+// good API
+pub struct SmartrestPayload(pub(crate) String);
+
+impl SmartrestPayload {
+    /// Creates a payload that consists of a single record.
+    ///
+    /// Doesn't trim any fields, so if the resulting payload is above size limit, returns an error.
+    pub fn serialize<S: Serialize>(record: S) -> Result<Self, SmartrestPayloadError> {
+        let mut wtr = csv::Writer::from_writer(vec![]);
+        wtr.serialize(record)?;
+        let mut vec = wtr.into_inner().unwrap();
+
+        // remove newline character
+        vec.pop();
+
+        let payload = String::from_utf8(vec).expect("csv::Writer should never write invalid utf-8");
+
+        if payload.len() > MAX_PAYLOAD_LIMIT_IN_BYTES {
+            return Err(SmartrestPayloadError::TooLarge(payload.len()));
+        }
+
+        Ok(Self(payload))
+    }
+
+    /// Returns a string slice view of the payload.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Moves the underlying `String` out of the payload.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+/// Errors that can occur when trying to create a SmartREST payload.
+#[derive(Debug, thiserror::Error)]
+pub enum SmartrestPayloadError {
+    #[error("Payload size ({0}) would be bigger than the limit ({MAX_PAYLOAD_LIMIT_IN_BYTES})")]
+    TooLarge(usize),
+
+    #[error("Could not serialize the record")]
+    SerializeError(#[from] csv::Error),
+}
+
+impl From<SmartrestPayload> for Vec<u8> {
+    fn from(value: SmartrestPayload) -> Self {
+        value.0.into_bytes()
+    }
+}
+
+impl Display for SmartrestPayload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_payload() {
+        let payload = SmartrestPayload::serialize((121, true)).unwrap();
+        assert_eq!(payload.as_str(), "121,true");
+    }
+
+    #[test]
+    fn returns_err_when_over_size_limit() {
+        let payload = "A".repeat(MAX_PAYLOAD_LIMIT_IN_BYTES + 1);
+        let payload = SmartrestPayload::serialize(payload);
+        assert!(matches!(payload, Err(SmartrestPayloadError::TooLarge(_))))
+    }
+}

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -154,14 +154,16 @@ impl TEdgeComponent for CumulocityMapper {
                     &c8y_mapper_name,
                     service_type.as_str(),
                     "down",
-                )?;
+                )?
+                .into_inner();
             let last_will_message_bridge =
                 c8y_api::smartrest::inventory::service_creation_message_payload(
                     mapper_service_external_id.as_ref(),
                     &c8y_mapper_config.bridge_service_name,
                     service_type.as_str(),
                     "down",
-                )?;
+                )?
+                .into_inner();
 
             cloud_config.set_last_will(LastWill {
                 topic: "s/us".into(),

--- a/crates/extensions/c8y_mapper_ext/src/alarm_converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/alarm_converter.rs
@@ -82,7 +82,10 @@ impl AlarmConverter {
                         let smartrest_topic = C8yTopic::from(&c8y_alarm)
                             .to_topic(c8y_prefix)
                             .expect("Infallible");
-                        output_messages.push(MqttMessage::new(&smartrest_topic, smartrest_alarm));
+                        output_messages.push(MqttMessage::new(
+                            &smartrest_topic,
+                            smartrest_alarm.into_inner(),
+                        ));
                     }
                 }
 

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -1063,7 +1063,7 @@ impl CumulocityConverter {
                                     };
 
                                     mqtt_publisher
-                                        .send(MqttMessage::new(&topic, payload.as_bytes()))
+                                        .send(MqttMessage::new(&topic, payload.as_str()))
                                         .await
                                         .unwrap_or_else(|err| {
                                             error!(
@@ -1401,7 +1401,9 @@ impl CumulocityConverter {
 
         Ok(MqttMessage::new(
             &topic,
-            Operations::try_new(path)?.create_smartrest_ops_message(),
+            Operations::try_new(path)?
+                .create_smartrest_ops_message()
+                .into_inner(),
         ))
     }
 

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/mod.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/mod.rs
@@ -17,6 +17,7 @@ use crate::actor::IdUploadRequest;
 use crate::actor::IdUploadResult;
 use crate::Capabilities;
 use c8y_api::http_proxy::C8yEndPoint;
+use c8y_api::smartrest::payload::SmartrestPayload;
 use c8y_api::smartrest::smartrest_serializer::fail_operation_with_id;
 use c8y_api::smartrest::smartrest_serializer::fail_operation_with_name;
 use c8y_api::smartrest::smartrest_serializer::set_operation_executing_with_id;
@@ -200,7 +201,7 @@ impl OperationContext {
         &self,
         operation: CumulocitySupportedOperations,
         cmd_id: &str,
-    ) -> c8y_api::smartrest::smartrest_serializer::SmartRest {
+    ) -> SmartrestPayload {
         match self.get_operation_id(cmd_id) {
             Some(op_id) if self.smart_rest_use_operation_id => {
                 succeed_operation_with_id_no_parameters(&op_id)
@@ -214,7 +215,7 @@ impl OperationContext {
         operation: CumulocitySupportedOperations,
         reason: &str,
         cmd_id: &str,
-    ) -> c8y_api::smartrest::smartrest_serializer::SmartRest {
+    ) -> SmartrestPayload {
         match self.get_operation_id(cmd_id) {
             Some(op_id) if self.smart_rest_use_operation_id => {
                 fail_operation_with_id(&op_id, reason)
@@ -342,7 +343,7 @@ pub fn get_smartrest_response_for_upload_result(
     operation: c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations,
     use_operation_id: bool,
     op_id: Option<String>,
-) -> c8y_api::smartrest::smartrest_serializer::SmartRest {
+) -> SmartrestPayload {
     match upload_result {
         Ok(_) => match op_id {
             Some(op_id) if use_operation_id => {


### PR DESCRIPTION
## Proposed changes

NOTE: there are some `.expect("TODO: ...")` calls where it's unclear what should be done on certain corner cases, e.g. when operation name is so pathologically long that it increases the size of the payload over the limit. These TODOs will have to be resolved before merging. 

This PR introduces a `SmartrestPayload` type, meant to encode assumptions about payload of SmartREST messages, i.e. that:
- it is a "CSV-like" format
- it has a size limit

This type should be used in places where we previously just used a plain `String` or constructed smartrest messages directly with `format!`, to ensure that above invariants always hold, and as the diff shows, in some places these invariants were being ignored. Most of them are corner cases, i.e. where it is technically possible for a device id or template id to increase the payload size over the limit, which should not normally happen. 

One more advantage is also that we can more easily see where smartrest payloads are being constructed or used by looking up references to `SmartrestPayload` type in an IDE or rust-analyzer.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

### Next steps

This PR only introduces the type and introduces it in some functions that construct SmartREST messages that are later sent, but there remain some more functions in other modules that sanitize smartrest payloads. These functions read and return strings, which is maybe why they weren't eagerly used (hard to know if you need to call them). The next step would be to integrate these sanitizing functions into the `SmartrestPayload` type. 

