### PR TITLE
test: soften failure reason assertions for certificate required errors

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -59,23 +59,21 @@ Configuration snapshots are uploaded to File Transfer Service via HTTPS with cli
     Get Configuration Should Succeed    device=${CHILD_SN}    external_id=${PARENT_SN}:device:${CHILD_SN}
 
 Configuration operation fails when configuration-plugin does not supply client certificate
-    [Tags]    test:retry(2)
     Enable Certificate Authentication for File Transfer Service
     Disable HTTP Client Certificate for FTS client
     Get Configuration Should Fail
-    ...    failure_reason=config-manager failed uploading configuration snapshot:.+https://${FTS_IP}:8000/tedge/file-transfer/.+received fatal alert: CertificateRequired
+    ...    failure_reason=config-manager failed uploading configuration snapshot:.+https://${FTS_IP}:8000/tedge/file-transfer/
     ...    external_id=${PARENT_SN}:device:${CHILD_SN}
     Update Configuration Should Fail
-    ...    failure_reason=config-manager failed downloading a file:.+https://${parent_ip}:8001/c8y/inventory/binaries/.+received fatal alert: CertificateRequired
+    ...    failure_reason=config-manager failed downloading a file:.+https://${parent_ip}:8001/c8y/inventory/binaries/
     ...    external_id=${PARENT_SN}:device:${CHILD_SN}
 
 Configuration snapshot fails when mapper does not supply client certificate
-    [Tags]    test:retry(2)
     Enable Certificate Authentication for File Transfer Service
     Disable HTTP Client Certificate for Mapper
     Enable HTTP Client Certificate for FTS client
     Get Configuration Should Fail
-    ...    failure_reason=tedge-mapper-c8y failed to download configuration snapshot from file-transfer service:.+https://${FTS_IP}:8000/tedge/file-transfer/.+received fatal alert: CertificateRequired
+    ...    failure_reason=tedge-mapper-c8y failed to download configuration snapshot from file-transfer service:.+https://${FTS_IP}:8000/tedge/file-transfer/
     ...    external_id=${PARENT_SN}:device:${CHILD_SN}
     [Teardown]    Re-enable HTTP Client Certificate for Mapper
 


### PR DESCRIPTION
## Proposed changes
Some tests checking that the mapper reports "CertificateRequired" errors have become flaky since the hyper 1.0 upgrade.

I've been unable to reproduce the alternative "channel closed" error from hyper-util locally. We still assert that "CertificateRequired" appears in the unit tests, so we are confirming that the rust code passes on the required information to the end user in this case. As I'm unable to reproduce, this PR softens the assertions on the failure reason to not check for "CertificateRequired" in the robot tests.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #3401 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

