### PR TITLE
Refactoring: Simplify entity registration internal API

### DIFF
--- a/crates/core/tedge_agent/src/entity_manager/server.rs
+++ b/crates/core/tedge_agent/src/entity_manager/server.rs
@@ -9,7 +9,7 @@ use tedge_api::entity_store::EntityRegistrationMessage;
 use tedge_api::mqtt_topics::Channel;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
-use tedge_api::pending_entity_store::PendingEntityData;
+use tedge_api::pending_entity_store::RegisteredEntityData;
 use tedge_api::EntityStore;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::QoS;
@@ -27,7 +27,7 @@ pub enum EntityStoreRequest {
 #[derive(Debug)]
 pub enum EntityStoreResponse {
     Get(Option<EntityMetadata>),
-    Create(Result<Vec<PendingEntityData>, entity_store::Error>),
+    Create(Result<Vec<RegisteredEntityData>, entity_store::Error>),
     Delete(Vec<EntityTopicId>),
     Ok,
 }
@@ -149,7 +149,7 @@ impl EntityStoreServer {
     async fn register_entity(
         &mut self,
         entity: EntityRegistrationMessage,
-    ) -> Result<Vec<PendingEntityData>, entity_store::Error> {
+    ) -> Result<Vec<RegisteredEntityData>, entity_store::Error> {
         if self.entity_store.get(&entity.topic_id).is_some() {
             return Err(entity_store::Error::EntityAlreadyRegistered(
                 entity.topic_id,

--- a/crates/core/tedge_agent/src/entity_manager/server.rs
+++ b/crates/core/tedge_agent/src/entity_manager/server.rs
@@ -164,9 +164,9 @@ impl EntityStoreServer {
             }
         }
 
-        let (affected, pending) = self.entity_store.update(entity.clone())?;
+        let registered = self.entity_store.update(entity.clone())?;
 
-        if !affected.is_empty() {
+        if !registered.is_empty() {
             let message = entity.to_mqtt_message(&self.mqtt_schema);
             if let Err(err) = self.mqtt_publisher.send(message.clone()).await {
                 error!(
@@ -174,7 +174,7 @@ impl EntityStoreServer {
                 )
             }
         }
-        Ok(pending)
+        Ok(registered)
     }
 
     async fn deregister_entity(&mut self, topic_id: EntityTopicId) -> Vec<EntityTopicId> {

--- a/crates/core/tedge_agent/src/entity_manager/server.rs
+++ b/crates/core/tedge_agent/src/entity_manager/server.rs
@@ -27,7 +27,7 @@ pub enum EntityStoreRequest {
 #[derive(Debug)]
 pub enum EntityStoreResponse {
     Get(Option<EntityMetadata>),
-    Create(Result<(Vec<EntityTopicId>, Vec<PendingEntityData>), entity_store::Error>),
+    Create(Result<Vec<PendingEntityData>, entity_store::Error>),
     Delete(Vec<EntityTopicId>),
     Ok,
 }
@@ -149,7 +149,7 @@ impl EntityStoreServer {
     async fn register_entity(
         &mut self,
         entity: EntityRegistrationMessage,
-    ) -> Result<(Vec<EntityTopicId>, Vec<PendingEntityData>), entity_store::Error> {
+    ) -> Result<Vec<PendingEntityData>, entity_store::Error> {
         if self.entity_store.get(&entity.topic_id).is_some() {
             return Err(entity_store::Error::EntityAlreadyRegistered(
                 entity.topic_id,
@@ -174,7 +174,7 @@ impl EntityStoreServer {
                 )
             }
         }
-        Ok((affected, pending))
+        Ok(pending)
     }
 
     async fn deregister_entity(&mut self, topic_id: EntityTopicId) -> Vec<EntityTopicId> {

--- a/crates/core/tedge_agent/src/http_server/entity_store.rs
+++ b/crates/core/tedge_agent/src/http_server/entity_store.rs
@@ -252,10 +252,7 @@ mod tests {
                         && entity.r#type == EntityType::ChildDevice
                     {
                         req.reply_to
-                            .send(EntityStoreResponse::Create(Ok((
-                                vec![EntityTopicId::default_main_device()],
-                                vec![],
-                            ))))
+                            .send(EntityStoreResponse::Create(Ok(vec![])))
                             .await
                             .unwrap();
                     }

--- a/crates/core/tedge_api/src/entity_store.rs
+++ b/crates/core/tedge_api/src/entity_store.rs
@@ -18,8 +18,8 @@ use crate::mqtt_topics::EntityTopicId;
 use crate::mqtt_topics::MqttSchema;
 use crate::store::message_log::MessageLogReader;
 use crate::store::message_log::MessageLogWriter;
-use crate::store::pending_entity_store::PendingEntityData;
 use crate::store::pending_entity_store::PendingEntityStore;
+use crate::store::pending_entity_store::RegisteredEntityData;
 use log::debug;
 use log::error;
 use log::info;
@@ -292,7 +292,7 @@ impl EntityStore {
     pub fn update(
         &mut self,
         message: EntityRegistrationMessage,
-    ) -> Result<(Vec<EntityTopicId>, Vec<PendingEntityData>), Error> {
+    ) -> Result<(Vec<EntityTopicId>, Vec<RegisteredEntityData>), Error> {
         match self.register_and_persist_entity(message.clone()) {
             Ok(affected_entities) => {
                 if affected_entities.is_empty() {
@@ -971,7 +971,7 @@ mod tests {
         .unwrap();
         let updated_entities = store.update(entity.clone()).unwrap();
 
-        let pending_entity: PendingEntityData = entity.into();
+        let pending_entity: RegisteredEntityData = entity.into();
         assert_eq!(updated_entities.0.len(), 1);
         assert_eq!(updated_entities.0, ["device/main//"]);
         assert_eq!(updated_entities.1.len(), 1);

--- a/crates/extensions/c8y_mapper_ext/src/actor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/actor.rs
@@ -28,7 +28,7 @@ use tedge_actors::SimpleMessageBoxBuilder;
 use tedge_api::entity_store::EntityRegistrationMessage;
 use tedge_api::mqtt_topics::Channel;
 use tedge_api::mqtt_topics::ChannelFilter;
-use tedge_api::pending_entity_store::PendingEntityData;
+use tedge_api::pending_entity_store::RegisteredEntityData;
 use tedge_downloader_ext::DownloadRequest;
 use tedge_downloader_ext::DownloadResult;
 use tedge_file_system_ext::FsWatchEvent;
@@ -216,7 +216,7 @@ impl C8yMapperActor {
     /// followed by repeating the same for its cached data messages.
     pub(crate) async fn process_registered_entities(
         &mut self,
-        pending_entities: Vec<PendingEntityData>,
+        pending_entities: Vec<RegisteredEntityData>,
     ) -> Result<(), RuntimeError> {
         for pending_entity in pending_entities {
             self.process_registration_message(pending_entity.reg_message)

--- a/crates/extensions/c8y_mapper_ext/src/entity_cache.rs
+++ b/crates/extensions/c8y_mapper_ext/src/entity_cache.rs
@@ -9,8 +9,8 @@ use tedge_api::entity_store::EntityRegistrationMessage;
 use tedge_api::entity_store::EntityTwinMessage;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
-use tedge_api::pending_entity_store::PendingEntityData;
 use tedge_api::pending_entity_store::PendingEntityStore;
+use tedge_api::pending_entity_store::RegisteredEntityData;
 use tedge_mqtt_ext::MqttMessage;
 use thiserror::Error;
 use tracing::debug;
@@ -114,7 +114,7 @@ impl EntityCache {
     pub(crate) fn register_entity(
         &mut self,
         entity: EntityRegistrationMessage,
-    ) -> Result<Vec<PendingEntityData>, Error> {
+    ) -> Result<Vec<RegisteredEntityData>, Error> {
         let parent = entity.parent.as_ref().unwrap_or(&self.main_device_tid);
         if self.entities.contains_key(parent) {
             let outcome = self.register_single_entity(entity.clone())?;


### PR DESCRIPTION
## Proposed changes

- [x] Simplify EntityStoreServer::register_entity signature. The returned list of affected EntityTopicId was confusing and never used
- [x]  Rename PendingEntityData as ResolvedEntityData. The previous name was confusing as applied to entities fully registered.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

