### PR TITLE
Make `--debug` flag override `RUST_LOG`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3945,6 +3945,7 @@ dependencies = [
  "assert_matches",
  "camino",
  "certificate",
+ "clap",
  "doku",
  "figment",
  "humantime",

--- a/crates/common/tedge_config/Cargo.toml
+++ b/crates/common/tedge_config/Cargo.toml
@@ -16,6 +16,7 @@ test = []
 anyhow = { workspace = true }
 camino = { workspace = true, features = ["serde", "serde1"] }
 certificate = { workspace = true, features = ["reqwest"] }
+clap = { workspace = true }
 doku = { workspace = true }
 figment = { workspace = true, features = ["env", "toml"] }
 humantime = { workspace = true }

--- a/crates/common/tedge_config/src/system_services/log_config.rs
+++ b/crates/common/tedge_config/src/system_services/log_config.rs
@@ -1,9 +1,55 @@
 use camino::Utf8Path;
+use clap::Args;
 
 use crate::system_services::SystemConfig;
 use crate::system_services::SystemServiceError;
 use std::io::IsTerminal;
 use std::str::FromStr;
+
+#[derive(Args, Debug, PartialEq, Eq, Clone)]
+pub struct LogConfigArgs {
+    /// Turn-on the DEBUG log level.
+    ///
+    /// If off only reports ERROR, WARN, and INFO, if on also reports DEBUG
+    #[clap(long, global = true)]
+    pub debug: bool,
+}
+
+/// Configures and enables logging taking into account flags, env variables and file config.
+///
+/// 1. Log config is taken from the file configuration first
+/// 2. If `RUST_LOG` variable is set, it overrides file-based configuration
+/// 3. If `--debug` or `--log-level` flags are set, they override previous steps
+///
+/// Reports all the log events sent either with the `log` crate or the `tracing`
+/// crate.
+pub fn log_init(
+    sname: &str,
+    flags: &LogConfigArgs,
+    config_dir: &Utf8Path,
+) -> Result<(), SystemServiceError> {
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_ansi(std::io::stderr().is_terminal())
+        .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339());
+
+    if flags.debug {
+        subscriber.with_max_level(tracing::Level::DEBUG).init();
+        return Ok(());
+    }
+
+    if std::env::var("RUST_LOG").is_ok() {
+        subscriber
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .init();
+        return Ok(());
+    }
+
+    let log_level = get_log_level(sname, config_dir)?;
+    subscriber.with_max_level(log_level).init();
+
+    Ok(())
+}
 
 pub fn get_log_level(
     sname: &str,

--- a/crates/core/tedge_watchdog/src/lib.rs
+++ b/crates/core/tedge_watchdog/src/lib.rs
@@ -23,12 +23,8 @@ version = clap::crate_version!(),
 about = clap::crate_description!()
 )]
 pub struct WatchdogOpt {
-    /// Turn-on the debug log level.
-    ///
-    /// If off only reports ERROR, WARN, and INFO
-    /// If on also reports DEBUG
-    #[clap(long)]
-    pub debug: bool,
+    #[command(flatten)]
+    pub log_args: LogConfigArgs,
 
     /// Start the watchdog from custom path
     ///
@@ -46,16 +42,11 @@ pub async fn run(watchdog_opt: WatchdogOpt) -> Result<(), anyhow::Error> {
     let tedge_config_location =
         tedge_config::TEdgeConfigLocation::from_custom_root(watchdog_opt.config_dir.clone());
 
-    let log_level = if watchdog_opt.debug {
-        tracing::Level::DEBUG
-    } else {
-        get_log_level(
-            "tedge-watchdog",
-            &tedge_config_location.tedge_config_root_path,
-        )?
-    };
-
-    set_log_level(log_level);
+    log_init(
+        "tedge-watchdog",
+        &watchdog_opt.log_args,
+        &tedge_config_location.tedge_config_root_path,
+    )?;
 
     watchdog::start_watchdog(watchdog_opt.config_dir).await
 }

--- a/crates/extensions/c8y_mapper_ext/src/operations/handler.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handler.rs
@@ -671,7 +671,6 @@ mod tests {
 
     #[tokio::test]
     async fn shouldnt_process_invalid_status_transitions() {
-        tedge_config::system_services::set_log_level(tracing::Level::DEBUG);
         let TestHandle {
             operation_handler: mut sut,
             ttd: _ttd,

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -2628,7 +2628,6 @@ async fn mapper_doesnt_update_status_of_subworkflow_commands_3048() {
 
 #[tokio::test]
 async fn mapper_doesnt_send_duplicate_operation_status() {
-    tedge_config::system_services::set_log_level(tracing::Level::DEBUG);
     let ttd = TempTedgeDir::new();
     let test_handle = spawn_c8y_mapper_actor(&ttd, true).await;
     let TestHandle {


### PR DESCRIPTION
## Proposed changes

Flags should always take precedence over environment variables because are often used by users to override the environment which they usually have little control over.

To implement this change it was necessary to refactor the code a little bit as previously `set_log_level` function was not aware if desired log level was specifically requested by the user (`--debug` flag) or just the default (`INFO` level). As such, the new `log_init` function takes into account all sources that decide what log level we should select: CLI options, `RUST_LOG` env variable, and tedge configuration file.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

To be merged before #3205
