### PR TITLE
fix: add device.csr_path to cloud profiles

### DIFF
--- a/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_config_cli/tedge_config.rs
@@ -127,7 +127,7 @@ define_tedge_config! {
         cert_path: Utf8PathBuf,
 
         /// Path where the device's certificate signing request is stored
-        #[tedge_config(example = "/etc/tedge/device-certs/tedge.csr", default(function = "default_device_csr"))]
+        #[tedge_config(example = "/etc/tedge/device-certs/tedge.csr", default(function = "default_device_csr"), reader(private))]
         #[doku(as = "PathBuf")]
         csr_path: Utf8PathBuf,
 
@@ -204,6 +204,11 @@ define_tedge_config! {
             #[tedge_config(example = "/etc/tedge/device-certs/tedge-certificate.pem", default(from_key = "device.cert_path"))]
             #[doku(as = "PathBuf")]
             cert_path: Utf8PathBuf,
+
+            /// Path where the device's certificate signing request is stored
+            #[tedge_config(example = "/etc/tedge/device-certs/tedge.csr", default(from_key = "device.csr_path"))]
+            #[doku(as = "PathBuf")]
+            csr_path: Utf8PathBuf,
         },
 
         smartrest: {
@@ -399,6 +404,11 @@ define_tedge_config! {
             #[tedge_config(example = "/etc/tedge/device-certs/tedge-certificate.pem", default(from_key = "device.cert_path"))]
             #[doku(as = "PathBuf")]
             cert_path: Utf8PathBuf,
+
+            /// Path where the device's certificate signing request is stored
+            #[tedge_config(example = "/etc/tedge/device-certs/tedge.csr", default(from_key = "device.csr_path"))]
+            #[doku(as = "PathBuf")]
+            csr_path: Utf8PathBuf,
         },
 
         mapper: {
@@ -468,6 +478,11 @@ define_tedge_config! {
             #[tedge_config(example = "/etc/tedge/device-certs/tedge-certificate.pem", default(from_key = "device.cert_path"))]
             #[doku(as = "PathBuf")]
             cert_path: Utf8PathBuf,
+
+            /// Path where the device's certificate signing request is stored
+            #[tedge_config(example = "/etc/tedge/device-certs/tedge.csr", default(from_key = "device.csr_path"))]
+            #[doku(as = "PathBuf")]
+            csr_path: Utf8PathBuf,
         },
 
         mapper: {
@@ -899,6 +914,18 @@ impl TEdgeConfigReader {
             Some(Cloud::C8y(profile)) => &self.c8y.try_get(profile)?.device.cert_path,
             Some(Cloud::Az(profile)) => &self.az.try_get(profile)?.device.cert_path,
             Some(Cloud::Aws(profile)) => &self.aws.try_get(profile)?.device.cert_path,
+        })
+    }
+
+    pub fn device_csr_path<'a>(
+        &self,
+        cloud: Option<impl Into<Cloud<'a>>>,
+    ) -> Result<&Utf8Path, MultiError> {
+        Ok(match cloud.map(<_>::into) {
+            None => &self.device.csr_path,
+            Some(Cloud::C8y(profile)) => &self.c8y.try_get(profile)?.device.csr_path,
+            Some(Cloud::Az(profile)) => &self.az.try_get(profile)?.device.csr_path,
+            Some(Cloud::Aws(profile)) => &self.aws.try_get(profile)?.device.csr_path,
         })
     }
 

--- a/crates/core/tedge/src/cli/certificate/cli.rs
+++ b/crates/core/tedge/src/cli/certificate/cli.rs
@@ -102,7 +102,11 @@ impl BuildCommand for TEdgeCertCli {
                     id: get_device_id(id, &config, &cloud)?,
                     key_path: config.device_key_path(cloud.as_ref())?.to_owned(),
                     // Use output file instead of csr_path from tedge config if provided
-                    csr_path: output_path.unwrap_or_else(|| config.device.csr_path.clone()),
+                    csr_path: if let Some(output_path) = output_path {
+                        output_path
+                    } else {
+                        config.device_csr_path(cloud.as_ref())?.to_owned()
+                    },
                     user: user.to_owned(),
                     group: group.to_owned(),
                 };

--- a/tests/RobotFramework/tests/tedge/certificate_signing_request.robot
+++ b/tests/RobotFramework/tests/tedge/certificate_signing_request.robot
@@ -85,6 +85,26 @@ Generate CSR using the device-id from an existing certificate and private key of
     Should Be Equal    ${hash_before_cert}    ${hash_after_cert}
     Should Be Equal    ${hash_before_private_key}    ${hash_after_private_key}
 
+Generate CSR using the CSR path from tedge config
+    [Setup]    Setup Without Certificate
+    File Should Not Exist    /etc/tedge/device-certs/tedge-certificate.pem
+    File Should Not Exist    /etc/tedge/device-certs/tedge-private-key.pem
+
+    Execute Command
+    ...    tedge config set c8y.device.csr_path /etc/tedge/device-certs/example_dev_test0001-test1.csr
+
+    Execute Command    sudo tedge cert create-csr c8y --device-id test-user
+
+    ${output_csr_subject}=    Execute Command
+    ...    openssl req -noout -subject -in /etc/tedge/device-certs/example_dev_test0001-test1.csr | tr -d ' '
+    Should Contain    ${output_csr_subject}    subject=CN=test-user
+
+    ${output_private_key_md5}=    Execute Command
+    ...    openssl pkey -in /etc/tedge/device-certs/tedge-private-key.pem -pubout | openssl md5
+    ${output_csr_md5}=    Execute Command
+    ...    openssl req -in /etc/tedge/device-certs/example_dev_test0001-test1.csr -pubkey -noout | openssl md5
+    Should Be Equal    ${output_private_key_md5}    ${output_csr_md5}
+
 
 *** Keywords ***
 Setup With Self-Signed Certificate


### PR DESCRIPTION
## Proposed changes
As mentioned in #3413 user could not specified `device.csr_path` per cloud profile. This PR appends multi profile config with `csr_path` and replaces old approach of accessing config value in `tedge cert create-csr`.

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #3413 
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

