### PR TITLE
fix: broken links in tedge http docs

### DIFF
--- a/docs/src/references/cli/tedge-http.md
+++ b/docs/src/references/cli/tedge-http.md
@@ -8,9 +8,9 @@ sidebar_position: 6
 
 A `tedge` sub command to interact with the HTTP services hosted on the device by the Cumulocity mapper and the agent:
 
-- the [Cumulocity Proxy](/references/cumulocity-proxy/)
-- the [File Transfer Service](/references/file-transfer-service/)
-- the [Entity Store Service](/operate/registration/register/).
+- the [Cumulocity Proxy](../../cumulocity-proxy/)
+- the [File Transfer Service](../../file-transfer-service/)
+- the [Entity Store Service](../../../operate/registration/register/).
 
 This command uses `tedge config` to get the appropriate host, port and credentials to reach these local HTTP services.
 So the same command can be used unchanged from the main device or a child device, with TLS or mTLS enabled or not.
@@ -41,19 +41,19 @@ Options:
 
 The requests are forwarded to the appropriate service depending on the URL prefix.
 
-- URIs prefixed by `/c8y/` are forwarded to the [Cumulocity Proxy](/references/cumulocity-proxy/)
+- URIs prefixed by `/c8y/` are forwarded to the [Cumulocity Proxy](../../cumulocity-proxy/)
 
    ```sh title="Interacting with Cumulocity"
    tedge http get /c8y/inventory/managedObjects
    ```
 
-- URIs starting with `/tedge/file-transfer/` are directed to the [File Transfer Service](/references/file-transfer-service)
+- URIs starting with `/tedge/file-transfer/` are directed to the [File Transfer Service](../../file-transfer-service)
 
    ```sh title="Transferring files to/from the main device"
    tedge http put /tedge/file-transfer/target.txt --file source.txt
    ```
   
-- URIs starting with `/tedge/entity-store` are directed to the [Entity Store Service](/operate/registration/register)
+- URIs starting with `/tedge/entity-store` are directed to the [Entity Store Service](../../../operate/registration/register)
 
    ```sh title="Listing all entities"
    tedge http get /tedge/entity-store/v1/entities
@@ -70,7 +70,7 @@ have to be properly configured on the main device as well as the child devices.
 
 The following `tedge config` settings control the access granted to child devices
 on the HTTP services provided by the main agent
-([file transfer](/references/file-transfer-service) and entity registration).
+([file transfer](../../file-transfer-service) and entity registration).
 This can be done along three security levels.
 
 ```sh title="Listening HTTP requests"
@@ -95,7 +95,7 @@ This can be done along three security levels.
 ### On the host running the cumulocity mapper
 
 The following `tedge config` settings control the access granted to child devices
-on the HTTP services provided by the Cumulocity mapper ([Cumulocity proxy](/references/cumulocity-proxy/)).
+on the HTTP services provided by the Cumulocity mapper ([Cumulocity proxy](../../cumulocity-proxy/)).
 This can be done along three security levels.
 
 ```sh title="Listening HTTP requests"


### PR DESCRIPTION
## Proposed changes

Replace absolute paths (e.g. `/references/cumulocity-proxy/`) with relative ones (e.g. `(../../cumulocity-proxy/`)

- The absolute paths are version agnostic: i.e. jumping from the *new* release to the *official* one.
- The entity store documentation being tagged as draft in the *official* docs, this was causing broken links.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/actions/runs/13291559191

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

