### PR TITLE
feat: PKCS#11 support for aws and azure

### DIFF
--- a/crates/common/tedge_config/src/tedge_toml/models/cryptoki.rs
+++ b/crates/common/tedge_config/src/tedge_toml/models/cryptoki.rs
@@ -10,6 +10,12 @@ pub enum Cryptoki {
     Module,
 }
 
+impl Cryptoki {
+    pub fn enabled(&self) -> bool {
+        *self != Self::Off
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 #[error("Failed to parse flag: {input}. Supported values are: off, module, socket")]
 pub struct InvalidCryptoki {

--- a/crates/core/tedge/src/bridge/aws.rs
+++ b/crates/core/tedge/src/bridge/aws.rs
@@ -112,7 +112,6 @@ impl From<BridgeConfigAwsParams> for BridgeConfig {
             auth_type: AuthType::Certificate,
             mosquitto_version: None,
             keepalive_interval,
-            use_cryptoki: false,
         }
     }
 }
@@ -170,7 +169,6 @@ fn test_bridge_config_from_aws_params() -> anyhow::Result<()> {
         auth_type: AuthType::Certificate,
         mosquitto_version: None,
         keepalive_interval: Duration::from_secs(60),
-        use_cryptoki: false,
     };
 
     assert_eq!(bridge, expected);
@@ -233,7 +231,6 @@ fn test_bridge_config_aws_custom_topic_prefix() -> anyhow::Result<()> {
         auth_type: AuthType::Certificate,
         mosquitto_version: None,
         keepalive_interval: Duration::from_secs(60),
-        use_cryptoki: false,
     };
 
     assert_eq!(bridge, expected);

--- a/crates/core/tedge/src/bridge/azure.rs
+++ b/crates/core/tedge/src/bridge/azure.rs
@@ -108,7 +108,6 @@ impl From<BridgeConfigAzureParams> for BridgeConfig {
             auth_type: AuthType::Certificate,
             mosquitto_version: None,
             keepalive_interval,
-            use_cryptoki: false,
         }
     }
 }
@@ -170,7 +169,6 @@ fn test_bridge_config_from_azure_params() -> anyhow::Result<()> {
         auth_type: AuthType::Certificate,
         mosquitto_version: None,
         keepalive_interval: Duration::from_secs(60),
-        use_cryptoki: false,
     };
 
     assert_eq!(bridge, expected);
@@ -236,7 +234,6 @@ fn test_azure_bridge_config_with_custom_prefix() -> anyhow::Result<()> {
         auth_type: AuthType::Certificate,
         mosquitto_version: None,
         keepalive_interval: Duration::from_secs(60),
-        use_cryptoki: false,
     };
 
     assert_eq!(bridge, expected);

--- a/crates/core/tedge/src/bridge/c8y.rs
+++ b/crates/core/tedge/src/bridge/c8y.rs
@@ -193,8 +193,6 @@ impl From<BridgeConfigC8yParams> for BridgeConfig {
             auth_type,
             mosquitto_version,
             keepalive_interval,
-            // this is orthogonal to
-            // use_cryptoki: false,
         }
     }
 }

--- a/crates/core/tedge/src/bridge/c8y.rs
+++ b/crates/core/tedge/src/bridge/c8y.rs
@@ -34,7 +34,6 @@ pub struct BridgeConfigC8yParams {
     pub profile_name: Option<ProfileName>,
     pub mqtt_schema: MqttSchema,
     pub keepalive_interval: Duration,
-    pub use_cryptoki: bool,
 }
 
 impl From<BridgeConfigC8yParams> for BridgeConfig {
@@ -56,7 +55,6 @@ impl From<BridgeConfigC8yParams> for BridgeConfig {
             profile_name,
             mqtt_schema,
             keepalive_interval,
-            use_cryptoki,
         } = params;
 
         let mut topics: Vec<String> = vec![
@@ -195,7 +193,8 @@ impl From<BridgeConfigC8yParams> for BridgeConfig {
             auth_type,
             mosquitto_version,
             keepalive_interval,
-            use_cryptoki,
+            // this is orthogonal to
+            // use_cryptoki: false,
         }
     }
 }
@@ -256,7 +255,6 @@ mod tests {
             profile_name: None,
             mqtt_schema: MqttSchema::with_root("te".into()),
             keepalive_interval: Duration::from_secs(60),
-            use_cryptoki: false,
         };
 
         let bridge = BridgeConfig::from(params);
@@ -328,7 +326,6 @@ mod tests {
             auth_type: AuthType::Certificate,
             mosquitto_version: None,
             keepalive_interval: Duration::from_secs(60),
-            use_cryptoki: false,
         };
 
         assert_eq!(bridge, expected);
@@ -355,7 +352,6 @@ mod tests {
             profile_name: Some("profile".parse().unwrap()),
             mqtt_schema: MqttSchema::with_root("te".into()),
             keepalive_interval: Duration::from_secs(60),
-            use_cryptoki: false,
         };
 
         let bridge = BridgeConfig::from(params);
@@ -434,7 +430,6 @@ mod tests {
             auth_type: AuthType::Basic,
             mosquitto_version: None,
             keepalive_interval: Duration::from_secs(60),
-            use_cryptoki: false,
         };
 
         assert_eq!(bridge, expected);

--- a/crates/core/tedge/src/bridge/config.rs
+++ b/crates/core/tedge/src/bridge/config.rs
@@ -42,7 +42,6 @@ pub struct BridgeConfig {
     pub auth_type: AuthType,
     pub mosquitto_version: Option<String>,
     pub keepalive_interval: Duration,
-    pub use_cryptoki: bool,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
@@ -206,7 +205,6 @@ mod test {
             auth_type: AuthType::Certificate,
             mosquitto_version: None,
             keepalive_interval: Duration::from_secs(60),
-            use_cryptoki: false,
         };
 
         let mut serialized_config = Vec::<u8>::new();
@@ -279,7 +277,6 @@ keepalive_interval 60
             auth_type: AuthType::Certificate,
             mosquitto_version: None,
             keepalive_interval: Duration::from_secs(60),
-            use_cryptoki: false,
         };
         let mut serialized_config = Vec::<u8>::new();
         bridge.serialize(&mut serialized_config).await?;
@@ -354,7 +351,6 @@ keepalive_interval 60
             auth_type: AuthType::Certificate,
             mosquitto_version: None,
             keepalive_interval: Duration::from_secs(60),
-            use_cryptoki: false,
         };
 
         let mut buffer = Vec::new();
@@ -429,7 +425,6 @@ keepalive_interval 60
             auth_type: AuthType::Basic,
             mosquitto_version: None,
             keepalive_interval: Duration::from_secs(60),
-            use_cryptoki: false,
         };
 
         let mut buffer = Vec::new();

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -383,7 +383,7 @@ impl ConnectCommand {
                 "Connection test failed, attempt {} of {}\n",
                 i, max_attempts,
             );
-            std::thread::sleep(std::time::Duration::from_secs(2));
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
         }
         self.check_connection().await
     }

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -38,7 +38,6 @@ use tedge_api::mqtt_topics::TopicIdError;
 use tedge_api::service_health_topic;
 use tedge_config;
 use tedge_config::models::auth_method::AuthType;
-use tedge_config::models::Cryptoki;
 use tedge_config::models::HostPort;
 use tedge_config::models::TopicPrefix;
 use tedge_config::tedge_toml::MultiError;
@@ -91,6 +90,7 @@ impl Command for ConnectCommand {
         let bridge_config = bridge_config(config, &self.cloud).map_err(anyhow::Error::new)?;
         let credentials_path =
             credentials_path_for(config, &self.cloud).map_err(anyhow::Error::new)?;
+        let use_cryptoki = config.device.cryptoki.mode.enabled();
 
         ConfigLogger::log(
             self.description(),
@@ -98,6 +98,7 @@ impl Command for ConnectCommand {
             &*self.service_manager,
             &self.cloud,
             credentials_path,
+            use_cryptoki,
         );
 
         validate_config(config, &self.cloud)?;
@@ -644,7 +645,6 @@ pub fn bridge_config(
                 profile_name: profile.clone().map(Cow::into_owned),
                 mqtt_schema,
                 keepalive_interval: c8y_config.bridge.keepalive_interval.duration(),
-                use_cryptoki: config.device.cryptoki.mode != Cryptoki::Off,
             };
 
             Ok(BridgeConfig::from(params))
@@ -773,12 +773,11 @@ pub async fn chown_certificate_and_key(bridge_config: &BridgeConfig) {
         warn!("Failed to change ownership of {path} to {user}:{group}: {err}");
     }
 
-    // if using cryptoki, no private key to chown
-    if bridge_config.use_cryptoki {
+    let path = &bridge_config.bridge_keyfile;
+    // if not using a private key (e.g. because we're signing with an HSM) don't chown it
+    if !path.exists() {
         return;
     }
-
-    let path = &bridge_config.bridge_keyfile;
     if let Err(err) =
         tedge_utils::file::change_user_and_group(path.into(), user.to_owned(), group.to_owned())
             .await

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -301,11 +301,11 @@ impl ConnectCommand {
         bridge_config: &BridgeConfig,
         certificate_shift: &CertificateShift,
     ) -> anyhow::Result<()> {
-        if bridge_config.cloud_name.eq("c8y") {
+        if let Cloud::C8y(profile_name) = &self.cloud {
             let use_basic_auth = false;
             let device_type = &self.config.device.ty;
-            let profile_name = self.cloud.profile_name().map(|p| p.as_ref());
-            let mut mqtt_auth_config = self.config.mqtt_auth_config_cloud_broker(profile_name)?;
+            let c8y_config = self.config.c8y.try_get(profile_name.as_deref())?;
+            let mut mqtt_auth_config = self.config.mqtt_auth_config_cloud_broker(c8y_config)?;
             if let Some(client_config) = mqtt_auth_config.client.as_mut() {
                 client_config.cert_file = certificate_shift.new_cert_path.to_owned()
             }
@@ -696,8 +696,8 @@ impl ConnectCommand {
             if self.offline_mode {
                 println!("Offline mode. Skipping device creation in Cumulocity cloud.")
             } else {
-                let profile_name = profile_name.as_deref().map(|p| p.as_ref());
-                let mqtt_auth_config = tedge_config.mqtt_auth_config_cloud_broker(profile_name)?;
+                let c8y_config = self.config.c8y.try_get(profile_name.as_deref())?;
+                let mqtt_auth_config = self.config.mqtt_auth_config_cloud_broker(c8y_config)?;
                 let spinner = Spinner::start("Creating device in Cumulocity cloud");
                 let res = create_device_with_direct_connection(
                     use_basic_auth,

--- a/crates/core/tedge/src/cli/log.rs
+++ b/crates/core/tedge/src/cli/log.rs
@@ -266,6 +266,7 @@ impl<'a> ConfigLogger<'a> {
         service_manager: &'a dyn SystemServiceManager,
         cloud: &'a MaybeBorrowedCloud<'a>,
         credentials_path: Option<&'a Utf8Path>,
+        use_cryptoki: bool,
     ) {
         println!(
             "{}",
@@ -280,7 +281,7 @@ impl<'a> ConfigLogger<'a> {
                 service_manager,
                 mosquitto_version: config.mosquitto_version.as_deref(),
                 cloud,
-                cryptoki: config.use_cryptoki
+                cryptoki: use_cryptoki
             }
         )
     }

--- a/crates/core/tedge_mapper/src/aws/mapper.rs
+++ b/crates/core/tedge_mapper/src/aws/mapper.rs
@@ -16,7 +16,7 @@ use tedge_config::models::TopicPrefix;
 use tedge_config::tedge_toml::ProfileName;
 use tedge_config::tedge_toml::TEdgeConfigReaderAws;
 use tedge_config::TEdgeConfig;
-use tedge_mqtt_bridge::use_key_and_cert;
+use tedge_mqtt_bridge::rumqttc::Transport;
 use tedge_mqtt_bridge::BridgeConfig;
 use tedge_mqtt_bridge::MqttBridgeActorBuilder;
 use tracing::warn;
@@ -52,7 +52,15 @@ impl TEdgeComponent for AwsMapper {
             );
             cloud_config.set_clean_session(false);
             cloud_config.set_keep_alive(aws_config.bridge.keepalive_interval.duration());
-            use_key_and_cert(&mut cloud_config, aws_config)?;
+
+            // set tls config
+            let cloud_broker_auth_config = tedge_config
+                .mqtt_auth_config_cloud_broker(aws_config)
+                .expect("error getting cloud broker auth config");
+            let client_config = cloud_broker_auth_config
+                .to_rustls_client_config()
+                .expect("error getting cloud broker auth config");
+            cloud_config.set_transport(Transport::tls_with_config(client_config.into()));
 
             let bridge_name = format!("tedge-mapper-bridge-{prefix}");
             let health_topic = service_health_topic(&mqtt_schema, &device_topic_id, &bridge_name);

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -153,13 +153,10 @@ impl TEdgeComponent for CumulocityMapper {
             cloud_config.set_clean_session(true);
 
             if use_certificate {
-                let cloud_broker_auth_config = tedge_config
-                    .mqtt_auth_config_cloud_broker(c8y_config)
-                    .expect("error getting cloud broker auth config");
-                let client_config = cloud_broker_auth_config
-                    .to_rustls_client_config()
-                    .expect("error getting cloud broker auth config");
-                cloud_config.set_transport(Transport::tls_with_config(client_config.into()));
+                let tls_config = tedge_config
+                    .mqtt_client_config_rustls(c8y_config)
+                    .context("Failed to create MQTT TLS config")?;
+                cloud_config.set_transport(Transport::tls_with_config(tls_config.into()));
             } else {
                 // TODO(marcel): integrate credentials auth into MqttAuthConfig?
                 let (username, password) = read_c8y_credentials(&c8y_config.credentials_path)?;

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -154,7 +154,7 @@ impl TEdgeComponent for CumulocityMapper {
 
             if use_certificate {
                 let cloud_broker_auth_config = tedge_config
-                    .mqtt_auth_config_cloud_broker(c8y_profile)
+                    .mqtt_auth_config_cloud_broker(c8y_config)
                     .expect("error getting cloud broker auth config");
                 let client_config = cloud_broker_auth_config
                     .to_rustls_client_config()

--- a/crates/extensions/tedge-p11-server/src/client.rs
+++ b/crates/extensions/tedge-p11-server/src/client.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::bail;
+use anyhow::Context;
 use tracing::debug;
 use tracing::trace;
 
@@ -21,7 +22,12 @@ impl TedgeP11Client {
         offered: &[rustls::SignatureScheme],
     ) -> anyhow::Result<Option<rustls::SignatureScheme>> {
         trace!("Connecting to socket...");
-        let stream = UnixStream::connect(&self.socket_path)?;
+        let stream = UnixStream::connect(&self.socket_path).with_context(|| {
+            format!(
+                "Failed to connect to tedge-p11-server UNIX socket at '{}'",
+                self.socket_path.display()
+            )
+        })?;
         let mut connection = crate::connection::Connection::new(stream);
 
         debug!("Connected to socket");
@@ -54,7 +60,12 @@ impl TedgeP11Client {
     // realistically it won't ever be called in our case
     pub fn algorithm(&self) -> anyhow::Result<rustls::SignatureAlgorithm> {
         trace!("Connecting to socket...");
-        let stream = UnixStream::connect(&self.socket_path)?;
+        let stream = UnixStream::connect(&self.socket_path).with_context(|| {
+            format!(
+                "Failed to connect to tedge-p11-server UNIX socket at '{}'",
+                self.socket_path.display()
+            )
+        })?;
         let mut connection = crate::connection::Connection::new(stream);
 
         debug!("Connected to socket");
@@ -75,7 +86,12 @@ impl TedgeP11Client {
     }
 
     pub fn sign(&self, message: &[u8]) -> anyhow::Result<Vec<u8>> {
-        let stream = UnixStream::connect(&self.socket_path)?;
+        let stream = UnixStream::connect(&self.socket_path).with_context(|| {
+            format!(
+                "Failed to connect to tedge-p11-server UNIX socket at '{}'",
+                self.socket_path.display()
+            )
+        })?;
         let mut connection = crate::connection::Connection::new(stream);
         debug!("Connected to socket");
 

--- a/tests/RobotFramework/requirements/requirements.txt
+++ b/tests/RobotFramework/requirements/requirements.txt
@@ -3,7 +3,7 @@ paho-mqtt~=1.6.1
 python-dotenv~=1.0.0
 robotframework~=7.0.0
 robotframework-c8y @ git+https://github.com/thin-edge/robotframework-c8y.git@0.41.0
-robotframework-aws @ git+https://github.com/thin-edge/robotframework-aws.git@0.0.9
+robotframework-aws @ git+https://github.com/thin-edge/robotframework-aws.git@0.0.10
 robotframework-debuglibrary~=2.5.0
 robotframework-jsonlibrary~=0.5
 robotframework-pabot~=2.18.0

--- a/tests/RobotFramework/tests/pkcs11/private_key_storage_aws.robot
+++ b/tests/RobotFramework/tests/pkcs11/private_key_storage_aws.robot
@@ -1,0 +1,56 @@
+*** Settings ***
+Documentation       Test thin-edge.io MQTT client authentication using a Hardware Security Module (HSM).
+...
+...                 To do this, we install SoftHSM2 which allows us to create software-backed PKCS#11 (cryptoki)
+...                 cryptographic tokens that will be read by thin-edge. In real production environments a dedicated
+...                 hardware device would be used.
+
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+Library             AWS
+
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           adapter:docker    theme:cryptoki    theme:aws    test:on_demand
+
+
+*** Test Cases ***
+Connect to AWS Using PKCS11 Private Key
+    Execute Command    sudo tedge reconnect aws    retries=0
+    ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-aws
+    ThinEdgeIO.Bridge Should Be Up    aws
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}=    Setup    skip_bootstrap=${True}
+    Set Suite Variable    $DEVICE_SN
+    Execute Command    test -f ./bootstrap.sh && ./bootstrap.sh --no-connect || true
+
+    # Allow the tedge user to access softhsm
+    Execute Command    sudo usermod -a -G softhsm tedge
+    Transfer To Device    ${CURDIR}/data/init_softhsm.sh    /usr/bin/
+    Remove Existing Certificates
+
+    # initialize the soft hsm and create a self-signed certificate
+    Configure tedge-p11-server    module_path=/usr/lib/softhsm/libsofthsm2.so    pin=123456
+    Execute Command    sudo -u tedge /usr/bin/init_softhsm.sh --self-signed --device-id "${DEVICE_SN}" --pin 123456
+
+    # configure tedge
+    ${aws_url}=    AWS.Get IoT URL
+    Execute Command    sudo tedge config set aws.url ${aws_url}
+    Execute Command    tedge config set mqtt.bridge.built_in true
+    Execute Command    tedge config set device.cryptoki.mode socket
+
+    # Upload the self-signed certificate
+    ${cert_contents}=    Execute Command    cat $(tedge config get device.cert_path)
+    ${aws}=    AWS.Create Thing With Self-Signed Certificate    name=${DEVICE_SN}    certificate_pem=${cert_contents}
+
+Configure tedge-p11-server
+    [Arguments]    ${module_path}    ${pin}
+    Execute Command
+    ...    cmd=printf 'TEDGE_DEVICE_CRYPTOKI_MODULE_PATH=%s\nTEDGE_DEVICE_CRYPTOKI_PIN=%s\n' "${module_path}" "${pin}" | sudo tee /etc/tedge/plugins/tedge-p11-server.conf
+
+Remove Existing Certificates
+    Execute Command    cmd=rm -f "$(tedge config get device.key_path)" "$(tedge config get device.cert_path)"


### PR DESCRIPTION
## Proposed changes

Add PKCS#11 support for AWS and Azure built-in bridges.

I have manually tested `tedge connect aws` and `tedge connect az` using a self-signed certificate created by `tedge cert create` which now creates a cert that uses the ECDSA P-256 with SHA256 sigscheme.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- #3543 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

