### PR TITLE
feat: support read-write device.id in tedge cert/connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,12 +1042,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -1066,15 +1066,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim 0.11.1",
  "syn 2.0.77",
 ]
 
@@ -1091,11 +1091,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.10",
  "quote",
  "syn 2.0.77",
 ]
@@ -4153,7 +4153,7 @@ dependencies = [
 name = "tedge_config_macros-impl"
 version = "1.4.2"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.10",
  "heck 0.4.1",
  "itertools 0.13.0",
  "pretty_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,6 +4134,7 @@ version = "1.4.2"
 dependencies = [
  "anyhow",
  "camino",
+ "certificate",
  "clap",
  "clap_complete",
  "doku",

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -483,8 +483,7 @@ define_tedge_config! {
             /// Identifier of the device within the fleet. It must be globally
             /// unique and is derived from the device certificate.
             #[tedge_config(reader(function = "c8y_device_id"))]
-            // TODO make this work
-            // #[tedge_config(default(from_optional_key = "device.id"))]
+            #[tedge_config(default(from_optional_key = "device.id"))]
             #[tedge_config(example = "Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665")]
             #[doku(as = "String")]
             id: Result<String, ReadError>,
@@ -1365,14 +1364,20 @@ fn device_id(
     device: &TEdgeConfigReaderDevice,
     dto_value: &OptionalConfig<String>,
 ) -> Result<String, ReadError> {
-    device_id_from_cert(&device.cert_path)
+    match dto_value.or_none() {
+        Some(id) => Ok(id.clone()),
+        None => device_id_from_cert(&device.cert_path)
+    }
 }
 
 fn c8y_device_id(
-    device: &TEdgeConfigReaderC8yDevice,
+    c8y_device: &TEdgeConfigReaderC8yDevice,
     dto_value: &OptionalConfig<String>,
 ) -> Result<String, ReadError> {
-    device_id_from_cert(&device.cert_path)
+    match dto_value.or_none() {
+        Some(id) => Ok(id.clone()),
+        None => device_id_from_cert(&c8y_device.cert_path)
+    }
 }
 
 fn az_device_id(device: &TEdgeConfigReaderAzDevice, _: &()) -> Result<String, ReadError> {

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -428,15 +428,8 @@ define_tedge_config! {
     device: {
         /// Identifier of the device within the fleet. It must be globally
         /// unique and is derived from the device certificate.
-        #[tedge_config(readonly(
-            write_error = "\
-                The device id is read from the device certificate and cannot be set directly.\n\
-                To set 'device.id' to some <id>, you can use `tedge cert create --device-id <id>`.",
-            function = "device_id",
-        ))]
+        #[tedge_config(reader(function = "device_id"))]
         #[tedge_config(example = "Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665")]
-        #[tedge_config(note = "This setting is derived from the device certificate and is therefore read only.")]
-        #[tedge_config(reader(private))]
         #[doku(as = "String")]
         id: Result<String, ReadError>,
 
@@ -489,14 +482,10 @@ define_tedge_config! {
         device: {
             /// Identifier of the device within the fleet. It must be globally
             /// unique and is derived from the device certificate.
-            #[tedge_config(readonly(
-                write_error = "\
-                    The device id is read from the device certificate and cannot be set directly.\n\
-                    To set 'device.id' to some <id>, you can use `tedge cert create --device-id <id>`.",
-                function = "c8y_device_id",
-            ))]
+            #[tedge_config(reader(function = "c8y_device_id"))]
+            // TODO make this work
+            // #[tedge_config(default(from_optional_key = "device.id"))]
             #[tedge_config(example = "Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665")]
-            #[tedge_config(note = "This setting is derived from the device certificate and is therefore read only.")]
             #[doku(as = "String")]
             id: Result<String, ReadError>,
 
@@ -692,7 +681,6 @@ define_tedge_config! {
                 function = "az_device_id",
             ))]
             #[tedge_config(example = "Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665")]
-            #[tedge_config(note = "This setting is derived from the device certificate and is therefore read only.")]
             #[doku(as = "String")]
             id: Result<String, ReadError>,
 
@@ -762,7 +750,6 @@ define_tedge_config! {
                 function = "aws_device_id",
             ))]
             #[tedge_config(example = "Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665")]
-            #[tedge_config(note = "This setting is derived from the device certificate and is therefore read only.")]
             #[doku(as = "String")]
             id: Result<String, ReadError>,
 
@@ -1367,26 +1354,32 @@ fn default_http_bind_address(dto: &TEdgeConfigDto) -> IpAddr {
 
 fn device_id_from_cert(cert_path: &Utf8Path) -> Result<String, ReadError> {
     let pem = PemCertificate::from_pem_file(cert_path)
-        .map_err(|err| cert_error_into_config_error(ReadOnlyKey::DeviceId.to_cow_str(), err))?;
+        .map_err(|err| cert_error_into_config_error(ReadableKey::DeviceId.to_cow_str(), err))?;
     let device_id = pem
         .subject_common_name()
-        .map_err(|err| cert_error_into_config_error(ReadOnlyKey::DeviceId.to_cow_str(), err))?;
+        .map_err(|err| cert_error_into_config_error(ReadableKey::DeviceId.to_cow_str(), err))?;
     Ok(device_id)
 }
 
-fn device_id(device: &TEdgeConfigReaderDevice) -> Result<String, ReadError> {
+fn device_id(
+    device: &TEdgeConfigReaderDevice,
+    dto_value: &OptionalConfig<String>,
+) -> Result<String, ReadError> {
     device_id_from_cert(&device.cert_path)
 }
 
-fn c8y_device_id(device: &TEdgeConfigReaderC8yDevice) -> Result<String, ReadError> {
+fn c8y_device_id(
+    device: &TEdgeConfigReaderC8yDevice,
+    dto_value: &OptionalConfig<String>,
+) -> Result<String, ReadError> {
     device_id_from_cert(&device.cert_path)
 }
 
-fn az_device_id(device: &TEdgeConfigReaderAzDevice) -> Result<String, ReadError> {
+fn az_device_id(device: &TEdgeConfigReaderAzDevice, _: &()) -> Result<String, ReadError> {
     device_id_from_cert(&device.cert_path)
 }
 
-fn aws_device_id(device: &TEdgeConfigReaderAwsDevice) -> Result<String, ReadError> {
+fn aws_device_id(device: &TEdgeConfigReaderAwsDevice, _: &()) -> Result<String, ReadError> {
     device_id_from_cert(&device.cert_path)
 }
 

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -428,7 +428,7 @@ define_tedge_config! {
     device: {
         /// Identifier of the device within the fleet. It must be globally
         /// unique and is derived from the device certificate.
-        #[tedge_config(reader(function = "device_id"))]
+        #[tedge_config(reader(function = "device_id", private))]
         #[tedge_config(example = "Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665")]
         #[doku(as = "String")]
         id: Result<String, ReadError>,
@@ -673,12 +673,8 @@ define_tedge_config! {
         device: {
             /// Identifier of the device within the fleet. It must be globally
             /// unique and is derived from the device certificate.
-            #[tedge_config(readonly(
-                write_error = "\
-                    The device id is read from the device certificate and cannot be set directly.\n\
-                    To set 'device.id' to some <id>, you can use `tedge cert create --device-id <id>`.",
-                function = "az_device_id",
-            ))]
+            #[tedge_config(reader(function = "az_device_id"))]
+            #[tedge_config(default(from_optional_key = "device.id"))]
             #[tedge_config(example = "Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665")]
             #[doku(as = "String")]
             id: Result<String, ReadError>,
@@ -742,12 +738,8 @@ define_tedge_config! {
         device: {
             /// Identifier of the device within the fleet. It must be globally
             /// unique and is derived from the device certificate.
-            #[tedge_config(readonly(
-                write_error = "\
-                    The device id is read from the device certificate and cannot be set directly.\n\
-                    To set 'device.id' to some <id>, you can use `tedge cert create --device-id <id>`.",
-                function = "aws_device_id",
-            ))]
+            #[tedge_config(reader(function = "aws_device_id"))]
+            #[tedge_config(default(from_optional_key = "device.id"))]
             #[tedge_config(example = "Raspberrypi-4d18303a-6d3a-11eb-b1a6-175f6bb72665")]
             #[doku(as = "String")]
             id: Result<String, ReadError>,
@@ -1366,7 +1358,7 @@ fn device_id(
 ) -> Result<String, ReadError> {
     match dto_value.or_none() {
         Some(id) => Ok(id.clone()),
-        None => device_id_from_cert(&device.cert_path)
+        None => device_id_from_cert(&device.cert_path),
     }
 }
 
@@ -1376,16 +1368,28 @@ fn c8y_device_id(
 ) -> Result<String, ReadError> {
     match dto_value.or_none() {
         Some(id) => Ok(id.clone()),
-        None => device_id_from_cert(&c8y_device.cert_path)
+        None => device_id_from_cert(&c8y_device.cert_path),
     }
 }
 
-fn az_device_id(device: &TEdgeConfigReaderAzDevice, _: &()) -> Result<String, ReadError> {
-    device_id_from_cert(&device.cert_path)
+fn az_device_id(
+    az_device: &TEdgeConfigReaderAzDevice,
+    dto_value: &OptionalConfig<String>,
+) -> Result<String, ReadError> {
+    match dto_value.or_none() {
+        Some(id) => Ok(id.clone()),
+        None => device_id_from_cert(&az_device.cert_path),
+    }
 }
 
-fn aws_device_id(device: &TEdgeConfigReaderAwsDevice, _: &()) -> Result<String, ReadError> {
-    device_id_from_cert(&device.cert_path)
+fn aws_device_id(
+    aws_device: &TEdgeConfigReaderAwsDevice,
+    dto_value: &OptionalConfig<String>,
+) -> Result<String, ReadError> {
+    match dto_value.or_none() {
+        Some(id) => Ok(id.clone()),
+        None => device_id_from_cert(&aws_device.cert_path),
+    }
 }
 
 fn cert_error_into_config_error(key: Cow<'static, str>, err: CertificateError) -> ReadError {

--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config_location.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config_location.rs
@@ -102,6 +102,10 @@ impl TEdgeConfigLocation {
         Ok(TEdgeConfig::from_dto(&dto, self))
     }
 
+    pub fn load_dto_from_toml_and_env(&self) -> Result<TEdgeConfigDto, TEdgeConfigError> {
+        self.load_dto::<FileAndEnvironment>(self.toml_path())
+    }
+
     fn load_dto<Sources: ConfigSources>(
         &self,
         path: &Utf8Path,

--- a/crates/common/tedge_config_macros/Cargo.toml
+++ b/crates/common/tedge_config_macros/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+certificate = { workspace = true, features = ["reqwest"] }
 clap = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }

--- a/crates/common/tedge_config_macros/examples/macro.rs
+++ b/crates/common/tedge_config_macros/examples/macro.rs
@@ -189,7 +189,7 @@ define_tedge_config! {
     }
 }
 
-fn device_id(_reader: &TEdgeConfigReaderDevice) -> Result<String, ReadError> {
+fn device_id(_reader: &TEdgeConfigReaderDevice, _: &()) -> Result<String, ReadError> {
     Ok("dummy-device-id".to_owned())
 }
 

--- a/crates/common/tedge_config_macros/examples/multi.rs
+++ b/crates/common/tedge_config_macros/examples/multi.rs
@@ -111,14 +111,14 @@ fn main() {
         keys,
         [
             "c8y.http",
-            "c8y.smartrest.use_operation_id",
-            "c8y.url",
             "c8y.profiles.cloud.http",
             "c8y.profiles.cloud.smartrest.use_operation_id",
             "c8y.profiles.cloud.url",
             "c8y.profiles.edge.http",
             "c8y.profiles.edge.smartrest.use_operation_id",
-            "c8y.profiles.edge.url"
+            "c8y.profiles.edge.url",
+            "c8y.smartrest.use_operation_id",
+            "c8y.url",
         ]
     );
 }

--- a/crates/common/tedge_config_macros/examples/reader_function.rs
+++ b/crates/common/tedge_config_macros/examples/reader_function.rs
@@ -1,0 +1,147 @@
+use camino::{Utf8Path, Utf8PathBuf};
+use certificate::CertificateError;
+use certificate::PemCertificate;
+use std::borrow::Cow;
+use tedge_config_macros::*;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ReadError {
+    #[error(transparent)]
+    ConfigNotSet(#[from] ConfigNotSet),
+
+    #[error(transparent)]
+    Multi(#[from] MultiError),
+
+    #[error("Config value {key}, cannot be read: {message} ")]
+    ReadOnlyNotFound {
+        key: Cow<'static, str>,
+        message: &'static str,
+    },
+
+    #[error("Derivation for `{key}` failed: {cause}")]
+    DerivationFailed {
+        key: Cow<'static, str>,
+        cause: String,
+    },
+}
+
+pub trait AppendRemoveItem {
+    type Item;
+
+    fn append(current_value: Option<Self::Item>, new_value: Self::Item) -> Option<Self::Item>;
+
+    fn remove(current_value: Option<Self::Item>, remove_value: Self::Item) -> Option<Self::Item>;
+}
+
+impl<T> AppendRemoveItem for T {
+    type Item = T;
+
+    fn append(_current_value: Option<Self::Item>, _new_value: Self::Item) -> Option<Self::Item> {
+        unimplemented!()
+    }
+
+    fn remove(_current_value: Option<Self::Item>, _remove_value: Self::Item) -> Option<Self::Item> {
+        unimplemented!()
+    }
+}
+
+define_tedge_config! {
+    device: {
+        #[tedge_config(reader(function = "device_id"))]
+        #[doku(as = "String")]
+        id: Result<String, ReadError>,
+
+        #[doku(as = "String")]
+        cert_path: Utf8PathBuf,
+    },
+
+    #[tedge_config(multi)]
+    c8y: {
+        device: {
+            #[tedge_config(reader(function = "c8y_device_id"))]
+            #[tedge_config(default(from_optional_key = "device.id"))]
+            #[doku(as = "String")]
+            id: Result<String, ReadError>,
+
+            #[doku(as = "String")]
+            #[tedge_config(default(from_optional_key = "device.cert_path"))]
+            cert_path: Utf8PathBuf,
+        }
+    },
+}
+
+fn device_id(
+    device: &TEdgeConfigReaderDevice,
+    dto_value: &OptionalConfig<String>,
+) -> Result<String, ReadError> {
+    match dto_value.or_none() {
+        Some(dto_value) => Ok(dto_value.to_owned()),
+        None => {
+            let cert = device.cert_path.or_config_not_set()?;
+            device_id_from_cert(cert)
+        }
+    }
+}
+
+fn c8y_device_id(
+    c8y_device: &TEdgeConfigReaderC8yDevice,
+    dto_value: &OptionalConfig<String>,
+) -> Result<String, ReadError> {
+    match dto_value.or_none() {
+        Some(dto_value) => Ok(dto_value.to_owned()),
+        None => {
+            let cert = c8y_device.cert_path.or_config_not_set()?;
+            device_id_from_cert(cert)
+        }
+    }
+}
+
+fn device_id_from_cert(cert_path: &Utf8Path) -> Result<String, ReadError> {
+    let pem = PemCertificate::from_pem_file(cert_path)
+        .map_err(|err| cert_error_into_config_error(ReadableKey::DeviceId.to_cow_str(), err))?;
+    let device_id = pem
+        .subject_common_name()
+        .map_err(|err| cert_error_into_config_error(ReadableKey::DeviceId.to_cow_str(), err))?;
+    Ok(device_id)
+}
+
+fn cert_error_into_config_error(key: Cow<'static, str>, err: CertificateError) -> ReadError {
+    match &err {
+        CertificateError::IoError { error, .. } => match error.kind() {
+            std::io::ErrorKind::NotFound => ReadError::ReadOnlyNotFound {
+                key,
+                message: concat!(
+                    "The device id is read from the device certificate.\n",
+                    "To set 'device.id' to some <id>, you can use `tedge cert create --device-id <id>`.",
+                ),
+            },
+            _ => ReadError::DerivationFailed {
+                key,
+                cause: format!("{}", err),
+            },
+        },
+        _ => ReadError::DerivationFailed {
+            key,
+            cause: format!("{}", err),
+        },
+    }
+}
+
+fn read_config(toml: &str) -> TEdgeConfigReader {
+    let c8y_dto = toml::from_str(toml).unwrap();
+    TEdgeConfigReader::from_dto(&c8y_dto, &TEdgeConfigLocation)
+}
+
+fn main() {
+    let config = read_config("device.id = \"test-device-id\"");
+    let c8y = config.c8y.try_get::<&str>(None).unwrap();
+
+    assert_eq!(config.device.id().unwrap(), "test-device-id");
+    assert_eq!(c8y.device.id().unwrap(), "test-device-id");
+
+    let config = read_config("device.id = \"test-device-id\"\nc8y.device.id = \"c8y-device-id\"");
+    let c8y = config.c8y.try_get::<&str>(None).unwrap();
+
+    assert_eq!(config.device.id().unwrap(), "test-device-id");
+    assert_eq!(c8y.device.id().unwrap(), "c8y-device-id");
+}

--- a/crates/common/tedge_config_macros/examples/reader_function.rs
+++ b/crates/common/tedge_config_macros/examples/reader_function.rs
@@ -1,4 +1,5 @@
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use certificate::CertificateError;
 use certificate::PemCertificate;
 use std::borrow::Cow;

--- a/crates/common/tedge_config_macros/impl/src/dto.rs
+++ b/crates/common/tedge_config_macros/impl/src/dto.rs
@@ -275,12 +275,12 @@ mod tests {
 
     fn assert_eq(actual: &syn::File, expected: &syn::File) {
         pretty_assertions::assert_eq!(
-            prettyplease::unparse(&actual),
-            prettyplease::unparse(&expected),
+            prettyplease::unparse(actual),
+            prettyplease::unparse(expected),
         )
     }
 
-    fn only_struct_named<'a>(target: &'a str) -> impl Fn(&Item) -> bool + 'a {
+    fn only_struct_named(target: &str) -> impl Fn(&Item) -> bool + '_ {
         move |i| matches!(i, Item::Struct(ItemStruct { ident, .. }) if ident == target)
     }
 }

--- a/crates/common/tedge_config_macros/impl/src/input/parse.rs
+++ b/crates/common/tedge_config_macros/impl/src/input/parse.rs
@@ -3,10 +3,6 @@
 //! This is designed to take a [proc_macro2::TokenStream] and turn it into
 //! something useful with the aid of [syn].
 
-// FIXME: if let can be simplified with `.unwrap_or_default()`
-//        for all `#[darling(default)]`
-// #![allow(clippy::manual_unwrap_or_default)]
-
 use darling::util::SpannedValue;
 use darling::FromAttributes;
 use darling::FromField;

--- a/crates/common/tedge_config_macros/impl/src/input/parse.rs
+++ b/crates/common/tedge_config_macros/impl/src/input/parse.rs
@@ -5,7 +5,7 @@
 
 // FIXME: if let can be simplified with `.unwrap_or_default()`
 //        for all `#[darling(default)]`
-#![allow(clippy::manual_unwrap_or_default)]
+// #![allow(clippy::manual_unwrap_or_default)]
 
 use darling::util::SpannedValue;
 use darling::FromAttributes;
@@ -198,6 +198,7 @@ pub struct FieldDtoSettings {
 pub struct ReaderSettings {
     #[darling(default)]
     pub private: bool,
+    pub function: Option<syn::Path>,
     #[darling(default)]
     pub skip: bool,
 }

--- a/crates/common/tedge_config_macros/impl/src/input/validate.rs
+++ b/crates/common/tedge_config_macros/impl/src/input/validate.rs
@@ -13,6 +13,7 @@ use syn::Meta;
 use syn::MetaNameValue;
 
 use crate::error::combine_errors;
+use crate::error::extract_type_from_result;
 use crate::optional_error::OptionalError;
 use crate::optional_error::SynResultExt;
 use crate::reader::PathItem;
@@ -242,6 +243,40 @@ impl ReadOnlyField {
     }
 }
 
+impl ReadWriteField {
+    pub fn lazy_reader_name(&self, parents: &[PathItem]) -> syn::Ident {
+        format_ident!(
+            "LazyReader{}{}",
+            parents
+                .iter()
+                .filter_map(PathItem::as_static)
+                .map(|p| p.to_string().to_upper_camel_case())
+                .collect::<Vec<_>>()
+                .join(""),
+            self.rename()
+                .map(<_>::to_owned)
+                .unwrap_or_else(|| self.ident.to_string())
+                .to_upper_camel_case()
+        )
+    }
+
+    pub fn parent_name(&self, parents: &[PathItem]) -> syn::Ident {
+        format_ident!(
+            "TEdgeConfigReader{}",
+            parents
+                .iter()
+                .filter_map(PathItem::as_static)
+                .map(|p| p.to_string().to_upper_camel_case())
+                .collect::<Vec<_>>()
+                .join(""),
+        )
+    }
+
+    pub fn rename(&self) -> Option<&str> {
+        Some(self.rename.as_ref()?.as_str())
+    }
+}
+
 #[derive(Debug)]
 pub struct ReadWriteField {
     pub attrs: Vec<syn::Attribute>,
@@ -336,6 +371,21 @@ impl ConfigurableField {
         }
     }
 
+    pub fn reader_function(&self) -> Option<(&syn::Path, &ReadWriteField)> {
+        match self {
+            Self::ReadWrite(
+                field @ ReadWriteField {
+                    reader:
+                        ReaderSettings {
+                            function: Some(f), ..
+                        },
+                    ..
+                },
+            ) => Some((f, field)),
+            _ => None,
+        }
+    }
+
     pub fn deprecated_keys(&self) -> impl Iterator<Item = &str> {
         let keys = match self {
             Self::ReadOnly(field) => &field.deprecated_keys,
@@ -390,6 +440,14 @@ impl TryFrom<super::parse::ConfigurableField> for ConfigurableField {
             value
                 .attrs
                 .push(parse_quote_spanned!(span=> #[serde(rename = #literal)]))
+        }
+
+        if value.reader.function.is_some() && value.from.is_none() {
+            value.from = Some(
+                extract_type_from_result(&value.ty)
+                    .map_or(&value.ty, |tys| tys.0)
+                    .clone(),
+            );
         }
 
         for name in value.deprecated_names {

--- a/crates/common/tedge_config_macros/impl/src/query.rs
+++ b/crates/common/tedge_config_macros/impl/src/query.rs
@@ -674,7 +674,7 @@ fn generate_string_readers(paths: &[VecDeque<&FieldOrGroup>]) -> TokenStream {
             parent_segments.remove(parent_segments.len() - 1);
             let to_string = quote_spanned!(field.ty().span()=> .to_string());
             let match_variant = configuration_key.match_read_write;
-            if field.read_only().is_some() {
+            if field.read_only().is_some() || field.reader_function().is_some() {
                 if extract_type_from_result(field.ty()).is_some() {
                     parse_quote! {
                         ReadableKey::#match_variant => Ok(self.#(#segments).*()?#to_string),
@@ -730,16 +730,21 @@ fn generate_string_writers(paths: &[VecDeque<&FieldOrGroup>]) -> TokenStream {
                 .unwrap();
             let match_variant = configuration_key.match_read_write;
 
-            let ty = field.ty();
+            let ty = if field.reader_function().is_some() {
+                extract_type_from_result(field.ty()).map(|tys| tys.0).unwrap_or(field.ty())
+            } else {
+                field.ty()
+            };
+
             let parse_as = field.from().unwrap_or(field.ty());
             let parse = quote_spanned! {parse_as.span()=> parse::<#parse_as>() };
             let convert_to_field_ty = quote_spanned! {ty.span()=> map(<#ty>::from)};
 
-            let current_value = if field.read_only().is_some() {
+            let current_value = if field.read_only().is_some() || field.reader_function().is_some() {
                 if extract_type_from_result(field.ty()).is_some() {
-                    quote_spanned! {ty.span()=> reader.#(#read_segments).*.try_read(reader).ok()}
+                    quote_spanned! {ty.span()=> reader.#(#read_segments).*().ok().cloned()}
                 } else {
-                    quote_spanned! {ty.span()=> Some(reader.#(#read_segments).*.read(reader))}
+                    quote_spanned! {ty.span()=> Some(reader.#(#read_segments).*())}
                 }
             } else if field.has_guaranteed_default() {
                 quote_spanned! {ty.span()=> Some(reader.#(#read_segments).*.to_owned())}
@@ -1503,6 +1508,47 @@ mod tests {
                         WritableKey::SudoEnable => {
                             self.sudo.enable = None;
                         },
+                    };
+                    Ok(())
+                }
+            }
+        };
+
+        pretty_assertions::assert_eq!(
+            prettyplease::unparse(&parse_quote!(#impl_dto_block)),
+            prettyplease::unparse(&expected)
+        )
+    }
+
+    #[test]
+    fn impl_try_append_calls_method_for_current_value() {
+        let input: crate::input::Configuration = parse_quote!(
+            #[tedge_config(multi)]
+            c8y: {
+                device: {
+                    #[tedge_config(reader(function = "device_id"))]
+                    id: String,
+                },
+            }
+        );
+        let paths = configuration_paths_from(&input.groups);
+        let writers = generate_string_writers(&paths);
+        let impl_dto_block = syn::parse2(writers).unwrap();
+        let impl_dto_block = retain_fn(impl_dto_block, "try_append_str");
+
+        let expected = parse_quote! {
+            impl TEdgeConfigDto {
+                pub fn try_append_str(&mut self, reader: &TEdgeConfigReader, key: &WritableKey, value: &str) -> Result<(), WriteError> {
+                    match key {
+                        WritableKey::C8yDeviceId(key0) => {
+                            self.c8y.try_get_mut(key0.as_deref(), "c8y")?.device.id = <String as AppendRemoveItem>::append(
+                                Some(reader.c8y.try_get(key0.as_deref())?.device.id()),
+                                value
+                                    .parse::<String>()
+                                    .map(<String>::from)
+                                    .map_err(|e| WriteError::ParseValue(Box::new(e)))?,
+                            );
+                        }
                     };
                     Ok(())
                 }

--- a/crates/common/tedge_config_macros/src/define_tedge_config_docs.md
+++ b/crates/common/tedge_config_macros/src/define_tedge_config_docs.md
@@ -935,10 +935,18 @@ define_tedge_config! {
     ))]
     #[doku(as = "String")]
     id: Result<String, ReadError>,
+
+    #[tedge_config(reader(function = "try_read_device_id_with_dto"))]
+    #[doku(as = "String")]
+    dto_backed_id: Result<String, ReadError>,
   }
 }
 
-fn try_read_device_id(_reader: &TEdgeConfigReaderDevice) -> Result<String, ReadError> {
+fn try_read_device_id(_reader: &TEdgeConfigReaderDevice, _: &()) -> Result<String, ReadError> {
+    unimplemented!()
+}
+
+fn try_read_device_id_with_dto(_reader: &TEdgeConfigReaderDevice, _dto_value: &OptionalConfig<String>) -> Result<String, ReadError> {
     unimplemented!()
 }
 ```

--- a/crates/core/tedge/src/cli/certificate/create.rs
+++ b/crates/core/tedge/src/cli/certificate/create.rs
@@ -1,4 +1,5 @@
 use super::error::CertError;
+use crate::cli::certificate::show::ShowCertCmd;
 use crate::command::Command;
 use crate::log::MaybeFancy;
 use camino::Utf8PathBuf;
@@ -41,7 +42,11 @@ impl Command for CreateCertCmd {
     fn execute(&self) -> Result<(), MaybeFancy<anyhow::Error>> {
         let config = NewCertificateConfig::default();
         self.create_test_certificate(&config)?;
-        eprintln!("Certificate was successfully created");
+        eprintln!("Certificate was successfully created\n");
+        let show_cert_cmd = ShowCertCmd {
+            cert_path: self.cert_path.clone(),
+        };
+        show_cert_cmd.execute()?;
         Ok(())
     }
 }

--- a/crates/core/tedge/src/cli/certificate/create.rs
+++ b/crates/core/tedge/src/cli/certificate/create.rs
@@ -10,6 +10,7 @@ use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 use std::path::Path;
+use tedge_config::TEdgeConfigLocation;
 use tedge_utils::paths::set_permission;
 use tedge_utils::paths::validate_parent_dir_exists;
 
@@ -27,6 +28,9 @@ pub struct CreateCertCmd {
     /// The owner of the private key
     pub user: String,
     pub group: String,
+
+    /// The tedge.toml file location, required to access to TEdgeConfigDto
+    pub config_location: TEdgeConfigLocation,
 }
 
 impl Command for CreateCertCmd {
@@ -185,6 +189,7 @@ mod tests {
             key_path: key_path.clone(),
             user: "mosquitto".to_string(),
             group: "mosquitto".to_string(),
+            config_location: TEdgeConfigLocation::from_custom_root(dir.path()),
         };
 
         assert_matches!(
@@ -214,6 +219,7 @@ mod tests {
             key_path: key_path.clone(),
             user: "mosquitto".to_string(),
             group: "mosquitto".to_string(),
+            config_location: TEdgeConfigLocation::from_custom_root(dir.path()),
         };
 
         assert!(cmd
@@ -237,6 +243,7 @@ mod tests {
             key_path,
             user: "mosquitto".to_string(),
             group: "mosquitto".to_string(),
+            config_location: TEdgeConfigLocation::from_custom_root(dir.path()),
         };
 
         let cert_error = cmd
@@ -257,6 +264,7 @@ mod tests {
             key_path,
             user: "mosquitto".to_string(),
             group: "mosquitto".to_string(),
+            config_location: TEdgeConfigLocation::from_custom_root(dir.path()),
         };
 
         let cert_error = cmd

--- a/crates/core/tedge/src/cli/certificate/create_csr.rs
+++ b/crates/core/tedge/src/cli/certificate/create_csr.rs
@@ -71,6 +71,7 @@ mod tests {
     use crate::CreateCertCmd;
     use assert_matches::assert_matches;
     use std::path::Path;
+    use tedge_config::TEdgeConfigLocation;
     use tempfile::*;
     use x509_parser::der_parser::asn1_rs::FromDer;
     use x509_parser::nom::AsBytes;
@@ -113,6 +114,7 @@ mod tests {
             key_path: key_path.clone(),
             user: "mosquitto".to_string(),
             group: "mosquitto".to_string(),
+            config_location: TEdgeConfigLocation::from_custom_root(dir.path()),
         };
 
         // create private key and public cert with standard command

--- a/crates/core/tedge/src/cli/certificate/renew.rs
+++ b/crates/core/tedge/src/cli/certificate/renew.rs
@@ -59,6 +59,7 @@ mod tests {
     use std::path::Path;
     use std::thread::sleep;
     use std::time::Duration;
+    use tedge_config::TEdgeConfigLocation;
     use tempfile::*;
 
     #[test]
@@ -73,6 +74,7 @@ mod tests {
             key_path: key_path.clone(),
             user: "mosquitto".to_string(),
             group: "mosquitto".to_string(),
+            config_location: TEdgeConfigLocation::from_custom_root(dir.path()),
         };
 
         // First create both cert and key

--- a/crates/core/tedge/src/cli/config/cli.rs
+++ b/crates/core/tedge/src/cli/config/cli.rs
@@ -113,6 +113,7 @@ pub enum ConfigCmd {
     },
 }
 
+#[macro_export]
 macro_rules! try_with_profile {
     ($key:ident, $profile:ident) => {{
         use anyhow::Context;

--- a/crates/core/tedge/src/cli/config/commands/list.rs
+++ b/crates/core/tedge/src/cli/config/commands/list.rs
@@ -30,21 +30,13 @@ impl Command for ListConfigCommand {
     }
 }
 
-fn should_hide(key: &str) -> bool {
-    (key.starts_with("c8y") || key.starts_with("az") || key.starts_with("aws"))
-        && key.contains(".device.")
-}
-
 fn print_config_list(
     config: &TEdgeConfig,
     all: bool,
     filter: Option<&str>,
 ) -> Result<(), anyhow::Error> {
     let mut keys_without_values = Vec::new();
-    for config_key in config
-        .readable_keys()
-        .filter(|key| !should_hide(&key.to_cow_str()))
-    {
+    for config_key in config.readable_keys() {
         if !key_matches_filter(&config_key.to_cow_str(), filter) {
             continue;
         }
@@ -75,9 +67,6 @@ fn print_config_doc(filter: Option<&str>) {
         .unwrap_or_default();
 
     for (key, ty) in READABLE_KEYS.iter() {
-        if should_hide(key) {
-            continue;
-        }
         if !key_matches_filter(key, filter) {
             continue;
         }

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -375,21 +375,19 @@ fn disallow_matching_url_device_id(
                 .map(|&(k, _)| format!("{}", url(k.clone()).yellow().bold()))
                 .collect::<Vec<_>>()
                 .join(", ");
-            // TODO re-enable this logic once multiple device IDs are properly supported
-            // let device_id_keys: String = matches
-            //     .iter()
-            //     .map(|(_, key)| format!("{}", key.yellow().bold()))
-            //     .collect::<Vec<_>>()
-            //     .join(", ");
-            //             bail!(
-            //                 "You have matching URLs and device IDs for different profiles.
+            let device_id_keys: String = matches
+                .iter()
+                .map(|(_, key)| format!("{}", key.yellow().bold()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!(
+                "You have matching URLs and device IDs for different profiles.
 
-            // {url_keys} are set to the same value, but so are {device_id_keys}.
+{url_keys} are set to the same value, but so are {device_id_keys}.
 
-            // Each cloud profile requires either a unique URL or unique device ID, \
-            // so it corresponds to a unique device in the associated cloud."
-            //             );
-            bail!("The configurations: {url_keys} should be set to different values before connecting, but are currently set to the same value");
+Each cloud profile requires either a unique URL or unique device ID, \
+so it corresponds to a unique device in the associated cloud."
+            );
         }
     }
     Ok(())
@@ -1322,8 +1320,7 @@ mod tests {
             let config = loc.load().unwrap();
 
             let err = validate_config(&config, &cloud).unwrap_err();
-            // TODO change me to assert eq once device IDs are properly supported
-            assert_ne!(err.to_string(), "You have matching URLs and device IDs for different profiles.
+            assert_eq!(err.to_string(), "You have matching URLs and device IDs for different profiles.
 
 c8y.url, c8y.profiles.new.url are set to the same value, but so are c8y.device.id, c8y.profiles.new.device.id.
 

--- a/crates/core/tedge/src/cli/upload/mod.rs
+++ b/crates/core/tedge/src/cli/upload/mod.rs
@@ -79,8 +79,9 @@ impl BuildCommand for UploadCmd {
                 let identity = config.http.client.auth.identity()?;
                 let cloud_root_certs = config.cloud_root_certs();
                 let c8y = C8yEndPoint::local_proxy(&config, profile.as_deref())?;
+                let c8y_config = config.c8y.try_get(profile.as_deref())?;
                 let device_id = match device_id {
-                    None => config.device.id()?.clone(),
+                    None => c8y_config.device.id()?.clone(),
                     Some(device_id) => device_id,
                 };
                 let text = text.unwrap_or_else(|| format!("Uploaded file: {file:?}"));

--- a/crates/core/tedge/tests/main.rs
+++ b/crates/core/tedge/tests/main.rs
@@ -85,7 +85,7 @@ mod tests {
         // The remove command can be run when there is no certificate
         remove_cmd.assert().success();
 
-        // We start we no certificate, hence no device id
+        // We start with no certificate, hence no device id
         get_device_id_cmd
             .assert()
             .failure()
@@ -127,7 +127,7 @@ mod tests {
             .failure()
             .stderr(predicate::str::contains("device.id"));
 
-        // The a new certificate can then be created.
+        // A new certificate can then be created.
         create_cmd.assert().success();
 
         Ok(())

--- a/crates/core/tedge/tests/main.rs
+++ b/crates/core/tedge/tests/main.rs
@@ -133,54 +133,6 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn run_config_set_get_unset_read_only_key() -> Result<(), Box<dyn std::error::Error>> {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let temp_dir_path = temp_dir.path();
-        let test_home_str = temp_dir_path.to_str().unwrap();
-
-        let device_id = "test";
-
-        // allowed to get read-only key by CLI
-        let mut get_device_id_cmd = tedge_command_with_test_home([
-            "--config-dir",
-            test_home_str,
-            "config",
-            "get",
-            "device.id",
-        ])?;
-
-        get_device_id_cmd
-            .assert()
-            .failure()
-            .stderr(predicate::str::contains("device.id"));
-
-        // forbidden to set read-only key by CLI
-        let mut set_device_id_cmd = tedge_command_with_test_home([
-            "--config-dir",
-            test_home_str,
-            "config",
-            "set",
-            "device.id",
-            device_id,
-        ])?;
-
-        set_device_id_cmd.assert().failure();
-
-        // forbidden to unset read-only key by CLI
-        let mut unset_device_id_cmd = tedge_command_with_test_home([
-            "--config-dir",
-            test_home_str,
-            "config",
-            "unset",
-            "device.id",
-        ])?;
-
-        unset_device_id_cmd.assert().failure();
-
-        Ok(())
-    }
-
     // #[test_case(config key, config value, expected unset value)]
     #[test_case(
         "c8y.url",

--- a/docs/src/operate/c8y/smartrest-one.md
+++ b/docs/src/operate/c8y/smartrest-one.md
@@ -1,0 +1,73 @@
+---
+title: SmartREST 1.0 and basic auth
+tags: [Operate, Cumulocity]
+description: Establishing connection with Basic auth and using SmartREST 1.0
+---
+
+%%te%% supports basic authentication and [SmartREST 1.0.](https://cumulocity.com/docs/smartrest/smartrest-one/)
+This page explains how to use basic authentication and SmartREST 1.0 with Cumulocity.
+
+:::important
+It is highly recommended to use certificate-based authentication and SmartREST 2.0.
+This guide is intended for users who must use the SmartREST 1.0 for specific reasons.
+:::
+
+## Setting up basic authentication
+
+To use SmartREST 1.0, the authentication mode must be set to `basic` using the `tedge config` CLI tool:
+
+```sh
+sudo tedge config set c8y.auth_mode basic
+```
+
+Next, provide credentials (username/password) in a credential file formatted as follows.
+The default location of the credentials file is `/etc/tedge/credentials.toml`:
+
+```toml
+[c8y]
+username = "t5678/octocat"
+password = "abcd1234"
+```
+
+If needed, you can specify a custom location for the credentials file using the `tedge config` CLI tool:
+
+```sh
+sudo tedge config set c8y.credentials_path </custom/path/to/credentials.toml>
+```
+
+## Configuring the device ID
+
+The device ID must be explicitly set. This ID will be used as the external ID of the device in your Cumulocity tenant.
+
+```sh
+sudo tedge config set device.id <id>
+```
+
+## Adding SmartREST 1.0 template to %%te%% config
+
+You need to specify all the external IDs of the SmartREST 1.0 templates you plan to use.
+This can be achieved by providing a comma-separated list of the external IDs:
+
+```sh
+sudo tedge config set c8y.smartrest1.templates template-1,template-2
+```
+
+Alternatively, you can add the template IDs one by one:
+
+```sh
+sudo tedge config add c8y.smartrest1.templates template-1
+sudo tedge config add c8y.smartrest1.templates template-2
+```
+
+## Connecting to Cumulocity
+
+Before connecting to Cumulocity, ensure the following prerequisites are met:
+
+- The device has already been registered in Cumulocity using the [Bulk Registration API](https://cumulocity.com/docs/device-management-application/registering-devices/#bulk-device-registration).
+- The SmartREST 1.0 templates have been registered in your Cumulocity tenant.
+
+Once these steps are complete, you can connect to Cumulocity:
+
+```sh
+sudo tedge connect c8y
+```

--- a/tests/RobotFramework/tests/cumulocity/smartrest_one/smartrest_one.robot
+++ b/tests/RobotFramework/tests/cumulocity/smartrest_one/smartrest_one.robot
@@ -31,6 +31,12 @@ Register and Use SmartREST 1.0. Templates
     [Arguments]    ${use_builtin_bridge}
     Custom Setup    use_builtin_bridge=${use_builtin_bridge}
 
+    # device.id should be set by tedge config and confirm the test doesn't use certificate
+    Execute Command    tedge config set device.id ${DEVICE_SN}
+    Execute Command    tedge cert remove
+    File Should Not Exist    /etc/tedge/device-certs/tedge-certificate.pem
+    File Should Not Exist    /etc/tedge/device-certs/tedge-private-key.pem
+
     ${TEMPLATE_XID}=    Get Random Name    prefix=TST_Template
     Set Test Variable    $TEMPLATE_XID
     Execute Command    tedge config set c8y.smartrest1.templates "${TEMPLATE_XID}"

--- a/tests/RobotFramework/tests/tedge/tedge_cert_create.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_cert_create.robot
@@ -1,0 +1,133 @@
+*** Settings ***
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+
+Suite Teardown      Get Logs
+Test Setup          Custom Setup
+
+Test Tags           theme:cli
+
+
+*** Test Cases ***
+Run tedge cert create
+    # device.id doesn't exist yet
+    Execute Command    tedge config get device.id    exp_exit_code=1
+
+    Execute Command    tedge cert create --device-id ${DEVICE_SN}
+    File Should Exist    /etc/tedge/device-certs/tedge-certificate.pem
+    File Should Exist    /etc/tedge/device-certs/tedge-private-key.pem
+
+    ${subject}=    Execute Command    openssl x509 -noout -subject -in /etc/tedge/device-certs/tedge-certificate.pem
+    Should Match Regexp    ${subject}    pattern=^subject=CN = ${DEVICE_SN},.+$
+
+    # device.id is read from the cert's CN
+    ${device_id}=    Execute Command    tedge config get device.id    strip=${True}
+    Should Be Equal    ${device_id}    ${DEVICE_SN}
+
+    # Remove the cert and key
+    Execute Command    tedge cert remove
+    File Should Not Exist    /etc/tedge/device-certs/tedge-certificate.pem
+    File Should Not Exist    /etc/tedge/device-certs/tedge-private-key.pem
+    Execute Command    tedge config get device.id    exp_exit_code=1
+
+    # New cert/key can be also created without --device-id option if device.id is set in config
+    Execute Command    tedge config set device.id ${DEVICE_SN}-two
+    Execute Command    tedge cert create
+    File Should Exist    /etc/tedge/device-certs/tedge-certificate.pem
+    File Should Exist    /etc/tedge/device-certs/tedge-private-key.pem
+    ${subject_two}=    Execute Command
+    ...    openssl x509 -noout -subject -in /etc/tedge/device-certs/tedge-certificate.pem
+    Should Match Regexp    ${subject_two}    pattern=^subject=CN = ${DEVICE_SN}-two,.+$
+
+Run tedge cert create with cloud profile
+    Set Test Variable    $SECOND_DEVICE_SN    ${device_sn}-second
+    Set Test Variable    $THIRD_DEVICE_SN    ${device_sn}-third
+
+    Execute Command
+    ...    tedge config set c8y.device.cert_path --profile second /etc/tedge/device-certs/tedge-certificate@second.pem
+    Execute Command
+    ...    tedge config set c8y.device.key_path --profile second /etc/tedge/device-certs/tedge-private-key@second.pem
+
+    Execute Command    tedge cert create --device-id ${SECOND_DEVICE_SN} c8y --profile second
+    File Should Exist    /etc/tedge/device-certs/tedge-certificate@second.pem
+    File Should Exist    /etc/tedge/device-certs/tedge-private-key@second.pem
+
+    ${subject}=    Execute Command
+    ...    openssl x509 -noout -subject -in /etc/tedge/device-certs/tedge-certificate@second.pem
+    Should Match Regexp    ${subject}    pattern=^subject=CN = ${SECOND_DEVICE_SN},.+$
+
+    # c8y.profiles.second.device.id is read from the cert's CN of the cloud profile "second"
+    ${config_output}=    Execute Command
+    ...    tedge config get c8y.device.id --profile second
+    ...    strip=${True}
+    Should Be Equal    ${config_output}    ${SECOND_DEVICE_SN}
+
+    # Using another cloud profile. c8y.profiles.third.device.id is set by tedge config set
+    Execute Command    tedge config set c8y.device.id --profile third ${THIRD_DEVICE_SN}
+    Execute Command
+    ...    tedge config set c8y.device.cert_path --profile third /etc/tedge/device-certs/tedge-certificate@third.pem
+    Execute Command
+    ...    tedge config set c8y.device.key_path --profile third /etc/tedge/device-certs/tedge-private-key@third.pem
+
+    Execute Command    tedge cert create c8y --profile third
+
+    File Should Exist    /etc/tedge/device-certs/tedge-certificate@third.pem
+    File Should Exist    /etc/tedge/device-certs/tedge-private-key@third.pem
+    ${subject}=    Execute Command
+    ...    openssl x509 -noout -subject -in /etc/tedge/device-certs/tedge-certificate@third.pem
+    Should Match Regexp    ${subject}    pattern=^subject=CN = ${THIRD_DEVICE_SN},.+$
+
+Device ID derivation
+    ${output}=    Execute Command    tedge cert create --device-id input
+    Should Contain    ${output}    CN=input
+    Execute Command    tedge cert remove
+
+    Execute Command    tedge config set device.id testid
+    # Mismached device id returns error
+    Execute Command    tedge cert create --device-id different    exp_exit_code=1
+    # Matched device id passes
+    ${output}=    Execute Command    tedge cert create --device-id testid
+    Should Contain    ${output}    CN=testid
+    Execute Command    tedge cert remove
+
+    # The generic device.id is used as "default" value if cloud profile doesn't have it explicitly
+    ${output}=    Execute Command    tedge cert create c8y
+    Should Contain    ${output}    CN=testid
+    Execute Command    tedge cert remove c8y
+
+    Execute Command    tedge config set c8y.url example.com --profile foo
+    ${output}=    Execute Command    tedge cert create c8y --profile foo
+    Should Contain    ${output}    CN=testid
+    Execute Command    tedge cert remove c8y --profile foo
+
+    # input value is used if cloud profile doesn't have explicit device id
+    ${output}=    Execute Command    tedge cert create c8y --device-id input
+    Should Contain    ${output}    CN=input
+    Execute Command    tedge cert remove c8y
+
+    ${output}=    Execute Command    tedge cert create c8y --device-id input --profile foo
+    Should Contain    ${output}    CN=input
+    Execute Command    tedge cert remove c8y --profile foo
+
+    # the value from cloud profile is used over the "default" value from the generic device.id
+    Execute Command    tedge config set c8y.device.id c8y-testid
+    ${output}=    Execute Command    tedge cert create c8y
+    Should Contain    ${output}    CN=c8y-testid
+    Execute Command    tedge cert remove c8y
+    # Mismatched device id returns error
+    Execute Command    tedge cert create c8y --device-id different    exp_exit_code=1
+
+    Execute Command    tedge config set c8y.device.id c8y-foo-testid --profile foo
+    ${output}=    Execute Command    tedge cert create c8y --profile foo
+    Should Contain    ${output}    CN=c8y-foo-testid
+    Execute Command    tedge cert remove c8y --profile foo
+    # Mismatched device id returns error
+    Execute Command    tedge cert create c8y --device-id different --profile foo    exp_exit_code=1
+
+
+*** Keywords ***
+Custom Setup
+    ${device_sn}=    Setup    skip_bootstrap=${True}
+    Execute Command    ./bootstrap.sh --no-bootstrap --no-connect
+
+    Set Test Variable    $DEVICE_SN    ${device_sn}

--- a/tests/RobotFramework/tests/tedge_connect/tedge_connect_cn_validation.robot
+++ b/tests/RobotFramework/tests/tedge_connect/tedge_connect_cn_validation.robot
@@ -1,0 +1,34 @@
+*** Settings ***
+Resource            ../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+Library             ../../.venv/lib/python3.11/site-packages/robot/libraries/String.py
+
+Suite Teardown      Get Logs
+Test Setup          Custom Setup
+
+Test Tags           theme:c8y    theme:cli
+
+
+*** Test Cases ***
+Certificate's CN must match device.id
+    ${cert_output}=    Execute Command    tedge cert show
+    Should Contain    ${cert_output}    ${DEVICE_SN}
+
+    Execute Command    tedge config set device.id foo
+    ${output}=    Execute Command    tedge connect c8y
+    ...    exp_exit_code=1
+    ...    stdout=False
+    ...    stderr=True
+    ...    timeout=0
+    ...    strip=True
+    Should Be Equal
+    ...    ${output}
+    ...    error: device.id 'foo' mismatches to the device certificate's CN '${DEVICE_SN}'
+
+
+*** Keywords ***
+Custom Setup
+    ${device_sn}=    Setup    skip_bootstrap=${True}
+    Execute Command    ./bootstrap.sh --no-connect
+    Set Test Variable    $DEVICE_SN    ${device_sn}


### PR DESCRIPTION
## Proposed changes
This PR aims to open up `device.id` as read-write key. This is the last piece of supporting basic authentication, as it needs `device.id` but not need for device cert.

TODOs:

**tedge cert/connect part**
- [x] ~~`tedge cert create` writes `device.id` in `tedge.toml` explicitly.~~ Reverted.
- [x]  `tedge connect` returns an error if `device.id` mismatches the certificate's CN. The only exception is when `c8y.auth_mode` is `basic`.
- [x] Updated `smart_rest_one` system test to confirm that `tedge connect c8y` uses `device.id` directly when using basic auth.
- [x] ~~`tedge cert create-csr` also sets `device.id` if not configured.~~ Reverted.
- [x] `tedge cert create` should work without `--device-id` option when `device.id` is already set.
- [x] ~~Don't overwrite a certificate and `device.id` when the values of option `--device-id` and config `device.id` are conflicting. This case should return an error.~~ If a certificate exists already in the given path, anyway it will not be overwritten (known behavour)

**tedge_config part** (originally started in the PR #3318 by @jarhodes314 )
- [x] Introduce new read-write macro
- [x] Clippy warnings & doc test error fix
- [x] Move `get_device_id_from_config()` function to `tedge_config` to keep `config.device.id()` as private. https://github.com/thin-edge/thin-edge.io/pull/3318#discussion_r1910487052

**doc part**
- [x] Create Basic auth and SmartREST1.0 support doc

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3242 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

