### PR TITLE
feat: support retained-only flag in tedge mqtt sub

### DIFF
--- a/crates/core/tedge/src/cli/mqtt/cli.rs
+++ b/crates/core/tedge/src/cli/mqtt/cli.rs
@@ -52,6 +52,10 @@ pub enum TEdgeMqttCli {
         /// Disconnect and exit after receiving the specified number of messages
         #[clap(long, short = 'C')]
         count: Option<u32>,
+        /// Only show retained messages and disconnect and exit after receiving
+        /// the first non-retained message
+        #[clap(long)]
+        retained_only: bool,
     },
 }
 
@@ -89,6 +93,7 @@ impl BuildCommand for TEdgeMqttCli {
                     hide_topic,
                     duration,
                     count,
+                    retained_only,
                 } => MqttSubscribeCommand {
                     host: config.mqtt.client.host.clone(),
                     port: config.mqtt.client.port.into(),
@@ -101,6 +106,7 @@ impl BuildCommand for TEdgeMqttCli {
                     client_auth_config: auth_config.client,
                     duration: duration.map(|v| v.duration()),
                     count,
+                    retained_only,
                 }
                 .into_boxed(),
             }

--- a/crates/core/tedge/src/cli/mqtt/subscribe.rs
+++ b/crates/core/tedge/src/cli/mqtt/subscribe.rs
@@ -25,6 +25,7 @@ pub struct MqttSubscribeCommand {
     pub client_auth_config: Option<MqttAuthClientConfig>,
     pub duration: Option<Duration>,
     pub count: Option<u32>,
+    pub retained_only: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -83,6 +84,10 @@ async fn subscribe(cmd: &MqttSubscribeCommand) -> Result<(), anyhow::Error> {
 
         match message.payload_str() {
             Ok(payload) => {
+                if cmd.retained_only && !message.retain {
+                    info!(target: "MQTT", "Received first non-retained message. topic={}", message.topic.name);
+                    break;
+                }
                 let line = if cmd.hide_topic {
                     format!("{payload}\n")
                 } else {


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Adding support for the `--retained-only` flag (same function as the mosquitto_sub flag of the same name), to allow users to only get the retained messages from the local MQTT broker.

Note: When subscribing to the retained messages, it will only return the messages with the retain flag set, and it will actively stop when receiving the first non-retained message, or if the user specifies a duration timeout.

Below shows the most common usage of the flag.

```sh
tedge mqtt sub '#' --retained-only --duration 1s
```

The change will also allow the remaining usage of `mosquitto_sub` in the system tests to be replaced with `tedge mqtt sub` and also providing a useful tool to users.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

