### PR TITLE
fix: skip bridge status messages in aws/az mappers

### DIFF
--- a/crates/extensions/aws_mapper_ext/src/converter.rs
+++ b/crates/extensions/aws_mapper_ext/src/converter.rs
@@ -107,10 +107,16 @@ impl AwsConverter {
         let topic_prefix = &self.topic_prefix;
         let source = normalize_name(source);
         let out_topic = format!("{topic_prefix}/td/{source}/status/health");
-        let payload = self.with_timestamp(input)?;
-        let output = MqttMessage::new(&Topic::new(&out_topic).unwrap(), payload);
-
-        Ok(vec![output])
+        match self.with_timestamp(input) {
+            Ok(payload) => {
+                let output = MqttMessage::new(&Topic::new(&out_topic).unwrap(), payload);
+                Ok(vec![output])
+            }
+            Err(err) => {
+                error!("Could not add timestamp to payload for {out_topic}: {err}. Skipping");
+                Ok(vec![])
+            }
+        }
     }
 
     fn convert_telemetry_message(
@@ -120,7 +126,13 @@ impl AwsConverter {
         telemetry_type: &String,
     ) -> Result<Vec<MqttMessage>, ConversionError> {
         let topic_prefix = &self.topic_prefix;
-        let payload = self.with_timestamp(input)?;
+        let payload = match self.with_timestamp(input) {
+            Ok(payload) => payload,
+            Err(err) => {
+                error!("Could not add timestamp to payload: {err}. Skipping");
+                return Ok(vec![]);
+            }
+        };
         let source = normalize_name(&source);
         // XXX: should match on `Channel` instead
         let out_topic = match input.topic.name.split('/').collect::<Vec<_>>()[..] {
@@ -199,7 +211,6 @@ impl Converter for AwsConverter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::ConversionError::FromSerdeJson;
     use assert_json_diff::*;
     use assert_matches::*;
     use serde_json::json;
@@ -223,27 +234,13 @@ mod tests {
     }
 
     #[test]
-    fn convert_error() {
-        let mut converter = create_test_converter(true);
-
-        let input = "Invalid JSON";
-
-        let output = converter.convert(&new_tedge_message(input)).unwrap();
-
-        assert_eq!(output.first().unwrap().topic.name, "te/errors");
-        assert_eq!(
-            extract_first_message_payload(output),
-            "expected value at line 1 column 1"
-        );
-    }
-
-    #[test]
-    fn try_convert_invalid_json_returns_error() {
+    fn try_convert_invalid_json_skips_message() {
         let mut converter = create_test_converter(false);
 
         let input = "This is not Thin Edge JSON";
         let result = converter.try_convert(&new_tedge_message(input));
-        assert_matches!(result, Err(FromSerdeJson(_)))
+
+        assert!(result.unwrap().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Proposed changes
Currently, we skip the conversion message when it comes on the `aws` or `az` bridge status topics. However, this is not sufficient, as the mapper reacts to all bridge status topics. Moreover, it always fails if the payload cannot be parsed into the `Map<String, Value>` format.

This PR changes the logic: instead of checking the topic, we now attempt to parse the payload as a `u8` and check if value is 0 or 1. If so, we skip the conversion. For other payload formats, a more descriptive error message will be logged.

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #3488
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

