### PR TITLE
fix: c8y mapper config should use the value of c8y.mqtt as mqtt endpoint

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -171,6 +171,7 @@ impl C8yMapperConfig {
         let device_topic_id = EntityTopicId::from_str(&tedge_config.mqtt.device_topic_id)?;
         let service = tedge_config.service.clone();
         let c8y_host = c8y_config.http.or_config_not_set()?.to_string();
+        let c8y_mqtt = c8y_config.mqtt.or_config_not_set()?.to_string();
         let tedge_http_address = tedge_config.http.client.host.clone();
         let tedge_http_port = tedge_config.http.client.port;
         let mqtt_schema = MqttSchema::with_root(tedge_config.mqtt.topic_root.clone());
@@ -237,8 +238,8 @@ impl C8yMapperConfig {
             device_topic_id,
             device_type,
             service,
-            c8y_host.clone(),
             c8y_host,
+            c8y_mqtt,
             tedge_http_host,
             topics,
             capabilities,


### PR DESCRIPTION
## Proposed changes
This PR fixes the issue in https://github.com/thin-edge/thin-edge.io/issues/3545#issuecomment-2789804235.

`C8yMapperConfig` used the HTTP endpoint as its MQTT endpoint by mistake. This causes the issue highlighted by #3545. 
Unfortunately, the method `C8yMapperConfig::from_tedge_config()` cannot be tested by unit tests or integration tests. This is the reason of why this bug was not detected easily, although we have good unit/integration test coverage for that. The logic of replacing with proxy url that we have is correctly addressing the difference of these endpoints.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3545 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

