### PR TITLE
feat: parse `TEDGE_` environment variables using `FromStr` implementation

### DIFF
--- a/crates/common/tedge_config/src/tedge_toml/figment.rs
+++ b/crates/common/tedge_config/src/tedge_toml/figment.rs
@@ -51,11 +51,11 @@ pub fn extract_data<T: DeserializeOwned, Sources: ConfigSources>(
     let env = TEdgeEnv::default();
     let figment = Figment::new().merge(Toml::file(path));
 
-    let figment = if Sources::INCLUDE_ENVIRONMENT {
-        figment.merge(env.provider())
-    } else {
-        figment
-    };
+    // let figment = if Sources::INCLUDE_ENVIRONMENT {
+    //     figment.merge(env.provider())
+    // } else {
+    //     figment
+    // };
 
     let data = extract_exact(&figment, &env);
 


### PR DESCRIPTION
## Proposed changes
Supersedes #3516 

This is an attempt at a better solution to the lossy parsing we currently encounter when processing `TEDGE_` environment variables. Since we don't need to process environment variables via serde now (I believe we did when figment was introduced pre-macro), serde/figment are proving a hinderance for processing the variables as we discovered with #3394.

The changes (will) remove figment as a dependency, and move to a model where we parse `tedge.toml` to a DTO, then insert the values from the environment variables into the DTO (parsing them in the same way `tedge config set` does). Unlike `tedge config set`, this will also accept TOML-formatted values for backwards compatibility with the current figment behaviour.

The code changes are still quite a way from being finished at the time of opening this PR, but ignoring error cases/warnings, this I believe has all the intended behaviour, so can be manually tested. If you do specify an unknown environment variable, this will currently result in a hard error, whereas it will ultimately result in a warning like we get from figment currently.

### Examples
Here are some examples of how the new solution works, showing how it handles leading zeroes intelligently depending on the target key, and how it parses TOML syntax like figment did.

```bash
$ TEDGE_MQTT_CLIENT_PORT=1883 tedge config get mqtt.client.port
1883 # simple case, works as before
$ TEDGE_MQTT_CLIENT_PORT=01883 tedge config get mqtt.client.port
1883 # leading zero, works as before
$ TEDGE_HTTP_CLIENT_HOST=012345 tedge config get http.client.host
012345 # parsed as a string, previously this was rejected
$ TEDGE_C8Y_SMARTREST_TEMPLATES=test,values tedge config get c8y.smartrest.templates
["test","values"] # custom FromStr implementation, works as before
$ TEDGE_C8Y_SMARTREST_TEMPLATES=[\"test\",\"values\"] tedge config get c8y.smartrest.templates
["test","values"] # TOML syntax in environment variable, works as before
$ TEDGE_C8Y_SMARTREST_TEMPLATES=[\"single,value,with,comma\"] tedge config get c8y.smartrest.templates
["single,value,with,comma"] # TOML syntax, works as before
```

### Minor breaking change
This is again technically a breaking change, but not really in practice. Previously, the environment variables overrode the `tedge.toml` values before deserialisation occurred, which could cause an invalid `tedge.toml` to be masked by environment variables. Thus the following would previously have worked:

```bash
$ cat /etc/tedge/tedge.toml
mqtt.client.port = "not a number"
$ TEDGE_MQTT_CLIENT_PORT=1883 tedge config get mqtt.client.port
1883
```

With this change, this will (correctly) fail when parsing `tedge.toml`.

### TODOs
- [ ] Handle empty environment variables
- [ ] Tests
- [ ] Preserve the existing warning behaviour
- [ ] Remove figment now it's not needed
- [ ] Proptest? - probably should do this, I suspect there are things we can do that aren't that difficult

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #3394

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

