### PR TITLE
Add `--log-level` to `tedge` and `c8y-remote-access-plugin`

### DIFF
--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -10,6 +10,7 @@ use c8y_remote_access_plugin::C8yRemoteAccessPluginOpt;
 pub use connect::*;
 use tedge_agent::AgentOpt;
 use tedge_config::get_config_dir;
+use tedge_config::system_services::LogConfigArgs;
 use tedge_mapper::MapperOpt;
 use tedge_watchdog::WatchdogOpt;
 use tedge_write::bin::Args as TedgeWriteOpt;
@@ -50,6 +51,9 @@ pub enum TEdgeOptMulticall {
             global = true,
         )]
         config_dir: PathBuf,
+
+        #[command(flatten)]
+        log_args: LogConfigArgs,
     },
 
     #[clap(flatten)]

--- a/crates/core/tedge/src/main.rs
+++ b/crates/core/tedge/src/main.rs
@@ -15,7 +15,7 @@ use tedge::log::MaybeFancy;
 use tedge::Component;
 use tedge::TEdgeOptMulticall;
 use tedge_apt_plugin::AptCli;
-use tedge_config::system_services::set_log_level;
+use tedge_config::system_services::log_init;
 use tracing::log;
 
 #[global_allocator]
@@ -56,8 +56,19 @@ fn main() -> anyhow::Result<()> {
             block_on(tedge_watchdog::run(opt))
         }
         TEdgeOptMulticall::Component(Component::TedgeWrite(opt)) => tedge_write::bin::run(opt),
-        TEdgeOptMulticall::Tedge { cmd, config_dir } => {
-            set_log_level(tracing::Level::WARN);
+        TEdgeOptMulticall::Tedge {
+            cmd,
+            config_dir,
+            log_args,
+        } => {
+            let tedge_config_location =
+                tedge_config::TEdgeConfigLocation::from_custom_root(&config_dir);
+
+            log_init(
+                "tedge",
+                &log_args,
+                &tedge_config_location.tedge_config_root_path,
+            )?;
 
             let build_context = BuildContext::new(config_dir);
             let cmd = cmd

--- a/plugins/c8y_remote_access_plugin/src/input.rs
+++ b/plugins/c8y_remote_access_plugin/src/input.rs
@@ -8,6 +8,7 @@ use std::io::stdin;
 use std::io::BufRead;
 use std::path::PathBuf;
 use tedge_config::get_config_dir;
+use tedge_config::system_services::LogConfigArgs;
 use tedge_config::Path;
 use tedge_config::ProfileName;
 use tedge_config::TEdgeConfigLocation;
@@ -40,6 +41,9 @@ pub struct C8yRemoteAccessPluginOpt {
         hide_default_value = true,
     )]
     config_dir: PathBuf,
+
+    #[command(flatten)]
+    pub log_args: LogConfigArgs,
 
     #[arg(long)]
     /// Complete the installation of c8y-remote-access-plugin by declaring the supported operation.

--- a/plugins/c8y_remote_access_plugin/src/lib.rs
+++ b/plugins/c8y_remote_access_plugin/src/lib.rs
@@ -8,6 +8,7 @@ use miette::Context;
 use miette::IntoDiagnostic;
 use std::io;
 use std::process::Stdio;
+use tedge_config::system_services::log_init;
 use tedge_config::TEdgeConfig;
 use tedge_utils::file::change_user_and_group;
 use tedge_utils::file::create_directory_with_user_group;
@@ -39,6 +40,13 @@ pub async fn run(opt: C8yRemoteAccessPluginOpt) -> miette::Result<()> {
     let tedge_config = TEdgeConfig::try_new(config_dir.clone())
         .into_diagnostic()
         .context("Reading tedge config")?;
+
+    log_init(
+        "c8y_remote_access_plugin",
+        &opt.log_args,
+        &config_dir.tedge_config_root_path,
+    )
+    .into_diagnostic()?;
 
     let command = parse_arguments(opt)?;
 


### PR DESCRIPTION
## Proposed changes

Adds `--log-level` flag to previously missed `tedge` and `c8y-remote-access-plugin` components.

Together with #3205, the flag is present in these top-level components:

- tedge
- tedge-mapper
- tedge-agent
- tedge-watchdog
- c8y-firmware-plugin
- c8y-remote-access-plugin

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

#2089

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

