### PR TITLE
docs: remove workflow warnings

### DIFF
--- a/docs/src/references/agent/operation-workflow.md
+++ b/docs/src/references/agent/operation-workflow.md
@@ -206,7 +206,7 @@ when a state message is published for a command on a topic matching the global t
 i.e. `te/+/+/+/+/cmd/+/+`.
 - Each running instance of the __tedge_agent__ reacts only on commands targeting its own device.
 - If a user-defined workflow has been defined for this operation, then this workflow is used to determine the required action.
-- If no workflow has been defined by the user for this operation, then the built-in workflow is used.
+- If no workflow has been defined by the user for this operation, then the builtin workflow is used.
 - If there is no workflow or no defined action for the current state,
   then the __tedge_agent__ simply waits for another component to take over the command.
 
@@ -610,14 +610,14 @@ In order to customize a builtin operation, the first step is to materialize its 
 For instance, here is the builtin workflow for the `software_update` operation:
 
 ```toml title="/etc/tedge/operations/software_update.toml"
-operation = "software_update"            # any builtion operation can be customized
+operation = "software_update"            # any builtin operation can be customized
 
 ["init"]
 action = "proceed"                       # open to customization
 on_success = "scheduled"
 
 [scheduled]
-operation = "builtin:software_update"    # trigger the built-in behavior for software update
+operation = "builtin:software_update"    # trigger the builtin behavior for software update
 on_exec = "executing"
 
 [executing]
@@ -648,7 +648,7 @@ on_success = "scheduled"
 on_error = { status = "failed", reason = "not timely" }
 
 [scheduled]
-operation = "builtin:software_update"                     # trigger the built-in behavior for software update
+operation = "builtin:software_update"                     # trigger the builtin behavior for software update
 on_success = "executing"
 
 [executing]

--- a/docs/src/references/agent/operation-workflow.md
+++ b/docs/src/references/agent/operation-workflow.md
@@ -349,11 +349,7 @@ Note that:
 - No `on_exit` nor `on_kill` status can be provided, as the script is not monitored.
 - If the script cannot be launched, the workflow will be moved to the final `"failed"` state.
 
-### 🚧 Sub-Operation Execution {#sub-operation-execution}
-
-:::info
-🚧 The syntax for triggering other workflows from an existing workflow is still being finalized so please avoid using it in production environments.
-:::
+### Sub-Operation Execution {#sub-operation-execution}
 
 An operation workflow can trigger a command defined by another workflow.
 
@@ -580,11 +576,7 @@ on_success = "scheduled"
 on_error = { status = "failed", reason = "not timely" }
 ```
 
-### 🚧 Customizing builtin operations
-
-:::info
-🚧 The syntax for customizing builtin workflows is still being finalized so please avoid using it in production environments.
-:::
+### Customizing builtin operations
 
 __tedge-agent__ supports out-of-the-box a set of so-called builtin operations:
 `software_list`, `software_update`, `restart`, `config_snapshot`, `config_update`, `log_upload`.

--- a/docs/src/references/agent/operation-workflow.md
+++ b/docs/src/references/agent/operation-workflow.md
@@ -604,7 +604,7 @@ For each, there are *two* workflows: an internal workflow and a customized versi
   with a step triggering `operation = "builtin:<operation-name>"`.
   - A customized workflow can also be a complete rework of the feature, ignoring the builtin behavior.
   - However, the builtin behavior can only be invoked from the workflow for the same operation
-    (e.g. `builtin:sofware_update` can only be invoked from `sofware_update`).
+    (e.g. `builtin:software_update` can only be invoked from `software_update`).
 
 In order to customize a builtin operation, the first step is to materialize its definition in `/etc/tedge/operations`.
 For instance, here is the builtin workflow for the `software_update` operation:


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Remove warning about some of the workflow features not being finalized.

In addition, some minor typos and consistencies were fixed (e.g. use "builtin" over "built-in" so the language reflects the workflow keyword `builtin`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

