### PR TITLE
fix: subscribe to topics on reconnection when session persistence is not enabled or broken

### DIFF
--- a/crates/common/mqtt_channel/src/connection.rs
+++ b/crates/common/mqtt_channel/src/connection.rs
@@ -271,9 +271,10 @@ impl Connection {
                                 .await?;
                         }
 
-                        if config.session_name.is_none() {
+                        if config.session_name.is_none() || !ack.session_present {
                             // Workaround for  https://github.com/bytebeamio/rumqtt/issues/250
-                            // If session_name is not provided, then re-subscribe
+                            // If session_name is not provided or if the broker session persistence
+                            // is not enabled or working, then re-subscribe
 
                             let subscriptions = config.subscriptions.filters();
                             // Need check here otherwise it will hang waiting for a SubAck, and none will come when there is no subscription.

--- a/tests/RobotFramework/tests/mqtt/session_persistence.robot
+++ b/tests/RobotFramework/tests/mqtt/session_persistence.robot
@@ -1,0 +1,30 @@
+*** Settings ***
+Resource            ../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:mqtt    theme:c8y
+
+
+*** Test Cases ***
+Agent Processes Operations After Local MQTT Broker Disconnects Without Mosquitto Persistence Settings
+    # Force tedge-agent to disconnect by restarting mosquitto
+    Restart Service    mosquitto
+    ${operation}=    Cumulocity.Get Configuration    tedge-configuration-plugin
+    Operation Should Be SUCCESSFUL    ${operation}
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Device Should Exist    ${DEVICE_SN}
+    # Remove mosquitto persistence settings
+    Execute Command    sed -i '/^persistence.*/d' /etc/mosquitto/mosquitto.conf
+
+    # Restart mosquitto to start again ignoring pre-existing persisted data
+    # Note: Tests should not rely on the mosquitto service restarting in the test setup
+    Restart Service    mosquitto


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Resubscribe to MQTT topics on reconnection when the no session is present. No session is present when mosquitto persistence has not been configured, or inaccessible (e.g. corrupt or incorrect ownership/permissions).

Previously, the reconnection logic was assuming that the only time the client needs to resubscribe to the MQTT topics is when an anonymous session is used. However if the MQTT broker persistence layer is not working, then the client should be checking if a session is present or not, and then resubscribing to the topics if no session was restored.

The most notable symptom without this change was that the tedge-agent would stop reacting to operations sent via MQTT if it would be disconnected from the local MQTT broker and if the MQTT broker persistence layer was not working or enabled. Restarting the tedge-agent service would "fix" the situation but only until the next reconnection event.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

* Discovered during the investigation of this ticket: https://github.com/thin-edge/thin-edge.io/issues/3456


## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

