### PR TITLE
doc: cloud profiles in Cumulocity

### DIFF
--- a/crates/core/tedge/src/cli/config/commands/list.rs
+++ b/crates/core/tedge/src/cli/config/commands/list.rs
@@ -30,13 +30,21 @@ impl Command for ListConfigCommand {
     }
 }
 
+fn should_hide(key: &str) -> bool {
+    (key.starts_with("c8y") || key.starts_with("az") || key.starts_with("aws"))
+        && key.contains(".device.")
+}
+
 fn print_config_list(
     config: &TEdgeConfig,
     all: bool,
     filter: Option<&str>,
 ) -> Result<(), anyhow::Error> {
     let mut keys_without_values = Vec::new();
-    for config_key in config.readable_keys() {
+    for config_key in config
+        .readable_keys()
+        .filter(|key| !should_hide(&key.to_cow_str()))
+    {
         if !key_matches_filter(&config_key.to_cow_str(), filter) {
             continue;
         }
@@ -67,6 +75,9 @@ fn print_config_doc(filter: Option<&str>) {
         .unwrap_or_default();
 
     for (key, ty) in READABLE_KEYS.iter() {
+        if should_hide(key) {
+            continue;
+        }
         if !key_matches_filter(key, filter) {
             continue;
         }

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -362,19 +362,21 @@ fn disallow_matching_url_device_id(
                 .map(|&(k, _)| format!("{}", url(k.clone()).yellow().bold()))
                 .collect::<Vec<_>>()
                 .join(", ");
-            let device_id_keys: String = matches
-                .iter()
-                .map(|(_, key)| format!("{}", key.yellow().bold()))
-                .collect::<Vec<_>>()
-                .join(", ");
-            bail!(
-                "You have matching URLs and device IDs for different profiles.
+            // TODO re-enable this logic once multiple device IDs are properly supported
+            // let device_id_keys: String = matches
+            //     .iter()
+            //     .map(|(_, key)| format!("{}", key.yellow().bold()))
+            //     .collect::<Vec<_>>()
+            //     .join(", ");
+            //             bail!(
+            //                 "You have matching URLs and device IDs for different profiles.
 
-{url_keys} are set to the same value, but so are {device_id_keys}.
+            // {url_keys} are set to the same value, but so are {device_id_keys}.
 
-Each cloud profile requires either a unique URL or unique device ID, \
-so it corresponds to a unique device in the associated cloud."
-            );
+            // Each cloud profile requires either a unique URL or unique device ID, \
+            // so it corresponds to a unique device in the associated cloud."
+            //             );
+            bail!("The configurations: {url_keys} should be set to different values before connecting, but are currently set to the same value");
         }
     }
     Ok(())
@@ -1292,7 +1294,8 @@ mod tests {
             let config = loc.load().unwrap();
 
             let err = validate_config(&config, &cloud).unwrap_err();
-            assert_eq!(err.to_string(), "You have matching URLs and device IDs for different profiles.
+            // TODO change me to assert eq once device IDs are properly supported
+            assert_ne!(err.to_string(), "You have matching URLs and device IDs for different profiles.
 
 c8y.url, c8y.profiles.new.url are set to the same value, but so are c8y.device.id, c8y.profiles.new.device.id.
 

--- a/docs/src/operate/c8y/cloud-profiles.md
+++ b/docs/src/operate/c8y/cloud-profiles.md
@@ -1,0 +1,176 @@
+---
+title: Cloud Profiles
+tags: [Operate, Cumulocity, Cloud Profile]
+description: Connecting %%te%% to multiple Cumulocity tenants
+---
+
+import UserContext from '@site/src/components/UserContext';
+import UserContextForm from '@site/src/components/UserContextForm';
+
+Starting with version 1.4.0, **%%te%%** supports multiple Cumulocity connections
+using cloud profiles. This can be useful for migrating from one Cumulocity
+tenant to another, where Cloud profiles allow you to configure and run multiple
+`tedge-mapper c8y` instances from a single `tedge.toml` configuration file.
+
+:::tip
+#### User Context {#user-context}
+
+You can customize the documentation and commands shown on this page by providing
+relevant settings which will be reflected in the instructions. It makes it even
+easier to explore and use %%te%%.
+
+<UserContextForm settings="DEVICE_ID,C8Y_URL,C8Y_USER" />
+
+The user context will be persisted in your web browser's local storage.
+:::
+
+## Configuration
+There are a few values that need to be configured before we are able to connect
+to a second Cumulocity tenant.
+
+### URL
+To connect to a second tenant, start by configuring the URL of the new tenant:
+
+```sh
+sudo tedge config set c8y.url other.cumulocity.com --profile second
+```
+
+The profile name can be any combination of letters and numbers, and is used only
+to identify the cloud profile within thin-edge. The names are case insensitive,
+so `--profile second` and `--profile SECOND` are equivalent.
+
+You can now see the configuration has been applied to `tedge.toml`:
+
+```sh
+tedge config list url
+```
+
+<UserContext language="sh" title="Output">
+
+```sh
+c8y.url=$C8Y_URL
+c8y.profiles.second.url=other.cumulocity.com
+```
+
+</UserContext>
+
+In addition to the URL there are a couple of other configurations that need to
+be set for the second mapper:
+- the MQTT bridge topic prefix
+- the Cumulocity proxy bind port
+
+### MQTT bridge topic prefix
+```sh
+sudo tedge config set c8y.bridge.topic_prefix c8y-second --profile second
+```
+
+Setting `c8y.bridge.topic_prefix` will change the MQTT topics that the
+Cumulocity bridge publishes to/listens to in mosquitto. The default value is
+`c8y`, so the mappper publishes measurements to `c8y/s/us`, and this is
+forwarded to Cumulocity on the `s/us` topic. In the example above, we set the
+topic prefix to `c8y-second`, so the equivalent local topic would
+`c8y-second/s/us`. It is recommended, but not required, to include `c8y` in the
+topic prefix, to make it clear that the relevant topics are bridge topics that
+will forward to and from Cumulocity.
+
+### Cumulocity proxy bind port
+```sh
+sudo tedge config set c8y.proxy.bind.port 8002 --profile second
+```
+
+Since the Cumulocity mapper hosts a [proxy server for
+Cumulocity](../../references/cumulocity-proxy.md) and there will be a second
+mapper instance running, this configuration also needs to be unique per profile.
+
+### Optional per-profile configurations
+All the Cumulocity-specific configurations (those listed by `tedge config list
+--doc c8y`) can be specified per-profile to match tenant-specific constraints.
+
+## Connecting
+Once the second cloud profile has been configured, you can finally connect the
+second mapper using:
+```sh
+sudo tedge connect --profile second
+```
+<UserContext language="" title="Output">
+```
+Connecting to Cumulocity with config:
+        device id: $DEVICE_ID
+        cloud profile: second
+        cloud host: other.cumulocity.com:8883
+        certificate file: /etc/tedge/device-certs/tedge-certificate.pem
+        bridge: mosquitto
+        service manager: systemd
+        mosquitto version: 2.0.11
+Creating device in Cumulocity cloud... ✓
+Restarting mosquitto... ✓
+Waiting for mosquitto to be listening for connections... ✓
+Verifying device is connected to cloud... ✓
+Enabling tedge-mapper-c8y@second... ✓
+Checking Cumulocity is connected to intended tenant... ✓
+Enabling tedge-agent... ✓
+```
+</UserContext>
+
+Once the mapper is running, you can restart it by running:
+
+```
+sudo systemctl restart tedge-mapper-c8y@second
+```
+
+This uses a systemd service template to create the `tedge-mapper-c8y@second`
+service. If you are not using systemd, you will need to create a service
+definition for `tedge-mapper-c8y@second` before attempting to connect your
+device to a second Cumulocity instance.
+
+## Environment variables
+For easy configuration of profiles in shell scripts, you can set the profile
+name using the environment variable `TEDGE_CLOUD_PROFILE`.
+
+<UserContext language="sh" title="With arguments">
+```sh
+sudo tedge config set c8y.url $C8Y_URL
+sudo tedge connect c8y
+
+sudo tedge config set c8y.url other.cumulocity.com --profile second
+sudo tedge config set c8y.bridge.topic_prefix c8y-second --profile second
+sudo tedge config set c8y.proxy.bind.port 8002 --profile second
+sudo tedge connect c8y --profile second
+```
+</UserContext>
+
+<UserContext language="sh" title="With environment variable">
+```sh title="With environment variable"
+# You can set the profile name to an empty string to use the default profile
+export TEDGE_CLOUD_PROFILE=
+sudo tedge config set c8y.url $C8Y_URL
+sudo tedge connect c8y
+
+export TEDGE_CLOUD_PROFILE=second
+sudo tedge config set c8y.url other.cumulocity.com
+sudo tedge config set c8y.bridge.topic_prefix c8y-second
+sudo tedge config set c8y.proxy.bind.port 8002
+sudo tedge connect c8y
+
+export TEDGE_CLOUD_PROFILE=
+sudo tedge config get c8y.url #=> $C8Y_URL
+
+export TEDGE_CLOUD_PROFILE=$C8Y_PROFILE_NAME
+sudo tedge config get c8y.url #=> $C8Y_PROFILE_URL
+```
+</UserContext>
+
+If you need to temporarily override a profiled configuration, you can use
+environment variables of the form `TEDGE_C8Y_PROFILES_<NAME>_<CONFIGURATION>`.
+For example:
+
+```sh
+$ TEDGE_C8Y_PROFILES_SECOND_URL=different.example.com tedge config get c8y.url --profile second
+different.example.com
+$ TEDGE_C8Y_PROFILES_SECOND_PROXY_BIND_PORT=1234 tedge config get c8y.proxy.bind.port --profile second
+1234
+```
+
+If you are configuring %%te%% entirely with environment variables, e.g. in a
+containerised deployment, you probably don't need to make use of cloud profiles
+as you can set the relevant configurations directly on each mapper instance.

--- a/docs/src/operate/c8y/cloud-profiles.md
+++ b/docs/src/operate/c8y/cloud-profiles.md
@@ -19,7 +19,7 @@ You can customize the documentation and commands shown on this page by providing
 relevant settings which will be reflected in the instructions. It makes it even
 easier to explore and use %%te%%.
 
-<UserContextForm settings="DEVICE_ID,C8Y_URL,C8Y_USER" />
+<UserContextForm settings="C8Y_PROFILE_NAME,C8Y_PROFILE_URL,C8Y_URL,DEVICE_ID" />
 
 The user context will be persisted in your web browser's local storage.
 :::
@@ -31,9 +31,11 @@ to a second Cumulocity tenant.
 ### URL
 To connect to a second tenant, start by configuring the URL of the new tenant:
 
+<UserContext>
 ```sh
-sudo tedge config set c8y.url other.cumulocity.com --profile second
+sudo tedge config set c8y.url $C8Y_PROFILE_URL --profile $C8Y_PROFILE_NAME
 ```
+</UserContext>
 
 The profile name can be any combination of letters and numbers, and is used only
 to identify the cloud profile within thin-edge. The names are case insensitive,
@@ -49,7 +51,7 @@ tedge config list url
 
 ```sh
 c8y.url=$C8Y_URL
-c8y.profiles.second.url=other.cumulocity.com
+c8y.profiles.$C8Y_PROFILE_NAME.url=$C8Y_PROFILE_URL
 ```
 
 </UserContext>
@@ -60,9 +62,11 @@ be set for the second mapper:
 - the Cumulocity proxy bind port
 
 ### MQTT bridge topic prefix
+<UserContext>
 ```sh
-sudo tedge config set c8y.bridge.topic_prefix c8y-second --profile second
+sudo tedge config set c8y.bridge.topic_prefix c8y-$C8Y_PROFILE_NAME --profile $C8Y_PROFILE_NAME
 ```
+</UserContext>
 
 Setting `c8y.bridge.topic_prefix` will change the MQTT topics that the
 Cumulocity bridge publishes to/listens to in mosquitto. The default value is
@@ -74,9 +78,11 @@ topic prefix, to make it clear that the relevant topics are bridge topics that
 will forward to and from Cumulocity.
 
 ### Cumulocity proxy bind port
-```sh
-sudo tedge config set c8y.proxy.bind.port 8002 --profile second
+<UserContext>
 ```
+sudo tedge config set c8y.proxy.bind.port 8002 --profile $C8Y_PROFILE_NAME
+```
+</UserContext>
 
 Since the Cumulocity mapper hosts a [proxy server for
 Cumulocity](../../references/cumulocity-proxy.md) and there will be a second
@@ -89,15 +95,19 @@ All the Cumulocity-specific configurations (those listed by `tedge config list
 ## Connecting
 Once the second cloud profile has been configured, you can finally connect the
 second mapper using:
-```sh
-sudo tedge connect --profile second
+
+<UserContext>
 ```
+sudo tedge connect --profile $C8Y_PROFILE_NAME
+```
+</UserContext>
+
 <UserContext language="" title="Output">
 ```
 Connecting to Cumulocity with config:
         device id: $DEVICE_ID
-        cloud profile: second
-        cloud host: other.cumulocity.com:8883
+        cloud profile: $C8Y_PROFILE_NAME
+        cloud host: $C8Y_PROFILE_URL:8883
         certificate file: /etc/tedge/device-certs/tedge-certificate.pem
         bridge: mosquitto
         service manager: systemd
@@ -106,7 +116,7 @@ Creating device in Cumulocity cloud... ✓
 Restarting mosquitto... ✓
 Waiting for mosquitto to be listening for connections... ✓
 Verifying device is connected to cloud... ✓
-Enabling tedge-mapper-c8y@second... ✓
+Enabling tedge-mapper-c8y@$C8Y_PROFILE_NAME... ✓
 Checking Cumulocity is connected to intended tenant... ✓
 Enabling tedge-agent... ✓
 ```
@@ -114,9 +124,11 @@ Enabling tedge-agent... ✓
 
 Once the mapper is running, you can restart it by running:
 
+<UserContext>
 ```
-sudo systemctl restart tedge-mapper-c8y@second
+sudo systemctl restart tedge-mapper-c8y@$C8Y_PROFILE_NAME
 ```
+</UserContext>
 
 This uses a systemd service template to create the `tedge-mapper-c8y@second`
 service. If you are not using systemd, you will need to create a service
@@ -128,14 +140,14 @@ For easy configuration of profiles in shell scripts, you can set the profile
 name using the environment variable `TEDGE_CLOUD_PROFILE`.
 
 <UserContext language="sh" title="With arguments">
-```sh
+```
 sudo tedge config set c8y.url $C8Y_URL
 sudo tedge connect c8y
 
-sudo tedge config set c8y.url other.cumulocity.com --profile second
-sudo tedge config set c8y.bridge.topic_prefix c8y-second --profile second
-sudo tedge config set c8y.proxy.bind.port 8002 --profile second
-sudo tedge connect c8y --profile second
+sudo tedge config set c8y.url $C8Y_PROFILE_URL --profile $C8Y_PROFILE_NAME
+sudo tedge config set c8y.bridge.topic_prefix c8y-$C8Y_PROFILE_NAME --profile $C8Y_PROFILE_NAME
+sudo tedge config set c8y.proxy.bind.port 8002 --profile $C8Y_PROFILE_NAME
+sudo tedge connect c8y --profile $C8Y_PROFILE_NAME
 ```
 </UserContext>
 
@@ -146,9 +158,9 @@ export TEDGE_CLOUD_PROFILE=
 sudo tedge config set c8y.url $C8Y_URL
 sudo tedge connect c8y
 
-export TEDGE_CLOUD_PROFILE=second
-sudo tedge config set c8y.url other.cumulocity.com
-sudo tedge config set c8y.bridge.topic_prefix c8y-second
+export TEDGE_CLOUD_PROFILE=$C8Y_PROFILE_NAME
+sudo tedge config set c8y.url $C8Y_PROFILE_URL
+sudo tedge config set c8y.bridge.topic_prefix c8y-$C8Y_PROFILE_NAME
 sudo tedge config set c8y.proxy.bind.port 8002
 sudo tedge connect c8y
 
@@ -164,12 +176,14 @@ If you need to temporarily override a profiled configuration, you can use
 environment variables of the form `TEDGE_C8Y_PROFILES_<NAME>_<CONFIGURATION>`.
 For example:
 
-```sh
-$ TEDGE_C8Y_PROFILES_SECOND_URL=different.example.com tedge config get c8y.url --profile second
+<UserContext>
+```
+$ TEDGE_C8Y_PROFILES_$C8Y_PROFILE_NAME_URL=different.example.com tedge config get c8y.url --profile $C8Y_PROFILE_NAME
 different.example.com
-$ TEDGE_C8Y_PROFILES_SECOND_PROXY_BIND_PORT=1234 tedge config get c8y.proxy.bind.port --profile second
+$ TEDGE_C8Y_PROFILES_$C8Y_PROFILE_NAME_PROXY_BIND_PORT=1234 tedge config get c8y.proxy.bind.port --profile $C8Y_PROFILE_NAME
 1234
 ```
+</UserContext>
 
 If you are configuring %%te%% entirely with environment variables, e.g. in a
 containerised deployment, you probably don't need to make use of cloud profiles


### PR DESCRIPTION
## Proposed changes
Adds documentation for using cloud profiles to connect to multiple Cumulocity instances. Hides the `c8y.device.id` and related configurations since those don't yet work due to external ID issues.

Hiding the device ID is done in a single separate commit so it should be easy to revert once the feature works properly.

There is also a small change to ensure profile names are always lowercased, in case someone accesses a key using e.g. `tedge config get c8y.profiles.EDGE.url`, where we weren't previously lowercasing the profile name.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

