### PR TITLE
feat: Query parameter support for entity store query API

### DIFF
--- a/crates/core/tedge_agent/Cargo.toml
+++ b/crates/core/tedge_agent/Cargo.toml
@@ -12,7 +12,7 @@ repository = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-axum = { workspace = true }
+axum = { workspace = true, features = ["macros"] }
 axum-server = { workspace = true }
 axum_tls = { workspace = true }
 camino = { workspace = true }

--- a/crates/core/tedge_agent/src/http_server/entity_store.rs
+++ b/crates/core/tedge_agent/src/http_server/entity_store.rs
@@ -126,7 +126,7 @@ impl IntoResponse for Error {
         };
         let error_message = self.to_string();
 
-        (status_code, error_message).into_response()
+        (status_code, Json(json!({ "error": error_message }))).into_response()
     }
 }
 
@@ -319,6 +319,13 @@ mod tests {
 
         let response = app.call(req).await.unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let entity: Value = serde_json::from_slice(&body).unwrap();
+        assert_json_eq!(
+            entity,
+            json!( {"error":"Entity not found with topic id: device/test-child//"})
+        );
     }
 
     #[tokio::test]
@@ -410,6 +417,13 @@ mod tests {
 
         let response = app.call(req).await.unwrap();
         assert_eq!(response.status(), StatusCode::CONFLICT);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let entity: Value = serde_json::from_slice(&body).unwrap();
+        assert_json_eq!(
+            entity,
+            json!( {"error":"An entity with topic id: device/test-child// is already registered"})
+        );
     }
 
     #[tokio::test]
@@ -456,6 +470,13 @@ mod tests {
 
         let response = app.call(req).await.unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let entity: Value = serde_json::from_slice(&body).unwrap();
+        assert_json_eq!(
+            entity,
+            json!( {"error":"Specified parent \"test-child\" does not exist in the store"})
+        );
     }
 
     #[tokio::test]
@@ -705,6 +726,13 @@ mod tests {
 
         let response = app.call(req).await.unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let entity: Value = serde_json::from_slice(&body).unwrap();
+        assert_json_eq!(
+            entity,
+            json!( {"error":"An entity topic identifier has at most 4 segments"})
+        );
     }
 
     #[tokio::test]
@@ -722,6 +750,13 @@ mod tests {
 
         let response = app.call(req).await.unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let entity: Value = serde_json::from_slice(&body).unwrap();
+        assert_json_eq!(
+            entity,
+            json!( {"error":"The provided parameters: root and parent are mutually exclusive. Use either one."})
+        );
     }
 
     struct TestHandle {

--- a/crates/core/tedge_api/src/entity.rs
+++ b/crates/core/tedge_api/src/entity.rs
@@ -136,7 +136,7 @@ impl Display for EntityType {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
 #[error("Invalid entity type: {0}")]
 pub struct InvalidEntityType(String);
 

--- a/docs/src/operate/registration/register.md
+++ b/docs/src/operate/registration/register.md
@@ -85,17 +85,27 @@ GET /v1/entities/{topic-id}
 curl http://localhost:8000/tedge/entity-store/v1/entities/device/child01
 ```
 
-## Query Entities
-
-### Query All Entities
-
-List all entities registered with thin-edge starting from the `main` device.
+## Query entities
 
 **Endpoint**
 
 ```
 GET /v1/entities
 ```
+
+**Query parameters**
+
+| Parameter | Description                                                            | Examples                            |
+|-----------|------------------------------------------------------------------------|-------------------------------------|
+| `root`    | Entity tree starting from the given `root` node (including it) | `device/child2//`                   |
+| `parent`  | Direct child entities of the given `parent` entity (excluding it)             | `device/main//`                     |
+| `type`    | Entities of the given entity `type`                          | `main`, `child-device` or `service` |
+
+The following restrictions apply:
+* Multiple values can not be specified for the same parameter.
+* The same parameter can not be repeated multiple times.
+* The `root` and `parent` parameters can not be used together.
+
 
 **Responses**
 
@@ -107,7 +117,7 @@ GET /v1/entities
           "@type": "device"
       },
       {
-          "@topic-id": "device/main/service/tedge-agent",
+          "@topic-id": "device/main/service/service0",
           "@type": "service",
           "@parent": "device/main//"
       },
@@ -115,29 +125,310 @@ GET /v1/entities
           "@topic-id": "device/child0//",
           "@type": "child-device",
           "@parent": "device/main//"
-      },
-      {
-          "@topic-id": "device/child1//",
-          "@type": "child-device",
-          "@parent": "device/main//"
-      },
-      {
-          "@topic-id": "device/child00//",
-          "@type": "child-device",
-          "@parent": "device/child0//"
-      },
-      {
-          "@topic-id": "device/child01//",
-          "@type": "child-device",
-          "@parent": "device/child0//"
       }
+      ...
   ]
   ```
+* 404: Not Found
+  ```
+  Entity not found with topic id: device/unknown/topic/id
+  ```
 
-**Example**
+**Examples**
+
+To demonstrate different query examples, the following entity tree is assumed as the base:
+
+```
+main
+|-- service0
+|-- service1
+|-- child0
+|   |-- child00
+|   |   |-- child000
+|-- child1
+|   |-- service10
+|-- child2
+|   |-- service20
+|   |-- child20
+|   |   |-- child200
+|   |-- child21
+|   |   |-- service210
+|   |   |-- child210
+|   |-- child22
+```
+
+### Query all entities
+
+List all entities registered with thin-edge starting from the `main` device at the root.
+
+**Request**
 
 ```shell
 curl http://localhost:8000/tedge/entity-store/v1/entities
+```
+
+**Response**
+
+```json
+[
+    {
+        "@topic-id": "device/main//",
+        "@type": "device"
+    },
+    {
+        "@topic-id": "device/main/service/service0",
+        "@type": "service",
+        "@parent": "device/main//"
+    },
+    {
+        "@topic-id": "device/main/service/service1",
+        "@type": "service",
+        "@parent": "device/main//"
+    },
+    {
+        "@topic-id": "device/child0//",
+        "@type": "child-device",
+        "@parent": "device/main//"
+    },
+    {
+        "@topic-id": "device/child1//",
+        "@type": "child-device",
+        "@parent": "device/main//"
+    },
+    {
+        "@topic-id": "device/child2//",
+        "@type": "child-device",
+        "@parent": "device/main//"
+    },
+    {
+        "@topic-id": "device/child00//",
+        "@type": "child-device",
+        "@parent": "device/child0//"
+    },
+    {
+        "@topic-id": "device/child1/service/service10",
+        "@type": "service",
+        "@parent": "device/child1//"
+    },
+    {
+        "@topic-id": "device/child2/service/service20",
+        "@type": "service",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child20//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child21//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child22//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child200//",
+        "@type": "child-device",
+        "@parent": "device/child20//"
+    },
+    {
+        "@topic-id": "device/child21/service/service210",
+        "@type": "service",
+        "@parent": "device/child21//"
+    },
+    {
+        "@topic-id": "device/child210//",
+        "@type": "child-device",
+        "@parent": "device/child21//"
+    }
+]
+```
+
+### Query from a root
+
+Query the entity tree from a given root node.
+
+**Request**
+
+```shell
+curl http://localhost:8000/tedge/entity-store/v1/entities?root=device/child2//
+```
+
+**Response**
+
+```json
+[
+    {
+        "@topic-id": "device/child2//",
+        "@type": "child-device",
+        "@parent": "device/main//"
+    },
+    {
+        "@topic-id": "device/child2/service/service20",
+        "@type": "service",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child20//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child21//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child22//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child200//",
+        "@type": "child-device",
+        "@parent": "device/child20//"
+    },
+    {
+        "@topic-id": "device/child21/service/service210",
+        "@type": "service",
+        "@parent": "device/child21//"
+    },
+    {
+        "@topic-id": "device/child210//",
+        "@type": "child-device",
+        "@parent": "device/child21//"
+    }
+]
+```
+
+### Query by parent
+
+Query only the immediate child entities of a `parent`, excluding any nested entities.
+
+**Request**
+
+```shell
+curl http://localhost:8000/tedge/entity-store/v1/entities?parent=device/child2//
+```
+
+**Response**
+
+```json
+[
+    {
+        "@topic-id": "device/child2/service/service20",
+        "@type": "service",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child20//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child21//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child22//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    }
+]
+```
+
+### Query by type
+
+Query all entities of type: `child-device`
+
+**Request**
+
+```shell
+curl http://localhost:8000/tedge/entity-store/v1/entities?type=child-device
+```
+
+**Response**
+
+```json
+[
+    {
+        "@topic-id": "device/child0//",
+        "@type": "child-device",
+        "@parent": "device/main//"
+    },
+    {
+        "@topic-id": "device/child1//",
+        "@type": "child-device",
+        "@parent": "device/main//"
+    },
+    {
+        "@topic-id": "device/child2//",
+        "@type": "child-device",
+        "@parent": "device/main//"
+    },
+    {
+        "@topic-id": "device/child00//",
+        "@type": "child-device",
+        "@parent": "device/child0//"
+    },
+    {
+        "@topic-id": "device/child20//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child21//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child22//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child200//",
+        "@type": "child-device",
+        "@parent": "device/child20//"
+    },
+    {
+        "@topic-id": "device/child210//",
+        "@type": "child-device",
+        "@parent": "device/child21//"
+    }
+]
+```
+
+### Query with multiple parameters
+
+Query all child services of the parent: `device/child2//`.
+
+**Request**
+
+```shell
+curl 'http://localhost:8000/tedge/entity-store/v1/entities?parent=device/child2//&type=service'
+```
+
+**Response**
+
+```json
+[
+    {
+        "@topic-id": "device/child2/service/service20",
+        "@type": "service",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child21/service/service210",
+        "@type": "service",
+        "@parent": "device/child21//"
+    }
+]
 ```
 
 ## Delete entity

--- a/tests/RobotFramework/tests/tedge/tedge_http.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_http.robot
@@ -48,7 +48,7 @@ Displaying server errors
     ...    tedge http post /tedge/entity-store/v1/entities '{"@topic-id": "device/a//", "@type": "child-device", "@parent": "device/unknown//"}' 2>&1
     ...    exp_exit_code=1
     Should Contain    ${error_msg}    400 Bad Request
-    Should Contain    ${error_msg}    Specified parent "device/unknown//" does not exist in the store
+    Should Contain    ${error_msg}    Specified parent \\"device/unknown//\\" does not exist in the store
 
 
 *** Keywords ***

--- a/tests/RobotFramework/tests/tedge_agent/http_server/entity_query_rest_api.robot
+++ b/tests/RobotFramework/tests/tedge_agent/http_server/entity_query_rest_api.robot
@@ -1,0 +1,244 @@
+*** Settings ***
+Resource            ../../../resources/common.resource
+Library             ThinEdgeIO
+
+Suite Setup         Custom Setup
+Test Teardown       Get Logs    ${DEVICE_SN}
+
+Test Tags           theme:tedge_agent
+
+
+*** Variables ***
+${DEVICE_SN}    ${EMPTY}    # Main device serial number
+
+
+*** Test Cases ***
+Query all entities
+    ${entities}=    List Entities
+
+    Should Contain Entity    {"@topic-id": "device/main//", "@type": "device"}    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/main/service/service0","@parent":"device/main//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/main/service/service1","@parent":"device/main//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child0//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child00//","@parent":"device/child0//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child000//","@parent":"device/child00//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child1//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child1/service/service10","@parent":"device/child1//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2/service/service20","@parent":"device/child2//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2/service/service21","@parent":"device/child2//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child20//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child21//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child21/service/service210","@parent":"device/child21//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child210//","@parent":"device/child21//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child210/service/service2100","@parent":"device/child210//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2100//","@parent":"device/child210//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child22//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+
+Query from child root
+    ${entities}=    List Entities    root=device/child2//
+
+    Length Should Be    ${entities}    10
+
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2/service/service20","@parent":"device/child2//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2/service/service21","@parent":"device/child2//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child20//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child21//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child21/service/service210","@parent":"device/child21//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child210//","@parent":"device/child21//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child210/service/service2100","@parent":"device/child210//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2100//","@parent":"device/child210//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child22//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+
+Query by parent
+    ${entities}=    List Entities    parent=device/child2//
+
+    Length Should Be    ${entities}    5
+
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2/service/service20","@parent":"device/child2//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2/service/service21","@parent":"device/child2//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child20//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child21//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child22//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+
+Query all children
+    ${entities}=    List Entities    type=child-device
+    Length Should Be    ${entities}    10
+
+    Should Contain Entity
+    ...    {"@topic-id":"device/child0//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child00//","@parent":"device/child0//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child000//","@parent":"device/child00//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child1//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child20//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child21//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child210//","@parent":"device/child21//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2100//","@parent":"device/child210//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child22//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+
+Query all services
+    ${entities}=    List Entities    type=service
+
+    Should Contain Entity
+    ...    {"@topic-id":"device/main/service/service0","@parent":"device/main//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/main/service/service1","@parent":"device/main//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child1/service/service10","@parent":"device/child1//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2/service/service20","@parent":"device/child2//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2/service/service21","@parent":"device/child2//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child21/service/service210","@parent":"device/child21//","@type":"service","type":"service"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child210/service/service2100","@parent":"device/child210//","@type":"service","type":"service"}
+    ...    ${entities}
+
+Query with parent and type
+    ${entities}=    List Entities    parent=device/child2//    type=child-device
+    Length Should Be    ${entities}    3
+
+    Should Contain Entity
+    ...    {"@topic-id":"device/child20//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child21//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child22//","@parent":"device/child2//","@type":"child-device"}
+    ...    ${entities}
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+
+    # Build the entity tree:
+    # main
+    # |--- service0
+    # |--- service1
+    # |--- child0
+    # |    |--- child00
+    # |    |    |--- child000
+    # |--- child1
+    # |    |--- service10
+    # |--- child2
+    # |    |--- service20
+    # |    |--- service21
+    # |    |--- child20
+    # |    |--- child21
+    # |    |    |--- service210
+    # |    |    |--- child210
+    # |    |    |    |-- service2100
+    # |    |    |    |-- child2100
+    # |    |--- child22
+    Register Entity    device/main/service/service0    service    device/main//
+    Register Entity    device/main/service/service1    service    device/main//
+    Register Entity    device/child0//    child-device    device/main//
+    Register Entity    device/child00//    child-device    device/child0//
+    Register Entity    device/child000//    child-device    device/child00//
+    Register Entity    device/child1//    child-device    device/main//
+    Register Entity    device/child1/service/service10    service    device/child1//
+    Register Entity    device/child2//    child-device    device/main//
+    Register Entity    device/child2/service/service20    service    device/child2//
+    Register Entity    device/child2/service/service21    service    device/child2//
+    Register Entity    device/child20//    child-device    device/child2//
+    Register Entity    device/child21//    child-device    device/child2//
+    Register Entity    device/child21/service/service210    service    device/child21//
+    Register Entity    device/child210//    child-device    device/child21//
+    Register Entity    device/child210/service/service2100    service    device/child210//
+    Register Entity    device/child2100//    child-device    device/child210//
+    Register Entity    device/child22//    child-device    device/child2//

--- a/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
+++ b/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
@@ -36,64 +36,6 @@ CRUD apis
     ...    curl -o /dev/null --silent --write-out "%\{http_code\}" http://localhost:8000/tedge/entity-store/v1/entities/device/child01//
     Should Be Equal    ${get}    404
 
-Query api
-    # Build the entity tree:
-    # main
-    # |--- child0
-    # |    |--- child00
-    # |    |    |--- child000
-    # |--- child1
-    # |--- child2
-    # |    |--- child20
-    # |    |--- child21
-    # |    |    |--- child210
-    # |    |    |    |-- child2100
-    # |    |--- child22
-    Register Entity    device/child0//    child-device    device/main//
-    Register Entity    device/child00//    child-device    device/child0//
-    Register Entity    device/child000//    child-device    device/child00//
-    Register Entity    device/child1//    child-device    device/main//
-    Register Entity    device/child2//    child-device    device/main//
-    Register Entity    device/child20//    child-device    device/child2//
-    Register Entity    device/child21//    child-device    device/child2//
-    Register Entity    device/child210//    child-device    device/child21//
-    Register Entity    device/child2100//    child-device    device/child210//
-    Register Entity    device/child22//    child-device    device/child2//
-
-    ${entities}=    List Entities
-
-    Should Contain Entity    {"@topic-id": "device/main//", "@type": "device"}    ${entities}
-    Should Contain Entity
-    ...    {"@topic-id":"device/child0//","@parent":"device/main//","@type":"child-device"}
-    ...    ${entities}
-    Should Contain Entity
-    ...    {"@topic-id":"device/child00//","@parent":"device/child0//","@type":"child-device"}
-    ...    ${entities}
-    Should Contain Entity
-    ...    {"@topic-id":"device/child000//","@parent":"device/child00//","@type":"child-device"}
-    ...    ${entities}
-    Should Contain Entity
-    ...    {"@topic-id":"device/child1//","@parent":"device/main//","@type":"child-device"}
-    ...    ${entities}
-    Should Contain Entity
-    ...    {"@topic-id":"device/child2//","@parent":"device/main//","@type":"child-device"}
-    ...    ${entities}
-    Should Contain Entity
-    ...    {"@topic-id":"device/child20//","@parent":"device/child2//","@type":"child-device"}
-    ...    ${entities}
-    Should Contain Entity
-    ...    {"@topic-id":"device/child21//","@parent":"device/child2//","@type":"child-device"}
-    ...    ${entities}
-    Should Contain Entity
-    ...    {"@topic-id":"device/child210//","@parent":"device/child21//","@type":"child-device"}
-    ...    ${entities}
-    Should Contain Entity
-    ...    {"@topic-id":"device/child2100//","@parent":"device/child210//","@type":"child-device"}
-    ...    ${entities}
-    Should Contain Entity
-    ...    {"@topic-id":"device/child22//","@parent":"device/child2//","@type":"child-device"}
-    ...    ${entities}
-
 MQTT HTTP interoperability
     Execute Command    tedge mqtt pub --retain 'te/device/child_abc//' '{"@type":"child-device"}'
     Should Have MQTT Messages


### PR DESCRIPTION
## Proposed changes

- [x] Add query parameter support for the query API
- [x] Supported parameters:
  - [x] `root`
  - [x] `parent`
  - [x] `type`
- [x] Documentation

Decided not to add the `depth` parameter as agreed [here](https://github.com/thin-edge/thin-edge.io/pull/3383#issuecomment-2639211046).
Multiple values for the same parameter is also not supported.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

#3339 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

