### PR TITLE
fix: don't panic when --duration has less than 1s value

### DIFF
--- a/crates/core/tedge/src/cli/mqtt/cli.rs
+++ b/crates/core/tedge/src/cli/mqtt/cli.rs
@@ -46,10 +46,10 @@ pub enum TEdgeMqttCli {
         /// Avoid printing the message topics on the console
         #[clap(long = "no-topic")]
         hide_topic: bool,
-        /// Set a timeout duration (e.g., 60s, 1h)
+        /// Disconnect and exit after the specified timeout (e.g., 60s, 1h)
         #[clap(long, short = 'W')]
         duration: Option<SecondsOrHumanTime>,
-        /// Set the number of packets before stopping
+        /// Disconnect and exit after receiving the specified number of messages
         #[clap(long, short = 'C')]
         count: Option<u32>,
     },

--- a/crates/core/tedge/src/cli/mqtt/mod.rs
+++ b/crates/core/tedge/src/cli/mqtt/mod.rs
@@ -20,6 +20,7 @@ fn disconnect_if_interrupted(client: Client, timeout: Option<Duration>) -> Arc<A
         let interrupted = interrupted.clone();
         unsafe {
             let _ = signal_hook::low_level::register(*signal, move || {
+                eprintln!("INFO: Interrupted");
                 interrupted.store(true, Ordering::Relaxed);
                 let _ = client.disconnect();
             });

--- a/crates/core/tedge/src/cli/mqtt/publish.rs
+++ b/crates/core/tedge/src/cli/mqtt/publish.rs
@@ -90,7 +90,7 @@ fn publish(cmd: &MqttPublishCommand) -> Result<(), anyhow::Error> {
     let payload = cmd.message.as_bytes();
 
     let (client, mut connection) = rumqttc::Client::new(options, DEFAULT_QUEUE_CAPACITY);
-    super::disconnect_if_interrupted(client.clone());
+    super::disconnect_if_interrupted(client.clone(), None);
     let mut published = false;
     let mut acknowledged = false;
     let mut any_error = None;


### PR DESCRIPTION
## Proposed changes
The PR #3445 uses the MQTT keepalive mechanism to achieve a timeout. When an outgoing event `PINGREQ` occurs, the code checks the elapsed time, and if the elapsed time is larger than the specified duration, `tedge mqtt sub` exits.

MQTT keepalive must be at least 1s, that's why a panic occurred for the `100ms` input as the ticket #3447 describes.

After trying several approaches, I decided to take this approach https://github.com/thin-edge/thin-edge.io/pull/3448#discussion_r1984854857. It requires the least code changes compared to other approaches and `--duration` can even accept `100ms` input.

Also, this PR fixes regarding a `DISCONNECT` packet. Now it is sent before exiting the command when timeout occurred or message count limit is reached.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3447

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

