### PR TITLE
feat(packaging): manage tedge-mapper cloud profile service instances in install/upgrade/uninstall

### DIFF
--- a/configuration/init/systemd/tedge-mapper-aws.service
+++ b/configuration/init/systemd/tedge-mapper-aws.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=tedge-mapper-aws checks Thin Edge JSON measurements and forwards to AWS IoT Hub.
+Description=tedge-mapper-aws checks Thin Edge JSON measurements and forwards to AWS IoT Core.
 After=syslog.target network.target mosquitto.service
 
 [Service]

--- a/configuration/init/systemd/tedge-mapper-aws.target
+++ b/configuration/init/systemd/tedge-mapper-aws.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=tedge-mapper-aws cloud profile services
+
+[Install]
+WantedBy=multi-user.target

--- a/configuration/init/systemd/tedge-mapper-aws@.service
+++ b/configuration/init/systemd/tedge-mapper-aws@.service
@@ -1,6 +1,7 @@
 [Unit]
-Description=tedge-mapper-aws checks Thin Edge JSON measurements and forwards to AWS IoT Hub.
+Description=tedge-mapper-aws checks Thin Edge JSON measurements and forwards to AWS IoT Core.
 After=syslog.target network.target mosquitto.service
+PartOf=tedge-mapper-aws.target
 
 [Service]
 User=tedge

--- a/configuration/init/systemd/tedge-mapper-az.target
+++ b/configuration/init/systemd/tedge-mapper-az.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=tedge-mapper-az cloud profile services
+
+[Install]
+WantedBy=multi-user.target

--- a/configuration/init/systemd/tedge-mapper-az@.service
+++ b/configuration/init/systemd/tedge-mapper-az@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=tedge-mapper-az checks Thin Edge JSON measurements and forwards to Azure IoT Hub.
 After=syslog.target network.target mosquitto.service
+PartOf=tedge-mapper-az.target
 
 [Service]
 User=tedge

--- a/configuration/init/systemd/tedge-mapper-c8y.target
+++ b/configuration/init/systemd/tedge-mapper-c8y.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=tedge-mapper-c8y cloud profile services
+
+[Install]
+WantedBy=multi-user.target

--- a/configuration/init/systemd/tedge-mapper-c8y@.service
+++ b/configuration/init/systemd/tedge-mapper-c8y@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=tedge-mapper-c8y converts Thin Edge JSON measurements to Cumulocity JSON format.
 After=syslog.target network.target mosquitto.service
+PartOf=tedge-mapper-c8y.target
 
 [Service]
 User=tedge

--- a/configuration/package_manifests/nfpm.tedge-mapper.yaml
+++ b/configuration/package_manifests/nfpm.tedge-mapper.yaml
@@ -44,6 +44,17 @@ contents:
       mode: 0644
     packager: rpm
 
+  - src: ./configuration/init/systemd/tedge-mapper-aws.target
+    dst: /lib/systemd/system/tedge-mapper-aws.target
+    file_info:
+      mode: 0644
+    packager: deb
+  - src: ./configuration/init/systemd/tedge-mapper-aws.target
+    dst: /lib/systemd/system/tedge-mapper-aws.target
+    file_info:
+      mode: 0644
+    packager: rpm
+
   - src: ./configuration/init/systemd/tedge-mapper-aws@.service
     dst: /lib/systemd/system/tedge-mapper-aws@.service
     file_info:
@@ -66,6 +77,17 @@ contents:
       mode: 0644
     packager: rpm
 
+  - src: ./configuration/init/systemd/tedge-mapper-az.target
+    dst: /lib/systemd/system/tedge-mapper-az.target
+    file_info:
+      mode: 0644
+    packager: deb
+  - src: ./configuration/init/systemd/tedge-mapper-az.target
+    dst: /lib/systemd/system/tedge-mapper-az.target
+    file_info:
+      mode: 0644
+    packager: rpm
+
   - src: ./configuration/init/systemd/tedge-mapper-az@.service
     dst: /lib/systemd/system/tedge-mapper-az@.service
     file_info:
@@ -84,6 +106,17 @@ contents:
     packager: deb
   - src: ./configuration/init/systemd/tedge-mapper-c8y.service
     dst: /lib/systemd/system/tedge-mapper-c8y.service
+    file_info:
+      mode: 0644
+    packager: rpm
+
+  - src: ./configuration/init/systemd/tedge-mapper-c8y.target
+    dst: /lib/systemd/system/tedge-mapper-c8y.target
+    file_info:
+      mode: 0644
+    packager: deb
+  - src: ./configuration/init/systemd/tedge-mapper-c8y.target
+    dst: /lib/systemd/system/tedge-mapper-c8y.target
     file_info:
       mode: 0644
     packager: rpm

--- a/configuration/package_scripts/_generated/c8y-firmware-plugin/apk/postinst
+++ b/configuration/package_scripts/_generated/c8y-firmware-plugin/apk/postinst
@@ -1,3 +1,2 @@
 #!/bin/sh
 set -e
-

--- a/configuration/package_scripts/_generated/c8y-firmware-plugin/apk/postrm
+++ b/configuration/package_scripts/_generated/c8y-firmware-plugin/apk/postrm
@@ -1,3 +1,2 @@
 #!/bin/sh
 set -e
-

--- a/configuration/package_scripts/_generated/c8y-remote-access-plugin/apk/postinst
+++ b/configuration/package_scripts/_generated/c8y-remote-access-plugin/apk/postinst
@@ -3,6 +3,5 @@ set -e
 
 
 
-
 ### Create supported operation files
 c8y-remote-access-plugin --init

--- a/configuration/package_scripts/_generated/c8y-remote-access-plugin/apk/postrm
+++ b/configuration/package_scripts/_generated/c8y-remote-access-plugin/apk/postrm
@@ -1,3 +1,2 @@
 #!/bin/sh
 set -e
-

--- a/configuration/package_scripts/_generated/tedge-agent/apk/postrm
+++ b/configuration/package_scripts/_generated/tedge-agent/apk/postrm
@@ -40,4 +40,3 @@ case "$1" in
 esac
 
 
-

--- a/configuration/package_scripts/_generated/tedge-mapper/apk/postinst
+++ b/configuration/package_scripts/_generated/tedge-mapper/apk/postinst
@@ -3,10 +3,6 @@ set -e
 
 
 
-
-
-
-
 enable_start_service() {
     name="$1"
 

--- a/configuration/package_scripts/_generated/tedge-mapper/apk/postrm
+++ b/configuration/package_scripts/_generated/tedge-mapper/apk/postrm
@@ -16,4 +16,3 @@ case "$1" in
 esac
 
 
-

--- a/configuration/package_scripts/_generated/tedge-mapper/deb/postinst
+++ b/configuration/package_scripts/_generated/tedge-mapper/deb/postinst
@@ -71,6 +71,70 @@ fi
 # End automatically added section
 # Automatically added by thin-edge.io
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	# This will only remove masks created by d-s-h on package removal.
+	deb-systemd-helper unmask tedge-mapper-aws.target >/dev/null || true
+
+	# was-enabled defaults to true, so new installations run enable.
+	if deb-systemd-helper --quiet was-enabled tedge-mapper-aws.target; then
+		# Enables the unit on first installation, creates new
+		# symlinks on upgrades if the unit file has changed.
+		deb-systemd-helper enable tedge-mapper-aws.target >/dev/null || true
+	else
+		# Update the statefile to add new symlinks (if any), which need to be
+		# cleaned up on purge. Also remove old symlinks.
+		deb-systemd-helper update-state tedge-mapper-aws.target >/dev/null || true
+	fi
+fi
+# End automatically added section
+# Automatically added by thin-edge.io
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	# This will only remove masks created by d-s-h on package removal.
+	deb-systemd-helper unmask tedge-mapper-az.target >/dev/null || true
+
+	# was-enabled defaults to true, so new installations run enable.
+	if deb-systemd-helper --quiet was-enabled tedge-mapper-az.target; then
+		# Enables the unit on first installation, creates new
+		# symlinks on upgrades if the unit file has changed.
+		deb-systemd-helper enable tedge-mapper-az.target >/dev/null || true
+	else
+		# Update the statefile to add new symlinks (if any), which need to be
+		# cleaned up on purge. Also remove old symlinks.
+		deb-systemd-helper update-state tedge-mapper-az.target >/dev/null || true
+	fi
+fi
+# End automatically added section
+# Automatically added by thin-edge.io
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	# This will only remove masks created by d-s-h on package removal.
+	deb-systemd-helper unmask tedge-mapper-c8y.target >/dev/null || true
+
+	# was-enabled defaults to true, so new installations run enable.
+	if deb-systemd-helper --quiet was-enabled tedge-mapper-c8y.target; then
+		# Enables the unit on first installation, creates new
+		# symlinks on upgrades if the unit file has changed.
+		deb-systemd-helper enable tedge-mapper-c8y.target >/dev/null || true
+	else
+		# Update the statefile to add new symlinks (if any), which need to be
+		# cleaned up on purge. Also remove old symlinks.
+		deb-systemd-helper update-state tedge-mapper-c8y.target >/dev/null || true
+	fi
+fi
+# End automatically added section
+# Automatically added by thin-edge.io
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+	if [ -d /run/systemd/system ]; then
+		systemctl --system daemon-reload >/dev/null || true
+		if [ -n "$2" ]; then
+			_dh_action=restart
+		else
+			_dh_action=start
+		fi
+		deb-systemd-invoke $_dh_action tedge-mapper-aws.target tedge-mapper-az.target tedge-mapper-c8y.target >/dev/null || true
+	fi
+fi
+# End automatically added section
+# Automatically added by thin-edge.io
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
 	if [ -d /run/systemd/system ]; then
 		systemctl --system daemon-reload >/dev/null || true
 		if [ -n "$2" ]; then

--- a/configuration/package_scripts/_generated/tedge-mapper/deb/postrm
+++ b/configuration/package_scripts/_generated/tedge-mapper/deb/postrm
@@ -23,14 +23,14 @@ fi
 # Automatically added by thin-edge.io
 if [ "$1" = "remove" ]; then
 	if [ -x "/usr/bin/deb-systemd-helper" ]; then
-		deb-systemd-helper mask tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service >/dev/null || true
+		deb-systemd-helper mask tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service tedge-mapper-aws.target tedge-mapper-az.target tedge-mapper-c8y.target >/dev/null || true
 	fi
 fi
 
 if [ "$1" = "purge" ]; then
 	if [ -x "/usr/bin/deb-systemd-helper" ]; then
-		deb-systemd-helper purge tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service >/dev/null || true
-		deb-systemd-helper unmask tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service >/dev/null || true
+		deb-systemd-helper purge tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service tedge-mapper-aws.target tedge-mapper-az.target tedge-mapper-c8y.target >/dev/null || true
+		deb-systemd-helper unmask tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service tedge-mapper-aws.target tedge-mapper-az.target tedge-mapper-c8y.target >/dev/null || true
 	fi
 fi
 # End automatically added section

--- a/configuration/package_scripts/_generated/tedge-mapper/deb/prerm
+++ b/configuration/package_scripts/_generated/tedge-mapper/deb/prerm
@@ -2,6 +2,6 @@
 set -e
 # Automatically added by thin-edge.io
 if [ -d /run/systemd/system ] && [ "$1" = remove ]; then
-	deb-systemd-invoke stop tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service >/dev/null || true
+	deb-systemd-invoke stop tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service tedge-mapper-aws.target tedge-mapper-az.target tedge-mapper-c8y.target >/dev/null || true
 fi
 # End automatically added section

--- a/configuration/package_scripts/_generated/tedge-mapper/rpm/postinst
+++ b/configuration/package_scripts/_generated/tedge-mapper/rpm/postinst
@@ -26,6 +26,35 @@ if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
 fi
 # End automatically added section
 # Automatically added by thin-edge.io
+if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
+    # Initial installation
+    /usr/lib/systemd/systemd-update-helper install-system-units tedge-mapper-aws.target || :
+fi
+# End automatically added section
+# Automatically added by thin-edge.io
+if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
+    # Initial installation
+    /usr/lib/systemd/systemd-update-helper install-system-units tedge-mapper-az.target || :
+fi
+# End automatically added section
+# Automatically added by thin-edge.io
+if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
+    # Initial installation
+    /usr/lib/systemd/systemd-update-helper install-system-units tedge-mapper-c8y.target || :
+fi
+# End automatically added section
+# Automatically added by thin-edge.io
+if [ -d /run/systemd/system ]; then
+	systemctl --system daemon-reload >/dev/null || true
+	if [ $1 -eq 2 ]; then
+		_dh_action=restart
+	else
+		_dh_action=start
+	fi
+	systemctl $_dh_action tedge-mapper-aws.target tedge-mapper-az.target tedge-mapper-c8y.target >/dev/null || true
+fi
+# End automatically added section
+# Automatically added by thin-edge.io
 if [ $1 -eq 2 ]; then
 	if [ -d /run/systemd/system ]; then
 		systemctl --system daemon-reload >/dev/null || true

--- a/configuration/package_scripts/_generated/tedge-mapper/rpm/postrm
+++ b/configuration/package_scripts/_generated/tedge-mapper/rpm/postrm
@@ -23,7 +23,7 @@ fi
 # Automatically added by thin-edge.io
 if [ $1 -ge 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
     # Package upgrade, not uninstall
-    /usr/lib/systemd/systemd-update-helper mark-restart-system-units tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service || :
+    /usr/lib/systemd/systemd-update-helper mark-restart-system-units tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service tedge-mapper-aws.target tedge-mapper-az.target tedge-mapper-c8y.target || :
 fi
 
 # End automatically added section

--- a/configuration/package_scripts/_generated/tedge-mapper/rpm/prerm
+++ b/configuration/package_scripts/_generated/tedge-mapper/rpm/prerm
@@ -3,6 +3,6 @@ set -e
 # Automatically added by thin-edge.io
 if [ $1 -eq 0 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then
     # Package removal, not upgrade
-    /usr/lib/systemd/systemd-update-helper remove-system-units tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service || :
+    /usr/lib/systemd/systemd-update-helper remove-system-units tedge-mapper-aws.service tedge-mapper-az.service tedge-mapper-c8y.service tedge-mapper-collectd.service tedge-mapper-aws.target tedge-mapper-az.target tedge-mapper-c8y.target || :
 fi
 # End automatically added section

--- a/configuration/package_scripts/_generated/tedge-watchdog/apk/postinst
+++ b/configuration/package_scripts/_generated/tedge-watchdog/apk/postinst
@@ -1,3 +1,2 @@
 #!/bin/sh
 set -e
-

--- a/configuration/package_scripts/_generated/tedge-watchdog/apk/postrm
+++ b/configuration/package_scripts/_generated/tedge-watchdog/apk/postrm
@@ -1,3 +1,2 @@
 #!/bin/sh
 set -e
-

--- a/configuration/package_scripts/generate.py
+++ b/configuration/package_scripts/generate.py
@@ -88,6 +88,8 @@ def replace_variables(
 def write_script(
     input_contents, lines: List[str], output_file: Path, debug: bool = True
 ) -> str:
+    # filter out lines with only whitespace
+    lines = [line for line in lines if line.strip()]
     contents = replace_variables(
         input_contents,
         {

--- a/configuration/package_scripts/packages.json
+++ b/configuration/package_scripts/packages.json
@@ -35,7 +35,10 @@
                 {"name": "tedge-mapper-aws", "enable": false, "start": false, "restart_after_upgrade": true, "stop_on_upgrade": true},
                 {"name": "tedge-mapper-az", "enable": false, "start": false, "restart_after_upgrade": true, "stop_on_upgrade": true},
                 {"name": "tedge-mapper-c8y", "enable": false, "start": false, "restart_after_upgrade": true, "stop_on_upgrade": true},
-                {"name": "tedge-mapper-collectd", "enable": false, "start": false, "restart_after_upgrade": true, "stop_on_upgrade": true}
+                {"name": "tedge-mapper-collectd", "enable": false, "start": false, "restart_after_upgrade": true, "stop_on_upgrade": true},
+                {"name": "tedge-mapper-aws.target", "enable": true, "start": true, "restart_after_upgrade": true, "stop_on_upgrade": true},
+                {"name": "tedge-mapper-az.target", "enable": true, "start": true, "restart_after_upgrade": true, "stop_on_upgrade": true},
+                {"name": "tedge-mapper-c8y.target", "enable": true, "start": true, "restart_after_upgrade": true, "stop_on_upgrade": true}
             ]
         }
     }

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation_multi_cloud.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation_multi_cloud.robot
@@ -26,6 +26,13 @@ Get Configuration from Second Device
     Text file    topic_prefix=c8y-second    external_id=${SECOND_DEVICE_SN}    config_type=CONFIG1    device_file=/etc/config1.json
     Binary file    topic_prefix=c8y-second    external_id=${SECOND_DEVICE_SN}    config_type=CONFIG1_BINARY    device_file=/etc/binary-config1.tar.gz
 
+Mapper Services Are Restarted After Updates
+    Cumulocity.Set Device    ${DEVICE_SN}
+    ${pid_before}=    Execute Command    sudo systemctl show --property MainPID tedge-mapper-c8y@second
+    Execute Command    dpkg -i packages/tedge-mapper*.deb
+    ${pid_after}=    Execute Command    sudo systemctl show --property MainPID tedge-mapper-c8y@second
+    Should Not Be Equal    ${pid_before}    ${pid_after}
+
 
 *** Keywords ***
 Get Configuration from Device


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Add [systemd target](https://www.freedesktop.org/software/systemd/man/latest/systemd.target.html) unit definitions to ensure that any configured cloud service is restarted after updating the `tedge-mapper` package (for packages which use systemd only, e.g. deb and rpm packages).

The goal of this PR is not to offer users a way to manage all of the `tedge-mapper-<cloud>` template services with one command, but more so that the package will restart the services after the tedge-mapper package has been upgraded. The usage of the `.target` unit definitions may be extended in the future, but for now a low-risk approach is taken to not affect users who don't plan on using the cloud profile feature.

Some important design notes:

* Only the cloud profile service instances (e.g. the service template instances) are grouped to the `tedge-mapper-c8y.target` to ensure that existing installations are not affected. This may change in the future

* Upon tedge-mapper package upgrade, the `tedge-mapper-<cloud>@*.services` are restarted

* It is not intended (nor allowed) to enable/disable the systemd targets using `systemctl enable/disable tedge-mapper-c8y.target). However technically this works, `systemctl restart tedge-mapper-c8y.target`, but it is not intended to direct users to use this command, this is just normal systemd stuff.

**Notes**
* A small improvement was done to the maintainer script generation logic to remove entries which only contained whitespace (see commit f6084e2c4cca694d8bd4716d1c99fe5866cceb0a)
* Larger refactoring of the maintainer script generator was required due to previous erroneous handling of packages container more than 1 service (it would assume that all services have the same configuration) (see commit 4b53aeccc2ce189e147f7bae0bc08cded1c674a9)

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

* https://github.com/thin-edge/thin-edge.io/issues/3206
* Follow up from PR: https://github.com/thin-edge/thin-edge.io/pull/3278

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

