### PR TITLE
feat: Return entity metadata in delete REST API response

### DIFF
--- a/crates/common/mqtt_channel/src/topics.rs
+++ b/crates/common/mqtt_channel/src/topics.rs
@@ -6,11 +6,19 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashSet;
 use std::convert::TryInto;
+use std::fmt::Display;
+use std::fmt::Formatter;
 
 /// An MQTT topic
 #[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct Topic {
     pub name: String,
+}
+
+impl Display for Topic {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        Display::fmt(&self.name, f)
+    }
 }
 
 impl Topic {

--- a/crates/core/tedge_agent/src/entity_manager/tests.rs
+++ b/crates/core/tedge_agent/src/entity_manager/tests.rs
@@ -80,7 +80,10 @@ async fn check_registrations(registrations: Commands) {
                 .iter()
                 .map(|registered_entity| registered_entity.reg_message.topic_id.clone())
                 .collect(),
-            EntityStoreResponse::Delete(actual_updates) => HashSet::from_iter(actual_updates),
+            EntityStoreResponse::Delete(actual_updates) => actual_updates
+                .into_iter()
+                .map(|meta| meta.topic_id)
+                .collect(),
             _ => HashSet::new(),
         };
         assert_eq!(actual_updates, expected_updates);

--- a/docs/src/operate/registration/register.md
+++ b/docs/src/operate/registration/register.md
@@ -470,4 +470,4 @@ curl -X DELETE http://localhost:8000/tedge/entity-store/v1/entities/device/child
     }
   ]
   ```
-
+* 204: No Content, when nothing is deleted

--- a/docs/src/operate/registration/register.md
+++ b/docs/src/operate/registration/register.md
@@ -442,15 +442,32 @@ The deleted entities are cleared from the MQTT broker as well.
 DELETE /v1/entities/{topic-id}
 ```
 
-**Responses**
-
-* 200: OK
-  ```json
-  ["device/child01//"]
-  ```
-
 **Example**
 
 ```shell
-curl -X DELETE http://localhost:8000/tedge/entity-store/v1/entities/device/child01
+curl -X DELETE http://localhost:8000/tedge/entity-store/v1/entities/device/child21
 ```
+
+**Responses**
+
+* 200: OK, when entities are deleted
+  ```json
+  [
+    {
+        "@topic-id": "device/child21//",
+        "@type": "child-device",
+        "@parent": "device/child2//"
+    },
+    {
+        "@topic-id": "device/child21/service/service210",
+        "@type": "service",
+        "@parent": "device/child21//"
+    },
+    {
+        "@topic-id": "device/child210//",
+        "@type": "child-device",
+        "@parent": "device/child21//"
+    }
+  ]
+  ```
+

--- a/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
+++ b/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
@@ -28,9 +28,15 @@ CRUD apis
     ${entities}=    Execute Command    curl http://localhost:8000/tedge/entity-store/v1/entities
     Should Contain    ${entities}    {"@topic-id":"device/child01//","@parent":"device/main//","@type":"child-device"}
 
-    ${status}=    Execute Command
-    ...    curl -o /dev/null --silent --write-out "%\{http_code\}" -X DELETE http://localhost:8000/tedge/entity-store/v1/entities/device/child01//
-    Should Be Equal    ${status}    200
+    ${timestamp}=    Get Unix Timestamp
+    ${delete}=    Execute Command
+    ...    curl --silent -X DELETE http://localhost:8000/tedge/entity-store/v1/entities/device/child01//
+    Should Be Equal
+    ...    ${delete}
+    ...    [{"@topic-id":"device/child01//","@parent":"device/main//","@type":"child-device"}]
+    Should Have MQTT Messages
+    ...    te/device/child01//
+    ...    date_from=${timestamp}
 
     ${get}=    Execute Command
     ...    curl -o /dev/null --silent --write-out "%\{http_code\}" http://localhost:8000/tedge/entity-store/v1/entities/device/child01//
@@ -55,6 +61,48 @@ Entity auto-registration over MQTT
     Should Have MQTT Messages
     ...    te/device/auto_child/service/collectd
     ...    message_contains={"@parent":"device/auto_child//","@type":"service","name":"collectd","type":"service"}
+
+Delete entity tree
+    Register Entity    device/child0//    child-device    device/main//
+    Register Entity    device/child1//    child-device    device/main//
+    Register Entity    device/child0/service/service0    service    device/child0//
+    Register Entity    device/child00//    child-device    device/child0//
+    Register Entity    device/child000//    child-device    device/child00//
+
+    ${deleted}=    Deregister Entity    device/child0//
+    Length Should Be    ${deleted}    4
+
+    # Assert the deleted entities
+    Should Contain Entity
+    ...    {"@topic-id":"device/child0//","@parent":"device/main//","@type":"child-device"}
+    ...    ${deleted}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child00//","@parent":"device/child0//","@type":"child-device"}
+    ...    ${deleted}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child0/service/service0","@parent":"device/child0//","@type":"service","type":"service"}
+    ...    ${deleted}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child000//","@parent":"device/child00//","@type":"child-device"}
+    ...    ${deleted}
+
+    # Assert the remaining entities
+    ${entities}=    List Entities
+    Should Not Contain Entity
+    ...    "device/child0//"
+    ...    ${entities}
+
+    Should Not Contain Entity
+    ...    "device/child00//"
+    ...    ${entities}
+
+    Should Not Contain Entity
+    ...    "device/child000//"
+    ...    ${entities}
+
+    Should Contain Entity
+    ...    {"@topic-id":"device/child1//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
 
 
 *** Keywords ***

--- a/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
+++ b/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
@@ -65,6 +65,7 @@ Entity auto-registration over MQTT
 Delete entity tree
     Register Entity    device/child0//    child-device    device/main//
     Register Entity    device/child1//    child-device    device/main//
+    Register Entity    device/child2//    child-device    device/main//
     Register Entity    device/child0/service/service0    service    device/child0//
     Register Entity    device/child00//    child-device    device/child0//
     Register Entity    device/child000//    child-device    device/child00//
@@ -86,22 +87,23 @@ Delete entity tree
     ...    {"@topic-id":"device/child000//","@parent":"device/child00//","@type":"child-device"}
     ...    ${deleted}
 
-    # Assert the remaining entities
     ${entities}=    List Entities
     Should Not Contain Entity
     ...    "device/child0//"
     ...    ${entities}
-
     Should Not Contain Entity
     ...    "device/child00//"
     ...    ${entities}
-
     Should Not Contain Entity
     ...    "device/child000//"
     ...    ${entities}
 
+    # Assert the remaining entities
     Should Contain Entity
     ...    {"@topic-id":"device/child1//","@parent":"device/main//","@type":"child-device"}
+    ...    ${entities}
+    Should Contain Entity
+    ...    {"@topic-id":"device/child2//","@parent":"device/main//","@type":"child-device"}
     ...    ${entities}
 
 


### PR DESCRIPTION
## Proposed changes

Fixes:
- [x] Entity store DELETE API to return full entity metadata of deleted entities
- [x] Return HTTP 204 when deleting non-existent entity

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

* https://github.com/thin-edge/thin-edge.io/issues/3385
* https://github.com/thin-edge/thin-edge.io/issues/3387

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

