### PR TITLE
test: pretty print json payloads and disable robotidy to preserve leading whitespace

### DIFF
--- a/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
+++ b/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_operation.robot
@@ -20,33 +20,35 @@ Send device profile operation from Cumulocity IoT
     ...    file=${CURDIR}/tedge-configuration-plugin.toml
 
     ${PROFILE_NAME}=    Set Variable    Test Profile
-    ${PROFILE_PAYLOAD}=    Catenate    SEPARATOR=\n    {
-    ...    "firmware": {
-    ...    "name":"tedge-core",
-    ...    "version":"1.0.0",
-    ...    "url":"https://abc.com/some/firmware/url"
-    ...    },
-    ...    "software":[
+    # robotidy: off
+    ${PROFILE_PAYLOAD}=    Catenate    SEPARATOR=\n
     ...    {
-    ...    "name":"jq",
-    ...    "action":"install",
-    ...    "version":"latest",
-    ...    "url":""
-    ...    },
-    ...    {
-    ...    "name":"tree",
-    ...    "action":"install",
-    ...    "version":"latest",
-    ...    "url":""
-    ...    }
-    ...    ],
-    ...    "configuration":[
-    ...    {
-    ...    "name":"tedge-configuration-plugin",
-    ...    "type":"tedge-configuration-plugin",
-    ...    "url":"${config_url}"
-    ...    }
-    ...    ]
+    ...      "firmware": {
+    ...        "name": "tedge-core",
+    ...        "version": "1.0.0",
+    ...        "url": "https://abc.com/some/firmware/url"
+    ...      },
+    ...      "software": [
+    ...        {
+    ...          "name": "jq",
+    ...          "action": "install",
+    ...          "version": "latest",
+    ...          "url": ""
+    ...        },
+    ...        {
+    ...          "name": "tree",
+    ...          "action": "install",
+    ...          "version": "latest",
+    ...          "url": ""
+    ...        }
+    ...      ],
+    ...      "configuration": [
+    ...        {
+    ...          "name": "tedge-configuration-plugin",
+    ...          "type": "tedge-configuration-plugin",
+    ...          "url": "${config_url}"
+    ...        }
+    ...      ]
     ...    }
 
     ${profile}=    Cumulocity.Create Device Profile    ${PROFILE_NAME}    ${PROFILE_PAYLOAD}
@@ -60,95 +62,96 @@ Send device profile operation locally
 
     Execute Command    curl -X PUT --data-binary "bad toml" "${config_url}"
 
+    # robotidy: off
     ${payload}=    Catenate    SEPARATOR=\n
     ...    {
-    ...    "status": "init",
-    ...    "name": "dev-profile",
-    ...    "version": "v2",
-    ...    "operations": [
-    ...    {
-    ...    "operation": "firmware_update",
-    ...    "@skip": false,
-    ...    "payload": {
-    ...    "name": "tedge-core",
-    ...    "remoteUrl": "https://abc.com/some/firmware/url",
-    ...    "version": "1.0.0"
-    ...    }
-    ...    },
-    ...    {
-    ...    "operation": "software_update",
-    ...    "@skip": false,
-    ...    "payload": {
-    ...    "updateList": [
-    ...    {
-    ...    "type": "apt",
-    ...    "modules": [
-    ...    {
-    ...    "name": "yq",
-    ...    "version": "latest",
-    ...    "action": "install"
-    ...    },
-    ...    {
-    ...    "name": "jo",
-    ...    "version": "latest",
-    ...    "action": "install"
-    ...    }
-    ...    ]
-    ...    }
-    ...    ]
-    ...    }
-    ...    },
-    ...    {
-    ...    "operation": "config_update",
-    ...    "@skip": false,
-    ...    "payload": {
-    ...    "type": "tedge-configuration-plugin",
-    ...    "tedgeUrl": "${config_url}",
-    ...    "remoteUrl": ""
-    ...    }
-    ...    },
-    ...    {
-    ...    "operation": "software_update",
-    ...    "@skip": true,
-    ...    "payload": {
-    ...    "updateList": [
-    ...    {
-    ...    "type": "apt",
-    ...    "modules": [
-    ...    {
-    ...    "name": "htop",
-    ...    "version": "latest",
-    ...    "action": "install"
-    ...    }
-    ...    ]
-    ...    }
-    ...    ]
-    ...    }
-    ...    },
-    ...    {
-    ...    "operation": "restart",
-    ...    "skip": false,
-    ...    "payload": {}
-    ...    },
-    ...    {
-    ...    "operation": "software_update",
-    ...    "@skip": false,
-    ...    "payload": {
-    ...    "updateList": [
-    ...    {
-    ...    "type": "apt",
-    ...    "modules": [
-    ...    {
-    ...    "name": "rolldice",
-    ...    "version": "latest",
-    ...    "action": "install"
-    ...    }
-    ...    ]
-    ...    }
-    ...    ]
-    ...    }
-    ...    }
-    ...    ]
+    ...      "status": "init",
+    ...      "name": "dev-profile",
+    ...      "version": "v2",
+    ...      "operations": [
+    ...        {
+    ...          "operation": "firmware_update",
+    ...          "@skip": false,
+    ...          "payload": {
+    ...            "name": "tedge-core",
+    ...            "remoteUrl": "https://abc.com/some/firmware/url",
+    ...            "version": "1.0.0"
+    ...          }
+    ...        },
+    ...        {
+    ...          "operation": "software_update",
+    ...          "@skip": false,
+    ...          "payload": {
+    ...            "updateList": [
+    ...              {
+    ...                "type": "apt",
+    ...                "modules": [
+    ...                  {
+    ...                    "name": "yq",
+    ...                    "version": "latest",
+    ...                    "action": "install"
+    ...                  },
+    ...                  {
+    ...                    "name": "jo",
+    ...                    "version": "latest",
+    ...                    "action": "install"
+    ...                  }
+    ...                ]
+    ...              }
+    ...            ]
+    ...          }
+    ...        },
+    ...        {
+    ...          "operation": "config_update",
+    ...          "@skip": false,
+    ...          "payload": {
+    ...            "type": "tedge-configuration-plugin",
+    ...            "tedgeUrl": "${config_url}",
+    ...            "remoteUrl": ""
+    ...          }
+    ...        },
+    ...        {
+    ...          "operation": "software_update",
+    ...          "@skip": true,
+    ...          "payload": {
+    ...            "updateList": [
+    ...              {
+    ...                "type": "apt",
+    ...                "modules": [
+    ...                  {
+    ...                    "name": "htop",
+    ...                    "version": "latest",
+    ...                    "action": "install"
+    ...                  }
+    ...                ]
+    ...              }
+    ...            ]
+    ...          }
+    ...        },
+    ...        {
+    ...          "operation": "restart",
+    ...          "skip": false,
+    ...          "payload": {}
+    ...        },
+    ...        {
+    ...          "operation": "software_update",
+    ...          "@skip": false,
+    ...          "payload": {
+    ...            "updateList": [
+    ...              {
+    ...                "type": "apt",
+    ...                "modules": [
+    ...                  {
+    ...                    "name": "rolldice",
+    ...                    "version": "latest",
+    ...                    "action": "install"
+    ...                  }
+    ...                ]
+    ...              }
+    ...            ]
+    ...          }
+    ...        }
+    ...      ]
     ...    }
 
     Execute Command    tedge mqtt pub --retain 'te/device/main///cmd/device_profile/robot-123' '${payload}'


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Improve readability of tests using large json payloads by formatting them via pretty print (with 2 spaces) and disabling the robotidy auto formatter for such lines. Previously the payloads were pretty printed but the robotidy auto formatter would strip the leading whitespace.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

