### PR TITLE
cli: Update component crates descriptions

### DIFF
--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tedge-mapper"
-description = "tedge-mapper is the mapper that translates thin-edge.io data model to c8y/az data model."
+description = "tedge-mapper translates thin-edge.io data model to c8y/az/aws data model"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/core/tedge_watchdog/Cargo.toml
+++ b/crates/core/tedge_watchdog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tedge-watchdog"
-description = "tedge-watchdog checks the health of all the thin-edge.io components/services."
+description = "tedge-watchdog checks the health of all the thin-edge.io components/services"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }

--- a/plugins/c8y_firmware_plugin/Cargo.toml
+++ b/plugins/c8y_firmware_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c8y-firmware-plugin"
-description = "Thin-edge device firmware management for Cumulocity"
+description = "thin-edge.io device firmware management for Cumulocity"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }

--- a/plugins/c8y_remote_access_plugin/Cargo.toml
+++ b/plugins/c8y_remote_access_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c8y-remote-access-plugin"
-description = "Thin-edge.io plugin for the Cumulocity IoT's Cloud Remote Access feature"
+description = "thin-edge.io plugin for the Cumulocity Cloud Remote Access feature"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Proposed changes

Description of these crates is shown by clap in CLI help, so the descriptions were updated to make them more consistent.

- a trailing dot `.` was removed (looking at most popular Rust crates at https://lib.rs/std, none of those that have only a single sentence have a trailing dot)
- the descriptions were uncapitalized (they consist of a single sentence anyway and sometimes start with `thin-edge`)

Here's how the help text looks now:

```
Run thin-edge services and plugins

Usage: tedge run [OPTIONS] <COMMAND>

Commands:
  tedge-mapper              tedge-mapper translates thin-edge.io data model to c8y/az/aws data model
  tedge-agent               tedge-agent interacts with a Cloud Mapper and one or more Software Plugins
  c8y-firmware-plugin       thin-edge device firmware management for Cumulocity
  tedge-watchdog            tedge-watchdog checks the health of all the thin-edge.io components/services
  c8y-remote-access-plugin  thin-edge.io plugin for the Cumulocity IoT's Cloud Remote Access feature
  tedge-write               tee-like helper for writing to files which `tedge` user does not have write permissions to
  help                      Print this message or the help of the given subcommand(s)
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- https://github.com/thin-edge/thin-edge.io/pull/3313#pullrequestreview-2537065529

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

The descriptions could be improved further:

- the description starting with the name of the component is redundant; the name is already on the left of it, so it could be removed
- if the name of the component is removed, we could capitalize the sentence to be more consistent with what clap already does (`help` description is capitalized)
- a more structured and consistent indication of whether or not something is a plugin and what it entails