### PR TITLE
refactor(cli): use `CommonArgs` for common arguments

### DIFF
--- a/crates/common/tedge_config/src/cli.rs
+++ b/crates/common/tedge_config/src/cli.rs
@@ -1,0 +1,39 @@
+//! Common CLI arguments and helpers used by all thin-edge components.
+
+use camino::Utf8PathBuf;
+use clap::Args;
+
+/// CLI arguments that should be handled by all thin-edge components.
+#[derive(Args, Debug, PartialEq, Eq, Clone)]
+pub struct CommonArgs {
+    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+    #[clap(
+            long = "config-dir",
+            default_value = crate::get_config_dir().into_os_string(),
+            hide_env_values = true,
+            hide_default_value = true,
+            global = true,
+        )]
+    pub config_dir: Utf8PathBuf,
+
+    #[command(flatten)]
+    pub log_args: LogConfigArgs,
+}
+
+#[derive(Args, Debug, PartialEq, Eq, Clone)]
+pub struct LogConfigArgs {
+    /// Turn-on the DEBUG log level.
+    ///
+    /// If off only reports ERROR, WARN, and INFO, if on also reports DEBUG
+    #[clap(long, global = true)]
+    pub debug: bool,
+
+    /// Configures the logging level.
+    ///
+    /// One of error/warn/info/debug/trace. Logs with verbosity lower or equal to the selected level
+    /// will be printed, i.e. warn prints ERROR and WARN logs and trace prints logs of all levels.
+    ///
+    /// Overrides `--debug`
+    #[clap(long, global = true)]
+    pub log_level: Option<tracing::Level>,
+}

--- a/crates/common/tedge_config/src/lib.rs
+++ b/crates/common/tedge_config/src/lib.rs
@@ -3,6 +3,7 @@ mod sudo;
 pub mod system_services;
 pub mod tedge_config_cli;
 pub use sudo::SudoCommandBuilder;
+pub mod cli;
 
 pub use self::tedge_config_cli::config_setting::*;
 pub use self::tedge_config_cli::error::*;

--- a/crates/common/tedge_config/src/system_services/log_config.rs
+++ b/crates/common/tedge_config/src/system_services/log_config.rs
@@ -1,28 +1,10 @@
 use camino::Utf8Path;
-use clap::Args;
 
+use crate::cli::LogConfigArgs;
 use crate::system_services::SystemConfig;
 use crate::system_services::SystemServiceError;
 use std::io::IsTerminal;
 use std::str::FromStr;
-
-#[derive(Args, Debug, PartialEq, Eq, Clone)]
-pub struct LogConfigArgs {
-    /// Turn-on the DEBUG log level.
-    ///
-    /// If off only reports ERROR, WARN, and INFO, if on also reports DEBUG
-    #[clap(long, global = true)]
-    pub debug: bool,
-
-    /// Configures the logging level.
-    ///
-    /// One of error/warn/info/debug/trace. Logs with verbosity lower or equal to the selected level
-    /// will be printed, i.e. warn prints ERROR and WARN logs and trace prints logs of all levels.
-    ///
-    /// Overrides `--debug`
-    #[clap(long, global = true)]
-    pub log_level: Option<tracing::Level>,
-}
 
 /// Configures and enables logging taking into account flags, env variables and file config.
 ///

--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 pub use self::certificate::*;
 use self::refresh_bridges::RefreshBridgesCmd;
 use crate::command::BuildCommand;
@@ -9,8 +7,7 @@ use c8y_firmware_plugin::FirmwarePluginOpt;
 use c8y_remote_access_plugin::C8yRemoteAccessPluginOpt;
 pub use connect::*;
 use tedge_agent::AgentOpt;
-use tedge_config::get_config_dir;
-use tedge_config::system_services::LogConfigArgs;
+use tedge_config::cli::CommonArgs;
 use tedge_mapper::MapperOpt;
 use tedge_watchdog::WatchdogOpt;
 use tedge_write::bin::Args as TedgeWriteOpt;
@@ -42,18 +39,8 @@ pub enum TEdgeOptMulticall {
         #[clap(subcommand)]
         cmd: TEdgeOpt,
 
-        /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
-        #[clap(
-            long = "config-dir",
-            default_value = get_config_dir().into_os_string(),
-            hide_env_values = true,
-            hide_default_value = true,
-            global = true,
-        )]
-        config_dir: PathBuf,
-
         #[command(flatten)]
-        log_args: LogConfigArgs,
+        common: CommonArgs,
     },
 
     #[clap(flatten)]

--- a/crates/core/tedge/src/main.rs
+++ b/crates/core/tedge/src/main.rs
@@ -32,14 +32,14 @@ fn main() -> anyhow::Result<()> {
     let opt = parse_multicall_if_known(&executable_name);
     match opt {
         TEdgeOptMulticall::Component(Component::TedgeMapper(opt)) => {
-            let tedge_config = tedge_config::TEdgeConfig::load(&opt.config_dir)?;
+            let tedge_config = tedge_config::TEdgeConfig::load(&opt.common.config_dir)?;
             block_on_with(
                 tedge_config.run.log_memory_interval.duration(),
                 tedge_mapper::run(opt),
             )
         }
         TEdgeOptMulticall::Component(Component::TedgeAgent(opt)) => {
-            let tedge_config = tedge_config::TEdgeConfig::load(&opt.config_dir)?;
+            let tedge_config = tedge_config::TEdgeConfig::load(&opt.common.config_dir)?;
             block_on_with(
                 tedge_config.run.log_memory_interval.duration(),
                 tedge_agent::run(opt),
@@ -56,21 +56,17 @@ fn main() -> anyhow::Result<()> {
             block_on(tedge_watchdog::run(opt))
         }
         TEdgeOptMulticall::Component(Component::TedgeWrite(opt)) => tedge_write::bin::run(opt),
-        TEdgeOptMulticall::Tedge {
-            cmd,
-            config_dir,
-            log_args,
-        } => {
+        TEdgeOptMulticall::Tedge { cmd, common } => {
             let tedge_config_location =
-                tedge_config::TEdgeConfigLocation::from_custom_root(&config_dir);
+                tedge_config::TEdgeConfigLocation::from_custom_root(&common.config_dir);
 
             log_init(
                 "tedge",
-                &log_args,
+                &common.log_args,
                 &tedge_config_location.tedge_config_root_path,
             )?;
 
-            let build_context = BuildContext::new(config_dir);
+            let build_context = BuildContext::new(common.config_dir);
             let cmd = cmd
                 .build_command(build_context)
                 .with_context(|| "missing configuration parameter")?;

--- a/crates/core/tedge_agent/src/lib.rs
+++ b/crates/core/tedge_agent/src/lib.rs
@@ -14,10 +14,8 @@
 use std::sync::Arc;
 
 use agent::AgentConfig;
-use camino::Utf8PathBuf;
-use tedge_config::get_config_dir;
+use tedge_config::cli::CommonArgs;
 use tedge_config::system_services::log_init;
-use tedge_config::system_services::LogConfigArgs;
 use tracing::log::warn;
 
 mod agent;
@@ -37,23 +35,12 @@ version = clap::crate_version!(),
 about = clap::crate_description!()
 )]
 pub struct AgentOpt {
-    #[command(flatten)]
-    pub log_args: LogConfigArgs,
-
     /// Start the agent with clean session off, subscribe to the topics, so that no messages are lost
     #[clap(short, long)]
     pub init: bool,
 
-    /// Start the agent from custom path
-    ///
-    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
-    #[clap(
-        long = "config-dir",
-        default_value = get_config_dir().into_os_string(),
-        hide_env_values = true,
-        hide_default_value = true,
-    )]
-    pub config_dir: Utf8PathBuf,
+    #[command(flatten)]
+    pub common: CommonArgs,
 
     /// The device MQTT topic identifier
     #[clap(long)]
@@ -66,11 +53,11 @@ pub struct AgentOpt {
 
 pub async fn run(agent_opt: AgentOpt) -> Result<(), anyhow::Error> {
     let tedge_config_location =
-        tedge_config::TEdgeConfigLocation::from_custom_root(agent_opt.config_dir.clone());
+        tedge_config::TEdgeConfigLocation::from_custom_root(agent_opt.common.config_dir.clone());
 
     log_init(
         "tedge-agent",
-        &agent_opt.log_args,
+        &agent_opt.common.log_args,
         &tedge_config_location.tedge_config_root_path,
     )?;
 

--- a/crates/core/tedge_watchdog/src/dummy_watchdog.rs
+++ b/crates/core/tedge_watchdog/src/dummy_watchdog.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
+use std::path::Path;
 
-pub async fn start_watchdog(_config_dir: PathBuf) -> Result<(), anyhow::Error> {
+pub async fn start_watchdog(_config_dir: &Path) -> Result<(), anyhow::Error> {
     Err(anyhow::Error::from(WatchdogError::WatchdogNotAvailable))
 }
 

--- a/crates/core/tedge_watchdog/src/lib.rs
+++ b/crates/core/tedge_watchdog/src/lib.rs
@@ -1,5 +1,4 @@
-use std::path::PathBuf;
-use tedge_config::get_config_dir;
+use tedge_config::cli::CommonArgs;
 use tedge_config::system_services::*;
 
 // on linux, we use systemd
@@ -24,29 +23,18 @@ about = clap::crate_description!()
 )]
 pub struct WatchdogOpt {
     #[command(flatten)]
-    pub log_args: LogConfigArgs,
-
-    /// Start the watchdog from custom path
-    ///
-    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
-    #[clap(
-        long = "config-dir",
-        default_value = get_config_dir().into_os_string(),
-        hide_env_values = true,
-        hide_default_value = true,
-    )]
-    pub config_dir: PathBuf,
+    pub common: CommonArgs,
 }
 
 pub async fn run(watchdog_opt: WatchdogOpt) -> Result<(), anyhow::Error> {
     let tedge_config_location =
-        tedge_config::TEdgeConfigLocation::from_custom_root(watchdog_opt.config_dir.clone());
+        tedge_config::TEdgeConfigLocation::from_custom_root(watchdog_opt.common.config_dir.clone());
 
     log_init(
         "tedge-watchdog",
-        &watchdog_opt.log_args,
+        &watchdog_opt.common.log_args,
         &tedge_config_location.tedge_config_root_path,
     )?;
 
-    watchdog::start_watchdog(watchdog_opt.config_dir).await
+    watchdog::start_watchdog(watchdog_opt.common.config_dir.as_std_path()).await
 }

--- a/crates/core/tedge_watchdog/src/systemd_watchdog.rs
+++ b/crates/core/tedge_watchdog/src/systemd_watchdog.rs
@@ -10,7 +10,7 @@ use mqtt_channel::Topic;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
-use std::path::PathBuf;
+use std::path::Path;
 use std::process;
 use std::process::Command;
 use std::process::ExitStatus;
@@ -51,7 +51,7 @@ struct HealthStatusExt {
     pub time: Option<JsonValue>,
 }
 
-pub async fn start_watchdog(tedge_config_dir: PathBuf) -> Result<(), anyhow::Error> {
+pub async fn start_watchdog(tedge_config_dir: &Path) -> Result<(), anyhow::Error> {
     // Send ready notification to systemd.
     notify_systemd(process::id(), "--ready")?;
 
@@ -91,9 +91,9 @@ async fn start_watchdog_for_self() -> Result<(), WatchdogError> {
     }
 }
 
-async fn start_watchdog_for_tedge_services(tedge_config_dir: PathBuf) {
+async fn start_watchdog_for_tedge_services(tedge_config_dir: &Path) {
     let tedge_config_location =
-        tedge_config::TEdgeConfigLocation::from_custom_root(&tedge_config_dir);
+        tedge_config::TEdgeConfigLocation::from_custom_root(tedge_config_dir);
     let tedge_config = tedge_config::TEdgeConfig::try_new(tedge_config_location.clone())
         .expect("Could not load config");
 

--- a/crates/core/tedge_write/src/bin.rs
+++ b/crates/core/tedge_write/src/bin.rs
@@ -4,8 +4,8 @@ use anyhow::bail;
 use anyhow::Context;
 use camino::Utf8PathBuf;
 use clap::Parser;
+use tedge_config::cli::CommonArgs;
 use tedge_config::system_services::log_init;
-use tedge_config::system_services::LogConfigArgs;
 use tedge_utils::atomic::MaybePermissions;
 
 /// tee-like helper for writing to files which `tedge` user does not have write permissions to.
@@ -34,20 +34,15 @@ pub struct Args {
     group: Option<Box<str>>,
 
     #[command(flatten)]
-    log_args: LogConfigArgs,
-
-    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
-    #[clap(
-        long = "config-dir",
-        default_value = tedge_config::get_config_dir().into_os_string(),
-        hide_env_values = true,
-        hide_default_value = true,
-    )]
-    config_dir: Utf8PathBuf,
+    common: CommonArgs,
 }
 
 pub fn run(args: Args) -> anyhow::Result<()> {
-    log_init("tedge-write", &args.log_args, &args.config_dir)?;
+    log_init(
+        "tedge-write",
+        &args.common.log_args,
+        &args.common.config_dir,
+    )?;
 
     // /etc/sudoers can contain rules where sudo permissions are given to `tedge` user depending on
     // the files we write to, e.g:

--- a/plugins/c8y_firmware_plugin/src/lib.rs
+++ b/plugins/c8y_firmware_plugin/src/lib.rs
@@ -1,15 +1,13 @@
 use anyhow::Context;
 use c8y_firmware_manager::FirmwareManagerBuilder;
 use c8y_firmware_manager::FirmwareManagerConfig;
-use std::path::PathBuf;
 use tedge_actors::Runtime;
 use tedge_api::mqtt_topics::DeviceTopicId;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
 use tedge_api::mqtt_topics::Service;
-use tedge_config::get_config_dir;
+use tedge_config::cli::CommonArgs;
 use tedge_config::system_services::log_init;
-use tedge_config::system_services::LogConfigArgs;
 use tedge_config::ProfileName;
 use tedge_config::TEdgeConfig;
 use tedge_downloader_ext::DownloaderActor;
@@ -38,21 +36,12 @@ about = clap::crate_description!(),
 after_help = AFTER_HELP_TEXT
 )]
 pub struct FirmwarePluginOpt {
-    #[command(flatten)]
-    pub log_args: LogConfigArgs,
-
     /// Create required directories
     #[clap(short, long)]
     pub init: bool,
 
-    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
-    #[clap(
-        long = "config-dir",
-        default_value = get_config_dir().into_os_string(),
-        hide_env_values = true,
-        hide_default_value = true,
-    )]
-    pub config_dir: PathBuf,
+    #[command(flatten)]
+    pub common: CommonArgs,
 
     #[clap(long, env = "C8Y_PROFILE", hide = true)]
     pub profile: Option<ProfileName>,
@@ -61,11 +50,11 @@ pub struct FirmwarePluginOpt {
 pub async fn run(firmware_plugin_opt: FirmwarePluginOpt) -> Result<(), anyhow::Error> {
     // Load tedge config from the provided location
     let tedge_config_location =
-        tedge_config::TEdgeConfigLocation::from_custom_root(&firmware_plugin_opt.config_dir);
+        tedge_config::TEdgeConfigLocation::from_custom_root(&firmware_plugin_opt.common.config_dir);
 
     log_init(
         "c8y-firmware-plugin",
-        &firmware_plugin_opt.log_args,
+        &firmware_plugin_opt.common.log_args,
         &tedge_config_location.tedge_config_root_path,
     )?;
 

--- a/plugins/c8y_remote_access_plugin/src/input.rs
+++ b/plugins/c8y_remote_access_plugin/src/input.rs
@@ -6,9 +6,7 @@ use miette::Context;
 use serde::Deserialize;
 use std::io::stdin;
 use std::io::BufRead;
-use std::path::PathBuf;
-use tedge_config::get_config_dir;
-use tedge_config::system_services::LogConfigArgs;
+use tedge_config::cli::CommonArgs;
 use tedge_config::Path;
 use tedge_config::ProfileName;
 use tedge_config::TEdgeConfigLocation;
@@ -33,18 +31,6 @@ about = clap::crate_description!(),
 arg_required_else_help(true),
 )]
 pub struct C8yRemoteAccessPluginOpt {
-    /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
-    #[clap(
-        long = "config-dir",
-        default_value = get_config_dir().into_os_string(),
-        hide_env_values = true,
-        hide_default_value = true,
-    )]
-    config_dir: PathBuf,
-
-    #[command(flatten)]
-    pub log_args: LogConfigArgs,
-
     #[arg(long)]
     /// Complete the installation of c8y-remote-access-plugin by declaring the supported operation.
     init: bool,
@@ -75,11 +61,14 @@ pub struct C8yRemoteAccessPluginOpt {
     #[arg(long, env = "C8Y_PROFILE", hide = true)]
     /// The c8y profile to use
     pub profile: Option<ProfileName>,
+
+    #[command(flatten)]
+    pub common: CommonArgs,
 }
 
 impl C8yRemoteAccessPluginOpt {
     pub fn get_config_location(&self) -> TEdgeConfigLocation {
-        TEdgeConfigLocation::from_custom_root(&self.config_dir)
+        TEdgeConfigLocation::from_custom_root(&self.common.config_dir)
     }
 }
 

--- a/plugins/c8y_remote_access_plugin/src/lib.rs
+++ b/plugins/c8y_remote_access_plugin/src/lib.rs
@@ -43,7 +43,7 @@ pub async fn run(opt: C8yRemoteAccessPluginOpt) -> miette::Result<()> {
 
     log_init(
         "c8y_remote_access_plugin",
-        &opt.log_args,
+        &opt.common.log_args,
         &config_dir.tedge_config_root_path,
     )
     .into_diagnostic()?;


### PR DESCRIPTION
## Proposed changes

As suggested in https://github.com/thin-edge/thin-edge.io/pull/3271#discussion_r1861554564, since we want both `log_args` and `config_dir` be used by all thin-edge components, and because `log_args` also needs the `config_dir` to use in `log_init()`, use a shared `CommonArgs` in all thin-edge components to parse these arguments.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

