### PR TITLE
feat: REST API for querying entity store

### DIFF
--- a/crates/core/tedge_api/src/entity.rs
+++ b/crates/core/tedge_api/src/entity.rs
@@ -61,7 +61,7 @@ impl From<&EntityExternalId> for String {
 pub struct EntityMetadata {
     #[serde(rename = "@topic-id")]
     pub topic_id: EntityTopicId,
-    #[serde(rename = "@parent")]
+    #[serde(rename = "@parent", skip_serializing_if = "Option::is_none")]
     pub parent: Option<EntityTopicId>,
     #[serde(rename = "@type")]
     pub r#type: EntityType,

--- a/docs/src/operate/registration/register.md
+++ b/docs/src/operate/registration/register.md
@@ -86,6 +86,61 @@ GET /v1/entities/{topic-id}
 curl http://localhost:8000/tedge/entity-store/v1/entities/device/child01
 ```
 
+## Query Entities
+
+### Query All Entities
+
+List all entities registered with thin-edge starting from the `main` device.
+
+**Endpoint**
+
+```
+GET /v1/entities
+```
+
+**Responses**
+
+* 200: OK
+  ```json
+  [
+      {
+          "@topic-id": "device/main//",
+          "@type": "device"
+      },
+      {
+          "@topic-id": "device/main/service/tedge-agent",
+          "@type": "service",
+          "@parent": "device/main//"
+      },
+      {
+          "@topic-id": "device/child0//",
+          "@type": "child-device",
+          "@parent": "device/main//"
+      },
+      {
+          "@topic-id": "device/child1//",
+          "@type": "child-device",
+          "@parent": "device/main//"
+      },
+      {
+          "@topic-id": "device/child00//",
+          "@type": "child-device",
+          "@parent": "device/child0//"
+      },
+      {
+          "@topic-id": "device/child01//",
+          "@type": "child-device",
+          "@parent": "device/child0//"
+      }
+  ]
+  ```
+
+**Example**
+
+```shell
+curl http://localhost:8000/tedge/entity-store/v1/entities
+```
+
 ## Delete entity
 
 Deleting an entity results in the deletion of its immediate and nested child entities as well, to avoid leaving orphans behind.

--- a/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
+++ b/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
@@ -25,6 +25,9 @@ CRUD apis
     ...    te/device/child01//
     ...    message_contains="@type":"child-device"
 
+    ${entities}=    Execute Command    curl http://localhost:8000/tedge/entity-store/v1/entities
+    Should Contain    ${entities}    {"@topic-id":"device/child01//","@parent":"device/main//","@type":"child-device"}
+
     ${status}=    Execute Command
     ...    curl -o /dev/null --silent --write-out "%\{http_code\}" -X DELETE http://localhost:8000/tedge/entity-store/v1/entities/device/child01//
     Should Be Equal    ${status}    200
@@ -33,25 +36,83 @@ CRUD apis
     ...    curl -o /dev/null --silent --write-out "%\{http_code\}" http://localhost:8000/tedge/entity-store/v1/entities/device/child01//
     Should Be Equal    ${get}    404
 
+Query api
+    # Build the entity tree:
+    # main
+    # |--- child0
+    # |    |--- child00
+    # |    |    |--- child000
+    # |--- child1
+    # |--- child2
+    # |    |--- child20
+    # |    |--- child21
+    # |    |    |--- child210
+    # |    |    |    |-- child2100
+    # |    |--- child22
+    Register Entity    device/child0//    child-device    device/main//
+    Register Entity    device/child00//    child-device    device/child0//
+    Register Entity    device/child000//    child-device    device/child00//
+    Register Entity    device/child1//    child-device    device/main//
+    Register Entity    device/child2//    child-device    device/main//
+    Register Entity    device/child20//    child-device    device/child2//
+    Register Entity    device/child21//    child-device    device/child2//
+    Register Entity    device/child210//    child-device    device/child21//
+    Register Entity    device/child2100//    child-device    device/child210//
+    Register Entity    device/child22//    child-device    device/child2//
+
+    ${entities}=    List Entities
+
+    Should Contain Entity    {"@topic-id": "device/main//", "@type": "device"}    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child0//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child00//","@parent":"device/child0//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child000//","@parent":"device/child00//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child1//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child20//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child21//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child210//","@parent":"device/child21//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2100//","@parent":"device/child210//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child22//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+
 MQTT HTTP interoperability
-    Execute Command    tedge mqtt pub --retain 'te/device/child02//' '{"@type":"child-device"}'
+    Execute Command    tedge mqtt pub --retain 'te/device/child_abc//' '{"@type":"child-device"}'
     Should Have MQTT Messages
     ...    c8y/s/us
-    ...    message_contains=101,${DEVICE_SN}:device:child02
+    ...    message_contains=101,${DEVICE_SN}:device:child_abc
 
-    ${get}=    Execute Command    curl http://localhost:8000/tedge/entity-store/v1/entities/device/child02//
+    ${get}=    Execute Command    curl http://localhost:8000/tedge/entity-store/v1/entities/device/child_abc//
     Should Be Equal
     ...    ${get}
-    ...    {"@topic-id":"device/child02//","@parent":"device/main//","@type":"child-device"}
+    ...    {"@topic-id":"device/child_abc//","@parent":"device/main//","@type":"child-device"}
 
 Entity auto-registration over MQTT
-    Execute Command    tedge mqtt pub te/device/child00/service/collectd/m/ram '{"current": 6 }'
+    Execute Command    tedge mqtt pub te/device/auto_child/service/collectd/m/ram '{"current": 6 }'
     Should Have MQTT Messages
-    ...    te/device/child00//
-    ...    message_contains={"@parent":"device/main//","@type":"child-device","name":"child00"}
+    ...    te/device/auto_child//
+    ...    message_contains={"@parent":"device/main//","@type":"child-device","name":"auto_child"}
     Should Have MQTT Messages
-    ...    te/device/child00/service/collectd
-    ...    message_contains={"@parent":"device/child00//","@type":"service","name":"collectd","type":"service"}
+    ...    te/device/auto_child/service/collectd
+    ...    message_contains={"@parent":"device/auto_child//","@type":"service","name":"collectd","type":"service"}
 
 
 *** Keywords ***


### PR DESCRIPTION
## Proposed changes

Basic entity store query REST API implementation: `GET /tedge/entity-store/v1/entities` to list all entities.
Additional filtering capabilities to be added in follow-up PRs.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3339

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

