### PR TITLE
test: get_logs should look at the new location of entity_store.jsonl

### DIFF
--- a/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
+++ b/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
@@ -219,10 +219,10 @@ class ThinEdgeIO(DeviceLibrary):
             log.warning("Failed to retrieve logs. %s", ex, exc_info=True)
 
         try:
-            # tedge-mapper-c8y message log (if they exist)
-            log.info("tedge-mapper-c8y message log: /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl")
+            # entity_store.jsonl log (if they exist)
+            log.info("entity_store.jsonl log:")
             device.execute_command(
-                "cat /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl || true",
+                "head -n-1 /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl /etc/tedge/.agent/entity_store.jsonl 2>/dev/null || true",
                 shell=True,
             )
         except Exception as ex:


### PR DESCRIPTION
## Proposed changes
The location of `entity_store.jsonl` was moved from `/etc/tedge/.tedge-mapper-c8y` to `/etc/tedge/.agent` by #3230. However, since our system test `get_logs()` is still looking at the old location, the function always raises this error message in a system test log:

```
tedge-mapper-c8y message log: /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl

cmd: ['/bin/sh', '-c', 'cat /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl || true'], exit code: 0
stdout:
<<empty>>
stderr:
cat: /etc/tedge/.tedge-mapper-c8y/entity_store.jsonl: No such file or directory
```

This PR fixes the location and enables the `get_logs()` to retrive the contents of `entity_store.jsonl`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

