### PR TITLE
fix: process non-versioned in-progress commands on startup

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/self-update/apt_package_pinning
+++ b/tests/RobotFramework/tests/cumulocity/self-update/apt_package_pinning
@@ -1,0 +1,31 @@
+Package: tedge-full
+Pin: version %%VERSION%%
+Pin-Priority: 1001
+
+Package: tedge
+Pin: version %%VERSION%%
+Pin-Priority: 1001
+
+Package: tedge-mapper
+Pin: version %%VERSION%%
+Pin-Priority: 1001
+
+Package: tedge-agent
+Pin: version %%VERSION%%
+Pin-Priority: 1001
+
+Package: c8y-firmware-plugin
+Pin: version %%VERSION%%
+Pin-Priority: 1001
+
+Package: c8y-remote-access-plugin
+Pin: version %%VERSION%%
+Pin-Priority: 1001
+
+Package: tedge-apt-plugin
+Pin: version %%VERSION%%
+Pin-Priority: 1001
+
+Package: tedge-watchdog
+Pin: version %%VERSION%%
+Pin-Priority: 1001

--- a/tests/RobotFramework/tests/cumulocity/self-update/software_update.toml
+++ b/tests/RobotFramework/tests/cumulocity/self-update/software_update.toml
@@ -1,0 +1,38 @@
+operation = "software_update"
+
+[init]
+action = "proceed"
+on_success = "executing"
+
+[executing]
+action = "proceed"
+on_success = "prepare"
+
+[prepare]
+script = "sudo /etc/tedge/sm-plugins/apt prepare"
+on_success = "self-update"
+
+[self-update]
+# Note: update tedge as it is used by the tedge-agent (as tedge is a multi-call binary)
+# Note: installing the new tedge package will not restart the tedge-agent service
+script = "sudo /etc/tedge/sm-plugins/apt install tedge"
+on_success = "restart-agent"
+
+[restart-agent]
+background_script = "sudo systemctl restart tedge-agent"
+on_exec = "await-restart-agent"
+
+[await-restart-agent]
+script = "sleep 10"
+on_success = "finalize"
+on_kill = "finalize"
+
+[finalize]
+script = "sh -c 'echo Executing state: ${.payload.status}'"
+on_success = "successful"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix handling of in-progress commands/workflows which originate from the tedge-agent prior to 1.4.0.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3305

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

