### PR TITLE
fix: clear retained entity twin messages on deregister

### DIFF
--- a/crates/core/tedge_api/src/entity_store.rs
+++ b/crates/core/tedge_api/src/entity_store.rs
@@ -919,7 +919,7 @@ impl EntityRegistrationMessage {
         self
     }
 
-    pub fn with_other_fragment(mut self, key: String, value: JsonValue) -> Self {
+    pub fn with_twin_fragment(mut self, key: String, value: JsonValue) -> Self {
         let _ = self.twin_data.insert(key, value);
         self
     }

--- a/tests/RobotFramework/tests/cumulocity/registration/registration_lifecycle.robot
+++ b/tests/RobotFramework/tests/cumulocity/registration/registration_lifecycle.robot
@@ -516,6 +516,18 @@ Unexpected message doesn't cause a panic #3134
     Device Should Exist    ${DEVICE_SN}:device:child2:service:foo
     Service Health Status Should Be Up    tedge-mapper-c8y
 
+Deregister clears all entity retained messages
+    Execute Command    tedge mqtt pub --retain 'te/device/child_xyz//' '{"@type":"child-device", "name": "Child XYZ"}'
+    Execute Command    tedge mqtt pub --retain 'te/device/child_xyz///twin/foo' '"bar"'
+
+    Should Have Retained MQTT Messages    te/device/child_xyz///twin/name
+    Should Have Retained MQTT Messages    te/device/child_xyz///twin/foo
+
+    # Delete entity
+    Execute Command    tedge mqtt pub --retain 'te/device/child_xyz//' ""
+
+    Should Not Have Retained MQTT Messages    te/device/child_xyz//#
+
 
 *** Keywords ***
 Should Have Retained Message Count

--- a/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
+++ b/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
@@ -323,6 +323,33 @@ Entity twin api errors
     ...    ${resp}
     ...    Failed to buffer the request body: length limit exceeded|413
 
+Delete entity clears entity registration and twin messages
+    Register Entity    device/child0//    child-device    device/main//
+    Register Entity    device/child1//    child-device    device/main//
+    Register Entity    device/child2//    child-device    device/main//
+    Register Entity    device/child0/service/service0    service    device/child0//
+    Register Entity    device/child00//    child-device    device/child0//
+    Register Entity    device/child000//    child-device    device/child00//
+
+    Execute Command    tedge http put /tedge/v1/entities/device/child0///twin '{"x": 1, "y": 2, "z": 3}'
+    Execute Command    tedge mqtt pub --retain 'te/device/child0///twin/foo' '"bar"'
+    Execute Command    tedge mqtt pub --retain 'te/device/child0/service/service0/twin/foo' '"bar"'
+    Execute Command    tedge mqtt pub --retain 'te/device/child00///twin/foo' '"bar"'
+    Execute Command    tedge mqtt pub --retain 'te/device/child000///twin/foo' '"bar"'
+
+    Should Have Retained MQTT Messages    te/device/child0///twin/foo    message_contains="bar"
+    Should Have Retained MQTT Messages    te/device/child0///twin/x    message_contains=1
+    Should Have Retained MQTT Messages    te/device/child0///twin/y    message_contains=2
+    Should Have Retained MQTT Messages    te/device/child0///twin/z    message_contains=3
+    Should Have Retained MQTT Messages    te/device/child00///twin/foo    message_contains="bar"
+    Should Have Retained MQTT Messages    te/device/child000///twin/foo    message_contains="bar"
+
+    ${deleted}=    Deregister Entity    device/child0//
+
+    Should Not Have Retained MQTT Messages    te/device/child0//#
+    Should Not Have Retained MQTT Messages    te/device/child00//#
+    Should Not Have Retained MQTT Messages    te/device/child000//#
+
 
 *** Keywords ***
 Custom Setup


### PR DESCRIPTION
## Proposed changes

Clear retained twin data messages on entity deregister.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3492

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

