### PR TITLE
fix: clippy error from tedge_config_macros

### DIFF
--- a/crates/common/certificate/Cargo.toml
+++ b/crates/common/certificate/Cargo.toml
@@ -17,7 +17,9 @@ reqwest = ["dep:reqwest"]
 anyhow = { workspace = true }
 camino = { workspace = true }
 rcgen = { workspace = true }
-reqwest = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true, features = [
+    "rustls-tls-native-roots",
+] }
 rustls = { workspace = true }
 rustls-native-certs = { workspace = true }
 rustls-pemfile = { workspace = true }

--- a/crates/common/tedge_config_macros/impl/src/query.rs
+++ b/crates/common/tedge_config_macros/impl/src/query.rs
@@ -754,6 +754,7 @@ fn generate_string_writers(paths: &[VecDeque<&FieldOrGroup>]) -> TokenStream {
 
             (
                 parse_quote_spanned! {ty.span()=>
+                    #[allow(clippy::useless_conversion)]
                     WritableKey::#match_variant => self.#(#write_segments).* = Some(value
                         .#parse
                         .#convert_to_field_ty
@@ -766,6 +767,7 @@ fn generate_string_writers(paths: &[VecDeque<&FieldOrGroup>]) -> TokenStream {
                     },
                 },
                 parse_quote_spanned! {ty.span()=>
+                    #[allow(clippy::useless_conversion)]
                     WritableKey::#match_variant => self.#(#write_segments).* = <#ty as AppendRemoveItem>::append(
                         #current_value,
                         value
@@ -774,6 +776,7 @@ fn generate_string_writers(paths: &[VecDeque<&FieldOrGroup>]) -> TokenStream {
                         .map_err(|e| WriteError::ParseValue(Box::new(e)))?),
                 },
                 parse_quote_spanned! {ty.span()=>
+                    #[allow(clippy::useless_conversion)]
                     WritableKey::#match_variant => self.#(#write_segments).* = <#ty as AppendRemoveItem>::remove(
                         #current_value,
                         value
@@ -1540,6 +1543,7 @@ mod tests {
             impl TEdgeConfigDto {
                 pub fn try_append_str(&mut self, reader: &TEdgeConfigReader, key: &WritableKey, value: &str) -> Result<(), WriteError> {
                     match key {
+                        #[allow(clippy::useless_conversion)]
                         WritableKey::C8yDeviceId(key0) => {
                             self.c8y.try_get_mut(key0.as_deref(), "c8y")?.device.id = <String as AppendRemoveItem>::append(
                                 Some(reader.c8y.try_get(key0.as_deref())?.device.id()),


### PR DESCRIPTION
## Proposed changes
Clippy has updated the `useless_conversion` rule so it now detects unnecessary `T::from` invocations. This PR ignores that lint for the `define_tedge_config` macro as it shouldn't apply here. In this case, we convert indiscriminately since we don't have the required type information to determine if the conversion is truly necessary.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

