### PR TITLE
test: re-enable client certificate test

### DIFF
--- a/crates/common/axum_tls/src/acceptor.rs
+++ b/crates/common/axum_tls/src/acceptor.rs
@@ -171,7 +171,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn acceptor_rejects_untrusted_client_certificates() {
         let permitted_certificate =
             rcgen::generate_simple_self_signed(vec!["not-my-client".into()]).unwrap();
@@ -191,7 +190,7 @@ mod tests {
             .await
             .unwrap_err();
         println!("{}", err);
-        crate::error_matching::assert_error_matches(err, rustls::AlertDescription::UnknownCA);
+        crate::error_matching::assert_error_matches(err, rustls::AlertDescription::DecryptError);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Proposed changes
Remove the `#[ignore]` attribute on one of the client certificate tests. Due to a change in the underlying certificate verifier, the error  rustls produces is slightly different to what it was previously, and this was causing the test to fail. We aren't interested in the specifics of the error message produced, we simply care that the error arose from the client certificate verification and not some bug in the test code. Having updated the test to check for the updated error, I've verified that it still fails for otherwise failing connections (e.g. the client not trusting the server certificate). Therefore I think a simple update to the test to reflect the new behaviour is sufficient here.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #3375

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

