### PR TITLE
refactor: don't show loading spinner if stdout isn't a terminal

### DIFF
--- a/crates/core/tedge/src/cli/log.rs
+++ b/crates/core/tedge/src/cli/log.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::fmt;
+use std::io::IsTerminal;
 use std::io::Write;
 use std::sync::mpsc;
 use std::time::Duration;
@@ -108,13 +109,15 @@ where
         let mut stdout = std::io::stdout();
         let res = loop {
             let start_loop = Instant::now();
-            write!(
-                stdout,
-                "{title}... {}\r",
-                SPINNER[count_ticks % SPINNER.len()]
-            )
-            .unwrap();
-            stdout.flush().unwrap();
+            if stdout.is_terminal() {
+                write!(
+                    stdout,
+                    "{title}... {}\r",
+                    SPINNER[count_ticks % SPINNER.len()]
+                )
+                .unwrap();
+                stdout.flush().unwrap();
+            }
             std::thread::sleep(ms.saturating_sub(start_loop.elapsed()));
             count_ticks += 1;
 


### PR DESCRIPTION
## Proposed changes
Hides loading spinners when `stdout` is not a terminal, since it is not useful to indicate progress in such environments. 

This will print a e.g. `Verifying device is connected to cloud... ✓` line once the action is complete. It won't print anything for the given action until this is complete. This could be changed, but this current solution is a completely trivial change.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #3455

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

