### PR TITLE
Enable line numbers for logs when using RUST_LOG

### DIFF
--- a/crates/common/tedge_config/src/system_services/log_config.rs
+++ b/crates/common/tedge_config/src/system_services/log_config.rs
@@ -54,6 +54,8 @@ pub fn log_init(
     if std::env::var("RUST_LOG").is_ok() {
         subscriber
             .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_file(true)
+            .with_line_number(true)
             .init();
         return Ok(());
     }


### PR DESCRIPTION
RUST_LOG can be used to more precisely control logging configuration and is undocumented and used by developers. For this reason, I think when using it we can enable line numbers to show the location of the log statement to more easily find relevant code.

Example (issue #2739):

```sh
tedge mqtt pub -r te/device/child1///cmd/config_update ''
```

tedge-mapper-c8y output:

```
2024-10-29T09:58:14.710505474Z ERROR c8y_mapper_ext::converter: crates/extensions/c8y_mapper_ext/src/converter.rs:139: Mapping error: EOF while parsing a value at line 1 column 0
```

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

