### PR TITLE
feat: Trigger tedge multicall with symlinks as well as sub-commands

### DIFF
--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 readme = "README.md"
+default-run = "tedge"
 
 [dependencies]
 anstyle = { workspace = true }

--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -113,6 +113,15 @@ pub enum TEdgeOpt {
     /// Publish a message on a topic and subscribe a topic.
     #[clap(subcommand)]
     Mqtt(mqtt::TEdgeMqttCli),
+
+    /// Run thin-edge services and plugins
+    Run(ComponentOpt),
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct ComponentOpt {
+    #[clap(subcommand)]
+    pub component: Component,
 }
 
 fn styles() -> clap::builder::Styles {
@@ -174,6 +183,10 @@ impl BuildCommand for TEdgeOpt {
             TEdgeOpt::RefreshBridges => RefreshBridgesCmd::new(&context).map(Command::into_boxed),
             TEdgeOpt::Mqtt(opt) => opt.build_command(context),
             TEdgeOpt::Reconnect(opt) => opt.build_command(context),
+            TEdgeOpt::Run(_) => {
+                // This method has to be kept in sync with tedge::redirect_if_multicall()
+                panic!("tedge mapper|agent|write commands are launched as multicall")
+            }
         }
     }
 }

--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -7,6 +7,7 @@ use c8y_firmware_plugin::FirmwarePluginOpt;
 use c8y_remote_access_plugin::C8yRemoteAccessPluginOpt;
 pub use connect::*;
 use tedge_agent::AgentOpt;
+use tedge_apt_plugin::AptCli;
 use tedge_config::cli::CommonArgs;
 use tedge_mapper::MapperOpt;
 use tedge_watchdog::WatchdogOpt;
@@ -51,15 +52,18 @@ pub enum TEdgeOptMulticall {
 
 #[derive(clap::Parser, Debug)]
 pub enum Component {
-    TedgeMapper(MapperOpt),
+    C8yFirmwarePlugin(FirmwarePluginOpt),
+
+    C8yRemoteAccessPlugin(C8yRemoteAccessPluginOpt),
 
     TedgeAgent(AgentOpt),
 
-    C8yFirmwarePlugin(FirmwarePluginOpt),
+    #[clap(alias = "apt")]
+    TedgeAptPlugin(AptCli),
+
+    TedgeMapper(MapperOpt),
 
     TedgeWatchdog(WatchdogOpt),
-
-    C8yRemoteAccessPlugin(C8yRemoteAccessPluginOpt),
 
     TedgeWrite(TedgeWriteOpt),
 }

--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -36,6 +36,7 @@ mod upload;
     multicall(true),
 )]
 pub enum TEdgeOptMulticall {
+    /// Command line interface to interact with thin-edge.io
     Tedge {
         #[clap(subcommand)]
         cmd: TEdgeOpt,

--- a/crates/core/tedge/src/main.rs
+++ b/crates/core/tedge/src/main.rs
@@ -5,8 +5,11 @@ use anyhow::Context;
 use cap::Cap;
 use clap::error::ErrorFormatter;
 use clap::error::RichFormatter;
+use clap::CommandFactory;
+use clap::FromArgMatches;
 use clap::Parser;
 use std::alloc;
+use std::ffi::OsString;
 use std::future::Future;
 use std::io::IsTerminal;
 use std::path::PathBuf;
@@ -15,8 +18,11 @@ use tedge::command::BuildCommand;
 use tedge::command::BuildContext;
 use tedge::log::MaybeFancy;
 use tedge::Component;
+use tedge::ComponentOpt;
+use tedge::TEdgeOpt;
 use tedge::TEdgeOptMulticall;
 use tedge_apt_plugin::AptCli;
+use tedge_config::cli::CommonArgs;
 use tedge_config::system_services::log_init;
 use tracing::log;
 
@@ -31,7 +37,7 @@ fn main() -> anyhow::Result<()> {
         tedge_apt_plugin::run_and_exit(try_opt);
     }
 
-    let opt = parse_multicall_if_known(&executable_name);
+    let opt = parse_multicall(&executable_name, std::env::args_os());
     match opt {
         TEdgeOptMulticall::Component(Component::TedgeMapper(opt)) => {
             let tedge_config = tedge_config::TEdgeConfig::load(&opt.common.config_dir)?;
@@ -120,8 +126,12 @@ fn executable_name() -> Option<String> {
     )
 }
 
-fn parse_multicall_if_known<T: Parser>(executable_name: &Option<String>) -> T {
-    let cmd = T::command();
+fn parse_multicall<Arg, Args>(executable_name: &Option<String>, args: Args) -> TEdgeOptMulticall
+where
+    Args: IntoIterator<Item = Arg>,
+    Arg: Into<OsString> + Clone,
+{
+    let cmd = TEdgeOptMulticall::command();
 
     let is_known_subcommand = executable_name
         .as_deref()
@@ -129,11 +139,69 @@ fn parse_multicall_if_known<T: Parser>(executable_name: &Option<String>) -> T {
     let cmd = cmd.multicall(is_known_subcommand);
 
     let cmd2 = cmd.clone();
-    match T::from_arg_matches(&cmd.get_matches()) {
+    match TEdgeOptMulticall::from_arg_matches(&cmd.get_matches_from(args)) {
+        Ok(TEdgeOptMulticall::Tedge { cmd, common }) => redirect_if_multicall(cmd, common),
         Ok(t) => t,
         Err(e) => {
             eprintln!("{}", RichFormatter::format_error(&e.with_cmd(&cmd2)));
             std::process::exit(1);
+        }
+    }
+}
+
+// Transform `tedge mapper|agent|write` commands into multicalls
+//
+// This method has to be kept in sync with TEdgeOpt::build_command
+fn redirect_if_multicall(cmd: TEdgeOpt, common: CommonArgs) -> TEdgeOptMulticall {
+    match cmd {
+        TEdgeOpt::Run(ComponentOpt { component }) => TEdgeOptMulticall::Component(component),
+        cmd => TEdgeOptMulticall::Tedge { cmd, common },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parse_multicall;
+    use crate::Component;
+    use crate::TEdgeOptMulticall;
+    use test_case::test_case;
+
+    #[test]
+    fn launching_a_mapper() {
+        let exec = Some("tedge-mapper".to_string());
+        let cmd = parse_multicall(&exec, ["tedge-mapper", "c8y"]);
+        assert!(matches!(
+            cmd,
+            TEdgeOptMulticall::Component(Component::TedgeMapper(_))
+        ))
+    }
+
+    #[test]
+    fn using_tedge_to_launch_a_mapper() {
+        let exec = Some("tedge".to_string());
+        let cmd = parse_multicall(&exec, ["tedge", "run", "tedge-mapper", "c8y"]);
+        assert!(matches!(
+            cmd,
+            TEdgeOptMulticall::Component(Component::TedgeMapper(_))
+        ))
+    }
+
+    #[test_case("tedge-mapper c8y --config-dir /some/dir")]
+    #[test_case("tedge-mapper --config-dir /some/dir c8y")]
+    #[test_case("tedge run tedge-mapper c8y --config-dir /some/dir")]
+    #[test_case("tedge run tedge-mapper --config-dir /some/dir c8y")]
+    #[test_case("tedge --config-dir /some/dir run tedge-mapper c8y")]
+    // clap fails to raise an error here and takes the inner value for all global args
+    #[test_case("tedge --config-dir /oops run tedge-mapper c8y --config-dir /some/dir")]
+    fn setting_config_dir(cmd_line: &'static str) {
+        let args: Vec<&str> = cmd_line.split(' ').collect();
+        let exec = Some(args.get(0).unwrap().to_string());
+        let cmd = parse_multicall(&exec, args);
+        match cmd {
+            TEdgeOptMulticall::Component(Component::TedgeMapper(mapper)) => {
+                assert_eq!(mapper.common.config_dir, "/some/dir")
+            }
+            _ => panic!(),
         }
     }
 }

--- a/docs/src/references/cli/index.md
+++ b/docs/src/references/cli/index.md
@@ -7,18 +7,11 @@ sidebar_position: 4
 # The tedge command
 
 ```sh title="tedge"
-tedge is the cli tool for thin-edge.io
+Command line interface to interact with thin-edge.io
 
-USAGE:
-    tedge [OPTIONS] [SUBCOMMAND]
+Usage: tedge [OPTIONS] <COMMAND>
 
-OPTIONS:
-        --config-dir <CONFIG_DIR>    [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
-    -h, --help                       Print help information
-        --init                       Initialize the tedge
-    -V, --version                    Print version information
-
-SUBCOMMANDS:
+Commands:
   init             Initialize Thin Edge
   cert             Create and manage device certificate
   config           Configure Thin Edge
@@ -28,5 +21,30 @@ SUBCOMMANDS:
   refresh-bridges  Refresh all currently active mosquitto bridges
   upload           Upload files to the cloud
   mqtt             Publish a message on a topic and subscribe a topic
+  run              Run thin-edge services and plugins
   help             Print this message or the help of the given subcommand(s)
+
+Options:
+      --config-dir <CONFIG_DIR>
+          [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+
+      --debug
+          Turn-on the DEBUG log level.
+          
+          If off only reports ERROR, WARN, and INFO, if on also reports DEBUG
+
+      --log-level <LOG_LEVEL>
+          Configures the logging level.
+          
+          One of error/warn/info/debug/trace.
+          Logs with verbosity lower or equal to the selected level will be printed,
+          i.e. warn prints ERROR and WARN logs and trace prints logs of all levels.
+          
+          Overrides `--debug`
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 ```

--- a/plugins/tedge_apt_plugin/src/lib.rs
+++ b/plugins/tedge_apt_plugin/src/lib.rs
@@ -346,16 +346,7 @@ fn get_config(config_dir: &Path) -> Option<TEdgeConfig> {
     }
 }
 
-pub fn run_and_exit(cli: Result<AptCli, clap::Error>) -> ! {
-    let mut apt = match cli {
-        Ok(aptcli) => aptcli,
-        Err(err) => {
-            err.print().expect("Failed to print help message");
-            // re-write the clap exit_status from 2 to 1, if parse fails
-            std::process::exit(1)
-        }
-    };
-
+pub fn run_and_exit(mut apt: AptCli) -> ! {
     if let PluginOp::List { name, maintainer } = &mut apt.operation {
         if let Some(config) = get_config(apt.common.config_dir.as_std_path()) {
             if name.is_none() {


### PR DESCRIPTION
## Proposed changes

Simplify the way `tedge-mapper`, `tedge-agent` and `tedge-write` are launched: it's no more mandatory to create symlinks to `tedge` with appropriate names.

The following are now equivalent (for the mapper, but also the agent and  all tedge services and plugins ):

- `tedge run tedge-mapper c8y`
- `tedge-mapper c8y` where `tedge-mapper` is a copy or a symlink of `tedge`

The former `tedge` cli can be invoked as before:

```
$ tedge help
tedge is the cli tool for thin-edge.io

Usage: tedge [OPTIONS] <COMMAND>

Commands:
  init             Initialize Thin Edge
  cert             Create and manage device certificate
  ...
  run              Run thin-edge services and plugins
  ...
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/2696

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This PR supersedes https://github.com/thin-edge/thin-edge.io/pull/3311
