### PR TITLE
tests: replace mosquitto_sub with tedge mqtt sub

### DIFF
--- a/tests/RobotFramework/tests/tedge_agent/tedge_agent.robot
+++ b/tests/RobotFramework/tests/tedge_agent/tedge_agent.robot
@@ -34,7 +34,7 @@ Converter and file transfer service are not running on a child device
     ...    exp_exit_code=7
 
     # check that tedge-to-te-converter is not working while on a child device
-    Execute Command    mosquitto_pub -t tedge/measurements -h ${PARENT_IP} -m ''
+    Execute Command    tedge mqtt pub tedge/measurements ''
 
     Set Device Context    ${PARENT_SN}
     # Only parent converter should convert the message

--- a/tests/RobotFramework/tests/tedge_to_te_converter/convert_tedge_topics_to_te_topics.robot
+++ b/tests/RobotFramework/tests/tedge_to_te_converter/convert_tedge_topics_to_te_topics.robot
@@ -104,7 +104,7 @@ Convert main device alarm topic and retain
     ${message}=    Convert String To Json    ${messages[0]}
     Should Be Equal    ${message["severity"]}    minor
     # Check if the retained message received with new client or not
-    ${result}=    Execute Command    tedge mqtt sub te/device/main///a/test_alarm & sleep 2s; kill $!
+    ${result}=    Execute Command    tedge mqtt sub --duration 2s --count 1 te/device/main///a/test_alarm
     Should Contain    ${result}    "severity":"minor"
 
 Convert child device alarm topic


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Replace usage of mosquitto_sub with `tedge mqtt sub`  (where possible) in system tests.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

