### PR TITLE
fix: use both mqtt and http address when validating connecting c8y tenant url

### DIFF
--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -260,6 +260,11 @@ impl ConnectCommand {
                         .or_none()
                         .map(|u| u.host().to_string())
                         .unwrap_or_default(),
+                    &c8y_config
+                        .http
+                        .or_none()
+                        .map(|u| u.host().to_string())
+                        .unwrap_or_default(),
                 )
                 .await
                 .map(Some)
@@ -1233,18 +1238,20 @@ fn get_common_mosquitto_config_file_path(
 async fn tenant_matches_configured_url(
     tedge_config: &TEdgeConfig,
     c8y_prefix: Option<&str>,
-    configured_url: &str,
+    configured_mqtt_url: &str,
+    configured_http_url: &str,
 ) -> Result<bool, Fancy<ConnectError>> {
     let spinner = Spinner::start("Checking Cumulocity is connected to intended tenant");
     let res = get_connected_c8y_url(tedge_config, c8y_prefix).await;
     match spinner.finish(res) {
-        Ok(url) if url == configured_url => Ok(true),
+        Ok(url) if url == configured_mqtt_url || url == configured_http_url => Ok(true),
         Ok(url) => {
             warning!(
-            "The device is connected to {}, but the configured URL is {}.\
+            "The device is connected to {}, but the configured URL is (mqtt={}, http={}).\
             \n    To connect the device to the intended tenant, remove the device certificate from {url}, and then run `tedge reconnect c8y`", 
             url.bold(),
-            configured_url.bold(),
+            configured_mqtt_url.bold(),
+            configured_http_url.bold(),
         );
             Ok(false)
         }


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

When a custom Cumulocity domain is used (aka the Cumulocity enterprise feature), the HTTP and MQTT endpoints will differ, however thin-edge.io was previously only checking the MQTT endpoint against URL derived from the Cumulocity JWT (which has the HTTP URL). The error only resulted in an invalid warning being shown to the user, however it just adds noise and confusion for the user.

Now, both the HTTP and MQTT endpoints are compared to ensure that at least one of them match.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3501

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

