### PR TITLE
fix: tedge cert create-csr should use cloud profile's CN

### DIFF
--- a/tests/RobotFramework/tests/tedge/certificate_signing_request.robot
+++ b/tests/RobotFramework/tests/tedge/certificate_signing_request.robot
@@ -52,6 +52,39 @@ Generate CSR without an existing certificate and private key
     ...    openssl req -in /etc/tedge/device-certs/tedge.csr -pubkey -noout | openssl md5
     Should Be Equal    ${output_private_key_md5}    ${output_csr_md5}
 
+Generate CSR using the device-id from an existing certificate and private key of cloud profile
+    [Tags]    \#3315
+    [Setup]    Setup With Self-Signed Certificate
+
+    ${second_device_sn}=    Catenate    SEPARATOR=_    ${DEVICE_SN}    second
+    Execute Command
+    ...    tedge config set c8y.device.cert_path --profile second /etc/tedge/device-certs/tedge@second-certificate.pem
+    Execute Command
+    ...    tedge config set c8y.device.key_path --profile second /etc/tedge/device-certs/tedge@second-key.pem
+    Execute Command    tedge cert create --device-id ${second_device_sn} c8y --profile second
+
+    ${hash_before_cert}=    Execute Command    md5sum /etc/tedge/device-certs/tedge@second-certificate.pem
+    ${hash_before_private_key}=    Execute Command    md5sum /etc/tedge/device-certs/tedge@second-key.pem
+
+    Execute Command    sudo tedge cert create-csr c8y --profile second
+
+    ${output_cert_subject}=    Execute Command
+    ...    openssl x509 -noout -subject -in /etc/tedge/device-certs/tedge@second-certificate.pem
+    ${output_csr_subject}=    Execute Command
+    ...    openssl req -noout -subject -in /etc/tedge/device-certs/tedge.csr
+    Should Be Equal    ${output_cert_subject}    ${output_csr_subject}
+
+    ${output_private_key_md5}=    Execute Command
+    ...    openssl pkey -in /etc/tedge/device-certs/tedge@second-key.pem -pubout | openssl md5
+    ${output_csr_md5}=    Execute Command
+    ...    openssl req -in /etc/tedge/device-certs/tedge.csr -pubkey -noout | openssl md5
+    Should Be Equal    ${output_private_key_md5}    ${output_csr_md5}
+
+    ${hash_after_cert}=    Execute Command    md5sum /etc/tedge/device-certs/tedge@second-certificate.pem
+    ${hash_after_private_key}=    Execute Command    md5sum /etc/tedge/device-certs/tedge@second-key.pem
+    Should Be Equal    ${hash_before_cert}    ${hash_after_cert}
+    Should Be Equal    ${hash_before_private_key}    ${hash_after_private_key}
+
 
 *** Keywords ***
 Setup With Self-Signed Certificate


### PR DESCRIPTION
## Proposed changes
`tedge cert create-csr <cloud> --profile <profile>` should use the CN of the corresponding device certificate/private key if `--device-id` is not provided.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3315

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

