### PR TITLE
refactor: Simplify SmartREST publish topics

### DIFF
--- a/crates/core/c8y_api/src/smartrest/inventory.rs
+++ b/crates/core/c8y_api/src/smartrest/inventory.rs
@@ -9,7 +9,7 @@
 // smartrest messages are sent. There should be one comprehensive API for
 // generating them.
 
-use crate::smartrest::topic::publish_topic_from_ancestors;
+use crate::smartrest::topic::publish_topic_from_parent;
 use crate::smartrest::topic::C8yTopic;
 use mqtt_channel::MqttMessage;
 use std::time::Duration;
@@ -29,7 +29,8 @@ pub fn child_device_creation_message(
     child_id: &str,
     device_name: Option<&str>,
     device_type: Option<&str>,
-    ancestors: &[String],
+    parent: Option<&str>,
+    main_device_id: &str,
     prefix: &TopicPrefix,
 ) -> Result<MqttMessage, InvalidValueError> {
     if child_id.is_empty() {
@@ -60,7 +61,7 @@ pub fn child_device_creation_message(
     .expect("child_id, device_name, device_type should not increase payload size over the limit");
 
     Ok(MqttMessage::new(
-        &publish_topic_from_ancestors(ancestors, prefix),
+        &publish_topic_from_parent(parent, main_device_id, prefix),
         payload.into_inner(),
     ))
 }
@@ -73,11 +74,12 @@ pub fn service_creation_message(
     service_name: &str,
     service_type: &str,
     service_status: &str,
-    ancestors: &[String],
+    parent: Option<&str>,
+    main_device_id: &str,
     prefix: &TopicPrefix,
 ) -> Result<MqttMessage, InvalidValueError> {
     Ok(MqttMessage::new(
-        &publish_topic_from_ancestors(ancestors, prefix),
+        &publish_topic_from_parent(parent, main_device_id, prefix),
         service_creation_message_payload(service_id, service_name, service_type, service_status)?
             .into_inner(),
     ))

--- a/crates/core/tedge_api/src/entity_store.rs
+++ b/crates/core/tedge_api/src/entity_store.rs
@@ -354,6 +354,25 @@ impl EntityStore {
         self.get(&self.main_device).unwrap().external_id.clone()
     }
 
+    /// Returns the external id of the parent of the given entity.
+    /// Returns None for the main device, that doesn't have any parents.
+    pub fn parent_external_id(
+        &self,
+        entity_tid: &EntityTopicId,
+    ) -> Result<Option<&EntityExternalId>, Error> {
+        let entity = self.try_get(entity_tid)?;
+        let parent_xid = entity.parent.as_ref().map(|tid| {
+            &self
+                .try_get(tid)
+                .expect(
+                    "for every registered entity, its parent is also guaranteed to be registered",
+                )
+                .external_id
+        });
+
+        Ok(parent_xid)
+    }
+
     /// Returns an ordered list of ancestors of the given entity
     /// starting from the immediate parent all the way till the root main device.
     /// The last parent in the list for any entity would always be the main device.

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -336,7 +336,8 @@ pub fn service_monitor_client_config(
         c8y_mapper_name,
         service_type.as_str(),
         "down",
-        &[],
+        None,
+        main_device_xid.as_ref(),
         prefix,
     )?;
 

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -176,7 +176,7 @@ async fn child_device_registration_mapping() {
     assert_received_contains_str(
         &mut mqtt,
         [(
-            "c8y/s/us/test-device:device:child1/test-device:device:child2",
+            "c8y/s/us/test-device:device:child2",
             "101,child3,child3,thin-edge.io-child",
         )],
     )
@@ -326,7 +326,7 @@ async fn service_registration_mapping() {
     assert_received_contains_str(
         &mut mqtt,
         [(
-            "c8y/s/us/test-device:device:child1/test-device:device:child2",
+            "c8y/s/us/test-device:device:child2",
             "102,test-device:device:child2:service:collectd,systemd,Collectd,up",
         )],
     )

--- a/crates/extensions/tedge_mqtt_ext/src/test_helpers.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/test_helpers.rs
@@ -42,13 +42,13 @@ pub fn assert_message_contains_str(message: &MqttMessage, expected: (&str, &str)
     let expected_payload = expected.1;
     assert!(
         TopicFilter::new_unchecked(expected_topic).accept(message),
-        "\nReceived unexpected message: {:?} \nExpected: {expected_payload:?}",
+        "\nReceived unexpected message: {:?} \nExpected message with topic: {expected_topic}, payload: {expected_payload}",
         message
     );
     let payload = message.payload_str().expect("non UTF-8 payload");
     assert!(
         payload.contains(expected_payload),
-        "Payload assertion failed.\n Actual: {payload:?} \nExpected: {expected_payload:?}",
+        "Payload assertion failed.\n Actual: {payload:?} \nExpected message with topic: {expected_topic}, payload: {expected_payload}",
     )
 }
 


### PR DESCRIPTION
## Proposed changes

While publishing to a nested child device, publish directly to the SmartREST topic
of that device (`c8y/s/us/<xid>`), without specifying all of all its ancestors.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

