### PR TITLE
Add a warning about clearing command metadata being unsupported

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -1253,6 +1253,12 @@ impl CumulocityConverter {
             }
 
             Channel::CommandMetadata { operation } => {
+                // https://github.com/thin-edge/thin-edge.io/issues/2739
+                if message.payload().is_empty() {
+                    warn!(topic = ?message.topic.name, "Ignoring command metadata clearing message: clearing capabilities is not currently supported");
+                    return Ok(vec![]);
+                }
+
                 self.validate_operation_supported(operation, &source)?;
                 match operation {
                     OperationType::Restart => self.register_restart_operation(&source).await,


### PR DESCRIPTION
## Proposed changes

Replaces `ERROR: Mapping error: EOF while parsing a value at line 1 column 0` error log with a more meaningful warning log when publishing an empty message to a command metadata topic.

There are some unresolved questions wrt. clearing command metadata (see discussion in #2739), so for now we just provide a helpful message to the user. This feature will be implemented after the questions are resolved.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

#2739

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This PR was created so that the relevant issue can be closed, because the error message itself is not really a problem or a bug, but there's a much bigger design question about how clearing command capabilities should work, primarily when it comes to clearing capabilities of builtin agent commands. As such this PR provides a more meaningful warning to any users, while we can discuss the specifics. For that we can create a new, more design-focused issue about the capability clearing mechanism.