### PR TITLE
feat: support shell completions in `tedge` cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -376,7 +376,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdca6a10ecad987bda04e95606ef85a5417dcaac1a78455242d72e031e2b6b62"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -839,9 +839,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -849,23 +849,35 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a7e468e750fa4b6be660e8b5651ad47372e8fb114030b594c2d75d48c5ffd0"
+dependencies = [
+ "clap",
+ "clap_lex",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -873,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clock"
@@ -1048,7 +1060,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1062,7 +1074,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.77",
 ]
 
@@ -1628,6 +1640,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2036,15 @@ name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
+name = "is_executable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "itertools"
@@ -3592,6 +3619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,6 +3720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3701,7 +3740,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3824,6 +3863,7 @@ dependencies = [
  "cap",
  "certificate",
  "clap",
+ "clap_complete",
  "doku",
  "hyper 0.14.28",
  "mime_guess",
@@ -4060,6 +4100,7 @@ dependencies = [
  "camino",
  "certificate",
  "clap",
+ "clap_complete",
  "doku",
  "figment",
  "humantime",
@@ -4092,6 +4133,8 @@ version = "1.4.2"
 dependencies = [
  "anyhow",
  "camino",
+ "clap",
+ "clap_complete",
  "doku",
  "once_cell",
  "regex",
@@ -4109,7 +4152,7 @@ name = "tedge_config_macros-impl"
 version = "1.4.2"
 dependencies = [
  "darling 0.20.3",
- "heck",
+ "heck 0.4.1",
  "itertools 0.13.0",
  "pretty_assertions",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,13 +89,14 @@ base64 = "0.13"
 bytes = "1.4"
 camino = "1.1"
 cap = "0.1"
-clap = { version = "4.4", features = [
+clap = { version = "4.5", features = [
     "cargo",
     "derive",
     "string",
     "env",
     "unstable-styles",
 ] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 csv = "1.1"
 darling = "0.20"
 doku = "0.21"

--- a/crates/common/tedge_config/Cargo.toml
+++ b/crates/common/tedge_config/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 camino = { workspace = true, features = ["serde", "serde1"] }
 certificate = { workspace = true, features = ["reqwest"] }
 clap = { workspace = true }
+clap_complete = { workspace = true }
 doku = { workspace = true }
 figment = { workspace = true, features = ["env", "toml"] }
 humantime = { workspace = true }

--- a/crates/common/tedge_config/src/cli.rs
+++ b/crates/common/tedge_config/src/cli.rs
@@ -2,6 +2,7 @@
 
 use camino::Utf8PathBuf;
 use clap::Args;
+use clap::ValueHint;
 
 /// CLI arguments that should be handled by all thin-edge components.
 #[derive(Args, Debug, PartialEq, Eq, Clone)]
@@ -13,6 +14,7 @@ pub struct CommonArgs {
             hide_env_values = true,
             hide_default_value = true,
             global = true,
+            value_hint = ValueHint::DirPath,
         )]
     pub config_dir: Utf8PathBuf,
 

--- a/crates/common/tedge_config/src/cli.rs
+++ b/crates/common/tedge_config/src/cli.rs
@@ -3,6 +3,8 @@
 use camino::Utf8PathBuf;
 use clap::Args;
 use clap::ValueHint;
+use clap_complete::ArgValueCandidates;
+use clap_complete::CompletionCandidate;
 
 /// CLI arguments that should be handled by all thin-edge components.
 #[derive(Args, Debug, PartialEq, Eq, Clone)]
@@ -37,5 +39,15 @@ pub struct LogConfigArgs {
     ///
     /// Overrides `--debug`
     #[clap(long, global = true)]
+    #[clap(add(ArgValueCandidates::new(log_level_completions)))]
     pub log_level: Option<tracing::Level>,
+}
+
+fn log_level_completions() -> Vec<CompletionCandidate> {
+    use tracing::Level as L;
+    let options = [L::TRACE, L::DEBUG, L::INFO, L::WARN, L::ERROR];
+    options
+        .into_iter()
+        .map(|level| CompletionCandidate::new(level.to_string().to_lowercase()))
+        .collect()
 }

--- a/crates/common/tedge_config_macros/Cargo.toml
+++ b/crates/common/tedge_config_macros/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 camino = { workspace = true, features = ["serde1"] }
+clap_complete = { workspace = true }
 doku = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
@@ -21,6 +22,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+clap = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
 toml = { workspace = true }

--- a/crates/common/tedge_config_macros/tests/cli_completions.rs
+++ b/crates/common/tedge_config_macros/tests/cli_completions.rs
@@ -1,0 +1,106 @@
+use std::ffi::OsString;
+
+use camino::Utf8PathBuf;
+use clap::CommandFactory;
+use clap_complete::ArgValueCandidates;
+use clap_complete::CompletionCandidate;
+use tedge_config_macros::*;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ReadError {
+    #[error(transparent)]
+    ConfigNotSet(#[from] ConfigNotSet),
+}
+
+pub trait AppendRemoveItem {
+    type Item;
+
+    fn append(current_value: Option<Self::Item>, new_value: Self::Item) -> Option<Self::Item>;
+
+    fn remove(current_value: Option<Self::Item>, remove_value: Self::Item) -> Option<Self::Item>;
+}
+
+impl<T> AppendRemoveItem for T {
+    type Item = T;
+
+    fn append(_current_value: Option<Self::Item>, _new_value: Self::Item) -> Option<Self::Item> {
+        unimplemented!()
+    }
+
+    fn remove(_current_value: Option<Self::Item>, _remove_value: Self::Item) -> Option<Self::Item> {
+        unimplemented!()
+    }
+}
+
+define_tedge_config! {
+    #[tedge_config(deprecated_name = "azure")]
+    az: {
+        mapper: {
+            /// The azure mapper timestamp
+            timestamp: bool,
+        }
+    },
+    device: {
+        #[tedge_config(rename = "type")]
+        /// The device type
+        ty: bool,
+
+        #[doku(as = "String")]
+        /// The device type
+        cert_path: Utf8PathBuf,
+    }
+}
+
+#[derive(clap::Parser)]
+enum ExampleCli {
+    Read {
+        #[clap(add = ArgValueCandidates::new(ReadableKey::completions))]
+        key: ReadableKey,
+    },
+    Write {
+        #[clap(add = ArgValueCandidates::new(WritableKey::completions))]
+        key: WritableKey,
+    },
+}
+
+#[test]
+fn completion_returns_name_and_help_text() {
+    let completions = completions_for("example read a");
+    assert_eq!(completions.len(), 1);
+    assert_eq!(completions[0].get_value(), "az.mapper.timestamp");
+    assert_eq!(
+        completions[0].get_help().unwrap().to_string().trim(),
+        "The azure mapper timestamp"
+    );
+}
+
+#[test]
+fn completion_returns_all_possible_matches() {
+    let completions = completions_for("example read dev");
+    let completion_values = completions
+        .iter()
+        .map(|c| c.get_value())
+        .collect::<Vec<_>>();
+    assert_eq!(completion_values, ["device.type", "device.cert_path"]);
+}
+
+#[test]
+fn completions_are_generated_for_writable_keys() {
+    let completions = completions_for("example write dev");
+    let completion_values = completions
+        .iter()
+        .map(|c| c.get_value())
+        .collect::<Vec<_>>();
+    assert_eq!(completion_values, ["device.type", "device.cert_path"]);
+}
+
+/// Generates the [clap_complete] dynamic completions for an example cli invocation
+///
+/// The input looks like a shell string, e.g. `example read device.`
+///
+/// The output is the matching completions for the last argument
+fn completions_for(args: &str) -> Vec<CompletionCandidate> {
+    let args: Vec<_> = args.split_whitespace().map(OsString::from).collect();
+    let index = args.len() - 1;
+    clap_complete::engine::complete(&mut ExampleCli::command(), args, index, None).unwrap()
+}

--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -22,6 +22,7 @@ camino = { workspace = true }
 cap = { workspace = true }
 certificate = { workspace = true, features = ["reqwest-blocking"] }
 clap = { workspace = true }
+clap_complete = { version = "4.5.42", features = ["unstable-dynamic"] }
 doku = { workspace = true }
 hyper = { workspace = true, default-features = false }
 mime_guess = { workspace = true }

--- a/crates/core/tedge/src/cli/certificate/cli.rs
+++ b/crates/core/tedge/src/cli/certificate/cli.rs
@@ -1,6 +1,7 @@
 use crate::cli::common::Cloud;
 use crate::cli::common::CloudArg;
 use camino::Utf8PathBuf;
+use clap::ValueHint;
 use tedge_config::OptionalConfigError;
 use tedge_config::ProfileName;
 use tedge_config::ReadError;
@@ -37,7 +38,7 @@ pub enum TEdgeCertCli {
         id: Option<String>,
 
         /// Path where a Certificate signing request will be stored
-        #[clap(long = "output-path", global = true)]
+        #[clap(long = "output-path", global = true, value_hint = ValueHint::FilePath)]
         output_path: Option<Utf8PathBuf>,
 
         #[clap(subcommand)]

--- a/crates/core/tedge/src/cli/completions.rs
+++ b/crates/core/tedge/src/cli/completions.rs
@@ -1,0 +1,69 @@
+use super::TEdgeCli;
+use crate::command::BuildCommand;
+use crate::command::BuildContext;
+use crate::command::Command;
+use crate::ConfigError;
+use clap::CommandFactory;
+use std::io;
+
+#[derive(clap::ValueEnum, Clone, Copy, Debug, strum_macros::Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+impl From<Shell> for clap_complete::Shell {
+    fn from(value: Shell) -> Self {
+        match value {
+            Shell::Bash => Self::Bash,
+            Shell::Zsh => Self::Zsh,
+            Shell::Fish => Self::Fish,
+        }
+    }
+}
+
+impl From<Shell> for Box<dyn clap_complete::env::EnvCompleter> {
+    fn from(value: Shell) -> Self {
+        use clap_complete::env;
+        match value {
+            Shell::Bash => Box::new(env::Bash),
+            Shell::Zsh => Box::new(env::Zsh),
+            Shell::Fish => Box::new(env::Fish),
+        }
+    }
+}
+
+impl BuildCommand for Shell {
+    fn build_command(self, _: BuildContext) -> Result<Box<dyn Command>, ConfigError> {
+        Ok(Box::new(CompletionsCmd { shell: self }))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CompletionsCmd {
+    shell: Shell,
+}
+
+impl Command for CompletionsCmd {
+    fn description(&self) -> String {
+        format!("generate shell tab completion script for {}", self.shell)
+    }
+
+    fn execute(&self) -> Result<(), super::log::MaybeFancy<anyhow::Error>> {
+        let cmd = TEdgeCli::command();
+        let completer = std::env::current_exe().unwrap();
+        let completer = completer.to_str().unwrap();
+        Box::<dyn clap_complete::env::EnvCompleter>::from(self.shell)
+            .write_registration(
+                "COMPLETE",
+                "tedge",
+                cmd.get_bin_name().unwrap_or_else(|| cmd.get_name()),
+                completer,
+                &mut io::stdout(),
+            )
+            .unwrap();
+        Ok(())
+    }
+}

--- a/crates/core/tedge/src/cli/config/cli.rs
+++ b/crates/core/tedge/src/cli/config/cli.rs
@@ -1,6 +1,8 @@
+use crate::cli::common::profile_completions;
 use crate::cli::config::commands::*;
 use crate::command::*;
 use crate::ConfigError;
+use clap_complete::ArgValueCandidates;
 use tedge_config::ProfileName;
 use tedge_config::ReadableKey;
 use tedge_config::WritableKey;
@@ -10,6 +12,7 @@ pub enum ConfigCmd {
     /// Get the value of the provided configuration key
     Get {
         /// Configuration key. Run `tedge config list --doc` for available keys
+        #[arg(add = ArgValueCandidates::new(ReadableKey::completions))]
         key: ReadableKey,
 
         /// The cloud profile you wish to use, if accessing a cloud configuration
@@ -18,12 +21,14 @@ pub enum ConfigCmd {
         ///
         /// [env: TEDGE_CLOUD_PROFILE]
         #[clap(long)]
+        #[arg(add = ArgValueCandidates::new(profile_completions))]
         profile: Option<ProfileName>,
     },
 
     /// Set or update the provided configuration key with the given value
     Set {
         /// Configuration key. Run `tedge config list --doc` for available keys
+        #[arg(add = ArgValueCandidates::new(WritableKey::completions))]
         key: WritableKey,
 
         /// Configuration value.
@@ -35,12 +40,14 @@ pub enum ConfigCmd {
         ///
         /// [env: TEDGE_CLOUD_PROFILE]
         #[clap(long)]
+        #[arg(add = ArgValueCandidates::new(profile_completions))]
         profile: Option<ProfileName>,
     },
 
     /// Unset the provided configuration key
     Unset {
         /// Configuration key. Run `tedge config list --doc` for available keys
+        #[arg(add = ArgValueCandidates::new(WritableKey::completions))]
         key: WritableKey,
 
         /// The cloud profile you wish to use, if accessing a cloud configuration
@@ -49,12 +56,14 @@ pub enum ConfigCmd {
         ///
         /// [env: TEDGE_CLOUD_PROFILE]
         #[clap(long)]
+        #[arg(add = ArgValueCandidates::new(profile_completions))]
         profile: Option<ProfileName>,
     },
 
     /// Append or set the provided configuration key with the given value
     Add {
         /// Configuration key. Run `tedge config list --doc` for available keys
+        #[arg(add = ArgValueCandidates::new(WritableKey::completions))]
         key: WritableKey,
 
         /// Configuration value.
@@ -66,12 +75,14 @@ pub enum ConfigCmd {
         ///
         /// [env: TEDGE_CLOUD_PROFILE]
         #[clap(long)]
+        #[arg(add = ArgValueCandidates::new(profile_completions))]
         profile: Option<ProfileName>,
     },
 
     /// Remove value from the provided configuration key
     Remove {
         /// Configuration key. Run `tedge config list --doc` for available keys
+        #[arg(add = ArgValueCandidates::new(WritableKey::completions))]
         key: WritableKey,
 
         /// Configuration value.
@@ -83,6 +94,7 @@ pub enum ConfigCmd {
         ///
         /// [env: TEDGE_CLOUD_PROFILE]
         #[clap(long)]
+        #[arg(add = ArgValueCandidates::new(profile_completions))]
         profile: Option<ProfileName>,
     },
 

--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -5,6 +5,7 @@ use crate::command::BuildContext;
 use crate::command::Command;
 use c8y_firmware_plugin::FirmwarePluginOpt;
 use c8y_remote_access_plugin::C8yRemoteAccessPluginOpt;
+use completions::Shell;
 pub use connect::*;
 use tedge_agent::AgentOpt;
 use tedge_apt_plugin::AptCli;
@@ -16,6 +17,7 @@ use tedge_write::bin::Args as TedgeWriteOpt;
 use self::init::TEdgeInitCmd;
 mod certificate;
 mod common;
+mod completions;
 pub mod config;
 mod connect;
 mod disconnect;
@@ -38,16 +40,19 @@ mod upload;
 )]
 pub enum TEdgeOptMulticall {
     /// Command line interface to interact with thin-edge.io
-    Tedge {
-        #[clap(subcommand)]
-        cmd: TEdgeOpt,
-
-        #[command(flatten)]
-        common: CommonArgs,
-    },
+    Tedge(TEdgeCli),
 
     #[clap(flatten)]
     Component(Component),
+}
+
+#[derive(clap::Parser, Debug)]
+pub struct TEdgeCli {
+    #[clap(flatten)]
+    pub common: CommonArgs,
+
+    #[clap(subcommand)]
+    pub cmd: TEdgeOpt,
 }
 
 #[derive(clap::Parser, Debug)]
@@ -68,7 +73,7 @@ pub enum Component {
     TedgeWrite(TedgeWriteOpt),
 }
 
-#[derive(clap::Subcommand, Debug)]
+#[derive(clap::Parser, Debug)]
 #[clap(
     name = clap::crate_name!(),
     version = clap::crate_version!(),
@@ -121,6 +126,10 @@ pub enum TEdgeOpt {
 
     /// Run thin-edge services and plugins
     Run(ComponentOpt),
+
+    Completions {
+        shell: Shell,
+    },
 }
 
 #[derive(Debug, clap::Parser)]
@@ -192,6 +201,7 @@ impl BuildCommand for TEdgeOpt {
                 // This method has to be kept in sync with tedge::redirect_if_multicall()
                 panic!("tedge mapper|agent|write commands are launched as multicall")
             }
+            TEdgeOpt::Completions { shell } => shell.build_command(context),
         }
     }
 }

--- a/crates/core/tedge/src/cli/mqtt/cli.rs
+++ b/crates/core/tedge/src/cli/mqtt/cli.rs
@@ -4,6 +4,8 @@ use crate::cli::mqtt::MqttError;
 use crate::command::BuildCommand;
 use crate::command::BuildContext;
 use crate::command::Command;
+use clap_complete::ArgValueCandidates;
+use clap_complete::CompletionCandidate;
 use rumqttc::QoS;
 
 const PUB_CLIENT_PREFIX: &str = "tedge-pub";
@@ -20,6 +22,7 @@ pub enum TEdgeMqttCli {
         /// QoS level (0, 1, 2)
         #[clap(short, long, default_value = "0")]
         #[arg(value_parser = parse_qos)]
+        #[arg(add = ArgValueCandidates::new(qos_completions))]
         qos: QoS,
         /// Retain flag
         #[clap(short, long = "retain")]
@@ -33,6 +36,7 @@ pub enum TEdgeMqttCli {
         /// QoS level (0, 1, 2)
         #[clap(short, long, default_value = "0")]
         #[arg(value_parser = parse_qos)]
+        #[arg(add = ArgValueCandidates::new(qos_completions))]
         qos: QoS,
         /// Avoid printing the message topics on the console
         #[clap(long = "no-topic")]
@@ -96,6 +100,14 @@ fn parse_qos(src: &str) -> Result<QoS, MqttError> {
         2 => Ok(QoS::ExactlyOnce),
         _ => Err(MqttError::InvalidQoS),
     }
+}
+
+fn qos_completions() -> Vec<CompletionCandidate> {
+    vec![
+        CompletionCandidate::new("0").help(Some("At most once".into())),
+        CompletionCandidate::new("1").help(Some("At least once".into())),
+        CompletionCandidate::new("2").help(Some("Exactly once".into())),
+    ]
 }
 
 #[cfg(test)]

--- a/docs/src/install/index.md
+++ b/docs/src/install/index.md
@@ -221,3 +221,45 @@ The packages can be viewed directly from the [Cloudsmith.io](https://cloudsmith.
     </td>
 </tr>
 </table>
+
+## Shell completions
+:::note
+Shell-completions are supported with `tedge` >= 1.5.0
+:::
+
+To make using the CLI easier, `tedge` provides tab-completion support. This can
+be enabled by adding a small configuration to your shell environment:
+
+```sh title="~/.bashrc" tab={"label":"bash"}
+source <(tedge completions bash)
+```
+
+```sh title="~/.zshrc" tab={"label":"zsh"}
+source <(tedge completions zsh)
+```
+
+```sh title="~/.config/fish/config.fish" tab={"label":"fish"}
+tedge completions fish | source
+```
+
+Once you have configured this, reload your shell configuration:
+
+```sh tab={"label":"bash"}
+source ~/.bashrc
+```
+
+```sh tab={"label":"zsh"}
+source ~/.zshrc
+```
+
+```sh tab={"label":"fish"}
+source ~/.config/fish/config.fish
+```
+
+After this, you should be able to tab complete values (where `<TAB>` indicates
+pressing the tab key on your keyboard):
+
+```sh
+$ tedge con<TAB><TAB>
+config  (Configure Thin Edge)  connect  (Connect to cloud provider)
+```

--- a/docs/src/operate/troubleshooting/log-files.md
+++ b/docs/src/operate/troubleshooting/log-files.md
@@ -119,18 +119,21 @@ level in `system.toml`
 
 ### Setting the log level through cli {#configure-log-levels-cli}
 
-The log level can be enabled for a %%te%% service as below
-
-For example for tedge-mapper:
+The log-level can be configured for a %%te%% service using the `--log-level`
+argument. For example for tedge-mapper:
 
 ```sh
-sudo -u tedge -- tedge-mapper --debug c8y
+sudo -u tedge -- tedge-mapper c8y --log-level debug 
 ```
 
+The possible values for `--log-level` are `trace`, `debug`, `info` (the
+default), `warn` and `error`.
+
 :::note
-In a similar way it can be set for all the %%te%% services.
-Only `debug` level can be set through cli. Also, it enables `trace` level.
+In a similar way it can be set for all the %%te%% services and the `tedge` CLI.
 :::
+
+There is also a `--debug` argument, which is shorthand for `--log-level debug`.
 
 ### Setting log level through system.toml {#configure-log-levels-file}
 The log levels can also be configured through the `system.toml` file.


### PR DESCRIPTION
## Proposed changes
This adds shell completions (bash, zsh, fish) to the `tedge` CLI. It should be fairly self explanatory, and the documentation added in the PR should explain how you can enable the feature for testing locally.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #3331 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

