### PR TITLE
feat: cryptoki via UNIX socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,6 +3756,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sd-listen-fds"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb51d45a99c1bafff550fd40ce1d2152917dc9908fb3090c283e3f058d39b3f"
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4283,6 +4289,7 @@ dependencies = [
  "cryptoki",
  "postcard",
  "rustls 0.23.22",
+ "sd-listen-fds",
  "serde",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +958,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile 2.2.0",
  "sha1",
+ "tedge-p11-server",
  "tempfile",
  "thiserror 1.0.61",
  "time",
@@ -1030,6 +1040,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "collectd_ext"
 version = "1.4.2"
 dependencies = [
@@ -1106,6 +1122,12 @@ checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1414,6 +1436,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +1746,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,6 +1800,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http 1.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3007,6 +3064,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
+name = "postcard"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170a2601f67cc9dba8edd8c4870b15f71a6a2dc196daec8c83f72b59dff628a8"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4200,6 +4270,22 @@ dependencies = [
  "tedge_timer_ext",
  "tedge_uploader_ext",
  "tracing",
+]
+
+[[package]]
+name = "tedge-p11-server"
+version = "1.4.2"
+dependencies = [
+ "anyhow",
+ "asn1-rs 0.7.0",
+ "camino",
+ "clap",
+ "cryptoki",
+ "postcard",
+ "rustls 0.23.22",
+ "serde",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,6 @@ dependencies = [
  "assert_matches",
  "base64 0.22.1",
  "camino",
- "cryptoki",
  "rcgen",
  "reqwest",
  "rustls 0.23.22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ plugin_sm = { path = "crates/core/plugin_sm" }
 tedge-agent = { path = "crates/core/tedge_agent" }
 tedge-apt-plugin = { path = "plugins/tedge_apt_plugin" }
 tedge-mapper = { path = "crates/core/tedge_mapper" }
+tedge-p11-server = { path = "crates/extensions/tedge-p11-server" }
 tedge-watchdog = { path = "crates/core/tedge_watchdog" }
 tedge-write = { path = "crates/core/tedge_write" }
 tedge_actors = { path = "crates/core/tedge_actors" }
@@ -144,6 +145,7 @@ pad = "0.1"
 path-clean = "0.1"
 pem = "1.0"
 pin-project = { version = "1.1.3", features = [] }
+postcard = { version = "1.1.0", features = ["alloc"] }
 predicates = "2.1"
 pretty_assertions = "1.4.1"
 prettyplease = "0.2.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,6 +168,7 @@ rustls = { version = "0.23", default-features = false, features = [
 ] }
 rustls-native-certs = "0.8.1"
 rustls-pemfile = "2.2"
+sd-listen-fds = "0.2.0"
 serde = "1.0"
 serde_ignored = "0.1"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,11 @@ rpassword = "5.0"
 rstest = "0.16.0"
 rumqttc = { git = "https://github.com/jarhodes314/rumqtt", rev = "8c489faf6af910956c97b55587ff3ecb2ac4e96f" }
 rumqttd = "0.19"
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls = { version = "0.23", default-features = false, features = [
+    "std",
+    "tls12",
+    "ring",
+] }
 rustls-native-certs = "0.8.1"
 rustls-pemfile = "2.2"
 serde = "1.0"

--- a/crates/common/certificate/Cargo.toml
+++ b/crates/common/certificate/Cargo.toml
@@ -11,14 +11,12 @@ repository = { workspace = true }
 [features]
 default = []
 reqwest = ["dep:reqwest"]
-cryptoki = ["dep:cryptoki"]
 
 [dependencies]
 anyhow = { workspace = true }
 asn1-rs = { workspace = true }
 base64 = { workspace = true }
 camino = { workspace = true }
-cryptoki = { workspace = true, optional = true }
 rcgen = { workspace = true }
 reqwest = { workspace = true, optional = true, features = [
     "rustls-tls-native-roots",

--- a/crates/common/certificate/Cargo.toml
+++ b/crates/common/certificate/Cargo.toml
@@ -27,6 +27,7 @@ rustls = { workspace = true }
 rustls-native-certs = { workspace = true }
 rustls-pemfile = { workspace = true }
 sha1 = { workspace = true }
+tedge-p11-server = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true }
 tracing = { workspace = true }

--- a/crates/common/certificate/src/parse_root_certificate/mod.rs
+++ b/crates/common/certificate/src/parse_root_certificate/mod.rs
@@ -10,9 +10,7 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
-#[cfg(feature = "cryptoki")]
 pub use tedge_p11_server::CryptokiConfig;
-#[cfg(feature = "cryptoki")]
 pub use tedge_p11_server::CryptokiConfigDirect;
 
 use crate::CertificateError;
@@ -35,7 +33,6 @@ pub fn create_tls_config(
 ///
 /// This TLS configuration should be used for communication between a device (or bridge) and a cloud
 /// remote MQTT broker, not local MQTT broker.
-#[cfg(feature = "cryptoki")]
 pub fn create_tls_config_cryptoki(
     root_certificates: impl AsRef<Path>,
     client_certificate: impl AsRef<Path>,

--- a/crates/common/certificate/src/parse_root_certificate/mod.rs
+++ b/crates/common/certificate/src/parse_root_certificate/mod.rs
@@ -1,4 +1,3 @@
-use camino::Utf8PathBuf;
 use rustls::pki_types::pem::PemObject as _;
 use rustls::pki_types::CertificateDer;
 use rustls::pki_types::PrivateKeyDer;
@@ -10,12 +9,11 @@ use std::fs;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
-use std::sync::Arc;
 
 use crate::CertificateError;
 
 #[cfg(feature = "cryptoki")]
-mod pkcs11;
+pub use tedge_p11_server::CryptokiConfigDirect as CryptokiConfig;
 
 pub fn create_tls_config(
     root_certificates: impl AsRef<Path>,
@@ -42,31 +40,30 @@ pub fn create_tls_config_cryptoki(
     cryptoki_config: CryptokiConfig,
 ) -> Result<ClientConfig, CertificateError> {
     use anyhow::Context;
-    use pkcs11::Pkcs11Resolver;
-    use pkcs11::Pkcs11SigningKey;
+    use rustls::sign::CertifiedKey;
+    use std::sync::Arc;
+    use tedge_p11_server::single_cert_and_key::SingleCertAndKey;
+    use tedge_p11_server::Pkcs11SigningKey;
 
     let root_cert_store = new_root_store(root_certificates.as_ref())?;
     let cert_chain = read_cert_chain(client_certificate)?;
-    let pkcs11_signing_key = Pkcs11SigningKey::from_cryptoki_config(cryptoki_config)
-        .context("failed to create a TLS signer using PKCS#11 device")?;
+    let key = Arc::new(
+        Pkcs11SigningKey::from_cryptoki_config(&cryptoki_config)
+            .context("failed to create a TLS signer using PKCS#11 device")?,
+    );
 
-    let resolver = Arc::new(Pkcs11Resolver {
-        chain: cert_chain,
-        signing_key: Arc::new(pkcs11_signing_key),
-    });
+    let certified_key = CertifiedKey {
+        cert: cert_chain,
+        key,
+        ocsp: None,
+    };
+    let resolver: SingleCertAndKey = certified_key.into();
 
     let config = ClientConfig::builder()
         .with_root_certificates(root_cert_store)
-        .with_client_cert_resolver(resolver);
+        .with_client_cert_resolver(Arc::new(resolver));
 
     Ok(config)
-}
-
-#[derive(Debug, Clone)]
-pub struct CryptokiConfig {
-    pub module_path: Utf8PathBuf,
-    pub pin: Arc<str>,
-    pub serial: Option<Arc<str>>,
 }
 
 pub fn client_config_for_ca_certificates<P>(

--- a/crates/common/tedge_config/Cargo.toml
+++ b/crates/common/tedge_config/Cargo.toml
@@ -11,7 +11,6 @@ repository = { workspace = true }
 [features]
 default = []
 test = []
-cryptoki = ["certificate/cryptoki"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/common/tedge_config/src/tedge_toml/models/cryptoki.rs
+++ b/crates/common/tedge_config/src/tedge_toml/models/cryptoki.rs
@@ -1,0 +1,43 @@
+use std::fmt::Display;
+use std::fmt::Formatter;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, Eq, PartialEq, doku::Document)]
+#[serde(rename_all = "lowercase")]
+pub enum Cryptoki {
+    Off,
+    Socket,
+    Module,
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("Failed to parse flag: {input}. Supported values are: off, module, socket")]
+pub struct InvalidCryptoki {
+    input: String,
+}
+
+impl FromStr for Cryptoki {
+    type Err = InvalidCryptoki;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "off" => Ok(Cryptoki::Off),
+            "socket" => Ok(Cryptoki::Socket),
+            "module" => Ok(Cryptoki::Module),
+            _ => Err(InvalidCryptoki {
+                input: input.to_string(),
+            }),
+        }
+    }
+}
+
+impl Display for Cryptoki {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let output = match self {
+            Cryptoki::Off => "off",
+            Cryptoki::Socket => "socket",
+            Cryptoki::Module => "module",
+        };
+        output.fmt(f)
+    }
+}

--- a/crates/common/tedge_config/src/tedge_toml/models/mod.rs
+++ b/crates/common/tedge_config/src/tedge_toml/models/mod.rs
@@ -3,6 +3,7 @@ pub mod auth_method;
 pub mod auto;
 pub mod c8y_software_management;
 pub mod connect_url;
+pub mod cryptoki;
 pub mod flag;
 pub mod host_port;
 pub mod ipaddress;
@@ -25,6 +26,7 @@ pub use self::apt_config::*;
 pub use self::auto::*;
 pub use self::c8y_software_management::*;
 pub use self::connect_url::*;
+pub use self::cryptoki::Cryptoki;
 pub use self::flag::*;
 #[doc(inline)]
 pub use self::host_port::HostPort;

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -10,6 +10,7 @@ use super::models::AptConfig;
 use super::models::AutoFlag;
 use super::models::AutoLogUpload;
 use super::models::ConnectUrl;
+use super::models::Cryptoki;
 use super::models::HostPort;
 use super::models::MqttPayloadLimit;
 use super::models::SecondsOrHumanTime;
@@ -132,14 +133,17 @@ define_tedge_config! {
         csr_path: Utf8PathBuf,
 
         cryptoki: {
-            /// Use a Hardware Security Module for authenticating the MQTT connection with the cloud.
+            /// Whether to use a Hardware Security Module for authenticating the MQTT connection with the cloud.
             ///
-            /// When set to true, `key_path` option is ignored as PKCS#11 module is used for signing.
-            #[tedge_config(default(value = false))]
-            #[tedge_config(example = "true", example = "false")]
-            enable: bool,
+            /// "off" to not use the HSM, "module" to use the provided cryptoki dynamic module, "socket" to access the
+            /// HSM via tedge-p11-server signing service.
+            #[tedge_config(default(variable = Cryptoki::Off))]
+            #[tedge_config(example = "off", example = "module", example = "socket")]
+            mode: Cryptoki,
 
             /// A path to the PKCS#11 module used for interaction with the HSM.
+            ///
+            /// Needs to be set when `device.cryptoki.mode` is set to `module`
             #[tedge_config(example = "/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so")]
             #[doku(as = "PathBuf")]
             module_path: Utf8PathBuf,
@@ -148,13 +152,9 @@ define_tedge_config! {
             #[tedge_config(example = "123456", default(value = "123456"))]
             pin: Arc<str>,
 
-            /// A serial number of a Personal Identity Verification (PIV) device to be used.
-            ///
-            /// Necessary if two or more modules are connected.
-            #[tedge_config(example = "123456789")]
-            serial: Arc<str>,
-
             /// A path to the tedge-p11-server socket.
+            ///
+            /// Needs to be set when `device.cryptoki.mode` is set to `module`
             #[tedge_config(example = "./thin-edge-pkcs11.sock")]
             #[doku(as = "PathBuf")]
             socket_path: Utf8PathBuf,

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -153,6 +153,11 @@ define_tedge_config! {
             /// Necessary if two or more modules are connected.
             #[tedge_config(example = "123456789")]
             serial: Arc<str>,
+
+            /// A path to the tedge-p11-server socket.
+            #[tedge_config(example = "./thin-edge-pkcs11.sock")]
+            #[doku(as = "PathBuf")]
+            socket_path: Utf8PathBuf,
         },
 
         /// The default device type

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config/append_remove.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config/append_remove.rs
@@ -54,7 +54,8 @@ impl_append_remove_for_single_value!(
     u32,
     AptConfig,
     MqttPayloadLimit,
-    AuthMethod
+    AuthMethod,
+    Cryptoki
 );
 
 impl AppendRemoveItem for TemplatesSet {

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -42,6 +42,7 @@ use tedge_api::mqtt_topics::TopicIdError;
 use tedge_api::service_health_topic;
 use tedge_config;
 use tedge_config::models::auth_method::AuthType;
+use tedge_config::models::Cryptoki;
 use tedge_config::models::HostPort;
 use tedge_config::models::TopicPrefix;
 use tedge_config::tedge_toml::MultiError;
@@ -546,7 +547,7 @@ pub fn bridge_config(
                 profile_name: profile.clone().map(Cow::into_owned),
                 mqtt_schema,
                 keepalive_interval: c8y_config.bridge.keepalive_interval.duration(),
-                use_cryptoki: config.device.cryptoki.enable,
+                use_cryptoki: config.device.cryptoki.mode != Cryptoki::Off,
             };
 
             Ok(BridgeConfig::from(params))

--- a/crates/extensions/tedge-p11-server/Cargo.toml
+++ b/crates/extensions/tedge-p11-server/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tedge-p11-server"
+description = "thin-edge PKCS#11 server"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+asn1-rs.workspace = true
+camino.workspace = true
+clap.workspace = true
+cryptoki.workspace = true
+postcard.workspace = true
+rustls.workspace = true
+serde.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[lints]
+workspace = true

--- a/crates/extensions/tedge-p11-server/Cargo.toml
+++ b/crates/extensions/tedge-p11-server/Cargo.toml
@@ -17,6 +17,7 @@ clap.workspace = true
 cryptoki.workspace = true
 postcard.workspace = true
 rustls.workspace = true
+sd-listen-fds.workspace = true
 serde.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/extensions/tedge-p11-server/README.md
+++ b/crates/extensions/tedge-p11-server/README.md
@@ -1,0 +1,25 @@
+# tedge-p11-server
+
+A thin-edge server that allows thin-edge service possibly working in a container to access host's cryptographic tokens.
+
+## Building and using
+
+1. Compile on the host
+    ```sh
+    $ cargo build --bin tedge-p11-server
+    ```
+
+2. Run on the host, passing necessary configuration via CLI or tedge config
+    ```sh
+    target/debug/tedge-p11-server ./my-socket.sock --module-path /usr/lib/x86_64-linux-gnu/pkcs11/p11-kit-client.so --pin 821370
+    ```
+
+3. In the container, set `device.cryptoki.socket_path`
+    ```sh
+    tedge config set device.cryptoki.socket_path /path/to/my-socket.sock
+    ```
+
+4. Connect to c8y
+    ```sh
+    tedge reconnect c8y
+    ```

--- a/crates/extensions/tedge-p11-server/src/client.rs
+++ b/crates/extensions/tedge-p11-server/src/client.rs
@@ -1,0 +1,97 @@
+use std::os::unix::net::UnixStream;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::bail;
+use tracing::debug;
+use tracing::trace;
+
+use super::connection::Frame1;
+use super::service::ChooseSchemeRequest;
+use super::service::SignRequest;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TedgeP11Client {
+    pub socket_path: Arc<Path>,
+}
+
+impl TedgeP11Client {
+    pub fn choose_scheme(
+        &self,
+        offered: &[rustls::SignatureScheme],
+    ) -> anyhow::Result<Option<rustls::SignatureScheme>> {
+        trace!("Connecting to socket...");
+        let stream = UnixStream::connect(&self.socket_path)?;
+        let mut connection = crate::connection::Connection::new(stream);
+
+        debug!("Connected to socket");
+
+        let request = Frame1::ChooseSchemeRequest(ChooseSchemeRequest {
+            offered: offered
+                .iter()
+                .copied()
+                .map(super::service::SignatureScheme)
+                .collect::<Vec<_>>(),
+        });
+        connection.write_frame(&request)?;
+
+        let response = connection.read_frame()?;
+
+        let Frame1::ChooseSchemeResponse(response) = response else {
+            bail!("protocol error: bad response, expected chose scheme");
+        };
+
+        debug!("Choose scheme complete");
+
+        let Some(scheme) = response.scheme else {
+            return Ok(None);
+        };
+
+        Ok(Some(scheme.0))
+    }
+
+    // this function is called only on the server when handling ClientHello message, so
+    // realistically it won't ever be called in our case
+    pub fn algorithm(&self) -> anyhow::Result<rustls::SignatureAlgorithm> {
+        trace!("Connecting to socket...");
+        let stream = UnixStream::connect(&self.socket_path)?;
+        let mut connection = crate::connection::Connection::new(stream);
+
+        debug!("Connected to socket");
+
+        // if passed empty set of schemes, service doesn't return a scheme but returns an algorithm
+        let request = Frame1::ChooseSchemeRequest(ChooseSchemeRequest { offered: vec![] });
+        connection.write_frame(&request)?;
+
+        let response = connection.read_frame()?;
+
+        let Frame1::ChooseSchemeResponse(response) = response else {
+            bail!("protocol error: bad response, expected chose scheme");
+        };
+
+        debug!("Choose scheme complete");
+
+        Ok(response.algorithm.0)
+    }
+
+    pub fn sign(&self, message: &[u8]) -> anyhow::Result<Vec<u8>> {
+        let stream = UnixStream::connect(&self.socket_path)?;
+        let mut connection = crate::connection::Connection::new(stream);
+        debug!("Connected to socket");
+
+        let request = Frame1::SignRequest(SignRequest {
+            to_sign: message.to_vec(),
+        });
+        connection.write_frame(&request)?;
+
+        let response = connection.read_frame()?;
+
+        let Frame1::SignResponse(response) = response else {
+            bail!("protocol error: bad response, expected sign");
+        };
+
+        debug!("Sign complete");
+
+        Ok(response.0)
+    }
+}

--- a/crates/extensions/tedge-p11-server/src/connection.rs
+++ b/crates/extensions/tedge-p11-server/src/connection.rs
@@ -1,0 +1,96 @@
+//! A connection between tedge-p11-server and client that provides a way to send and receive frames.
+//!
+//! Because connecting to the UNIX socket is very cheap, we can use a simple approach of only
+//! sending one request/response per connection.
+
+use std::io::Read;
+use std::io::Write;
+use std::net::Shutdown;
+use std::os::unix::net::UnixStream;
+
+use anyhow::Context;
+use serde::Deserialize;
+use serde::Serialize;
+use tracing::warn;
+
+use crate::service::ChooseSchemeRequest;
+use crate::service::ChooseSchemeResponse;
+use crate::service::SignRequest;
+use crate::service::SignResponse;
+
+pub struct Connection {
+    stream: UnixStream,
+}
+
+impl Connection {
+    pub fn new(stream: UnixStream) -> Self {
+        Self { stream }
+    }
+
+    /// Reads a frame and closes the reading half of the connection.
+    ///
+    /// NOTE: can only be called once
+    pub fn read_frame(&mut self) -> anyhow::Result<Frame1> {
+        let mut buf = Vec::new();
+        self.stream.read_to_end(&mut buf)?;
+
+        // will fail if not version 1
+        let frame: Frame =
+            postcard::from_bytes(&buf).context("Failed to parse the received frame")?;
+
+        let Frame::Version1(frame) = frame;
+
+        // by that time the sender should've already closed this connection half, so we ignore
+        // ENOTCONN that can possibly be returned on some platforms (MacOS?)
+        let _ = self.stream.shutdown(Shutdown::Read);
+
+        Ok(frame)
+    }
+
+    /// Writes a frame and closes the writing half of the connection.
+    ///
+    /// NOTE: can only be called once
+    pub fn write_frame(&mut self, frame: &Frame1) -> anyhow::Result<()> {
+        let frame = Frame::Version1(frame.clone());
+
+        let buf = postcard::to_allocvec(&frame).context("Failed to serialize message")?;
+
+        self.stream.write_all(&buf)?;
+        self.stream.flush()?;
+
+        // shutdown sends an EOF, which is important
+        if let Err(err) = self.stream.shutdown(Shutdown::Write) {
+            warn!("Failed to shutdown connection writing half: {err:?}");
+        }
+
+        Ok(())
+    }
+}
+
+/// The actual frame that we serialize and send/receive.
+///
+/// This essentially just adds a version tag and should deal with cases when non-backwards
+/// compatible changes are added to new versions.
+///
+/// For example, current connection semantics is one request/response per connection (client
+/// connects, sends request and closes sending half, server reads, sends response and closes sending
+/// half, etc.) but if we wanted to move away from that model, we can very easily because the
+/// version is the first byte sent by the client so maintaining compatibility should be easy.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+enum Frame {
+    Version1(Frame1),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Frame1 {
+    Error(ProtocolError),
+    ChooseSchemeRequest(ChooseSchemeRequest),
+    SignRequest(SignRequest),
+    ChooseSchemeResponse(ChooseSchemeResponse),
+    SignResponse(SignResponse),
+}
+
+/// An error that can be returned to the client by the server.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProtocolError(pub String);

--- a/crates/extensions/tedge-p11-server/src/lib.rs
+++ b/crates/extensions/tedge-p11-server/src/lib.rs
@@ -1,0 +1,23 @@
+/// The signer service that handles requests.
+mod service;
+
+/// A server listening on the UNIX domain socket, wrapping the service.
+mod server;
+pub use server::TedgeP11Server;
+
+/// Serialization and framing of messages sent between the client and server.
+mod connection;
+
+/// A rustls SigningKey that connects to the server.
+mod signer;
+pub use signer::signing_key;
+pub use signer::CryptokiConfig;
+
+/// A client that connects to the UNIX server, used by the signer.
+pub mod client;
+
+/// Interfaces with the PKCS#11 dynamic module using cryptoki crate.
+mod pkcs11;
+pub use pkcs11::CryptokiConfigDirect;
+
+pub mod single_cert_and_key;

--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -1,0 +1,70 @@
+//! thin-edge.io PKCS#11 server.
+//!
+//! The purpose of this crate is to allow thin-edge services that possibly run in containers to access PKCS#11 tokens in
+//! all of our supported architectures.
+//!
+//! There are 2 main problems with using a PKCS#11 module directly by thin-edge:
+//! 1. One needs to use a dynamic loader to load the PKCS#11 module, which is not possible in statically compiled musl
+//! 2. When thin-edge runs in a container, additional setup needs to be done by the user to expose cryptographic tokens
+//!    in the container, using software like p11-kit.
+//!
+//! To avoid extra dependencies and possibly implement new features in the future, it was decided that thin-edge.io will
+//! provide its own bundled p11-kit-like service.
+
+use std::sync::Arc;
+
+use camino::Utf8PathBuf;
+use clap::command;
+use clap::Parser;
+use tracing::info;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+
+use tedge_p11_server::CryptokiConfigDirect;
+use tedge_p11_server::TedgeP11Server;
+
+/// thin-edge.io service for passing PKCS#11 cryptographic tokens.
+#[derive(Debug, Clone, PartialEq, Eq, Parser)]
+#[command(version)]
+pub struct Args {
+    /// A path where the service's unix token will be created.
+    #[arg(default_value = "./tedge-p11-server.sock")]
+    socket_path: Utf8PathBuf,
+
+    /// The path to the PKCS#11 module.
+    #[arg(long)]
+    module_path: Utf8PathBuf,
+
+    /// The PIN for the PKCS#11 token.
+    #[arg(long, default_value = "123456")]
+    pin: Arc<str>,
+}
+
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_file(true)
+        .with_line_number(true)
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env()
+                .unwrap(),
+        )
+        .init();
+
+    let args = Args::parse();
+    let socket_path = args.socket_path;
+    let cryptoki_config = CryptokiConfigDirect {
+        module_path: args.module_path,
+        pin: args.pin,
+        serial: None,
+    };
+
+    info!(?cryptoki_config, "Using cryptoki configuration");
+
+    info!(%socket_path, "Server listening");
+
+    TedgeP11Server::from_config(cryptoki_config).serve(&socket_path)?;
+
+    Ok(())
+}

--- a/crates/extensions/tedge-p11-server/src/server.rs
+++ b/crates/extensions/tedge-p11-server/src/server.rs
@@ -1,0 +1,60 @@
+use std::os::unix::net::UnixListener;
+
+use anyhow::Context;
+use camino::Utf8Path;
+use tracing::error;
+use tracing::info;
+
+use super::connection::Connection;
+use crate::connection::Frame1;
+use crate::connection::ProtocolError;
+use crate::pkcs11::CryptokiConfigDirect;
+use crate::service::P11SignerService;
+
+pub struct TedgeP11Server {
+    config: CryptokiConfigDirect,
+}
+
+impl TedgeP11Server {
+    pub fn from_config(config: CryptokiConfigDirect) -> Self {
+        Self { config }
+    }
+
+    pub fn serve(&self, socket_path: &Utf8Path) -> anyhow::Result<()> {
+        let listener = UnixListener::bind(socket_path).context("Failed to bind to socket")?;
+
+        // Accept a connection
+        loop {
+            let (stream, _) = listener.accept().context("Failed to accept connection")?;
+
+            let connection = Connection::new(stream);
+
+            match process(&self.config, connection) {
+                Ok(_) => info!("Incoming request successful"),
+                Err(e) => error!("Incoming request failed: {e:?}"),
+            }
+        }
+    }
+}
+
+fn process(config: &CryptokiConfigDirect, mut connection: Connection) -> anyhow::Result<()> {
+    let service = P11SignerService::new(config);
+
+    let request = connection.read_frame()?;
+
+    let response = match request {
+        Frame1::Error(_) | Frame1::ChooseSchemeResponse { .. } | Frame1::SignResponse { .. } => {
+            let error = ProtocolError("invalid request".to_string());
+            let _ = connection.write_frame(&Frame1::Error(error));
+            anyhow::bail!("protocol error: invalid request")
+        }
+        Frame1::ChooseSchemeRequest(request) => {
+            Frame1::ChooseSchemeResponse(service.choose_scheme(request))
+        }
+        Frame1::SignRequest(request) => Frame1::SignResponse(service.sign(request)),
+    };
+
+    connection.write_frame(&response)?;
+
+    Ok(())
+}

--- a/crates/extensions/tedge-p11-server/src/server.rs
+++ b/crates/extensions/tedge-p11-server/src/server.rs
@@ -1,7 +1,6 @@
 use std::os::unix::net::UnixListener;
 
 use anyhow::Context;
-use camino::Utf8Path;
 use tracing::error;
 use tracing::info;
 
@@ -20,9 +19,8 @@ impl TedgeP11Server {
         Self { config }
     }
 
-    pub fn serve(&self, socket_path: &Utf8Path) -> anyhow::Result<()> {
-        let listener = UnixListener::bind(socket_path).context("Failed to bind to socket")?;
-
+    /// Handle multiple requests on a given listener.
+    pub fn serve(&self, listener: UnixListener) -> anyhow::Result<()> {
         // Accept a connection
         loop {
             let (stream, _) = listener.accept().context("Failed to accept connection")?;

--- a/crates/extensions/tedge-p11-server/src/service.rs
+++ b/crates/extensions/tedge-p11-server/src/service.rs
@@ -1,0 +1,119 @@
+use crate::pkcs11;
+use crate::pkcs11::CryptokiConfigDirect;
+
+use crate::pkcs11::Pkcs11SigningKey;
+use crate::pkcs11::PkcsSigner;
+
+use rustls::sign::SigningKey;
+use serde::Deserialize;
+use serde::Serialize;
+use tracing::instrument;
+
+#[derive(Debug)]
+pub struct P11SignerService {
+    signing_key: Pkcs11SigningKey,
+}
+
+impl P11SignerService {
+    // TODO(marcel): would be nice to check if there are any keys upon starting the server and warn the user if there is not
+    pub fn new(config: &CryptokiConfigDirect) -> Self {
+        let signing_key = pkcs11::Pkcs11SigningKey::from_cryptoki_config(config)
+            .expect("failed to get pkcs11 signing key");
+
+        Self { signing_key }
+    }
+
+    #[instrument]
+    pub fn choose_scheme(&self, request: ChooseSchemeRequest) -> ChooseSchemeResponse {
+        let offered = request.offered.into_iter().map(|s| s.0).collect::<Vec<_>>();
+
+        let signer = self.signing_key.choose_scheme(&offered);
+        let algorithm = SignatureAlgorithm(self.signing_key.algorithm());
+
+        let Some(signer) = signer else {
+            return ChooseSchemeResponse {
+                scheme: None,
+                algorithm,
+            };
+        };
+
+        ChooseSchemeResponse {
+            scheme: Some(SignatureScheme(signer.scheme())),
+            algorithm,
+        }
+    }
+
+    #[instrument]
+    pub fn sign(&self, request: SignRequest) -> SignResponse {
+        let session = match &self.signing_key {
+            Pkcs11SigningKey::Ecdsa(key) => &key.pkcs11,
+            Pkcs11SigningKey::Rsa(key) => &key.pkcs11,
+        };
+        let signer = PkcsSigner::from_session(session.clone());
+        let signature = signer.sign(&request.to_sign).unwrap();
+        SignResponse(signature)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChooseSchemeRequest {
+    pub offered: Vec<SignatureScheme>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChooseSchemeResponse {
+    pub scheme: Option<SignatureScheme>,
+    pub algorithm: SignatureAlgorithm,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignRequest {
+    pub to_sign: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SignResponse(pub Vec<u8>);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureScheme(pub rustls::SignatureScheme);
+
+impl Serialize for SignatureScheme {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        u16::from(self.0).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SignatureScheme {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = u16::deserialize(deserializer)?;
+        Ok(Self(rustls::SignatureScheme::from(value)))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureAlgorithm(pub rustls::SignatureAlgorithm);
+
+impl Serialize for SignatureAlgorithm {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        u8::from(self.0).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SignatureAlgorithm {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = u8::deserialize(deserializer)?;
+        Ok(Self(rustls::SignatureAlgorithm::from(value)))
+    }
+}

--- a/crates/extensions/tedge-p11-server/src/signer.rs
+++ b/crates/extensions/tedge-p11-server/src/signer.rs
@@ -1,0 +1,102 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Context;
+use camino::Utf8PathBuf;
+use rustls::sign::Signer;
+use rustls::sign::SigningKey;
+use tracing::error;
+use tracing::instrument;
+
+use crate::client::TedgeP11Client;
+use crate::pkcs11::CryptokiConfigDirect;
+use crate::pkcs11::Pkcs11SigningKey;
+
+#[derive(Debug, Clone)]
+pub enum CryptokiConfig {
+    Direct(CryptokiConfigDirect),
+    SocketService { socket_path: Utf8PathBuf },
+}
+
+/// Returns a rustls SigningKey that depending on the config, either connects to
+/// tedge-p11-server or calls cryptoki module directly.
+pub fn signing_key(config: CryptokiConfig) -> anyhow::Result<Arc<dyn SigningKey>> {
+    let signing_key: Arc<dyn SigningKey> = match config {
+        CryptokiConfig::Direct(config_direct) => Arc::new(
+            Pkcs11SigningKey::from_cryptoki_config(&config_direct)
+                .context("failed to create a TLS signer using PKCS#11 device")?,
+        ),
+        CryptokiConfig::SocketService { socket_path } => Arc::new(TedgeP11ClientSigningKey {
+            socket_path: Arc::from(Path::new(&socket_path)),
+        }),
+    };
+
+    Ok(signing_key)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TedgeP11ClientSigningKey {
+    pub socket_path: Arc<Path>,
+}
+
+impl SigningKey for TedgeP11ClientSigningKey {
+    #[instrument(skip_all)]
+    fn choose_scheme(
+        &self,
+        offered: &[rustls::SignatureScheme],
+    ) -> Option<Box<dyn rustls::sign::Signer>> {
+        let client = TedgeP11Client {
+            socket_path: self.socket_path.clone(),
+        };
+        let response = match client.choose_scheme(offered) {
+            Ok(response) => response,
+            Err(err) => {
+                error!(?err, "Failed to choose scheme using cryptoki signer");
+                return None;
+            }
+        };
+        let scheme = response?;
+
+        Some(Box::new(TedgeP11ClientSigner {
+            socket_path: self.socket_path.clone(),
+            scheme,
+        }))
+    }
+
+    fn algorithm(&self) -> rustls::SignatureAlgorithm {
+        let client = TedgeP11Client {
+            socket_path: self.socket_path.clone(),
+        };
+
+        // here we have no choice but to panic but this is only called by servers when verifying
+        // client hello so it should never be called in our case
+        client.algorithm().unwrap()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TedgeP11ClientSigner {
+    pub socket_path: Arc<Path>,
+    scheme: rustls::SignatureScheme,
+}
+
+impl Signer for TedgeP11ClientSigner {
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
+        let client = TedgeP11Client {
+            socket_path: self.socket_path.clone(),
+        };
+        let response = match client.sign(message) {
+            Ok(response) => response,
+            Err(err) => {
+                return Err(rustls::Error::Other(rustls::OtherError(Arc::from(
+                    Box::from(err),
+                ))));
+            }
+        };
+        Ok(response)
+    }
+
+    fn scheme(&self) -> rustls::SignatureScheme {
+        self.scheme
+    }
+}

--- a/crates/extensions/tedge-p11-server/src/single_cert_and_key.rs
+++ b/crates/extensions/tedge-p11-server/src/single_cert_and_key.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use rustls::client::ResolvesClientCert;
+use rustls::sign::CertifiedKey;
+use rustls::SignatureScheme;
+
+/// A clone of `rustls::sign::SingleCertAndKey`, but without the additional cert v3 check.
+///
+/// rustls previously allowed usage of v1 certificates with client authentication, but they
+/// introduced v3 check in `SingleCertAndKey` resolver. Adding this check can break some user
+/// setups, so we avoid using it for now.
+#[derive(Debug)]
+pub struct SingleCertAndKey(Arc<CertifiedKey>);
+
+impl From<CertifiedKey> for SingleCertAndKey {
+    fn from(certified_key: CertifiedKey) -> Self {
+        Self(Arc::new(certified_key))
+    }
+}
+
+impl ResolvesClientCert for SingleCertAndKey {
+    fn resolve(
+        &self,
+        _root_hint_subjects: &[&[u8]],
+        _sigschemes: &[SignatureScheme],
+    ) -> Option<Arc<CertifiedKey>> {
+        Some(Arc::clone(&self.0))
+    }
+
+    fn has_certs(&self) -> bool {
+        true
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR adds the `tedge-p11-server` component, that unlike other services is built separately and runs directly on the host to allow other thin-edge services access to PKCS#11 cryptographic tokens. The server listens on a UNIX domain socket and exposes two kinds of procedures that is passes for execution to the PKCS#11 cryptographic token:

1. choosing the signature scheme from offered candidates
2. signing the message

The crate also exports a client that performs `rustls`' choosing scheme and signing operations by connecting via the UNIX socket and requesting them from the server, which interacts with the cryptoki device directly.

### Configuration changes

Replaced `device.cryptoki.enable` with `device.cryptoki.mode` which can be one of `off`/`module`/`socket`

- `off` - cryptoki is disabled and private key is read from a file
- `module` - thin-edge uses a cryptoki dynamic module directly, which is preferable in environments where that's supported, i.e. dynamic module can be loaded and thin-edge process has access to the cryptographic token (e.g. running directly on the host and using GNU libc)
- `socket` Connecting to `tedge-p11-server` via a UNIX socket. This is preferable when not using GNU libc or when no access to cryptographic token due to running in an unprivileged container

Setting to `module` implies required `device.cryptoki.module_path`. Similarly, setting to `socket` implies required the new `device/cryptoki.socket_path` setting, which contains the path to the `tedge-p11-server` UNIX socket.

`device.cryptoki.serial` setting was removed, because it's currently unused. Once related functionality is implemented, it will be reintroduced.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

#3363

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## TODO

- [x] implement scheme selection
- [x] write and compare to non-grpc version
- [x] use a binary serialization format like CBOR or postcard
- [x] extract the parts that deal with raw byte streams into a `Connection` struct like in [tokio framing guide](https://tokio.rs/tokio/tutorial/framing)
- [x] figure out how to do versioning
- [x] allow socket being created by systemd and activate the service upon connection

## Follow-up
- [ ] allow passing in token identifier (e.g. `pkcs11:model=PKCS%%2315%%20emulated;manufacturer=piv_II;`)
- [ ] allow tedge-p11-server to read configuration from file
- [ ] create a ticket to handle MQTT client error handling
    At the moment, errors are wrapped multiple times which results in duplicated info, for instance when the key pairs are mismatched (e.g. certificate does not match the private key), then the following error message shows the same error message repeated multiple times:
    ```
    error: Connection error while creating device in Cumulocity: Mqtt state: Mqtt serialization/deserialization error: IO: received fatal alert: HandshakeFailure: Mqtt serialization/deserialization error: IO: received fatal alert: HandshakeFailure: IO: received fatal alert: HandshakeFailure: received fatal alert: HandshakeFailure
    ````
- [ ] figure out what parts to test and test them
- [ ] Add documentation


## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

