### PR TITLE
test: fix `tedge_c8y_upload.robot` not setting device context

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/upload/tedge_c8y_upload.robot
+++ b/tests/RobotFramework/tests/cumulocity/upload/tedge_c8y_upload.robot
@@ -17,6 +17,7 @@ ${CHILD_SN}     ${EMPTY}
 *** Test Cases ***
 Upload a file to Cumulocity from main device
     ThinEdgeIO.Set Device Context    ${PARENT_SN}
+    Cumulocity.Set Managed Object    ${PARENT_SN}
     Execute Command    yes 0123456789 | head>/tmp/sample.txt
     ${event_id}=    Execute Command
     ...    tedge upload c8y --file /tmp/sample.txt --mime-type text/plain --type "test event" --text "testing file upload"


### PR DESCRIPTION
## Proposed changes

Because the first test didn't set device context like the other ones, library defaulted to returning events for other devices, so if there are other devices that run this test that were not deleted, the test will fail.

The library will be updated to warn/err if device context is not set, because in tests 99% of the time we want to get events only for the device we are testing, but for now update the test to fix failing CI.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

