### PR TITLE
fix #3279: Create a fast path for sending `PublishMessage`s

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/registration/processes_many_devices.robot
+++ b/tests/RobotFramework/tests/cumulocity/registration/processes_many_devices.robot
@@ -1,0 +1,40 @@
+*** Settings ***
+Documentation       A separate suite for #3279, because a lot of devices need to be registered, doesn't connect to the
+...                 cloud. Attempt to register many devices and check that messages are still processed.
+
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Test Setup          Test Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:monitoring    \#3279
+
+
+*** Variables ***
+${NUM_ENTITIES}     ${100}
+
+
+*** Test Cases ***
+Processes many devices
+    Stop Service    tedge-mapper-c8y
+
+    Execute Command
+    ...    for i in $(seq 0 ${NUM_ENTITIES}); do tedge mqtt pub --retain "te/device/child$i//" '{"@type":"child-device"}'; done
+
+    Start Service    tedge-mapper-c8y
+
+    FOR    ${index}    IN RANGE    ${NUM_ENTITIES}
+        Should Have MQTT Messages    c8y/s/us    message_pattern=101,.*child${index}
+    END
+
+
+*** Keywords ***
+Test Setup
+    ${DEVICE_SN}=    Setup    skip_bootstrap=True
+    Execute Command    ./bootstrap.sh
+
+    # Don't actually send topics c8y/... to the cloud, the test is 100% local
+    Execute Command    sed -i s/c8y/asdf/ /etc/tedge/mosquitto-conf/c8y-bridge.conf
+    Restart Service    mosquitto


### PR DESCRIPTION
## Proposed changes

Solve the deadlock that can arise when C8yMapperActor can't complete sending MqttMessage to some other actor because that other actor can't complete the send of a `PublishMessage` to C8yMapperActor by creating a fast path to drain PublishMessage buffer ASAP.

Previously when `PublishMessage`s were a part of the main message box we could not prioritize them because we had to process messages in order;

separating out the receiver for `PublishMessage`s makes it so no other messages can block `PublishMessage`s and allows us to use select! to concurrently process them when processing other events blocks

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- #3279

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

About the test: added one in Robot Framework, but it has some problems: for some reasons it takes very long and it publishes a lot of messages to the cloud. Given that this test could be 100% local and would complete almost instantly as a Rust unit test, it would probably be an improvement to move it there but it's easier to add in Robot Framework for now.
