### PR TITLE
fix: support relative output paths when creating a csr

### DIFF
--- a/crates/core/tedge/src/cli/certificate/create_csr.rs
+++ b/crates/core/tedge/src/cli/certificate/create_csr.rs
@@ -44,7 +44,7 @@ impl Command for CreateCsrCmd {
 impl CreateCsrCmd {
     pub async fn create_certificate_signing_request(&self) -> Result<(), CertError> {
         let id = &self.id;
-        let csr_path = &self.csr_path;
+        let csr_path = tedge_api::path::resolve_to_absolute_utf8_path(&self.csr_path)?;
         let key_path = &self.key_path;
 
         let previous_key = reuse_private_key(key_path)
@@ -64,7 +64,7 @@ impl CreateCsrCmd {
             .await
             .map_err(|err| err.key_context(key_path.clone()))?;
         }
-        override_public_key(csr_path, cert.certificate_signing_request_string()?)
+        override_public_key(&csr_path, cert.certificate_signing_request_string()?)
             .await
             .map_err(|err| err.cert_context(csr_path.clone()))?;
         Ok(())

--- a/crates/core/tedge_api/src/path.rs
+++ b/crates/core/tedge_api/src/path.rs
@@ -94,3 +94,149 @@ impl DataDir {
         self.0.join("firmware")
     }
 }
+
+/// Resolves a relative path to an absolute path as a Utf8PathBuf.
+/// The path does not need to exist on the file system.
+/// This can be removed once MSRV is updated to >= 1.79 as the 'absolute_utf8'
+/// function of camino can be used
+///
+/// # Arguments
+///
+/// * `relative_path` - A path-like object representing the relative path to resolve
+///
+/// # Returns
+///
+/// * `Result<Utf8PathBuf, io::Error>` - The absolute path as Utf8PathBuf or an error
+///
+/// # Examples
+///
+/// ```
+/// let abs_path = resolve_to_absolute_utf8_path("../some/file.txt")?;
+/// println!("Absolute path: {}", abs_path);
+/// ```
+pub fn resolve_to_absolute_utf8_path<P: AsRef<Utf8Path>>(
+    relative_path: P,
+) -> Result<Utf8PathBuf, std::io::Error> {
+    let path = relative_path.as_ref();
+
+    // If the path is already absolute, return it
+    if path.is_absolute() {
+        return Ok(path.to_owned());
+    }
+
+    // Get the current directory and convert to Utf8PathBuf
+    let current_dir = std::env::current_dir()?;
+    let current_dir = match Utf8PathBuf::from_path_buf(current_dir) {
+        Ok(dir) => dir,
+        Err(non_utf8_path) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "Current directory path is not valid UTF-8: {:?}",
+                    non_utf8_path
+                ),
+            ));
+        }
+    };
+
+    // Join with the relative path and canonicalize virtually
+    let joined_path = current_dir.join(path);
+    let absolute_path = joined_path.canonicalize_virtually();
+
+    Ok(absolute_path)
+}
+
+/// Extension trait for Utf8PathBuf that provides a way to canonicalize a path
+/// without requiring the path to exist on the file system.
+trait VirtualCanonicalize {
+    fn canonicalize_virtually(&self) -> Utf8PathBuf;
+}
+
+impl VirtualCanonicalize for Utf8PathBuf {
+    fn canonicalize_virtually(&self) -> Utf8PathBuf {
+        let mut result = Utf8PathBuf::new();
+        let is_absolute = self.is_absolute();
+
+        if is_absolute {
+            // For Windows, keep the drive or UNC prefix
+            #[cfg(windows)]
+            if let Some(prefix) = self.components().next() {
+                // Convert the prefix component to a string
+                let prefix_str = prefix.as_os_str().to_string_lossy();
+                result.push(prefix_str.as_ref());
+            }
+
+            // For Unix, start with root
+            #[cfg(unix)]
+            result.push("/");
+        }
+
+        for component in self.components() {
+            match component {
+                camino::Utf8Component::Prefix(_) if !is_absolute => {
+                    let comp_str = component.as_str();
+                    result.push(comp_str);
+                }
+                camino::Utf8Component::RootDir if !is_absolute => {
+                    let comp_str = component.as_str();
+                    result.push(comp_str);
+                }
+                camino::Utf8Component::CurDir => {} // Skip current directory components (.)
+                camino::Utf8Component::ParentDir => {
+                    // Handle parent directory (..)
+                    result.pop();
+                }
+                camino::Utf8Component::Normal(name) => {
+                    // Add normal components
+                    result.push(name);
+                }
+                _ => {}
+            }
+        }
+
+        result
+    }
+}
+
+/// Helper function to convert a standard Path to a Utf8Path
+pub fn to_utf8_path<P: AsRef<Path>>(path: P) -> Result<Utf8PathBuf, std::io::Error> {
+    match Utf8PathBuf::from_path_buf(path.as_ref().to_path_buf()) {
+        Ok(utf8_path) => Ok(utf8_path),
+        Err(non_utf8_path) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Path is not valid UTF-8: {:?}", non_utf8_path),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_already_absolute() {
+        #[cfg(windows)]
+        let abs_path = "C:\\path\\to\\file.txt";
+        #[cfg(unix)]
+        let abs_path = "/path/to/file.txt";
+
+        let result = resolve_to_absolute_utf8_path(abs_path).unwrap();
+        assert_eq!(result, abs_path);
+    }
+
+    #[test]
+    fn test_resolve_relative() {
+        // This test is harder to write in a platform-independent way
+        // since it depends on the current directory
+        let result = resolve_to_absolute_utf8_path("./test.txt").unwrap();
+        assert!(result.is_absolute());
+        assert!(result.ends_with("test.txt"));
+    }
+
+    #[test]
+    fn test_parent_navigation() {
+        let result = resolve_to_absolute_utf8_path("../parent_file.txt").unwrap();
+        assert!(result.is_absolute());
+        assert!(result.ends_with("parent_file.txt"));
+    }
+}

--- a/tests/RobotFramework/tests/tedge/certificate_signing_request.robot
+++ b/tests/RobotFramework/tests/tedge/certificate_signing_request.robot
@@ -105,6 +105,11 @@ Generate CSR using the CSR path from tedge config
     ...    openssl req -in /etc/tedge/device-certs/example_dev_test0001-test1.csr -pubkey -noout | openssl md5
     Should Be Equal    ${output_private_key_md5}    ${output_csr_md5}
 
+Generate CSR using a relative output path
+    [Setup]    Setup With Self-Signed Certificate
+    Execute Command
+    ...    sudo tedge cert create-csr c8y --device-id test-user --output-path ./local.csr && [ -f ./local.csr ]
+
 
 *** Keywords ***
 Setup With Self-Signed Certificate


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Allow users to provide a relative output path when using `tedge cert create-csr`.

**Example**

```
tedge cert create-csr c8y --device-id test-user --output-path ./local.csr
```

Note: In the future the code can be simplified once the MSRV can be increased beyond 1.78, however the current MSRV is required to support Yocto environments

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3547

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

