### PR TITLE
Custom operation handler should parse extra arguments for 503/506 messages

### DIFF
--- a/crates/core/tedge_api/src/mqtt_topics.rs
+++ b/crates/core/tedge_api/src/mqtt_topics.rs
@@ -853,6 +853,10 @@ impl IdGenerator {
             .strip_prefix(&self.prefix)
             .and_then(|s| s.strip_prefix('-'))
     }
+
+    pub fn prefix(&self) -> &str {
+        self.prefix.as_str()
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/tedge_api/src/workflow/state.rs
+++ b/crates/core/tedge_api/src/workflow/state.rs
@@ -274,9 +274,9 @@ impl GenericCommandState {
         GenericCommandState::extract_text_property(&self.payload, REASON)
     }
 
-    /// Return value of the result field if any
-    pub fn result(&self) -> Option<&str> {
-        GenericCommandState::extract_text_property(&self.payload, RESULT)
+    /// Return value of the result field
+    pub fn result(&self) -> &Value {
+        self.payload.get(RESULT).unwrap_or(&Value::Null)
     }
 
     /// Extract a text property from a Json object

--- a/crates/core/tedge_api/src/workflow/state.rs
+++ b/crates/core/tedge_api/src/workflow/state.rs
@@ -72,6 +72,7 @@ const EXECUTING: &str = "executing";
 const SUCCESSFUL: &str = "successful";
 const FAILED: &str = "failed";
 const REASON: &str = "reason";
+const RESULT: &str = "result";
 
 impl GenericCommandState {
     pub fn new(topic: Topic, status: String, payload: Value) -> Self {
@@ -271,6 +272,11 @@ impl GenericCommandState {
     /// Return the error reason if any
     pub fn failure_reason(&self) -> Option<&str> {
         GenericCommandState::extract_text_property(&self.payload, REASON)
+    }
+
+    /// Return value of the result field if any
+    pub fn result(&self) -> Option<&str> {
+        GenericCommandState::extract_text_property(&self.payload, RESULT)
     }
 
     /// Extract a text property from a Json object

--- a/crates/core/tedge_api/src/workflow/state.rs
+++ b/crates/core/tedge_api/src/workflow/state.rs
@@ -75,8 +75,9 @@ const REASON: &str = "reason";
 const RESULT: &str = "result";
 
 impl GenericCommandState {
-    pub fn new(topic: Topic, status: String, payload: Value) -> Self {
+    pub fn new(topic: Topic, status: String, mut payload: Value) -> Self {
         let invoking_command_topic = Self::infer_invoking_command_topic(topic.as_ref());
+        Self::inject_text_property(&mut payload, STATUS, &status);
         GenericCommandState {
             topic,
             status,

--- a/crates/core/tedge_api/src/workflow/state.rs
+++ b/crates/core/tedge_api/src/workflow/state.rs
@@ -72,7 +72,6 @@ const EXECUTING: &str = "executing";
 const SUCCESSFUL: &str = "successful";
 const FAILED: &str = "failed";
 const REASON: &str = "reason";
-const RESULT: &str = "result";
 
 impl GenericCommandState {
     pub fn new(topic: Topic, status: String, mut payload: Value) -> Self {
@@ -273,11 +272,6 @@ impl GenericCommandState {
     /// Return the error reason if any
     pub fn failure_reason(&self) -> Option<&str> {
         GenericCommandState::extract_text_property(&self.payload, REASON)
-    }
-
-    /// Return value of the result field
-    pub fn result(&self) -> &Value {
-        self.payload.get(RESULT).unwrap_or(&Value::Null)
     }
 
     /// Extract a text property from a Json object

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/custom_operation.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/custom_operation.rs
@@ -1,15 +1,16 @@
 use anyhow::Context;
+use c8y_api::smartrest::payload::SmartrestPayload;
 use c8y_api::smartrest::smartrest_serializer::CumulocitySupportedOperations;
 use c8y_api::smartrest::smartrest_serializer::EmbeddedCsv;
 use c8y_api::smartrest::smartrest_serializer::TextOrCsv;
 use serde_json::Value;
 use tedge_api::workflow::GenericCommandState;
+use tedge_api::workflow::StateExcerpt;
 use tedge_api::CommandStatus;
 use tedge_mqtt_ext::MqttMessage;
 
 use super::EntityTarget;
 use super::OperationContext;
-use super::OperationError;
 use super::OperationOutcome;
 
 impl OperationContext {
@@ -18,26 +19,62 @@ impl OperationContext {
         target: &EntityTarget,
         cmd_id: &str,
         message: &MqttMessage,
-        operation_name: &str,
-    ) -> Result<OperationOutcome, OperationError> {
+    ) -> (OperationOutcome, Option<CumulocitySupportedOperations>) {
         let command = match GenericCommandState::from_command_message(message)
             .context("Could not parse command as a custom operation command")
         {
             Ok(command) => command,
-            Err(_) => return Ok(OperationOutcome::Ignored),
+            Err(_) => return (OperationOutcome::Ignored, None),
+        };
+
+        let mapper_id = self.command_id.prefix();
+        let operation = match get_c8y_operation(mapper_id, &command.payload)
+            .context("Could not get CumulocitySupportedOperation from payload")
+        {
+            Ok(c8y_operation) => c8y_operation,
+            Err(_) => return (OperationOutcome::Ignored, None),
         };
 
         let sm_topic = &target.smartrest_publish_topic;
-
-        match command.get_command_status() {
-            CommandStatus::Executing => Ok(OperationOutcome::Executing {
+        let outcome = match command.get_command_status() {
+            CommandStatus::Executing => OperationOutcome::Executing {
                 extra_messages: vec![],
-            }),
+            },
             CommandStatus::Successful => {
-                let operation =
-                    CumulocitySupportedOperations::C8yCustom(operation_name.to_string());
+                let smartrest_set_operation =
+                    self.convert_output(mapper_id, &command, operation.clone(), cmd_id);
+                let c8y_notification = MqttMessage::new(sm_topic, smartrest_set_operation);
 
-                let smartrest_set_operation = match command.result() {
+                OperationOutcome::Finished {
+                    messages: vec![c8y_notification],
+                }
+            }
+            CommandStatus::Failed { reason } => {
+                let smartrest_set_operation =
+                    self.get_smartrest_failed_status_payload(operation.clone(), &reason, cmd_id);
+                let c8y_notification = MqttMessage::new(sm_topic, smartrest_set_operation);
+
+                OperationOutcome::Finished {
+                    messages: vec![c8y_notification],
+                }
+            }
+            _ => OperationOutcome::Ignored,
+        };
+
+        (outcome, Some(operation))
+    }
+
+    fn convert_output(
+        &self,
+        mapper_id: &str,
+        state: &GenericCommandState,
+        operation: CumulocitySupportedOperations,
+        cmd_id: &str,
+    ) -> SmartrestPayload {
+        match state.payload.pointer(&format!("/{mapper_id}/output")) {
+            Some(output) => {
+                let excerpt = StateExcerpt::from(output.clone());
+                match excerpt.extract_value_from(state) {
                     Value::Null => self.get_smartrest_successful_status_payload(operation, cmd_id),
                     Value::String(text) => {
                         let text_or_csv = TextOrCsv::Text(text.clone());
@@ -56,35 +93,31 @@ impl OperationContext {
                             text_or_csv,
                         )
                     }
-                    Value::Bool(_) | Value::Object(_) | Value::Number(_) => self
+                    Value::Bool(_) | Value::Number(_) | Value::Object(_) => self
                         .get_smartrest_failed_status_payload(
                             operation,
-                            "'result' field must have String or Array",
+                            "'output' supports only String or Array",
                             cmd_id,
                         ),
-                };
-
-                let c8y_notification = MqttMessage::new(sm_topic, smartrest_set_operation);
-
-                Ok(OperationOutcome::Finished {
-                    messages: vec![c8y_notification],
-                })
+                }
             }
-            CommandStatus::Failed { reason } => {
-                let smartrest_set_operation = self.get_smartrest_failed_status_payload(
-                    CumulocitySupportedOperations::C8yCustom(operation_name.to_string()),
-                    &reason,
-                    cmd_id,
-                );
-                let c8y_notification = MqttMessage::new(sm_topic, smartrest_set_operation);
-
-                Ok(OperationOutcome::Finished {
-                    messages: vec![c8y_notification],
-                })
-            }
-            _ => Ok(OperationOutcome::Ignored),
+            None => self.get_smartrest_successful_status_payload(operation, cmd_id),
         }
     }
+}
+
+fn get_c8y_operation(
+    mapper_id: &str,
+    value: &serde_json::Value,
+) -> Option<CumulocitySupportedOperations> {
+    if let Some(maybe_c8y_operation) = value.pointer(&format!("/{mapper_id}/on_fragment")) {
+        if let Some(c8y_operation) = maybe_c8y_operation.as_str() {
+            return Some(CumulocitySupportedOperations::C8yCustom(
+                c8y_operation.to_string(),
+            ));
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -125,7 +158,11 @@ mod tests {
             &Topic::new_unchecked("te/device/main///cmd/command/c8y-mapper-1234"),
             json!({
                 "status": "executing",
-                "text": "do something"
+                "text": "do something",
+                "c8y-mapper": {
+                    "on_fragment": "c8y_Something",
+                    "output": null
+                }
             })
             .to_string(),
         ))
@@ -141,7 +178,11 @@ mod tests {
             json!({
                 "status": "failed",
                 "text": "do something",
-                "reason": "Something went wrong"
+                "reason": "Something went wrong",
+                "c8y-mapper": {
+                    "on_fragment": "c8y_Something",
+                    "output": null
+                }
             })
             .to_string(),
         ))
@@ -157,7 +198,7 @@ mod tests {
     async fn handle_custom_operation_executing_and_failed_cmd_for_child_device() {
         let ttd = TempTedgeDir::new();
         let config = C8yMapperConfig {
-            smartrest_use_operation_id: true,
+            smartrest_use_operation_id: false,
             ..test_mapper_config(&ttd)
         };
         let test_handle = spawn_c8y_mapper_actor_with_config(&ttd, config, true).await;
@@ -180,15 +221,19 @@ mod tests {
             &Topic::new_unchecked("te/device/child1///cmd/command/c8y-mapper-1234"),
             json!({
                 "status": "executing",
-                "text": "do something"
+                "text": "do something",
+                "c8y-mapper": {
+                    "on_fragment": "c8y_Something",
+                    "output": null
+                }
             })
             .to_string(),
         ))
         .await
         .expect("Send failed");
 
-        // Expect `504` smartrest message on `c8y/s/us`.
-        assert_received_contains_str(&mut mqtt, [("c8y/s/us/child1", "504,1234")]).await;
+        // Expect `501` smartrest message on `c8y/s/us`.
+        assert_received_contains_str(&mut mqtt, [("c8y/s/us/child1", "501,c8y_Something")]).await;
 
         // Simulate custom operation command with "failed" state
         mqtt.send(MqttMessage::new(
@@ -196,17 +241,21 @@ mod tests {
             json!({
                 "status": "failed",
                 "text": "do something",
-                "reason": "Something went wrong"
+                "reason": "Something went wrong",
+                "c8y-mapper": {
+                    "on_fragment": "c8y_Something",
+                    "output": null
+                }
             })
             .to_string(),
         ))
         .await
         .expect("Send failed");
 
-        // Expect `505` smartrest message on `c8y/s/us`.
+        // Expect `502` smartrest message on `c8y/s/us`.
         assert_received_contains_str(
             &mut mqtt,
-            [("c8y/s/us/child1", "505,1234,Something went wrong")],
+            [("c8y/s/us/child1", "502,c8y_Something,Something went wrong")],
         )
         .await;
     }
@@ -215,7 +264,7 @@ mod tests {
     async fn handle_custom_operation_successful_cmd_for_main_device() {
         let ttd = TempTedgeDir::new();
         let config = C8yMapperConfig {
-            smartrest_use_operation_id: true,
+            smartrest_use_operation_id: false,
             ..test_mapper_config(&ttd)
         };
         let test_handle = spawn_c8y_mapper_actor_with_config(&ttd, config, true).await;
@@ -229,19 +278,23 @@ mod tests {
             &Topic::new_unchecked("te/device/main///cmd/command/c8y-mapper-1234"),
             json!({
                 "status": "successful",
-                "text": "do something"
+                "text": "do something",
+                "c8y-mapper": {
+                    "on_fragment": "c8y_Something",
+                    "output": null
+                }
             })
             .to_string(),
         ))
         .await
         .expect("Send failed");
 
-        // Expect `506` smartrest message on `c8y/s/us`.
-        assert_received_contains_str(&mut mqtt, [("c8y/s/us", "506,1234")]).await;
+        // Expect `503` smartrest message on `c8y/s/us`.
+        assert_received_contains_str(&mut mqtt, [("c8y/s/us", "503,c8y_Something")]).await;
     }
 
     #[tokio::test]
-    async fn handle_custom_operation_successful_cmd_for_main_device_with_result() {
+    async fn handle_custom_operation_successful_cmd_for_main_device_with_output() {
         let ttd = TempTedgeDir::new();
         let config = C8yMapperConfig {
             smartrest_use_operation_id: true,
@@ -259,7 +312,11 @@ mod tests {
             json!({
                 "status": "successful",
                 "text": "do something",
-                "result": ["on","off","on"]
+                "result": ["on","off","on"],
+                "c8y-mapper": {
+                    "on_fragment": "c8y_Something",
+                    "output": "${.payload.result}"
+                }
             })
             .to_string(),
         ))
@@ -289,7 +346,11 @@ mod tests {
             json!({
                 "status": "successful",
                 "text": "do something",
-                "result": true
+                "result": true,
+                "c8y-mapper": {
+                    "on_fragment": "c8y_Something",
+                    "output": "${.payload.result}"
+                }
             })
             .to_string(),
         ))
@@ -301,7 +362,7 @@ mod tests {
             &mut mqtt,
             [(
                 "c8y/s/us",
-                "502,command,'result' field must have String or Array",
+                "502,c8y_Something,'output' supports only String or Array",
             )],
         )
         .await;
@@ -336,7 +397,11 @@ mod tests {
             json!({
                 "status": "successful",
                 "text": "do something",
-                "result": "on,off,on"
+                "result": "on,off,on",
+                "c8y-mapper": {
+                    "on_fragment": "c8y_Something",
+                    "output": "${.payload.result}"
+                }
             })
             .to_string(),
         ))

--- a/crates/extensions/c8y_mapper_ext/src/supported_operations/operation.rs
+++ b/crates/extensions/c8y_mapper_ext/src/supported_operations/operation.rs
@@ -51,6 +51,14 @@ impl Operation {
         })
     }
 
+    pub fn workflow_output(&self) -> Option<&serde_json::Value> {
+        self.exec().and_then(|exec| {
+            exec.workflow
+                .as_ref()
+                .and_then(|workflow| workflow.output.as_ref())
+        })
+    }
+
     pub fn topic(&self) -> Option<String> {
         self.exec().and_then(|exec| exec.topic.clone())
     }
@@ -199,6 +207,7 @@ where
 struct ExecWorkflow {
     operation: Option<String>,
     input: Option<serde_json::Value>,
+    output: Option<serde_json::Value>,
 }
 
 pub fn get_operations<C: Record + C8yPrefix>(

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -2183,6 +2183,7 @@ async fn mapper_converts_custom_operation_for_main_device() {
             [exec.workflow]
             operation = "command"
             input = "${.payload.c8y_Command}"
+            output = "${.payload.result}"
             "#,
         );
 
@@ -2229,7 +2230,11 @@ async fn mapper_converts_custom_operation_for_main_device() {
             "te/device/main///cmd/command/c8y-mapper-1234",
             json!({
                 "status": "init",
-                "text": "do something"
+                "text": "do something",
+                "c8y-mapper": {
+                    "on_fragment": "c8y_Command",
+                    "output": "${.payload.result}"
+                }
             }),
         )],
     )
@@ -2310,6 +2315,9 @@ async fn mapper_converts_custom_operation_with_combined_input() {
                 "y": 42,
                 "z": {
                     "foo": "bar"
+                },
+                "c8y-mapper": {
+                    "on_fragment": "c8y_CombinedInput"
                 }
             }),
         )],
@@ -2376,6 +2384,9 @@ async fn mapper_converts_custom_operation_for_main_device_without_workflow_input
             "te/device/main///cmd/command/c8y-mapper-1234",
             json!({
                 "status": "init",
+                "c8y-mapper": {
+                    "on_fragment": "c8y_Command"
+                }
             }),
         )],
     )
@@ -2519,7 +2530,10 @@ async fn mapper_converts_custom_operation_for_child_device() {
             "te/device/child1///cmd/command/c8y-mapper-1234",
             json!({
                 "status": "init",
-                "text": "do something"
+                "text": "do something",
+                "c8y-mapper": {
+                    "on_fragment": "c8y_Command"
+                }
             }),
         )],
     )

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray_workflow/c8y_RelayArray.template
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray_workflow/c8y_RelayArray.template
@@ -1,0 +1,7 @@
+[exec]
+topic = "c8y/devicecontrol/notifications"
+on_fragment = "c8y_RelayArray"
+
+[exec.workflow]
+operation = "set_relay"
+input.relay = "${.payload.c8y_RelayArray}"

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray_workflow/c8y_RelayArray.template
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray_workflow/c8y_RelayArray.template
@@ -5,3 +5,4 @@ on_fragment = "c8y_RelayArray"
 [exec.workflow]
 operation = "set_relay"
 input.relay = "${.payload.c8y_RelayArray}"
+output = "${.payload.result}"

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray_workflow/operation_relay_array_workflow.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray_workflow/operation_relay_array_workflow.robot
@@ -1,0 +1,56 @@
+*** Settings ***
+Resource            ../../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:troubleshooting    theme:plugins
+
+
+*** Variables ***
+${PARENT_IP}    ${EMPTY}
+${PARENT_SN}    ${EMPTY}
+
+
+*** Test Cases ***
+Run c8y_RelayArray operation with workflow execution
+    Symlink Should Exist    /etc/tedge/operations/c8y/c8y_RelayArray
+    Cumulocity.Should Contain Supported Operations    c8y_RelayArray
+
+    ${operation}=    Cumulocity.Create Operation
+    ...    description=Set relays
+    ...    fragments={"c8y_RelayArray":["OPEN", "CLOSED"]}
+
+    Should Have MQTT Messages
+    ...    c8y/s/us
+    ...    message_pattern=^506,[0-9]+,OPEN,CLOSED
+    ...    minimum=1
+    ...    maximum=1
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+    Cumulocity.Managed Object Should Have Fragment Values    c8y_RelayArray\=["OPEN", "CLOSED"]
+
+
+*** Keywords ***
+Transfer Configuration Files
+    Transfer To Device    ${CURDIR}/c8y_RelayArray.template    /etc/tedge/operations/c8y/
+    Transfer To Device    ${CURDIR}/set_relay.toml    /etc/tedge/operations/
+    Transfer To Device    ${CURDIR}/set_relay.sh    /etc/tedge/operations/
+    Execute Command    chmod a+x /etc/tedge/operations/set_relay.sh
+
+Custom Setup
+    # Parent
+    ${parent_sn}=    Setup    skip_bootstrap=False
+    Set Suite Variable    $PARENT_SN    ${parent_sn}
+
+    ${parent_ip}=    Get IP Address
+    Set Suite Variable    $PARENT_IP    ${parent_ip}
+
+    Set Device Context    ${PARENT_SN}
+    Transfer Configuration Files
+    Execute Command    tedge config set mqtt.external.bind.address ${PARENT_IP}
+    Execute Command    tedge config set mqtt.external.bind.port 1883
+    Execute Command    tedge reconnect c8y
+
+    Cumulocity.Device Should Exist    ${PARENT_SN}

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray_workflow/set_relay.sh
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray_workflow/set_relay.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+MESSAGE="$1"
+
+echo :::begin-tedge:::
+printf '{"result":%s}\n' "$MESSAGE"
+echo :::end-tedge:::

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray_workflow/set_relay.toml
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_c8y_RelayArray_workflow/set_relay.toml
@@ -1,0 +1,20 @@
+operation = "set_relay"
+
+[init]
+  action = "proceed"
+  on_success = "executing"
+
+[executing]
+  action = "proceed"
+  on_success = "run"
+
+[run]
+  script = "/etc/tedge/operations/set_relay.sh ${.payload.relay}"
+  on_success = "successful"
+  on_error = { status = "failed", reason = "Command returned a non-zero exit code" }
+
+[successful]
+  action = "cleanup"
+
+[failed]
+  action = "cleanup"

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command_workflow/c8y_Command.template
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command_workflow/c8y_Command.template
@@ -5,3 +5,4 @@ on_fragment = "c8y_Command"
 [exec.workflow]
 operation = "shell_execute"
 input.command = "${.payload.c8y_Command.text}"
+output = "${.payload.result}"

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command_workflow/c8y_Command.template
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command_workflow/c8y_Command.template
@@ -1,0 +1,7 @@
+[exec]
+topic = "c8y/devicecontrol/notifications"
+on_fragment = "c8y_Command"
+
+[exec.workflow]
+operation = "shell_execute"
+input.command = "${.payload.c8y_Command.text}"

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command_workflow/operation_command_workflow.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command_workflow/operation_command_workflow.robot
@@ -1,0 +1,55 @@
+*** Settings ***
+Resource            ../../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:troubleshooting    theme:plugins
+
+
+*** Variables ***
+${PARENT_IP}    ${EMPTY}
+${PARENT_SN}    ${EMPTY}
+
+
+*** Test Cases ***
+Run c8y_Command operation with workflow execution
+    Symlink Should Exist    /etc/tedge/operations/c8y/c8y_Command
+    Cumulocity.Should Contain Supported Operations    c8y_Command
+
+    ${operation}=    Cumulocity.Create Operation
+    ...    description=echo helloworld
+    ...    fragments={"c8y_Command":{"text":"echo helloworld"}}
+
+    Should Have MQTT Messages
+    ...    c8y/s/us
+    ...    message_pattern=^506,[0-9]+($|,\\"helloworld\n\\")
+    ...    minimum=1
+    ...    maximum=1
+    Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
+
+
+*** Keywords ***
+Transfer Configuration Files
+    Transfer To Device    ${CURDIR}/c8y_Command.template    /etc/tedge/operations/c8y/
+    Transfer To Device    ${CURDIR}/shell_execute.toml    /etc/tedge/operations/
+    Transfer To Device    ${CURDIR}/shell_execute.sh    /etc/tedge/operations/
+    Execute Command    chmod a+x /etc/tedge/operations/shell_execute.sh
+
+Custom Setup
+    # Parent
+    ${parent_sn}=    Setup    skip_bootstrap=False
+    Set Suite Variable    $PARENT_SN    ${parent_sn}
+
+    ${parent_ip}=    Get IP Address
+    Set Suite Variable    $PARENT_IP    ${parent_ip}
+
+    Set Device Context    ${PARENT_SN}
+    Transfer Configuration Files
+    Execute Command    tedge config set mqtt.external.bind.address ${PARENT_IP}
+    Execute Command    tedge config set mqtt.external.bind.port 1883
+    Execute Command    tedge reconnect c8y
+
+    Cumulocity.Device Should Exist    ${PARENT_SN}

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command_workflow/shell_execute.sh
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command_workflow/shell_execute.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+info() {
+    echo "$(date --iso-8601=seconds 2>/dev/null || date -Iseconds) : INFO : $*" >&2
+}
+
+# Parse the message
+COMMAND="${1}"
+
+TMP_OUTPUT=$(mktemp)
+info "Writing command output to file. path=$TMP_OUTPUT"
+
+EXIT_CODE=0
+
+set +e
+bash -c "$COMMAND" >"$TMP_OUTPUT" 2>&1
+EXIT_CODE=$?
+set -e
+
+if [ "${EXIT_CODE}" -ne 0 ]; then
+    info "Command returned a non-zero exit code. code=$EXIT_CODE"
+fi
+
+echo :::begin-tedge:::
+printf '{"result":%s}\n' "$(jq -R -s '.' < "$TMP_OUTPUT")"
+echo :::end-tedge:::
+
+exit "$EXIT_CODE"

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command_workflow/shell_execute.toml
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command_workflow/shell_execute.toml
@@ -1,0 +1,20 @@
+operation = "shell_execute"
+
+[init]
+  action = "proceed"
+  on_success = "executing"
+
+[executing]
+  action = "proceed"
+  on_success = "run"
+
+[run]
+  script = "/etc/tedge/operations/shell_execute.sh ${.payload.command}"
+  on_success = "successful"
+  on_error = { status = "failed", reason = "Command returned a non-zero exit code" }
+
+[successful]
+  action = "cleanup"
+
+[failed]
+  action = "cleanup"

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_workflow/custom_operation_workflow.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_workflow/custom_operation_workflow.robot
@@ -24,6 +24,12 @@ Run custom operation with workflow execution
     ...    description=take a picture
     ...    fragments={"c8y_TakePicture":{"parameters": {"duration": "5s", "quality": "HD"}}}
     Verify Local Command    main    take_picture
+
+    Should Have MQTT Messages
+    ...    c8y/s/us
+    ...    minimum=1
+    ...    maximum=1
+    ...    message_pattern=^506,[0-9]+,(5s HD)
     Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
 
 Add template and workflow file dynamically

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_workflow/custom_operation_workflow.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_workflow/custom_operation_workflow.robot
@@ -24,12 +24,6 @@ Run custom operation with workflow execution
     ...    description=take a picture
     ...    fragments={"c8y_TakePicture":{"parameters": {"duration": "5s", "quality": "HD"}}}
     Verify Local Command    main    take_picture
-
-    Should Have MQTT Messages
-    ...    c8y/s/us
-    ...    minimum=1
-    ...    maximum=1
-    ...    message_pattern=^506,[0-9]+,(5s HD)
     Cumulocity.Operation Should Be SUCCESSFUL    ${operation}
 
 Add template and workflow file dynamically

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_workflow/do_something.sh
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_workflow/do_something.sh
@@ -5,5 +5,5 @@ ARG1=$1
 ARG2=$2
 
 echo ':::begin-tedge:::'
-printf '{"result":"%s %s"}\n' "$ARG1" "$ARG2"
+printf '{"something":"%s %s"}\n' "$ARG1" "$ARG2"
 echo ':::end-tedge:::'

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_workflow/do_something.sh
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_workflow/do_something.sh
@@ -4,8 +4,6 @@ set -e
 ARG1=$1
 ARG2=$2
 
-echo ARG1="$ARG1", ARG2="$ARG2"
-
 echo ':::begin-tedge:::'
-echo '{"status":"successful"}'
+printf '{"result":"%s %s"}\n' "$ARG1" "$ARG2"
 echo ':::end-tedge:::'


### PR DESCRIPTION
## Proposed changes
### Issues
This PR solves two issues.
1. The new custom operation handlers with workflow execution didn't send the third or more argument(s) of SmartREST `503`/`506` messages (successful operation status update). This issue disabled supports for `c8y_Command` and `c8y_RelayArray`.
2. `501`-`503` messages didn't use the Cumulocity's operation name for custom operations. Instead, the command name (`<cmd_name>`)  from the topic `te/.../cmd/<cmd_name>/tedge-mapper-1234` was used.

### Solution

If user wants extra arguments for `503`/`506`, they have to provide `exec.workflow.output`.
```toml
[exec]
topic = "c8y/devicecontrol/notifications"
on_fragment = "c8y_Command"

[exec.workflow]
operation = "shell_execute"
input.command = "${.payload.c8y_Command.text}"
output = "${.payload.result}"
```

Once c8y-mapper receives a c8y_Command operation, it adds extra internal object `c8y-mapper` (note: not hard-coded value. It's the same as the prefix of the command ID) to include data from the corresponding custom operation handler.

topic: `te/device/main///cmd/set_relay/c8y-mapper-54228`
```json
{
   "c8y-mapper":{
      "on_fragment":"c8y_Command",
      "output":"${.payload.result}"
   },
   "command":"echo helloworld",
   "status":"init"
}
```

The workflow is expected to add `result` field, so that c8y-mapper can convert the output to extra argument of the SmartREST message.

```json
{
  "@version": "3a52d32db97c0cd907624956ed28ed6869452257634e8b87317b5296145a0f92",
  "c8y-mapper": {
    "on_fragment": "c8y_Command",
    "output": "${.payload.result}"
  },
  "logPath": "/var/log/tedge/agent/workflow-set_relay-c8y-mapper-54228.log",
  "command":"echo helloworld",
  "result":"helloworld\n",
  "status": "successful"
}
```

then, the final SmartREST message is
```
503,c8y_Command,"helloworld\n"
```
or
```
506,54228,"helloworld\n"
```

Or `result` also accepts a json array which will be used to translate to multiple parameters in the 503/506 SmartREST message. For example:

```json
{
  "@version": "3a52d32db97c0cd907624956ed28ed6869452257634e8b87317b5296145a0f92",
  "c8y-mapper": {
    "on_fragment": "c8y_RelayArray",
    "output": "${.payload.result}"
  },
  "logPath": "/var/log/tedge/agent/workflow-set_relay-c8y-mapper-54228.log",
  "relay": ["OPEN", "CLOSED"],
  "result": ["OPEN","CLOSED"],
  "status": "successful"
}
```

then, the output SmartREST message is
```
503,c8y_RelayArray,OPEN,CLOSED
```
or
```
506,54228,OPEN,CLOSED
```

(Note: If the `result` property is an array, then normal csv encoding rules should be used to add double quotes around each individual item of the array if necessary)



## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3095

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->
**References**
* See the [Cumulocity Documentation Operations page](https://cumulocity.com/docs/smartrest/mqtt-static-templates/#updating-operations) which details which Cumulocity operations accept parameters along with the `503/506` SmartREST 2.0 message
