### PR TITLE
test: add workflow test running on child device

### DIFF
--- a/tests/RobotFramework/tests/tedge_agent/workflows/run_workflow_on_child_device.robot
+++ b/tests/RobotFramework/tests/tedge_agent/workflows/run_workflow_on_child_device.robot
@@ -1,0 +1,66 @@
+*** Settings ***
+Resource            ../../../resources/common.resource
+Library             ThinEdgeIO
+
+Suite Setup         Custom Setup
+Suite Teardown      Get Logs    name=${PARENT_SN}
+
+Test Tags           theme:tedge_agent
+
+
+*** Variables ***
+${PARENT_IP}    ${EMPTY}
+${PARENT_SN}    ${EMPTY}
+${CHILD_SN}     ${EMPTY}
+
+
+*** Test Cases ***
+Run workflow on child device
+    Start Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent    device=${CHILD_SN}
+
+    Set Device Context    ${PARENT_SN}
+    Should Have MQTT Messages
+    ...    te/device/${CHILD_SN}///cmd/user-command
+    ...    pattern="^{}$"
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/${CHILD_SN}///cmd/user-command/child-test-1 '{"status":"init"}'
+    Should Have MQTT Messages
+    ...    te/device/${CHILD_SN}///cmd/user-command/child-test-1
+    ...    message_pattern=.*successful.*
+
+    Set Device Context    ${CHILD_SN}
+    ${workflow_log}=    Execute Command    cat /var/log/tedge/agent/workflow-user-command-child-test-1.log
+    Should Contain    ${workflow_log}    item="user-command":"first-version"
+
+
+*** Keywords ***
+Custom Setup
+    # Parent
+    ${parent_sn}=    Setup    skip_bootstrap=False
+    Set Suite Variable    $PARENT_SN    ${parent_sn}
+
+    ${parent_ip}=    Get IP Address
+    Set Suite Variable    $PARENT_IP    ${parent_ip}
+
+    Set Device Context    ${PARENT_SN}
+    Execute Command    tedge config set mqtt.external.bind.address ${PARENT_IP}
+    Execute Command    tedge config set mqtt.external.bind.port 1883
+    Execute Command    tedge reconnect c8y
+
+    # Child
+    ${child_sn}=    Setup    skip_bootstrap=True
+    Set Suite Variable    $CHILD_SN    ${child_sn}
+    Set Device Context    ${CHILD_SN}
+
+    Execute Command    dpkg -i packages/tedge_*.deb
+    Execute Command    dpkg -i packages/tedge-agent_*.deb
+
+    Execute Command    tedge config set mqtt.client.host ${PARENT_IP}
+    Execute Command    tedge config set mqtt.client.port 1883
+    Execute Command    tedge config set http.client.host ${PARENT_IP}
+    Execute Command    tedge config set mqtt.topic_root te
+    Execute Command    tedge config set mqtt.device_topic_id "device/${CHILD_SN}//"
+
+    Transfer To Device    ${CURDIR}/echo-as-json.sh    /etc/tedge/operations/
+    Transfer To Device    ${CURDIR}/user-command-v1.toml    /etc/tedge/operations/user-command.toml


### PR DESCRIPTION
## Proposed changes
Since there is no workflow test which is running on child device, this PR adds such a test.

The workflow definition file and the shellscript are reused from another test. Hence, this PR contains only a new robot file.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

