### PR TITLE
fix: c8y http proxy wrongly assumes any hostname is from the same tenant

### DIFF
--- a/crates/core/c8y_api/src/http_proxy.rs
+++ b/crates/core/c8y_api/src/http_proxy.rs
@@ -123,13 +123,13 @@ impl C8yEndPoint {
         let url = Url::parse(url).ok()?;
         let url_host = url.domain()?;
 
-        let (_, host) = url_host.split_once('.').unwrap_or((url_host, ""));
+        let (_, host) = url_host.split_once('.').unwrap_or(("", url_host));
         let (_, c8y_http_host) = tenant_http_host
             .split_once('.')
-            .unwrap_or((tenant_http_host, ""));
+            .unwrap_or(("", tenant_http_host));
         let (_, c8y_mqtt_host) = tenant_mqtt_host
             .split_once('.')
-            .unwrap_or((tenant_mqtt_host, ""));
+            .unwrap_or(("", tenant_mqtt_host));
 
         // The configured `c8y.http` setting may have a port value specified,
         // but the incoming URL is less likely to have any port specified.
@@ -408,6 +408,13 @@ mod tests {
         let c8y = C8yEndPoint::new("custom-domain", "non-custom-mqtt-domain", "test_device");
         let url = "http://custom-domain/path";
         assert_eq!(c8y.maybe_tenant_url(url), Some(url.parse().unwrap()));
+    }
+
+    #[test]
+    fn url_is_not_my_tenant_with_hostname_without_commas() {
+        let c8y = C8yEndPoint::new("custom-domain", "non-custom-mqtt-domain", "test_device");
+        let url = "http://unrelated-domain/path";
+        assert!(c8y.maybe_tenant_url(url).is_none());
     }
 
     #[ignore = "Until #2804 is fixed"]


### PR DESCRIPTION
## Proposed changes

When configured with hostnames without domains,
c8y_api::http_proxy::maybe_tenant_url wrongly assumes any hostname, given without a domain,
is related to the same tenant.

This was due to wrong defaults when parsing an url with no domain.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

