### PR TITLE
tests: default to using locally build packages

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -201,7 +201,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: packages-${{ matrix.job.target }}
-          path: tests/images/debian-systemd/files/packages/
+          path: target/${{ matrix.job.target }}/packages/
 
       - name: create .env file
         working-directory: tests/RobotFramework
@@ -230,7 +230,7 @@ jobs:
         working-directory: tests/RobotFramework
         run: |
           source .venv/bin/activate
-          invoke build
+          invoke build --arch "${{ matrix.job.target }}"
 
       - name: Run tests
         working-directory: tests/RobotFramework

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -228,6 +228,8 @@ jobs:
 
       - name: Build images
         working-directory: tests/RobotFramework
+        env:
+          BUILD_DISABLE_CI_DETECTION: 1
         run: |
           source .venv/bin/activate
           invoke build --arch "${{ matrix.job.target }}"

--- a/tests/RobotFramework/README.md
+++ b/tests/RobotFramework/README.md
@@ -158,16 +158,15 @@ Checkout the [dev container instructions](https://thin-edge.github.io/thin-edge.
 
 6. Build the container image used by the default `docker` test adapter
 
-    The following command will use the debian packages built using the latest packages from the main branch (provided by Cloudsmith.io)
-
     ```sh
-    invoke clean build
+    just release
+    invoke build
     ```
 
-    Or you can use the locally built debian packages (assuming you have already built them)
+    Or you can use the latest packages from the main branch (provided by Cloudsmith.io)
 
     ```sh
-    invoke build --local
+    invoke clean build --no-local
     ```
 
 7. Run the tests
@@ -243,7 +242,7 @@ The following dependencies are requires for the instructions:
 
 For very specific cases where you want to deploy externally built packages (e.g. stuff you downloaded from the GitHub release page), you can manually copy the debian packages into the special folder which is included when building the test container image.
 
-If you are looking to use packages that you locally built, then just use `invoke build --local` instead (it is much easier).
+The default test container image will use the locally built packages (e.g. created by using `just release`). If you want to build the test image using the packages which are published to Cloudsmith.io, then use `invoke build --no-local`.
 
 1. Open the terminal and navigate to the RobotFramework folder
 

--- a/tests/RobotFramework/tasks.py
+++ b/tests/RobotFramework/tasks.py
@@ -301,6 +301,9 @@ def build(
         # Use locally built x86_64 images then build container image
 
     """
+    # Temporary logic used to enable transitioning the build-workflow.yaml
+    if is_ci() and (os.getenv("BUILD_DISABLE_CI_DETECTION") != "1"):
+        local = False
 
     if local:
         clean(c)

--- a/tests/RobotFramework/tasks.py
+++ b/tests/RobotFramework/tasks.py
@@ -270,7 +270,7 @@ def use_local(c, arch="", package_type="deb"):
     },
 )
 def build(
-    c, name="debian-systemd", cache=True, local=False, binary=None, build_options=""
+    c, name="debian-systemd", cache=True, local=True, binary=None, build_options=""
 ):
     """Build the container integration test image
 
@@ -284,6 +284,9 @@ def build(
 
         invoke clean build
         # Build the test container image but remove any existing files
+
+        invoke build --no-local
+        # Build the test container image without copying the debian packages installed locally
 
         invoke build --local
         # Build the test container image using the locally build version (auto detecting your host's architecture)

--- a/tests/RobotFramework/tasks.py
+++ b/tests/RobotFramework/tasks.py
@@ -270,12 +270,15 @@ def use_local(c, arch="", package_type="deb"):
     },
 )
 def build(
-    c, name="debian-systemd", cache=True, local=True, binary=None, build_options=""
+    c, name="debian-systemd", cache=True, local=True, binary=None, arch="", build_options=""
 ):
     """Build the container integration test image
 
     Docker is used by default, unless if the DOCKER_HOST variable is pointing to podman
     and podman is installed.
+
+    Note: The arch argument is only used if local is set to True. The arch value can
+    either by the architecture or the target, e.g. aarch64 or x86_64-unknown-linux-musl
 
     Examples:
 
@@ -301,7 +304,7 @@ def build(
 
     if local:
         clean(c)
-        use_local(c)
+        use_local(c, arch=arch)
 
     # Support podman, and automatically switch if the DOCKER_HOST is set
     binary = binary or "docker"


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Change the default of `invoke build` to use the locally built packages as this is the option used the most by all developers.

Below shows how to migrate from the previous command defaults:

|Before|After|
|--|--|
|`invoke build --local` | `invoke build` |
|`invoke build` | `invoke build --no-local` |

Due to this change the build-workflow.yaml had to be updated so that it would place the packages under the `target/` directory. To facilitate migrating to the new workflow, a temporary commit had to be added to allow the PR checks to pass and the merge queue to pass (see commit 7cff046266c903c14b984a96e4d08542351f96e2). This commit can be removed after the PR is merged into main.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

