### PR TITLE
Change which download errors are retryable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,7 +1268,6 @@ name = "download"
 version = "1.3.1"
 dependencies = [
  "anyhow",
- "axum_tls",
  "backoff",
  "certificate",
  "hyper 0.14.28",

--- a/crates/common/download/Cargo.toml
+++ b/crates/common/download/Cargo.toml
@@ -11,7 +11,6 @@ repository = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
-axum_tls = { workspace = true, features = ["error-matching"] }
 backoff = { workspace = true }
 certificate = { workspace = true, features = ["reqwest"] }
 hyper = { workspace = true }

--- a/crates/common/download/src/download.rs
+++ b/crates/common/download/src/download.rs
@@ -927,7 +927,7 @@ mod tests {
         let target_path = target_dir_path.path().join("test_download");
         let mut downloader = Downloader::new(target_path, None, CloudRootCerts::from([]));
         downloader.set_backoff(ExponentialBackoff {
-            current_interval: Duration::ZERO,
+            max_elapsed_time: Some(Duration::ZERO),
             ..Default::default()
         });
         match downloader.download(&url).await {

--- a/crates/common/download/src/download.rs
+++ b/crates/common/download/src/download.rs
@@ -379,25 +379,8 @@ impl Downloader {
             request
                 .send()
                 .await
-                .map_err(|err| {
-                    // rustls errors are caused by e.g. CertificateRequired
-                    // If this is the case, retrying won't help us
-                    if err.is_builder()
-                        || err.is_connect()
-                        || axum_tls::rustls_error_from_reqwest(&err).is_some()
-                    {
-                        backoff::Error::Permanent(err)
-                    } else {
-                        backoff::Error::transient(err)
-                    }
-                })?
-                .error_for_status()
-                .map_err(|err| match err.status() {
-                    Some(status_error) if status_error.is_client_error() => {
-                        backoff::Error::Permanent(err)
-                    }
-                    _ => backoff::Error::transient(err),
-                })
+                .and_then(|response| response.error_for_status())
+                .map_err(reqwest_err_to_backoff)
         };
 
         retry_notify(backoff, operation, |err, dur: Duration| {
@@ -406,6 +389,19 @@ impl Downloader {
         })
         .await
     }
+}
+
+/// Decides whether HTTP request error is retryable.
+fn reqwest_err_to_backoff(err: reqwest::Error) -> backoff::Error<reqwest::Error> {
+    if err.is_timeout() || err.is_connect() {
+        return backoff::Error::transient(err);
+    }
+    if let Some(status) = err.status() {
+        if status.is_server_error() {
+            return backoff::Error::transient(err);
+        }
+    }
+    backoff::Error::permanent(err)
 }
 
 /// Saves a response body chunks starting from an offset.


### PR DESCRIPTION
## Proposed changes

Whereas previously we considered only some errors to be permanent and the rest to be retryable, that logic was inverted so we check if an error is one of a few that is transient, and the rest are considered permanent.

Biggest changes:
- connect errors are considered transient
- timeouts are considered transient

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- #3212

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

