### PR TITLE
fix: improve accessibility of tedge cert show

### DIFF
--- a/crates/core/tedge/src/cli/certificate/show.rs
+++ b/crates/core/tedge/src/cli/certificate/show.rs
@@ -117,9 +117,15 @@ impl ShowCertCmd {
 
 fn display_status(status: ValidityStatus, minimum: Duration) -> String {
     let text = match status {
-        ValidityStatus::Valid { expired_in } => {
+        ValidityStatus::Valid { expired_in } if expired_in > minimum => {
             format!(
                 "VALID (expires in: {})",
+                humantime::format_duration(expired_in)
+            )
+        }
+        ValidityStatus::Valid { expired_in } => {
+            format!(
+                "EXPIRES SOON (expires in: {})",
                 humantime::format_duration(expired_in)
             )
         }


### PR DESCRIPTION
## Proposed changes

Improve accessibility of tedge cert show: do not rely on color to distinguish a certificate which will expire soon from a certificate still valid for a safe period of time.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3526

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

