### PR TITLE
fix: agent leaves interrupted operations in non-final state 

### DIFF
--- a/crates/core/tedge_agent/src/operation_workflows/actor.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/actor.rs
@@ -514,6 +514,10 @@ impl WorkflowActor {
                     .workflow_repository
                     .load_pending_commands(pending_commands)
                 {
+                    // Make sure the latest state is visible over MQTT
+                    self.mqtt_publisher
+                        .send(command.clone().into_message())
+                        .await?;
                     self.process_command_update(command.clone()).await?;
                 }
             }

--- a/tests/RobotFramework/tests/tedge_agent/workflows/sleep-command.toml
+++ b/tests/RobotFramework/tests/tedge_agent/workflows/sleep-command.toml
@@ -1,0 +1,15 @@
+operation = "sleep"
+
+[init]
+action = "proceed"
+on_success = "executing"
+
+[executing]
+script = "sleep ${.payload.duration}"
+on_success = "successful"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"


### PR DESCRIPTION
## Proposed changes

- [x] Reproduce https://github.com/thin-edge/thin-edge.io/issues/3149
- [x] Correctly emit over MQTT the state of  commands interrupted by a restart.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

Reproduce https://github.com/thin-edge/thin-edge.io/issues/3149

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

