### PR TITLE
feat: Improve custom operation workflow input

### DIFF
--- a/crates/core/c8y_api/src/smartrest/operations.rs
+++ b/crates/core/c8y_api/src/smartrest/operations.rs
@@ -194,11 +194,11 @@ impl Operation {
         })
     }
 
-    pub fn workflow_input(&self) -> Option<&str> {
+    pub fn workflow_input(&self) -> Option<&serde_json::Value> {
         self.exec().and_then(|exec| {
             exec.workflow
                 .as_ref()
-                .and_then(|workflow| workflow.input.as_deref())
+                .and_then(|workflow| workflow.input.as_ref())
         })
     }
 
@@ -349,7 +349,7 @@ where
 #[serde(rename_all = "snake_case")]
 struct ExecWorkflow {
     operation: Option<String>,
-    input: Option<String>,
+    input: Option<serde_json::Value>,
 }
 
 fn get_operations(

--- a/crates/extensions/c8y_mapper_ext/src/operations/convert.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/convert.rs
@@ -416,7 +416,7 @@ impl CumulocityConverter {
         })?;
 
         let payload: Value = if let Some(workflow_input) = custom_handler.workflow_input() {
-            let excerpt = StateExcerpt::from(Value::String(workflow_input.to_string()));
+            let excerpt = StateExcerpt::from(workflow_input.clone());
             match excerpt.extract_value_from(&state) {
                 Value::Object(obj) => Value::Object(obj),
                 _ => {


### PR DESCRIPTION
## Proposed changes

Now the workflow input of a custom operation can be built from several excerpts of the json payload sent by Cumulocity.

```toml
 [exec.workflow]
    operation = "command"
    input.x = "${.payload.c8y_CombinedInput.inner.x}"
    input.y = "${.payload.c8y_CombinedInput.inner.y}"
    input.z = { foo = "bar" }
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3095

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

