### PR TITLE
feat: tedge-p11-server Select token using serial number

### DIFF
--- a/configuration/init/systemd/tedge-p11-server.service
+++ b/configuration/init/systemd/tedge-p11-server.service
@@ -6,7 +6,7 @@ Requires=tedge-p11-server.socket
 Type=simple
 StandardError=journal
 EnvironmentFile=-/etc/tedge/plugins/tedge-p11-server.conf
-ExecStart=/usr/bin/tedge-p11-server --module-path "${TEDGE_DEVICE_CRYPTOKI_MODULE_PATH}" --pin "${TEDGE_DEVICE_CRYPTOKI_PIN}"
+ExecStart=/usr/bin/tedge-p11-server --module-path "${TEDGE_DEVICE_CRYPTOKI_MODULE_PATH}" --pin "${TEDGE_DEVICE_CRYPTOKI_PIN}" --serial "${TEDGE_DEVICE_CRYPTOKI_SERIAL}"
 Restart=on-failure
 
 [Install]

--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -12,6 +12,7 @@
 //! provide its own bundled p11-kit-like service.
 
 use std::os::unix::net::UnixListener;
+use std::sync::Arc;
 
 use anyhow::Context;
 use camino::Utf8PathBuf;
@@ -44,6 +45,10 @@ pub struct Args {
     #[arg(long, default_value = "123456")]
     pin: String,
 
+    /// The serial number of the cryptographic token to use.
+    #[arg(long)]
+    serial: Option<Arc<str>>,
+
     /// Configures the logging level.
     ///
     /// One of error/warn/info/debug/trace. Logs with verbosity lower or equal to the selected level
@@ -71,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
     let cryptoki_config = CryptokiConfigDirect {
         module_path: args.module_path,
         pin: AuthPin::new(args.pin),
-        serial: None,
+        serial: args.serial.filter(|s| !s.is_empty()),
     };
 
     info!(?cryptoki_config, "Using cryptoki configuration");

--- a/tests/RobotFramework/tests/pkcs11/private_key_storage.robot
+++ b/tests/RobotFramework/tests/pkcs11/private_key_storage.robot
@@ -18,7 +18,6 @@ Test Tags           adapter:docker    theme:cryptoki
 Use Private Key in SoftHSM2 using tedge-p11-server
     # initialize the soft hsm and create a self-signed certificate
     Configure tedge-p11-server    module_path=/usr/lib/softhsm/libsofthsm2.so    pin=123456
-    Execute Command    sudo -u tedge /usr/bin/init_softhsm.sh --self-signed --device-id "${DEVICE_SN}" --pin 123456
 
     # configure tedge
     Execute Command    tedge config set c8y.url "$(echo ${C8Y_CONFIG.host} | sed 's|https?://||g')"
@@ -31,6 +30,23 @@ Use Private Key in SoftHSM2 using tedge-p11-server
 
     Execute Command    tedge reconnect c8y
 
+Fail if there's no token with given serial available
+    # initialize the soft hsm and create a self-signed certificate
+    # Configure tedge-p11-server    module_path=/usr/lib/softhsm/libsofthsm2.so    pin=123456    serial=000000000000
+
+    Execute Command    cmd=printf 'TEDGE_DEVICE_CRYPTOKI_MODULE_PATH=%s\nTEDGE_DEVICE_CRYPTOKI_PIN=%s\nTEDGE_DEVICE_CRYPTOKI_SERIAL=%s\n' "/usr/lib/softhsm/libsofthsm2.so" "123456" "000000000000" | sudo tee /etc/tedge/plugins/tedge-p11-server.conf
+    Restart Service    tedge-p11-server
+
+    # configure tedge
+    Execute Command    tedge config set c8y.url "$(echo ${C8Y_CONFIG.host} | sed 's|https?://||g')"
+    Execute Command    tedge config set mqtt.bridge.built_in true
+    Execute Command    tedge config set device.cryptoki.mode socket
+
+    # Upload the self-signed certificate
+    Execute Command
+    ...    cmd=sudo env C8Y_USER='${C8Y_CONFIG.username}' C8Y_PASSWORD='${C8Y_CONFIG.password}' tedge cert upload c8y
+
+    Run Keyword And Expect Error    *    Execute Command    tedge reconnect c8y
 
 *** Keywords ***
 Custom Setup
@@ -41,11 +57,12 @@ Custom Setup
     Execute Command    sudo usermod -a -G softhsm tedge
     Transfer To Device    ${CURDIR}/data/init_softhsm.sh    /usr/bin/
     Remove Existing Certificates
+    Execute Command    sudo -u tedge /usr/bin/init_softhsm.sh --self-signed --device-id "${DEVICE_SN}" --pin 123456
 
 Remove Existing Certificates
     Execute Command    cmd=rm -f "$(tedge config get device.key_path)" "$(tedge config get device.cert_path)"
 
 Configure tedge-p11-server
-    [Arguments]    ${module_path}    ${pin}
+    [Arguments]    ${module_path}    ${pin}    ${serial}=
     Execute Command
     ...    cmd=printf 'TEDGE_DEVICE_CRYPTOKI_MODULE_PATH=%s\nTEDGE_DEVICE_CRYPTOKI_PIN=%s\n' "${module_path}" "${pin}" | sudo tee /etc/tedge/plugins/tedge-p11-server.conf


### PR DESCRIPTION
## Proposed changes

Allow the user to select a token via a serial number. If a serial number is provided, we attempt to select a token with that number and fail if such token doesn't exist.

As of now this is implemented for tedge-p11-server, so works with `socket` cryptoki mode, but doesn't work yet with `module` mode.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #3538

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I'm aware that the issue asks for the URL and not serial numbers, but this was easy to do and should allow users to select which token to use if multiple are available, while supporting the [PKCS #11 URL scheme](https://www.rfc-editor.org/rfc/rfc7512.html) will involve more work, such as possibly writing a parser for these URLs.