### PR TITLE
fix: tedge cert renew returning success exit code on error 

### DIFF
--- a/crates/core/c8y_api/src/http_proxy.rs
+++ b/crates/core/c8y_api/src/http_proxy.rs
@@ -69,8 +69,6 @@ impl C8yEndPoint {
         c8y_profile: Option<&str>,
     ) -> Result<Self, C8yEndPointConfigError> {
         let c8y_config = tedge_config.c8y.try_get(c8y_profile)?;
-        let c8y_host = c8y_config.proxy.client.host.to_string();
-        let c8y_mqtt_host = c8y_host.clone();
         let auth_proxy_addr = c8y_config.proxy.client.host.clone();
         let auth_proxy_port = c8y_config.proxy.client.port;
         let auth_proxy_protocol = c8y_config
@@ -78,8 +76,12 @@ impl C8yEndPoint {
             .cert_path
             .or_none()
             .map_or(Protocol::Http, |_| Protocol::Https);
+        let c8y_host = format!(
+            "{}://{auth_proxy_addr}:{auth_proxy_port}",
+            auth_proxy_protocol.as_str()
+        );
+        let c8y_mqtt_host = c8y_host.clone();
         let proxy = ProxyUrlGenerator::new(auth_proxy_addr, auth_proxy_port, auth_proxy_protocol);
-
         Ok(C8yEndPoint {
             c8y_host,
             c8y_mqtt_host,

--- a/crates/core/tedge/src/cli/certificate/create.rs
+++ b/crates/core/tedge/src/cli/certificate/create.rs
@@ -166,6 +166,13 @@ pub async fn reuse_private_key(key_path: &Utf8PathBuf) -> Result<KeyKind, std::i
     tokio::fs::read_to_string(key_path)
         .await
         .map(|keypair_pem| KeyKind::Reuse { keypair_pem })
+        .or_else(|err| {
+            if key_path.exists() {
+                Err(err)
+            } else {
+                Ok(KeyKind::New)
+            }
+        })
 }
 
 async fn persist_private_key(

--- a/crates/core/tedge/src/cli/certificate/create_csr.rs
+++ b/crates/core/tedge/src/cli/certificate/create_csr.rs
@@ -47,7 +47,10 @@ impl CreateCsrCmd {
         let csr_path = &self.csr_path;
         let key_path = &self.key_path;
 
-        let previous_key = reuse_private_key(key_path).await.unwrap_or(KeyKind::New);
+        let previous_key = reuse_private_key(key_path)
+            .await
+            .map_err(|e| CertError::IoError(e).key_context(key_path.clone()))?;
+
         let cert =
             KeyCertPair::new_certificate_sign_request(&self.csr_template, id, &previous_key)?;
 

--- a/crates/core/tedge/src/cli/certificate/error.rs
+++ b/crates/core/tedge/src/cli/certificate/error.rs
@@ -25,6 +25,13 @@ pub enum CertError {
     )]
     CertificateNotFound { path: Utf8PathBuf },
 
+    #[error("I/O error accessing the certificate: {path:?}")]
+    CertificateIoError {
+        path: Utf8PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
     #[error(
         r#"No private key has been attached to that device.
         Missing file: {path:?}
@@ -40,6 +47,13 @@ pub enum CertError {
     "#
     )]
     KeyAlreadyExists { path: Utf8PathBuf },
+
+    #[error("I/O error accessing the private key: {path:?}")]
+    KeyIoError {
+        path: Utf8PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 
     #[error(transparent)]
     ConfigError(#[from] crate::ConfigError),
@@ -61,12 +75,6 @@ pub enum CertError {
 
     #[error(transparent)]
     CertificateError(#[from] certificate::CertificateError),
-
-    #[error(
-        r#"Certificate read error at: {1:?}
-        Run `tedge cert create` if you want to create a new certificate."#
-    )]
-    CertificateReadFailed(#[source] std::io::Error, String),
 
     #[error(transparent)]
     PathsError(#[from] PathsError),
@@ -106,10 +114,10 @@ impl CertError {
     /// Improve the error message in case the error in a IO error on the certificate file.
     pub fn cert_context(self, path: Utf8PathBuf) -> CertError {
         match self {
-            CertError::IoError(ref err) => match err.kind() {
+            CertError::IoError(err) => match err.kind() {
                 std::io::ErrorKind::AlreadyExists => CertError::CertificateAlreadyExists { path },
                 std::io::ErrorKind::NotFound => CertError::CertificateNotFound { path },
-                _ => self,
+                _ => CertError::CertificateIoError { path, source: err },
             },
             _ => self,
         }
@@ -118,10 +126,10 @@ impl CertError {
     /// Improve the error message in case the error in a IO error on the private key file.
     pub fn key_context(self, path: Utf8PathBuf) -> CertError {
         match self {
-            CertError::IoError(ref err) => match err.kind() {
+            CertError::IoError(err) => match err.kind() {
                 std::io::ErrorKind::AlreadyExists => CertError::KeyAlreadyExists { path },
                 std::io::ErrorKind::NotFound => CertError::KeyNotFound { path },
-                _ => self,
+                _ => CertError::KeyIoError { path, source: err },
             },
             _ => self,
         }

--- a/crates/core/tedge/src/cli/certificate/mod.rs
+++ b/crates/core/tedge/src/cli/certificate/mod.rs
@@ -1,5 +1,5 @@
 pub use self::cli::TEdgeCertCli;
-use std::path::Path;
+use camino::Utf8Path;
 use tokio::io::AsyncReadExt;
 
 mod c8y;
@@ -15,10 +15,12 @@ pub use self::cli::*;
 pub use self::create::*;
 pub use self::error::*;
 
-pub(crate) async fn read_cert_to_string(path: impl AsRef<Path>) -> Result<String, CertError> {
+pub(crate) async fn read_cert_to_string(path: impl AsRef<Utf8Path>) -> Result<String, CertError> {
     let mut file = tokio::fs::File::open(path.as_ref()).await.map_err(|err| {
-        let path = path.as_ref().display().to_string();
-        CertError::CertificateReadFailed(err, path)
+        CertError::CertificateIoError {
+            source: err,
+            path: path.as_ref().to_owned(),
+        }
     })?;
     let mut content = String::new();
     file.read_to_string(&mut content).await?;

--- a/crates/core/tedge/src/cli/certificate/renew.rs
+++ b/crates/core/tedge/src/cli/certificate/renew.rs
@@ -39,11 +39,6 @@ impl RenewCertCmd {
         let key_path = &self.key_path;
         let id = certificate_cn(cert_path).await?;
 
-        // Remove only certificate
-        tokio::fs::remove_file(&self.cert_path)
-            .await
-            .map_err(|e| CertError::IoError(e).cert_context(self.cert_path.clone()))?;
-
         // Re-create the certificate from the key, with new validity
         let previous_key = reuse_private_key(key_path)
             .await


### PR DESCRIPTION
## Proposed changes

- [x] `tedge cert renew` exits with status code 1 on error
- [x] `tedge cert renew`  returning a confusing error message when the private key cannot be read

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3524

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

