### PR TITLE
fix: builtin workflows don't have to be released

### DIFF
--- a/crates/core/tedge_agent/src/operation_workflows/persist.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/persist.rs
@@ -6,6 +6,7 @@ use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
 use tedge_api::mqtt_topics::OperationType;
 use tedge_api::workflow::supervisor::WorkflowSource;
+use tedge_api::workflow::version_is_builtin;
 use tedge_api::workflow::CommandBoard;
 use tedge_api::workflow::GenericCommandState;
 use tedge_api::workflow::IllFormedOperationWorkflow;
@@ -265,6 +266,9 @@ impl WorkflowRepository {
         operation: &OperationName,
         version: &WorkflowVersion,
     ) {
+        if version_is_builtin(version) {
+            return;
+        }
         if let Some(count) = self.in_use_copies.get_mut(version) {
             *count += 1;
             return;
@@ -302,6 +306,9 @@ impl WorkflowRepository {
     }
 
     async fn release_in_use_copy(&mut self, operation: &OperationName, version: &WorkflowVersion) {
+        if version_is_builtin(version) {
+            return;
+        }
         if let Some(count) = self.in_use_copies.get_mut(version) {
             *count -= 1;
             if *count > 0 {

--- a/crates/core/tedge_api/src/workflow/mod.rs
+++ b/crates/core/tedge_api/src/workflow/mod.rs
@@ -30,6 +30,12 @@ pub type CommandId = String;
 pub type JsonPath = String;
 pub type WorkflowVersion = String;
 
+const BUILT_IN: &str = "builtin";
+
+pub fn version_is_builtin(version: &WorkflowVersion) -> bool {
+    version == BUILT_IN
+}
+
 /// An OperationWorkflow defines the state machine that rules an operation
 #[derive(Clone, Debug, Deserialize)]
 #[serde(try_from = "toml_config::TomlOperationWorkflow")]

--- a/crates/core/tedge_api/src/workflow/supervisor.rs
+++ b/crates/core/tedge_api/src/workflow/supervisor.rs
@@ -338,15 +338,10 @@ impl<T> WorkflowSource<T> {
 use WorkflowSource::*;
 
 impl WorkflowVersions {
-    const BUILT_IN: &'static str = "builtin";
-
     fn new(source: WorkflowSource<WorkflowVersion>, workflow: OperationWorkflow) -> Self {
         let operation = workflow.operation.to_string();
         let (current, in_use) = match source {
-            BuiltIn => (
-                None,
-                HashMap::from([(Self::BUILT_IN.to_string(), workflow)]),
-            ),
+            BuiltIn => (None, HashMap::from([(BUILT_IN.to_string(), workflow)])),
             UserDefined(version) => (Some((version, workflow)), HashMap::new()),
             InUseCopy(version) => (None, HashMap::from([(version, workflow)])),
         };
@@ -361,7 +356,7 @@ impl WorkflowVersions {
     fn add(&mut self, source: WorkflowSource<WorkflowVersion>, workflow: OperationWorkflow) {
         match source {
             BuiltIn => {
-                self.in_use.insert(Self::BUILT_IN.to_string(), workflow);
+                self.in_use.insert(BUILT_IN.to_string(), workflow);
             }
             UserDefined(version) => {
                 self.current = Some((version, workflow));
@@ -371,7 +366,7 @@ impl WorkflowVersions {
             }
         };
 
-        if self.current.is_some() && self.in_use.contains_key(Self::BUILT_IN) {
+        if self.current.is_some() && self.in_use.contains_key(BUILT_IN) {
             info!(
                 "The built-in {operation} operation has been customized",
                 operation = self.operation
@@ -391,7 +386,7 @@ impl WorkflowVersions {
 
             None => self
                 .in_use
-                .get_key_value(Self::BUILT_IN)
+                .get_key_value(BUILT_IN)
                 .map(|(builtin, _)| builtin),
         }
     }
@@ -400,7 +395,7 @@ impl WorkflowVersions {
     fn remove(&mut self, version: &WorkflowVersion) {
         if self.current.as_ref().map(|(v, _)| v == version) == Some(true) {
             self.current = None;
-        } else if version != Self::BUILT_IN {
+        } else if version != BUILT_IN {
             self.in_use.remove(version);
         }
     }
@@ -410,7 +405,7 @@ impl WorkflowVersions {
     }
 
     fn is_builtin(&self) -> bool {
-        self.in_use.contains_key(Self::BUILT_IN)
+        self.in_use.contains_key(BUILT_IN)
     }
 
     fn get(&self, version: &WorkflowVersion) -> Result<&OperationWorkflow, WorkflowExecutionError> {
@@ -426,7 +421,7 @@ impl WorkflowVersions {
         self.current
             .as_ref()
             .map(|(_, workflow)| workflow)
-            .or_else(|| self.in_use.get(Self::BUILT_IN))
+            .or_else(|| self.in_use.get(BUILT_IN))
     }
 }
 


### PR DESCRIPTION


## Proposed changes

Exclude builtin workflows from methods persisting workflow definitions that are in-use.

This was leading to confusing error messages as no files are related to builtin workflows.

```
ERROR tedge_agent::operation_workflows::persist: Fail to remove the workflow copy at /etc/tedge/.agent/workflows-in-use/software_list-builtin.toml: No such file or directory 
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3251

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

