### PR TITLE
Bump tokio to 1.44.2, resolve RUSTSEC-2025-0023

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,9 +5092,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ tempfile = "3.12"
 test-case = "3.2"
 thiserror = "1.0"
 time = "0.3"
-tokio = { version = "1.37", default-features = false }
+tokio = { version = "1.44", default-features = false }
 tokio-rustls = { version = "0.26.1", default-features = false }
 tokio-tungstenite = { version = "0.26.1" }
 tokio-util = { version = "0.7", features = ["codec"] }

--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -99,6 +99,7 @@ async fn main() -> anyhow::Result<()> {
         }
     };
     info!(listener = ?listener.local_addr().as_ref().ok().and_then(|s| s.as_pathname()), "Server listening");
+    listener.set_nonblocking(true)?;
     let listener = tokio::net::UnixListener::from_std(listener)?;
     let server = TedgeP11Server::from_config(cryptoki_config)?;
     tokio::spawn(async move { server.serve(listener).await });


### PR DESCRIPTION
## Proposed changes

Resolve RUSTSEC-2025-0023 by bumping tokio to 1.44.2.

The new version of tokio changes `UnixListener::from_std` to panic if the listener isn't set to nonblocking mode. This was the case in tedge-p11-server, so the PR also includes a commit to fix that issue.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue


## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

