### PR TITLE
feat: add MQTT keepalive_interval config to allow custom value per bridge

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -353,6 +353,10 @@ define_tedge_config! {
             /// forwarded to Cumulocity on the `s/us` topic
             #[tedge_config(example = "c8y", default(function = "c8y_topic_prefix"))]
             topic_prefix: TopicPrefix,
+
+            /// The amount of time after which the bridge should send a ping if no other traffic has occured
+            #[tedge_config(example = "60s", default(from_str = "60s"))]
+            keepalive_interval: SecondsOrHumanTime,
         },
 
         entity_store: {
@@ -458,6 +462,10 @@ define_tedge_config! {
             /// forwarded to Azure on the `$iothub/twin/GET/#` topic
             #[tedge_config(example = "az", default(function = "az_topic_prefix"))]
             topic_prefix: TopicPrefix,
+
+            /// The amount of time after which the bridge should send a ping if no other traffic has occured
+            #[tedge_config(example = "60s", default(from_str = "60s"))]
+            keepalive_interval: SecondsOrHumanTime,
         },
 
         /// Set of MQTT topics the Azure IoT mapper should subscribe to
@@ -528,6 +536,11 @@ define_tedge_config! {
             /// forwarded to AWS on the `$aws/things/shadow/#` topic
             #[tedge_config(example = "aws", default(function = "aws_topic_prefix"))]
             topic_prefix: TopicPrefix,
+
+
+            /// The amount of time after which the bridge should send a ping if no other traffic has occured
+            #[tedge_config(example = "60s", default(from_str = "60s"))]
+            keepalive_interval: SecondsOrHumanTime,
         },
 
         /// Set of MQTT topics the AWS IoT mapper should subscribe to

--- a/crates/core/tedge/src/bridge/aws.rs
+++ b/crates/core/tedge/src/bridge/aws.rs
@@ -2,6 +2,7 @@ use super::BridgeConfig;
 use crate::bridge::config::BridgeLocation;
 use camino::Utf8PathBuf;
 use std::borrow::Cow;
+use std::time::Duration;
 use tedge_api::mqtt_topics::Channel;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
@@ -22,6 +23,7 @@ pub struct BridgeConfigAwsParams {
     pub topic_prefix: TopicPrefix,
     pub profile_name: Option<ProfileName>,
     pub mqtt_schema: MqttSchema,
+    pub keepalive_interval: Duration,
 }
 
 impl From<BridgeConfigAwsParams> for BridgeConfig {
@@ -37,6 +39,7 @@ impl From<BridgeConfigAwsParams> for BridgeConfig {
             topic_prefix,
             profile_name,
             mqtt_schema,
+            keepalive_interval,
         } = params;
 
         let user_name = remote_clientid.to_string();
@@ -107,6 +110,7 @@ impl From<BridgeConfigAwsParams> for BridgeConfig {
             connection_check_attempts: 5,
             auth_method: None,
             mosquitto_version: None,
+            keepalive_interval,
         }
     }
 }
@@ -124,6 +128,7 @@ fn test_bridge_config_from_aws_params() -> anyhow::Result<()> {
         topic_prefix: "aws".try_into().unwrap(),
         profile_name: None,
         mqtt_schema: MqttSchema::with_root("te".into()),
+        keepalive_interval: Duration::from_secs(60),
     };
 
     let bridge = BridgeConfig::from(params);
@@ -162,6 +167,7 @@ fn test_bridge_config_from_aws_params() -> anyhow::Result<()> {
         connection_check_attempts: 5,
         auth_method: None,
         mosquitto_version: None,
+        keepalive_interval: Duration::from_secs(60),
     };
 
     assert_eq!(bridge, expected);
@@ -182,6 +188,7 @@ fn test_bridge_config_aws_custom_topic_prefix() -> anyhow::Result<()> {
         topic_prefix: "aws-custom".try_into().unwrap(),
         profile_name: Some("profile".parse().unwrap()),
         mqtt_schema: MqttSchema::with_root("te".into()),
+        keepalive_interval: Duration::from_secs(60),
     };
 
     let bridge = BridgeConfig::from(params);
@@ -222,6 +229,7 @@ fn test_bridge_config_aws_custom_topic_prefix() -> anyhow::Result<()> {
         connection_check_attempts: 5,
         auth_method: None,
         mosquitto_version: None,
+        keepalive_interval: Duration::from_secs(60),
     };
 
     assert_eq!(bridge, expected);

--- a/crates/core/tedge/src/bridge/azure.rs
+++ b/crates/core/tedge/src/bridge/azure.rs
@@ -2,6 +2,7 @@ use super::BridgeConfig;
 use crate::bridge::config::BridgeLocation;
 use camino::Utf8PathBuf;
 use std::borrow::Cow;
+use std::time::Duration;
 use tedge_api::mqtt_topics::Channel;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
@@ -22,6 +23,7 @@ pub struct BridgeConfigAzureParams {
     pub topic_prefix: TopicPrefix,
     pub profile_name: Option<ProfileName>,
     pub mqtt_schema: MqttSchema,
+    pub keepalive_interval: Duration,
 }
 
 impl From<BridgeConfigAzureParams> for BridgeConfig {
@@ -37,6 +39,7 @@ impl From<BridgeConfigAzureParams> for BridgeConfig {
             topic_prefix,
             profile_name,
             mqtt_schema,
+            keepalive_interval,
         } = params;
 
         let address = mqtt_host.clone();
@@ -103,6 +106,7 @@ impl From<BridgeConfigAzureParams> for BridgeConfig {
             connection_check_attempts: 1,
             auth_method: None,
             mosquitto_version: None,
+            keepalive_interval,
         }
     }
 }
@@ -122,6 +126,7 @@ fn test_bridge_config_from_azure_params() -> anyhow::Result<()> {
         topic_prefix: "az".try_into().unwrap(),
         profile_name: None,
         mqtt_schema: MqttSchema::with_root("te".into()),
+        keepalive_interval: Duration::from_secs(60),
     };
 
     let bridge = BridgeConfig::from(params);
@@ -162,6 +167,7 @@ fn test_bridge_config_from_azure_params() -> anyhow::Result<()> {
         connection_check_attempts: 1,
         auth_method: None,
         mosquitto_version: None,
+        keepalive_interval: Duration::from_secs(60),
     };
 
     assert_eq!(bridge, expected);
@@ -184,6 +190,7 @@ fn test_azure_bridge_config_with_custom_prefix() -> anyhow::Result<()> {
         topic_prefix: "az-custom".try_into().unwrap(),
         profile_name: Some("profile".parse().unwrap()),
         mqtt_schema: MqttSchema::with_root("te".into()),
+        keepalive_interval: Duration::from_secs(60),
     };
 
     let bridge = BridgeConfig::from(params);
@@ -225,6 +232,7 @@ fn test_azure_bridge_config_with_custom_prefix() -> anyhow::Result<()> {
         connection_check_attempts: 1,
         auth_method: None,
         mosquitto_version: None,
+        keepalive_interval: Duration::from_secs(60),
     };
 
     assert_eq!(bridge, expected);

--- a/crates/core/tedge/src/bridge/c8y.rs
+++ b/crates/core/tedge/src/bridge/c8y.rs
@@ -3,6 +3,7 @@ use crate::bridge::config::BridgeLocation;
 use camino::Utf8PathBuf;
 use std::borrow::Cow;
 use std::process::Command;
+use std::time::Duration;
 use tedge_api::mqtt_topics::Channel;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
@@ -32,6 +33,7 @@ pub struct BridgeConfigC8yParams {
     pub topic_prefix: TopicPrefix,
     pub profile_name: Option<ProfileName>,
     pub mqtt_schema: MqttSchema,
+    pub keepalive_interval: Duration,
 }
 
 impl From<BridgeConfigC8yParams> for BridgeConfig {
@@ -52,6 +54,7 @@ impl From<BridgeConfigC8yParams> for BridgeConfig {
             topic_prefix,
             profile_name,
             mqtt_schema,
+            keepalive_interval,
         } = params;
 
         let mut topics: Vec<String> = vec![
@@ -190,6 +193,7 @@ impl From<BridgeConfigC8yParams> for BridgeConfig {
             connection_check_attempts: 1,
             auth_method: Some(auth_method),
             mosquitto_version,
+            keepalive_interval,
         }
     }
 }
@@ -249,6 +253,7 @@ mod tests {
             topic_prefix: "c8y".try_into().unwrap(),
             profile_name: None,
             mqtt_schema: MqttSchema::with_root("te".into()),
+            keepalive_interval: Duration::from_secs(60),
         };
 
         let bridge = BridgeConfig::from(params);
@@ -319,6 +324,7 @@ mod tests {
             connection_check_attempts: 1,
             auth_method: Some(AuthMethod::Certificate),
             mosquitto_version: None,
+            keepalive_interval: Duration::from_secs(60),
         };
 
         assert_eq!(bridge, expected);
@@ -344,6 +350,7 @@ mod tests {
             topic_prefix: "c8y".try_into().unwrap(),
             profile_name: Some("profile".parse().unwrap()),
             mqtt_schema: MqttSchema::with_root("te".into()),
+            keepalive_interval: Duration::from_secs(60),
         };
 
         let bridge = BridgeConfig::from(params);
@@ -421,6 +428,7 @@ mod tests {
             connection_check_attempts: 1,
             auth_method: Some(AuthMethod::Basic),
             mosquitto_version: None,
+            keepalive_interval: Duration::from_secs(60),
         };
 
         assert_eq!(bridge, expected);

--- a/crates/core/tedge/src/bridge/config.rs
+++ b/crates/core/tedge/src/bridge/config.rs
@@ -1,8 +1,8 @@
-use core::fmt;
-use std::borrow::Cow;
-
 use anyhow::anyhow;
 use camino::Utf8PathBuf;
+use core::fmt;
+use std::borrow::Cow;
+use std::time::Duration;
 use tedge_config::auth_method::AuthMethod;
 use tedge_config::HostPort;
 use tedge_config::TEdgeConfigLocation;
@@ -43,6 +43,7 @@ pub struct BridgeConfig {
     pub connection_check_attempts: i32,
     pub auth_method: Option<AuthMethod>,
     pub mosquitto_version: Option<String>,
+    pub keepalive_interval: Duration,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
@@ -105,6 +106,11 @@ impl BridgeConfig {
             writer,
             "bridge_attempt_unsubscribe {}",
             self.bridge_attempt_unsubscribe
+        )?;
+        writeln!(
+            writer,
+            "keepalive_interval {}",
+            self.keepalive_interval.as_secs()
         )?;
 
         writeln!(writer, "\n### Topics",)?;
@@ -212,6 +218,7 @@ mod test {
             connection_check_attempts: 1,
             auth_method: None,
             mosquitto_version: None,
+            keepalive_interval: Duration::from_secs(60),
         };
 
         let mut serialized_config = Vec::<u8>::new();
@@ -239,6 +246,7 @@ notifications false
 notifications_local_only false
 notification_topic test_topic
 bridge_attempt_unsubscribe false
+keepalive_interval 60
 
 ### Topics
 "#,
@@ -282,6 +290,7 @@ bridge_attempt_unsubscribe false
             connection_check_attempts: 1,
             auth_method: None,
             mosquitto_version: None,
+            keepalive_interval: Duration::from_secs(60),
         };
         let mut serialized_config = Vec::<u8>::new();
         bridge.serialize(&mut serialized_config)?;
@@ -308,6 +317,7 @@ notifications false
 notifications_local_only false
 notification_topic test_topic
 bridge_attempt_unsubscribe false
+keepalive_interval 60
 
 ### Topics
 "#,
@@ -354,6 +364,7 @@ bridge_attempt_unsubscribe false
             connection_check_attempts: 1,
             auth_method: None,
             mosquitto_version: None,
+            keepalive_interval: Duration::from_secs(60),
         };
 
         let mut buffer = Vec::new();
@@ -383,6 +394,7 @@ bridge_attempt_unsubscribe false
         expected.insert("notifications_local_only false");
         expected.insert("notification_topic test_topic");
         expected.insert("bridge_attempt_unsubscribe false");
+        expected.insert("keepalive_interval 60");
 
         expected.insert("topic messages/events/ out 1 az/ devices/alpha/");
         expected.insert("topic messages/devicebound/# in 1 az/ devices/alpha/");
@@ -426,6 +438,7 @@ bridge_attempt_unsubscribe false
             connection_check_attempts: 1,
             auth_method: None,
             mosquitto_version: None,
+            keepalive_interval: Duration::from_secs(60),
         };
 
         let mut buffer = Vec::new();
@@ -454,6 +467,7 @@ bridge_attempt_unsubscribe false
         expected.insert("notifications_local_only false");
         expected.insert("notification_topic test_topic");
         expected.insert("bridge_attempt_unsubscribe false");
+        expected.insert("keepalive_interval 60");
         expected.insert(r#"topic inventory/managedObjects/update/# out 2 c8y/ """#);
         expected.insert(r#"topic measurement/measurements/create out 2 c8y/ """#);
         assert_eq!(config_set, expected);
@@ -545,6 +559,7 @@ bridge_attempt_unsubscribe false
             connection_check_attempts: 1,
             auth_method: None,
             mosquitto_version: None,
+            keepalive_interval: Duration::from_secs(60),
         }
     }
 }

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -452,6 +452,7 @@ pub fn bridge_config(
                 topic_prefix: az_config.bridge.topic_prefix.clone(),
                 profile_name: profile.clone().map(Cow::into_owned),
                 mqtt_schema,
+                keepalive_interval: az_config.bridge.keepalive_interval.duration(),
             };
 
             Ok(BridgeConfig::from(params))
@@ -472,6 +473,7 @@ pub fn bridge_config(
                 topic_prefix: aws_config.bridge.topic_prefix.clone(),
                 profile_name: profile.clone().map(Cow::into_owned),
                 mqtt_schema,
+                keepalive_interval: aws_config.bridge.keepalive_interval.duration(),
             };
 
             Ok(BridgeConfig::from(params))
@@ -505,6 +507,7 @@ pub fn bridge_config(
                 topic_prefix: c8y_config.bridge.topic_prefix.clone(),
                 profile_name: profile.clone().map(Cow::into_owned),
                 mqtt_schema,
+                keepalive_interval: c8y_config.bridge.keepalive_interval.duration(),
             };
 
             Ok(BridgeConfig::from(params))

--- a/crates/core/tedge_mapper/src/aws/mapper.rs
+++ b/crates/core/tedge_mapper/src/aws/mapper.rs
@@ -51,6 +51,7 @@ impl TEdgeComponent for AwsMapper {
                 8883,
             );
             cloud_config.set_clean_session(false);
+            cloud_config.set_keep_alive(aws_config.bridge.keepalive_interval.duration());
             use_key_and_cert(&mut cloud_config, aws_config)?;
 
             let bridge_name = format!("tedge-mapper-bridge-{prefix}");

--- a/crates/core/tedge_mapper/src/az/mapper.rs
+++ b/crates/core/tedge_mapper/src/az/mapper.rs
@@ -59,6 +59,7 @@ impl TEdgeComponent for AzureMapper {
                 ),
                 "",
             );
+            cloud_config.set_keep_alive(az_config.bridge.keepalive_interval.duration());
             use_key_and_cert(&mut cloud_config, az_config)?;
 
             let built_in_bridge_name = format!("tedge-mapper-bridge-{prefix}");

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -215,6 +215,7 @@ impl TEdgeComponent for CumulocityMapper {
                 message: format!("{last_will_message_bridge}\n{last_will_message_mapper}").into(),
                 retain: false,
             });
+            cloud_config.set_keep_alive(c8y_config.bridge.keepalive_interval.duration());
 
             runtime
                 .spawn(


### PR DESCRIPTION
## Proposed changes
As per the request in #3153, add `<cloud>.bridge.keepalive_interval` to the tedge config settings. 
Example usage:
```
tedge config set c8y.bridge.keepalive_interval 60s
```

With mosquitto, the value will be shown explicitly in `c8y-bridge.conf` as :
```
### Bridge
....
keepalive_interval 60
```

Using `60s` as default as I found 60 seconds is the default for both [mosquitto](https://mosquitto.org/man/mosquitto-conf-5.html) and [rumqttc](https://docs.rs/rumqttc/latest/src/rumqttc/lib.rs.html#493-515). 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3153 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

