### PR TITLE
feat: read device.id from credentials.toml when basic auth mode

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/models/auth_method.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/models/auth_method.rs
@@ -57,3 +57,22 @@ impl AuthMethod {
         }
     }
 }
+
+pub fn try_get_device_id_from_credentials_file(credentials_path: &Utf8Path) -> Option<String> {
+    if let Ok(contents) = std::fs::read_to_string(credentials_path) {
+        if let Ok(credentials) = toml::from_str::<CredentialsFile>(&contents) {
+            return Some(credentials.c8y.device_id);
+        }
+    }
+    None
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct CredentialsFile {
+    c8y: C8y,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct C8y {
+    device_id: String,
+}


### PR DESCRIPTION
## Proposed changes
Draft for further discussion.

1. Technically, it would be very difficult to switch "read-only" mode or "read-write" mode depending on `c8y.auth_mode`. This PR proposes to keep `device_id` in the `credentials.toml` file alternatively.
2. Reading all configs under `c8y` requires a profile name. However, it cannot be determined when `tedge config get device.id` is called. I parsed `None` as the device profile. Correct me if I am wrong.
```rust
    let c8y_profile: Option<&ProfileName> = None;
    let c8y_config = reader.c8y.try_get(c8y_profile)?;
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3240 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

