### PR TITLE
tests: Increase restart tedge-agent test timeout

### DIFF
--- a/tests/RobotFramework/tests/tedge_agent/workflows/restart-tedge-agent.toml
+++ b/tests/RobotFramework/tests/tedge_agent/workflows/restart-tedge-agent.toml
@@ -10,7 +10,7 @@ on_exec = "restarting"
 
 [restarting]
 script = "/etc/tedge/operations/tedge-agent-pid.sh test ${.payload.tedge-agent-pid}"
-timeout_second = 10
+timeout_second = 65 # A value higher than agent max shutdown timeout
 on_success = "tedge-agent-restarted"
 on_kill = { status = "failed", reason = "tedge-agent not restarted" }
 


### PR DESCRIPTION
## Proposed changes

Even though the tedge-agent would complete a shutdown within a matter milliseconds in most cases, sometimes all actors may not shutdown immediately as seen in #3415 extending the time taken for the shutdown. The actor runtime will wait upto 60 seconds for all actors to gracefully shutdown. So, adjusting the test workflow also accordingly.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3415

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

