### PR TITLE
ci: move cargo-test job to build-workflow

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -31,6 +31,63 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  cargo-test:
+    name: Run cargo test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check disk space before setting up
+        run: df -BM
+
+      - name: Reclaim some disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf /opt/hostedtoolcache
+
+      - name: Check disk space after freeing
+        run: df -BM
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Retrieve MSRV from workspace Cargo.toml
+        id: rust_version
+        uses: SebRollen/toml-action@v1.2.0
+        with:
+          file: Cargo.toml
+          field: "workspace.package.rust-version"
+
+      - name: Enable toolchain via github action
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Enable cache
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
+
+      - name: cargo install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: cargo llvm-cov
+        run: cargo llvm-cov nextest --no-fail-fast --locked --all-features --all-targets --codecov --output-path codecov.json
+
+      # https://github.com/rust-lang/cargo/issues/6669
+      - name: cargo test --doc
+        run: cargo test --locked --all-features --doc
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+
+      - name: Check disk space after completing workflow
+        run: df -BM
+
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.host_os }}
@@ -259,7 +316,7 @@ jobs:
       (needs.check-build.result == 'success') &&
       (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-22.04
-    needs: [check-build, test]
+    needs: [check-build, test, cargo-test]
     strategy:
       fail-fast: false
       matrix:
@@ -314,7 +371,7 @@ jobs:
       (needs.check-build.result == 'success') &&
       (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-22.04
-    needs: [check-build, test]
+    needs: [check-build, test, cargo-test]
     env:
       BUILDX_NO_DEFAULT_ATTESTATIONS: 1
     permissions:

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -3,7 +3,7 @@ name: Pull Request Checks
 on:
   workflow_dispatch:
   pull_request:
-  merge_group:
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -252,65 +252,6 @@ jobs:
 
       - name: Run `cargo check`
         run: cargo check --all-targets --all-features
-
-  cargo-test:
-    name: Run cargo test
-    runs-on: ubuntu-22.04
-    needs: changes
-    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true' }}
-    steps:
-      - name: Check disk space before setting up
-        run: df -BM
-
-      - name: Reclaim some disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf /opt/hostedtoolcache
-
-      - name: Check disk space after freeing
-        run: df -BM
-
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Retrieve MSRV from workspace Cargo.toml
-        id: rust_version
-        uses: SebRollen/toml-action@v1.2.0
-        with:
-          file: Cargo.toml
-          field: "workspace.package.rust-version"
-
-      - name: Enable toolchain via github action
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
-
-      - name: Enable cache
-        uses: Swatinem/rust-cache@v2
-
-      - name: Install latest nextest release
-        uses: taiki-e/install-action@nextest
-
-      - name: cargo install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: cargo llvm-cov
-        run: cargo llvm-cov nextest --no-fail-fast --locked --all-features --all-targets --codecov --output-path codecov.json
-
-      # https://github.com/rust-lang/cargo/issues/6669
-      - name: cargo test --doc
-        run: cargo test --locked --all-features --doc
-
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-
-      - name: Check disk space after completing workflow
-        run: df -BM
 
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -3,7 +3,7 @@ name: Pull Request Checks
 on:
   workflow_dispatch:
   pull_request:
-
+  merge_group:
 env:
   CARGO_TERM_COLOR: always
 
@@ -24,6 +24,7 @@ jobs:
   changes:
     name: Filter changes
     runs-on: ubuntu-22.04
+    if: ${{ github.event_name != 'merge_group' }}
     # Set job outputs to values from filter step
     outputs:
       rust: ${{ steps.filter.outputs.rust || 'true' }}
@@ -42,6 +43,7 @@ jobs:
               - 'crates/**'
               - 'plugins/**'
               - 'Cargo.*'
+              - '**/Cargo.toml'
             workflows:
               - '.github/workflows/**'
             docs:
@@ -53,9 +55,8 @@ jobs:
   check-lockfile-uptodate:
     name: Check whether Cargo.lock is up to date
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name == 'pull_request' }}
-    outputs:
-      locks: ${{ steps.filter.outputs.locks }}
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -74,15 +75,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            locks:
-              - '**/Cargo.toml'
-
       - name: Check whether lockfile is up to date
-        if: steps.filter.outputs.locks == 'true'
         run: cargo check --locked
 
   udeps:


### PR DESCRIPTION
## Proposed changes
We have an issue that the merge queue failed due to flaky unit tests, however, the artifacts are published to cloudsmith. To prevent the issue, this PR proposes:

1. Move `cargo-test` job from the Pull Request Check workflow to the Build workflow so that publishing artifacts can be prevented if `cargo-test` job fails.
2. ~~Merge queue (event: `merge_group`) triggers **only** the build workflow.~~ Not able to do this, since GitHub required checks don't differentiate checks under PR and Merge Queue :/
3. Instead of 2), `Filter changes` is skipped when the event is `merge_group`, that allows to skip all the following jobs.
![Screenshot 2025-04-08 at 16 26 54](https://github.com/user-attachments/assets/066fa494-840f-4b79-a618-113ee13af26c)
4. To do 3), I moved `Check whether Cargo.lock is up to date` after the filtering. Indeed, if the change is not related to Rust, this check should be skipped. 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

