### PR TITLE
feat: Trigger tedge multicall on symlinks as well as with an explicit subcommand parameter

### DIFF
--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -5,6 +5,7 @@ use crate::command::BuildContext;
 use crate::command::Command;
 use c8y_firmware_plugin::FirmwarePluginOpt;
 use c8y_remote_access_plugin::C8yRemoteAccessPluginOpt;
+use clap::Parser;
 pub use connect::*;
 use tedge_agent::AgentOpt;
 use tedge_config::cli::CommonArgs;
@@ -36,31 +37,44 @@ mod upload;
     multicall(true),
 )]
 pub enum TEdgeOptMulticall {
-    Tedge {
-        #[clap(subcommand)]
-        cmd: TEdgeOpt,
-
-        #[command(flatten)]
-        common: CommonArgs,
-    },
-
     #[clap(flatten)]
     Component(Component),
 }
 
 #[derive(clap::Parser, Debug)]
 pub enum Component {
+    #[clap(alias = "cli")]
+    TedgeCli(CliOpt),
+
+    #[clap(alias = "mapper")]
     TedgeMapper(MapperOpt),
 
+    #[clap(alias = "agent")]
     TedgeAgent(AgentOpt),
 
     C8yFirmwarePlugin(FirmwarePluginOpt),
 
+    #[clap(alias = "watchdog")]
     TedgeWatchdog(WatchdogOpt),
 
     C8yRemoteAccessPlugin(C8yRemoteAccessPluginOpt),
 
+    #[clap(alias = "write")]
     TedgeWrite(TedgeWriteOpt),
+}
+
+#[derive(Debug, Parser)]
+#[clap(
+name = "cli",
+version = clap::crate_version!(),
+about = clap::crate_description!()
+)]
+pub struct CliOpt {
+    #[clap(subcommand)]
+    pub cmd: TEdgeOpt,
+
+    #[command(flatten)]
+    pub common: CommonArgs,
 }
 
 #[derive(clap::Subcommand, Debug)]

--- a/crates/core/tedge/tests/main.rs
+++ b/crates/core/tedge/tests/main.rs
@@ -47,36 +47,36 @@ mod tests {
         let home_dir = tempdir.path().to_str().unwrap();
 
         let mut get_device_id_cmd =
-            tedge_command_with_test_home(["--config-dir", home_dir, "config", "get", "device.id"])?;
+            tedge_command_with_test_home(["config", "get", "device.id", "--config-dir", home_dir])?;
         let mut set_cert_path_cmd = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             home_dir,
-            "config",
             "set",
             "device.cert_path",
             &cert_path,
         ])?;
         let mut set_key_path_cmd = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             home_dir,
-            "config",
             "set",
             "device.key_path",
             &key_path,
         ])?;
 
         let mut create_cmd = tedge_command_with_test_home([
-            "--config-dir",
-            home_dir,
             "cert",
             "create",
             "--device-id",
             device_id,
+            "--config-dir",
+            home_dir,
         ])?;
         let mut show_cmd =
-            tedge_command_with_test_home(["--config-dir", home_dir, "cert", "show"])?;
+            tedge_command_with_test_home(["cert", "show", "--config-dir", home_dir])?;
         let mut remove_cmd =
-            tedge_command_with_test_home(["--config-dir", home_dir, "cert", "remove"])?;
+            tedge_command_with_test_home(["cert", "remove", "--config-dir", home_dir])?;
 
         // Configure tedge to use specific paths for the private key and the certificate
         set_cert_path_cmd.assert().success();
@@ -143,9 +143,9 @@ mod tests {
 
         // allowed to get read-only key by CLI
         let mut get_device_id_cmd = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "get",
             "device.id",
         ])?;
@@ -157,9 +157,9 @@ mod tests {
 
         // forbidden to set read-only key by CLI
         let mut set_device_id_cmd = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "set",
             "device.id",
             device_id,
@@ -169,9 +169,9 @@ mod tests {
 
         // forbidden to unset read-only key by CLI
         let mut unset_device_id_cmd = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "unset",
             "device.id",
         ])?;
@@ -200,9 +200,9 @@ mod tests {
         let test_home_str = temp_dir_path.to_str().unwrap();
 
         let mut get_config_command = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "get",
             config_key,
         ])?;
@@ -220,9 +220,9 @@ mod tests {
         }
 
         let mut set_config_command = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "set",
             config_key,
             config_value,
@@ -231,9 +231,9 @@ mod tests {
         set_config_command.assert().success();
 
         let mut get_config_command = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "get",
             config_key,
         ])?;
@@ -244,9 +244,9 @@ mod tests {
             .stdout(predicate::str::contains(config_value));
 
         let mut unset_config_command = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "unset",
             config_key,
         ])?;
@@ -254,9 +254,9 @@ mod tests {
         unset_config_command.assert().success();
 
         let mut get_config_command = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "get",
             config_key,
         ])?;
@@ -286,9 +286,9 @@ mod tests {
         let key_path = temp_path(&temp_dir, "device-certs/tedge-private-key.pem");
 
         let mut get_device_id_cmd = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "get",
             "device.id",
         ])?;
@@ -299,9 +299,9 @@ mod tests {
             .stderr(predicate::str::contains("device.id"));
 
         let mut get_cert_path_cmd = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "get",
             "device.cert_path",
         ])?;
@@ -312,9 +312,9 @@ mod tests {
             .stdout(predicate::str::contains(cert_path));
 
         let mut get_key_path_cmd = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "get",
             "device.key_path",
         ])?;
@@ -325,9 +325,9 @@ mod tests {
             .stdout(predicate::str::contains(key_path));
 
         let mut get_c8y_url_cmd = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "get",
             "c8y.url",
         ])?;
@@ -340,9 +340,9 @@ mod tests {
             ));
 
         let mut get_c8y_root_cert_path_cmd = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "get",
             "c8y.root_cert_path",
         ])?;
@@ -361,7 +361,7 @@ mod tests {
         let test_home_str = temp_dir.path().to_str().unwrap();
 
         let mut list_cmd =
-            tedge_command_with_test_home(["--config-dir", test_home_str, "config", "list"])
+            tedge_command_with_test_home(["config", "list", "--config-dir", test_home_str])
                 .unwrap();
         let assert = list_cmd.assert().success();
         let output = assert.get_output().clone();
@@ -391,7 +391,7 @@ mod tests {
         let test_home_str = temp_dir_path.to_str().unwrap();
 
         // If file doesn't exist exit code will be 0.
-        tedge_command_with_test_home(["--config-dir", test_home_str, "disconnect", "c8y"])
+        tedge_command_with_test_home(["disconnect", "c8y", "--config-dir", test_home_str])
             .unwrap()
             .assert()
             .success();
@@ -403,7 +403,7 @@ mod tests {
         let test_home_str = temp_dir.path().to_str().unwrap();
 
         let mut list_cmd =
-            tedge_command(["--config-dir", test_home_str, "config", "list", "--all"]).unwrap();
+            tedge_command(["config", "list", "--all", "--config-dir", test_home_str]).unwrap();
 
         let assert = list_cmd.assert().success();
         let output = assert.get_output();
@@ -431,9 +431,9 @@ mod tests {
         let test_home_str = temp_dir.path().to_str().unwrap();
 
         let mut list_cmd = tedge_command_with_test_home([
+            "config",
             "--config-dir",
             test_home_str,
-            "config",
             "list",
             "--doc",
         ])

--- a/crates/core/tedge/tests/mqtt.rs
+++ b/crates/core/tedge/tests/mqtt.rs
@@ -36,8 +36,8 @@ mod tests {
         let mut messages = broker.messages_published_on("topic").await;
 
         let mut cmd = Command::cargo_bin("tedge")?;
-        cmd.args(["--config-dir", tmpfile.path().to_str().unwrap()])
-            .args(["mqtt", "pub", "topic", "message"]);
+        cmd.args(["mqtt", "pub", "topic", "message"])
+            .args(["--config-dir", tmpfile.path().to_str().unwrap()]);
 
         if let Some(qos) = qos {
             cmd.args(["--qos", qos]);


### PR DESCRIPTION
## Proposed changes

- [ ] remove `main.rs` for the agent and the mapper, and all the plugins that can be launched using a symlink on `tedge`
- [x] trigger tedge multicall on symlinks as well as with an explicit subcommand parameters

The following are now equivalent:

- `tedge mapper c8y`
- `tedge-mapper c8y` where `tedge-mapper` is a copy or a symlink of `tedge`
- `tedge agent`
- `tedge-agent c8y` where `tedge-agent` is a copy or a symlink of `tedge`


The former `tedge` cli can be invoked as before or with the new sub-command approach:

- `tedge cert show`
- `tedge cli cert show`
- `tedge-cli cert show` where `tedge-cli` is a copy or a symlink of `tedge`



 
## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2696

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

The following are also accepted (as a side effect of using aliases for the sub-command names):

- `tedge tedge-cli cert show`
- `cli cert show` where `cli` is a copy or a symlink of `tedge`
- `tedge tedge-mapper c8y`
- `mapper c8y` where `mapper` is a copy or a symlink of `tedge`

