### PR TITLE
refactor: Create a module with smartrest message id consts

### DIFF
--- a/crates/core/c8y_api/src/smartrest/alarm.rs
+++ b/crates/core/c8y_api/src/smartrest/alarm.rs
@@ -1,5 +1,6 @@
 use crate::json_c8y::AlarmSeverity;
 use crate::json_c8y::C8yAlarm;
+use crate::smartrest::message_ids::*;
 use time::format_description::well_known::Rfc3339;
 
 use super::payload::SmartrestPayload;
@@ -9,21 +10,23 @@ pub fn serialize_alarm(c8y_alarm: &C8yAlarm) -> Result<SmartrestPayload, time::e
     let smartrest = match c8y_alarm {
         C8yAlarm::Create(alarm) => {
             let smartrest_code = match alarm.severity {
-                AlarmSeverity::Critical => "301",
-                AlarmSeverity::Major => "302",
-                AlarmSeverity::Minor => "303",
-                AlarmSeverity::Warning => "304",
+                AlarmSeverity::Critical => CREATE_CRITICAL_ALARM,
+                AlarmSeverity::Major => CREATE_MAJOR_ALARM,
+                AlarmSeverity::Minor => CREATE_MINOR_ALARM,
+                AlarmSeverity::Warning => CREATE_WARNING_ALARM,
             };
-            SmartrestPayload::serialize([
+            SmartrestPayload::serialize((
                 smartrest_code,
                 &alarm.alarm_type,
                 &alarm.text,
                 &alarm.time.format(&Rfc3339)?,
-            ])
+            ))
             .expect("TODO: should alarm text be trimmed?")
         }
-        C8yAlarm::Clear(alarm) => SmartrestPayload::serialize((306, &alarm.alarm_type))
-            .expect("alarm type should be shorter than payload size limit"),
+        C8yAlarm::Clear(alarm) => {
+            SmartrestPayload::serialize((CLEAR_EXISTING_ALARM, &alarm.alarm_type))
+                .expect("alarm type should be shorter than payload size limit")
+        }
     };
     Ok(smartrest)
 }

--- a/crates/core/c8y_api/src/smartrest/message_ids.rs
+++ b/crates/core/c8y_api/src/smartrest/message_ids.rs
@@ -1,0 +1,107 @@
+//! Definitions of Smartrest MQTT message ids.
+//!
+//! - https://cumulocity.com/docs/smartrest/smartrest-one/#built-in-messages
+//! - https://cumulocity.com/docs/smartrest/mqtt-static-templates/
+
+// Message IDs
+
+pub const ERROR: usize = 41;
+pub const JWT_TOKEN: usize = 71;
+
+// Static templates
+
+// Publish templates
+
+// Inventory templates (1xx)
+
+pub const DEVICE_CREATION: usize = 100;
+pub const CHILD_DEVICE_CREATION: usize = 101;
+pub const SERVICE_CREATION: usize = 102;
+pub const SERVICE_STATUS_UPDATE: usize = 104;
+pub const GET_CHILD_DEVICES: usize = 105;
+pub const CLEAR_DEVICE_FRAGMENT: usize = 107;
+pub const CONFIGURE_HARDWARE: usize = 110;
+pub const CONFIGURE_MOBILE: usize = 111;
+pub const CONFIGURE_POSITION: usize = 112;
+pub const SET_CONFIGURATION: usize = 113;
+pub const SET_SUPPORTED_OPERATIONS: usize = 114;
+pub const SET_FIRMWARE: usize = 115;
+pub const SET_SOFTWARE_LIST: usize = 116;
+pub const SET_REQUIRED_AVAILABILITY: usize = 117;
+pub const SET_SUPPORTED_LOGS: usize = 118;
+pub const SET_SUPPORTED_CONFIGURATIONS: usize = 119;
+pub const SET_CURRENTLY_INSTALLED_CONFIGURATION: usize = 120;
+pub const SET_DEVICE_PROFILE_THAT_IS_BEING_APPLIED: usize = 121;
+pub const SET_DEVICE_AGENT_INFORMATION: usize = 122;
+pub const GET_DEVICE_MANAGED_OBJECT_ID: usize = 123;
+pub const SEND_HEARTBEAT: usize = 125;
+pub const SET_ADVANCED_SOFTWARE_LIST: usize = 140;
+pub const APPEND_ADVANCED_SOFTWARE_ITEMS: usize = 141;
+pub const REMOVE_ADVANCED_SOFTWARE_ITEMS: usize = 142;
+pub const SET_SUPPORTED_SOFTWARE_TYPES: usize = 143;
+pub const SET_CLOUD_REMOTE_ACCESS: usize = 150;
+
+// Measurement templates (2xx)
+
+pub const CREATE_CUSTOM_MEASUREMENT: usize = 200;
+pub const CREATE_A_CUSTOM_MEASUREMENT_WITH_MULTIPLE_FRAGMENTS_AND_SERIES: usize = 201;
+pub const CREATE_SIGNAL_STRENGTH_MEASUREMENT: usize = 210;
+pub const CREATE_TEMPERATURE_MEASUREMENT: usize = 211;
+pub const CREATE_BATTERY_MEASUREMENT: usize = 212;
+
+// Alarm templates (3xx)
+
+pub const CREATE_CRITICAL_ALARM: usize = 301;
+pub const CREATE_MAJOR_ALARM: usize = 302;
+pub const CREATE_MINOR_ALARM: usize = 303;
+pub const CREATE_WARNING_ALARM: usize = 304;
+pub const UPDATE_SEVERITY_OF_EXISTING_ALARM: usize = 305;
+pub const CLEAR_EXISTING_ALARM: usize = 306;
+pub const CLEAR_ALARM_FRAGMENT: usize = 307;
+
+// Event templates (4xx)
+
+pub const CREATE_BASIC_EVENT: usize = 400;
+pub const CREATE_LOCATION_UPDATE_EVENT: usize = 401;
+pub const CREATE_LOCATION_UPDATE_EVENT_WITH_DEVICE_UPDATE: usize = 402;
+pub const CLEAR_EVENT_FRAGMENT: usize = 407;
+
+// Operation templates (5xx)
+
+pub const GET_PENDING_OPERATIONS: usize = 500;
+pub const SET_OPERATION_TO_EXECUTING: usize = 501;
+pub const SET_OPERATION_TO_FAILED: usize = 502;
+pub const SET_OPERATION_TO_SUCCESSFUL: usize = 503;
+pub const SET_OPERATION_TO_EXECUTING_ID: usize = 504;
+pub const SET_OPERATION_TO_FAILED_ID: usize = 505;
+pub const SET_OPERATION_TO_SUCCESSFUL_ID: usize = 506;
+pub const SET_EXECUTING_OPERATIONS_TO_FAILED: usize = 507;
+
+// Subscribe templates
+
+// Inventory templates (1xx)
+
+pub const GET_CHILDREN_OF_DEVICE: usize = 106;
+pub const GET_DEVICE_MANAGED_OBJECT_ID_RESPONSE: usize = 124;
+
+// Operation templates (5xx)
+
+pub const RESTART: usize = 510;
+pub const COMMAND: usize = 511;
+pub const CONFIGURATION: usize = 513;
+pub const FIRMWARE: usize = 515;
+pub const SOFTWARE_LIST: usize = 516;
+pub const MEASUREMENT_REQUEST_OPERATION: usize = 517;
+pub const RELAY: usize = 518;
+pub const RELAY_ARRAY: usize = 519;
+pub const UPLOAD_CONFIGURATION_FILE: usize = 520;
+pub const DOWNLOAD_CONFIGURATION_FILE: usize = 521;
+pub const LOGFILE_REQUEST: usize = 522;
+pub const COMMUNICATION_MODE: usize = 523;
+pub const DOWNLOAD_CONFIGURATION_FILE_WITH_TYPE: usize = 524;
+pub const FIRMWARE_FROM_PATCH: usize = 525;
+pub const UPLOAD_CONFIGURATION_FILE_WITH_TYPE: usize = 526;
+pub const SET_DEVICE_PROFILES: usize = 527;
+pub const UPDATE_SOFTWARE: usize = 528;
+pub const UPDATE_ADVANCED_SOFTWARE: usize = 529;
+pub const CLOUD_REMOTE_ACCESS_CONNECT: usize = 530;

--- a/crates/core/c8y_api/src/smartrest/mod.rs
+++ b/crates/core/c8y_api/src/smartrest/mod.rs
@@ -3,6 +3,7 @@ pub mod csv;
 pub mod error;
 pub mod inventory;
 pub mod message;
+pub mod message_ids;
 pub mod payload;
 pub mod smartrest_deserializer;
 pub mod smartrest_serializer;

--- a/crates/core/c8y_api/src/smartrest/payload.rs
+++ b/crates/core/c8y_api/src/smartrest/payload.rs
@@ -84,9 +84,12 @@ impl Display for SmartrestPayload {
 mod tests {
     use super::*;
 
+    use crate::smartrest::message_ids::SET_DEVICE_PROFILE_THAT_IS_BEING_APPLIED;
+
     #[test]
     fn serializes_payload() {
-        let payload = SmartrestPayload::serialize((121, true)).unwrap();
+        let payload =
+            SmartrestPayload::serialize((SET_DEVICE_PROFILE_THAT_IS_BEING_APPLIED, true)).unwrap();
         assert_eq!(payload.as_str(), "121,true");
     }
 

--- a/crates/core/c8y_api/src/smartrest/smartrest_deserializer.rs
+++ b/crates/core/c8y_api/src/smartrest/smartrest_deserializer.rs
@@ -1,3 +1,5 @@
+use super::message_ids::GET_CHILDREN_OF_DEVICE;
+use super::message_ids::JWT_TOKEN;
 use crate::smartrest::error::SmartRestDeserializerError;
 use csv::ReaderBuilder;
 use serde::de::Error;
@@ -136,7 +138,7 @@ pub struct SmartRestJwtResponse {
 impl Default for SmartRestJwtResponse {
     fn default() -> Self {
         Self {
-            id: 71,
+            id: JWT_TOKEN as u16,
             token: "".into(),
         }
     }
@@ -153,7 +155,7 @@ impl SmartRestJwtResponse {
             jwt = result.unwrap();
         }
 
-        if jwt.id != 71 {
+        if jwt.id != JWT_TOKEN as u16 {
             return Err(SmartRestDeserializerError::InvalidMessageId(jwt.id));
         }
 
@@ -177,7 +179,7 @@ impl SmartRestRequestGeneric for AvailableChildDevices {}
 impl Default for AvailableChildDevices {
     fn default() -> Self {
         Self {
-            message_id: "106".into(),
+            message_id: GET_CHILDREN_OF_DEVICE.to_string(),
             devices: Default::default(),
         }
     }

--- a/crates/core/c8y_api/src/utils.rs
+++ b/crates/core/c8y_api/src/utils.rs
@@ -1,4 +1,5 @@
 pub mod child_device {
+    use crate::smartrest::message_ids::CHILD_DEVICE_CREATION;
     use crate::smartrest::topic::C8yTopic;
     use mqtt_channel::MqttMessage;
     use tedge_config::TopicPrefix;
@@ -6,7 +7,7 @@ pub mod child_device {
     pub fn new_child_device_message(child_id: &str, prefix: &TopicPrefix) -> MqttMessage {
         MqttMessage::new(
             &C8yTopic::upstream_topic(prefix),
-            format!("101,{child_id},{child_id},thin-edge.io-child"),
+            format!("{CHILD_DEVICE_CREATION},{child_id},{child_id},thin-edge.io-child"),
         )
     }
 }

--- a/crates/core/tedge/src/cli/connect/c8y_direct_connection.rs
+++ b/crates/core/tedge/src/cli/connect/c8y_direct_connection.rs
@@ -146,12 +146,13 @@ fn publish_device_create_message(
     device_id: &str,
     device_type: &str,
 ) -> Result<(), ConnectError> {
+    use c8y_api::smartrest::message_ids::DEVICE_CREATION;
     const DEVICE_CREATE_PUBLISH_TOPIC: &str = "s/us";
     client.publish(
         DEVICE_CREATE_PUBLISH_TOPIC,
         QoS::ExactlyOnce,
         false,
-        format!("100,{},{}", device_id, device_type).as_bytes(),
+        format!("{DEVICE_CREATION},{},{}", device_id, device_type).as_bytes(),
     )?;
     Ok(())
 }

--- a/crates/extensions/c8y_firmware_manager/src/tests.rs
+++ b/crates/extensions/c8y_firmware_manager/src/tests.rs
@@ -3,6 +3,7 @@ use assert_json_diff::assert_json_include;
 use c8y_api::http_proxy::C8yEndPoint;
 use c8y_api::proxy_url::Protocol;
 use c8y_api::proxy_url::ProxyUrlGenerator;
+use c8y_api::smartrest::message_ids::FIRMWARE;
 use c8y_api::smartrest::topic::C8yTopic;
 use serde_json::json;
 use sha256::digest;
@@ -575,7 +576,7 @@ async fn publish_smartrest_firmware_operation(
 ) -> Result<(), DynError> {
     let c8y_firmware_update_msg = MqttMessage::new(
         &Topic::new_unchecked("c8y/s/ds"),
-        format!("515,{CHILD_DEVICE_ID},{FIRMWARE_NAME},{FIRMWARE_VERSION},{DOWNLOAD_URL}"),
+        format!("{FIRMWARE},{CHILD_DEVICE_ID},{FIRMWARE_NAME},{FIRMWARE_VERSION},{DOWNLOAD_URL}"),
     );
     mqtt_message_box.send(c8y_firmware_update_msg).await?;
     Ok(())

--- a/crates/extensions/c8y_firmware_manager/src/worker.rs
+++ b/crates/extensions/c8y_firmware_manager/src/worker.rs
@@ -5,6 +5,7 @@ use crate::mpsc;
 use crate::operation::FirmwareOperationEntry;
 use crate::operation::OperationKey;
 use crate::FirmwareManagerConfig;
+use c8y_api::smartrest::message_ids::GET_PENDING_OPERATIONS;
 use c8y_api::smartrest::smartrest_deserializer::SmartRestFirmwareRequest;
 use c8y_api::smartrest::smartrest_serializer::fail_operation_with_name;
 use c8y_api::smartrest::smartrest_serializer::set_operation_executing_with_name;
@@ -398,10 +399,11 @@ impl FirmwareManagerWorker {
         &mut self,
         operation_entry: &FirmwareOperationEntry,
     ) -> Result<(), FirmwareManagementError> {
+        use c8y_api::smartrest::message_ids::SET_FIRMWARE;
         let c8y_child_topic = C8yTopic::ChildSmartRestResponse(operation_entry.child_id.clone())
             .to_topic(&self.config.c8y_prefix)?;
         let installed_firmware_payload = format!(
-            "115,{},{},{}",
+            "{SET_FIRMWARE},{},{},{}",
             operation_entry.name, operation_entry.version, operation_entry.server_url
         );
         let installed_firmware_message =
@@ -437,7 +439,7 @@ impl FirmwareManagerWorker {
     ) -> Result<(), FirmwareManagementError> {
         let message = MqttMessage::new(
             &C8yTopic::SmartRestResponse.to_topic(&self.config.c8y_prefix)?,
-            "500",
+            GET_PENDING_OPERATIONS.to_string(),
         );
         self.mqtt_publisher.send(message).await?;
         Ok(())

--- a/crates/extensions/c8y_mapper_ext/src/operations/convert.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/convert.rs
@@ -5,6 +5,8 @@ use c8y_api::json_c8y_deserializer::C8yDownloadConfigFile;
 use c8y_api::json_c8y_deserializer::C8yFirmware;
 use c8y_api::json_c8y_deserializer::C8yLogfileRequest;
 use c8y_api::json_c8y_deserializer::C8yUploadConfigFile;
+use c8y_api::smartrest::message_ids::SET_SUPPORTED_CONFIGURATIONS;
+use c8y_api::smartrest::message_ids::SET_SUPPORTED_LOGS;
 use serde_json::Value;
 use std::sync::Arc;
 use tedge_api::commands::CommandStatus;
@@ -173,7 +175,7 @@ impl CumulocityConverter {
         let mut types = metadata.types;
         types.sort();
         let supported_log_types = types.join(",");
-        let payload = format!("118,{supported_log_types}");
+        let payload = format!("{SET_SUPPORTED_LOGS},{supported_log_types}");
         let c8y_topic = self.smartrest_publish_topic_for_entity(topic_id)?;
         messages.push(MqttMessage::new(&c8y_topic, payload));
 
@@ -306,7 +308,7 @@ impl CumulocityConverter {
         let mut types = metadata.types;
         types.sort();
         let supported_config_types = types.join(",");
-        let payload = format!("119,{supported_config_types}");
+        let payload = format!("{SET_SUPPORTED_CONFIGURATIONS},{supported_config_types}");
         let sm_topic = self.smartrest_publish_topic_for_entity(topic_id)?;
         messages.push(MqttMessage::new(&sm_topic, payload));
 


### PR DESCRIPTION
## Proposed changes

Create a single module that contains ids for Smartrest messages and static templates.

- user code is easier to read
- can easily jump to definition
- easier to see the dependency and find usages by grepping for the usage of the module

The next steps would be for thin-edge not to use these ids directly, but to provide a higher-level layer of abstraction for interacting with Cumulocity, much like go-c8y-cli.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

