### PR TITLE
tests: increase max inflight messages for mosquitto to avoid dropped messages

### DIFF
--- a/tests/images/debian-systemd/files/mosquitto.conf
+++ b/tests/images/debian-systemd/files/mosquitto.conf
@@ -1,2 +1,6 @@
 log_dest syslog
 log_type debug
+
+# increase default size (which is 20) to avoid problems where messages can be
+# silently dropped
+max_inflight_messages 200


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Increase the default mosquitto `max_inflight_messages` setting from 20 to 200 to avoid observed problems with the system test stability due to mosquitto 2.0.11 silently discarding some messages when the limit is exceeded.

The logs from the observed system test failures (currently they have only been visible on the CI workflow), show that some messages sent to the broker are not making it to the subscribed clients (e.g. niether the mqtt-logger nor the tedge-mapper) which makes the system tests fail.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

Flaky system test issues:

* https://github.com/thin-edge/thin-edge.io/issues/3512
* https://github.com/thin-edge/thin-edge.io/issues/3489

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

