### PR TITLE
feat: Allow name and type in inventory.json

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -1435,7 +1435,11 @@ impl CumulocityConverter {
     }
 
     fn try_init_messages(&mut self) -> Result<Vec<MqttMessage>, ConversionError> {
-        let mut messages = self.parse_base_inventory_file()?;
+        let device_data_message = self.inventory_device_type_update_message()?;
+        let mut messages = vec![device_data_message];
+
+        let inventory_data = self.parse_base_inventory_file()?;
+        messages.extend(inventory_data);
 
         self.supported_operations
             .load_all(&self.config.device_id, &self.config.bridge_config)?;
@@ -1444,14 +1448,11 @@ impl CumulocityConverter {
             &self.config.bridge_config.c8y_prefix,
         )?;
 
-        let device_data_message = self.inventory_device_type_update_message()?;
-
         let pending_operations_message =
             create_get_pending_operations_message(&self.config.bridge_config.c8y_prefix);
 
         messages.append(&mut vec![
             supported_operations_message,
-            device_data_message,
             pending_operations_message,
         ]);
         Ok(messages)

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -1435,11 +1435,7 @@ impl CumulocityConverter {
     }
 
     fn try_init_messages(&mut self) -> Result<Vec<MqttMessage>, ConversionError> {
-        let device_data_message = self.inventory_device_type_update_message()?;
-        let mut messages = vec![device_data_message];
-
-        let inventory_data = self.parse_base_inventory_file()?;
-        messages.extend(inventory_data);
+        let mut messages = self.base_inventory_twin_data()?;
 
         self.supported_operations
             .load_all(&self.config.device_id, &self.config.bridge_config)?;

--- a/crates/extensions/c8y_mapper_ext/src/entity_cache.rs
+++ b/crates/extensions/c8y_mapper_ext/src/entity_cache.rs
@@ -306,11 +306,6 @@ impl EntityCache {
     }
 
     /// Returns the external id of the main device.
-    pub fn main_device_topic_id(&self) -> &EntityTopicId {
-        &self.main_device_tid
-    }
-
-    /// Returns the external id of the main device.
     pub fn main_device_external_id(&self) -> &EntityExternalId {
         &self.main_device_xid
     }

--- a/crates/extensions/c8y_mapper_ext/src/fragments.rs
+++ b/crates/extensions/c8y_mapper_ext/src/fragments.rs
@@ -38,23 +38,3 @@ pub fn get_tedge_version() -> String {
     // Use package version over tedge cli to remove dependency on the optional tedge cli #1991
     env!("CARGO_PKG_VERSION").to_string()
 }
-
-#[derive(Debug, Serialize)]
-pub struct C8yDeviceDataFragment {
-    #[serde(rename = "type")]
-    device_type: String,
-}
-
-impl C8yDeviceDataFragment {
-    pub fn from_type(device_type: &str) -> Result<Self, ConversionError> {
-        Ok(Self {
-            device_type: device_type.into(),
-        })
-    }
-
-    pub fn to_json(&self) -> Result<serde_json::Value, ConversionError> {
-        let json_string = serde_json::to_string(&self)?;
-        let jsond: serde_json::Value = serde_json::from_str(&json_string)?;
-        Ok(jsond)
-    }
-}

--- a/crates/extensions/c8y_mapper_ext/src/inventory.rs
+++ b/crates/extensions/c8y_mapper_ext/src/inventory.rs
@@ -2,7 +2,6 @@
 use crate::converter::CumulocityConverter;
 use crate::error::ConversionError;
 use crate::fragments::C8yAgentFragment;
-use crate::fragments::C8yDeviceDataFragment;
 use serde_json::json;
 use serde_json::Value as JsonValue;
 use std::fs::File;
@@ -20,11 +19,8 @@ const INVENTORY_FRAGMENTS_FILE_LOCATION: &str = "device/inventory.json";
 const INVENTORY_MANAGED_OBJECTS_TOPIC: &str = "inventory/managedObjects/update";
 
 impl CumulocityConverter {
-    /// Creates the inventory update message with fragments from inventory.json file
-    /// while also updating the live `inventory_model` of this converter
-    pub(crate) fn parse_base_inventory_file(
-        &mut self,
-    ) -> Result<Vec<MqttMessage>, ConversionError> {
+    /// Creates the inventory twin messages with fragments from inventory.json file
+    pub(crate) fn base_inventory_twin_data(&mut self) -> Result<Vec<MqttMessage>, ConversionError> {
         let mut messages = vec![];
         let inventory_file_path = self
             .config
@@ -32,20 +28,16 @@ impl CumulocityConverter {
             .join(INVENTORY_FRAGMENTS_FILE_LOCATION);
         let inventory_base = Self::get_inventory_fragments(inventory_file_path.as_std_path())?;
 
-        let message =
-            self.inventory_update_message(&self.device_topic_id, inventory_base.clone())?;
-        messages.push(message);
+        if let JsonValue::Object(mut map) = inventory_base {
+            map.entry("name").or_insert(json!(self.device_name));
+            map.entry("type").or_insert(json!(self.device_type));
 
-        if let JsonValue::Object(map) = inventory_base {
             for (key, value) in map {
-                let main_device_tid = self.entity_cache.main_device_topic_id().clone();
-                let _ = self.entity_cache.update_twin_data(EntityTwinMessage::new(
-                    main_device_tid.clone(),
+                let mapped_message = self.entity_twin_data_message(
+                    &self.device_topic_id,
                     key.clone(),
                     value.clone(),
-                ))?;
-                let mapped_message =
-                    self.entity_twin_data_message(&main_device_tid, key.clone(), value.clone());
+                );
                 messages.push(mapped_message);
             }
         }
@@ -138,16 +130,6 @@ impl CumulocityConverter {
             &inventory_update_topic,
             fragment_value.to_string(),
         ))
-    }
-
-    /// Create the inventory update message to update the `type` of the main device
-    pub(crate) fn inventory_device_type_update_message(
-        &self,
-    ) -> Result<MqttMessage, ConversionError> {
-        let device_data = C8yDeviceDataFragment::from_type(&self.device_type)?;
-        let device_type_fragment = device_data.to_json()?;
-
-        self.inventory_update_message(&self.device_topic_id, device_type_fragment)
     }
 
     /// Return the contents of inventory.json file as a `JsonValue`

--- a/crates/extensions/c8y_mapper_ext/src/inventory.rs
+++ b/crates/extensions/c8y_mapper_ext/src/inventory.rs
@@ -15,7 +15,6 @@ use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::Topic;
 use tracing::info;
-use tracing::warn;
 
 const INVENTORY_FRAGMENTS_FILE_LOCATION: &str = "device/inventory.json";
 const INVENTORY_MANAGED_OBJECTS_TOPIC: &str = "inventory/managedObjects/update";
@@ -31,16 +30,7 @@ impl CumulocityConverter {
             .config
             .config_dir
             .join(INVENTORY_FRAGMENTS_FILE_LOCATION);
-        let mut inventory_base = Self::get_inventory_fragments(inventory_file_path.as_std_path())?;
-
-        if let Some(map) = inventory_base.as_object_mut() {
-            if map.remove("name").is_some() {
-                warn!("Ignoring `name` fragment key from inventory.json as updating the same using this file is not supported");
-            }
-            if map.remove("type").is_some() {
-                warn!("Ignoring `type` fragment key from inventory.json as updating the same using this file is not supported");
-            }
-        }
+        let inventory_base = Self::get_inventory_fragments(inventory_file_path.as_std_path())?;
 
         let message =
             self.inventory_update_message(&self.device_topic_id, inventory_base.clone())?;

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -80,6 +80,10 @@ async fn mapper_publishes_init_messages_on_startup() {
         [
             (
                 "c8y/inventory/managedObjects/update/test-device",
+                json!({"type":"test-device-type"}).to_string().as_str(),
+            ),
+            (
+                "c8y/inventory/managedObjects/update/test-device",
                 default_fragment_content.as_str(),
             ),
             (
@@ -92,10 +96,6 @@ async fn mapper_publishes_init_messages_on_startup() {
                 .to_string(),
             ),
             ("c8y/s/us", "114"),
-            (
-                "c8y/inventory/managedObjects/update/test-device",
-                &json!({"type":"test-device-type"}).to_string(),
-            ),
             ("c8y/s/us", "500"),
         ],
     )
@@ -1242,7 +1242,7 @@ async fn mapper_publishes_supported_operations() {
     let TestHandle { mqtt, .. } = test_handle;
     let mut mqtt = mqtt.with_timeout(TEST_TIMEOUT_MS);
 
-    mqtt.skip(2).await;
+    mqtt.skip(3).await;
 
     // Expect smartrest message on `c8y/s/us` with expected payload "114,c8y_TestOp1,c8y_TestOp2"
     assert_received_contains_str(&mut mqtt, [("c8y/s/us", "114,c8y_TestOp1,c8y_TestOp2")]).await;
@@ -1534,6 +1534,10 @@ async fn mapper_updating_the_inventory_fragments_from_file() {
         [
             (
                 "c8y/inventory/managedObjects/update/test-device",
+                json!({"type":"test-device-type"}),
+            ),
+            (
+                "c8y/inventory/managedObjects/update/test-device",
                 custom_fragment_content,
             ),
             ("te/device/main///twin/boolean_key", json!(true)),
@@ -1561,7 +1565,7 @@ async fn mapper_updating_the_inventory_fragments_from_file() {
 }
 
 #[tokio::test]
-async fn forbidden_keys_in_inventory_fragments_file_ignored() {
+async fn override_type_using_inventory_fragments_file() {
     // The test Creates an inventory file in (Temp_base_Dir)/device/inventory.json
     // The tedge-mapper parses the inventory fragment file and publishes on c8y/inventory/managedObjects/update/test-device
     // Verify the fragment message that is published
@@ -1570,7 +1574,7 @@ async fn forbidden_keys_in_inventory_fragments_file_ignored() {
     let version = env!("CARGO_PKG_VERSION");
     let custom_fragment_content = json!({
         "name": "new-name",
-        "type": "new-name",
+        "type": "new-type",
         "c8y_Firmware": {
             "name": "raspberrypi-bootloader",
             "url": "31aab9856861b1a587e2094690c2f6e272712cb1",
@@ -1588,7 +1592,13 @@ async fn forbidden_keys_in_inventory_fragments_file_ignored() {
         [
             (
                 "c8y/inventory/managedObjects/update/test-device",
+                json!({"type":"test-device-type"}),
+            ),
+            (
+                "c8y/inventory/managedObjects/update/test-device",
                 json!({
+                    "name": "new-name",
+                    "type": "new-type",
                     "c8y_Firmware": {
                         "name": "raspberrypi-bootloader",
                         "url": "31aab9856861b1a587e2094690c2f6e272712cb1",
@@ -3450,13 +3460,13 @@ pub(crate) async fn skip_init_messages(mqtt: &mut impl MessageReceiver<MqttMessa
     assert_received_contains_str(
         mqtt,
         [
+            (
+                "c8y/inventory/managedObjects/update/test-device",
+                json!({"type":"test-device-type"}).to_string().as_str(),
+            ),
             ("c8y/inventory/managedObjects/update/test-device", "{"),
             ("te/device/main///twin/c8y_Agent", "{"),
             ("c8y/s/us", "114"),
-            (
-                "c8y/inventory/managedObjects/update/test-device",
-                &json!({"type":"test-device-type"}).to_string(),
-            ),
             ("c8y/s/us", "500"),
         ],
     )

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -66,35 +66,22 @@ async fn mapper_publishes_init_messages_on_startup() {
     let mut mqtt = mqtt.with_timeout(TEST_TIMEOUT_MS);
 
     let version = env!("CARGO_PKG_VERSION");
-    let default_fragment_content = json!({
-        "c8y_Agent": {
-            "name": "thin-edge.io",
-            "url": "https://thin-edge.io",
-            "version": version
-        }
-    })
-    .to_string();
 
     assert_received_contains_str(
         &mut mqtt,
         [
             (
-                "c8y/inventory/managedObjects/update/test-device",
-                json!({"type":"test-device-type"}).to_string().as_str(),
-            ),
-            (
-                "c8y/inventory/managedObjects/update/test-device",
-                default_fragment_content.as_str(),
-            ),
-            (
                 "te/device/main///twin/c8y_Agent",
-                &json!({
+                json!({
                     "name": "thin-edge.io",
                     "url": "https://thin-edge.io",
                     "version": version
                 })
-                .to_string(),
+                .to_string()
+                .as_str(),
             ),
+            ("te/device/main///twin/name", "test-device"),
+            ("te/device/main///twin/type", "test-device-type"),
             ("c8y/s/us", "114"),
             ("c8y/s/us", "500"),
         ],
@@ -1532,14 +1519,6 @@ async fn mapper_updating_the_inventory_fragments_from_file() {
     assert_received_includes_json(
         &mut mqtt,
         [
-            (
-                "c8y/inventory/managedObjects/update/test-device",
-                json!({"type":"test-device-type"}),
-            ),
-            (
-                "c8y/inventory/managedObjects/update/test-device",
-                custom_fragment_content,
-            ),
             ("te/device/main///twin/boolean_key", json!(true)),
             (
                 "te/device/main///twin/c8y_Agent",
@@ -1557,8 +1536,10 @@ async fn mapper_updating_the_inventory_fragments_from_file() {
                     "version": "1.20140107-1"
                 }),
             ),
+            ("te/device/main///twin/name", json!("test-device")),
             ("te/device/main///twin/numeric_key", json!(10)),
             ("te/device/main///twin/string_key", json!("value")),
+            ("te/device/main///twin/type", json!("test-device-type")),
         ],
     )
     .await;
@@ -1591,22 +1572,6 @@ async fn override_type_using_inventory_fragments_file() {
         &mut mqtt,
         [
             (
-                "c8y/inventory/managedObjects/update/test-device",
-                json!({"type":"test-device-type"}),
-            ),
-            (
-                "c8y/inventory/managedObjects/update/test-device",
-                json!({
-                    "name": "new-name",
-                    "type": "new-type",
-                    "c8y_Firmware": {
-                        "name": "raspberrypi-bootloader",
-                        "url": "31aab9856861b1a587e2094690c2f6e272712cb1",
-                        "version": "1.20140107-1"
-                    }
-                }),
-            ),
-            (
                 "te/device/main///twin/c8y_Agent",
                 json!({
                     "name": "thin-edge.io",
@@ -1622,6 +1587,8 @@ async fn override_type_using_inventory_fragments_file() {
                     "version": "1.20140107-1"
                 }),
             ),
+            ("te/device/main///twin/name", json!("new-name")),
+            ("te/device/main///twin/type", json!("new-type")),
         ],
     )
     .await;
@@ -3460,12 +3427,9 @@ pub(crate) async fn skip_init_messages(mqtt: &mut impl MessageReceiver<MqttMessa
     assert_received_contains_str(
         mqtt,
         [
-            (
-                "c8y/inventory/managedObjects/update/test-device",
-                json!({"type":"test-device-type"}).to_string().as_str(),
-            ),
-            ("c8y/inventory/managedObjects/update/test-device", "{"),
             ("te/device/main///twin/c8y_Agent", "{"),
+            ("te/device/main///twin/name", "test-device"),
+            ("te/device/main///twin/type", "test-device-type"),
             ("c8y/s/us", "114"),
             ("c8y/s/us", "500"),
         ],

--- a/docs/src/references/mappers/c8y-mapper.md
+++ b/docs/src/references/mappers/c8y-mapper.md
@@ -782,15 +782,6 @@ c8y/inventory/managedObjects/update/<main-device-id>
 
 </div>
 
-:::warning
-Updating the following properties via the `twin` channel is not supported
-
-* `name`
-* `type`
-
-as they are included in the entity registration message and can only be updated with another registration message.
-:::
-
 
 ### Twin - Deleting a fragment
 
@@ -913,18 +904,9 @@ te/device/main///twin/c8y_Hardware
 }
 ```
 
-:::warning
-The following keys in the `inventory.json` file are also ignored:
-
-* `name`
-* `type`
-
-as they are included in the entity registration message and can only be updated with another registration message.
-:::
-
 ### Updating entity type in inventory
 
-After updating the inventory with `inventory.json` file contents, 
+If not included in the `inventory.json` file,
 the device `type` of the main device, set using the `device.type` tedge config key,
 is also updated in the inventory with the following message:
 

--- a/docs/src/references/mappers/c8y-mapper.md
+++ b/docs/src/references/mappers/c8y-mapper.md
@@ -904,21 +904,10 @@ te/device/main///twin/c8y_Hardware
 }
 ```
 
-### Updating entity type in inventory
-
-If not included in the `inventory.json` file,
-the device `type` of the main device, set using the `device.type` tedge config key,
-is also updated in the inventory with the following message:
-
-```text title="Topic"
-c8y/inventory/managedObjects/update
-```
-
-```json5 title="Payload"
-{
-  "type": "configured-device-type"
-}
-```
+:::note
+The `name` and `type` fragments, if defined in the `inventory.json` file,
+would override the config settings defined in `device.name` and `device.type`.
+:::
 
 
 ## Operations/Commands

--- a/tests/RobotFramework/tests/cumulocity/inventory/inventory.json
+++ b/tests/RobotFramework/tests/cumulocity/inventory/inventory.json
@@ -1,8 +1,13 @@
 {
+    "name": "TST_dark_knight",
+    "type": "RPi5",
     "customData": {
         "mode": "ACTIVE",
         "version": 1,
         "alertingEnabled": true
     },
-    "types": ["type1", "type2"]
+    "types": [
+        "type1",
+        "type2"
+    ]
 }

--- a/tests/RobotFramework/tests/cumulocity/inventory/inventory_update.robot
+++ b/tests/RobotFramework/tests/cumulocity/inventory/inventory_update.robot
@@ -17,6 +17,8 @@ Update Inventory data via inventory.json
     Should Be Equal    ${mo["customData"]["alertingEnabled"]}    ${True}
     Should Be Equal    ${mo["types"][0]}    type1
     Should Be Equal    ${mo["types"][1]}    type2
+    Should Be Equal    ${mo["name"]}    TST_dark_knight
+    Should Be Equal    ${mo["type"]}    RPi5
 
 Inventory includes the agent fragment with version information
     ${expected_version}=    Execute Command    tedge-mapper --version | cut -d' ' -f2    strip=${True}


### PR DESCRIPTION
## Proposed changes

Allow `name` and `type` in inventory.json. The `type` value in `inventory.json` overrides the `device.type` value provided in the `tedge.toml` file.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

* https://github.com/thin-edge/thin-edge.io/issues/1935
* https://github.com/thin-edge/thin-edge.io/issues/3055

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

