### PR TITLE
feat(tedge-p11-server): Remove owned socket file after exiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4290,6 +4290,7 @@ dependencies = [
  "rustls 0.23.22",
  "sd-listen-fds",
  "serde",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/extensions/tedge-p11-server/Cargo.toml
+++ b/crates/extensions/tedge-p11-server/Cargo.toml
@@ -19,6 +19,7 @@ postcard.workspace = true
 rustls.workspace = true
 sd-listen-fds.workspace = true
 serde.workspace = true
+tokio = { workspace = true, features = ["rt", "macros", "net", "signal"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 


### PR DESCRIPTION
## Proposed changes

If we bind the socket in tedge-p11-server (as opposed to receiving it from systemd), remove this socket after exiting.

Also improves error message when trying to bind at a path that already exists, as suggested in https://github.com/thin-edge/thin-edge.io/pull/3511#pullrequestreview-2724840631:

```
Error: Failed to bind to socket at '/run/tedge-p11-server/pkcs11.sock'

Caused by:
    Address already in use (os error 98)
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

