### PR TITLE
feat: allow tedge p11 server to be configured through tedge.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,6 +4483,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
+ "toml 0.8.8",
  "tracing",
  "tracing-subscriber",
 ]

--- a/configuration/contrib/tedge-p11-server/tedge-p11-server.conf
+++ b/configuration/contrib/tedge-p11-server/tedge-p11-server.conf
@@ -1,14 +1,2 @@
-TEDGE_DEVICE_CRYPTOKI_MODULE_PATH=
-TEDGE_DEVICE_CRYPTOKI_PIN=
-
-#
-# Examples
-#
-# Yubikiey / Nitrokey
-# You will need to change the exact path to the opensc-pkcs11 file depending on your devices CPU architecture
-#TEDGE_DEVICE_CRYPTOKI_MODULE_PATH=/usr/lib/aarch64-linux-gnu/opensc-pkcs11.so
-#TEDGE_DEVICE_CRYPTOKI_PIN=123456
-
 # TPM 2.0
-#TEDGE_DEVICE_CRYPTOKI_MODULE_PATH=/usr/lib/aarch64-linux-gnu/pkcs11/libtpm2_pkcs11.so
 #TPM2_PKCS11_STORE="/etc/tedge/tpm2"

--- a/configuration/init/systemd/tedge-p11-server.service
+++ b/configuration/init/systemd/tedge-p11-server.service
@@ -5,8 +5,9 @@ Requires=tedge-p11-server.socket
 [Service]
 Type=simple
 StandardError=journal
+; Read environment variables from file as some PKCS11 modules require additional environment variables to function
 EnvironmentFile=-/etc/tedge/plugins/tedge-p11-server.conf
-ExecStart=/usr/bin/tedge-p11-server --module-path "${TEDGE_DEVICE_CRYPTOKI_MODULE_PATH}" --pin "${TEDGE_DEVICE_CRYPTOKI_PIN}" --uri "${TEDGE_DEVICE_CRYPTOKI_URI}"
+ExecStart=/usr/bin/tedge-p11-server
 Restart=on-failure
 
 [Install]

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -150,6 +150,12 @@ define_tedge_config! {
             #[tedge_config(example = "123456", default(value = "123456"))]
             pin: Arc<str>,
 
+            /// A URI of the token/object to use.
+            ///
+            /// See RFC #7512.
+            #[tedge_config(example = "pkcs11:model=PKCS%2315%20emulated")]
+            uri: Arc<str>,
+
             /// A path to the tedge-p11-server socket.
             ///
             /// Needs to be set when `device.cryptoki.mode` is set to `module`

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config/mqtt_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config/mqtt_config.rs
@@ -224,8 +224,7 @@ impl TEdgeConfigReaderDeviceCryptoki {
                     .clone()
                     .into(),
                 pin: AuthPin::new(self.pin.to_string()),
-                serial: None,
-                uri: None,
+                uri: self.uri.clone().into(),
             }))),
             Cryptoki::Socket => Ok(Some(CryptokiConfig::SocketService {
                 socket_path: self.socket_path.clone(),

--- a/crates/extensions/tedge-p11-server/Cargo.toml
+++ b/crates/extensions/tedge-p11-server/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 [dependencies]
 anyhow.workspace = true
 asn1-rs.workspace = true
+camino.features = ["serde1"]
 camino.workspace = true
 clap.workspace = true
 cryptoki.workspace = true
@@ -27,7 +28,9 @@ tokio = { workspace = true, features = [
     "net",
     "signal",
     "time",
+    "fs",
 ] }
+toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -12,6 +12,7 @@
 //! provide its own bundled p11-kit-like service.
 
 use std::os::unix::net::UnixListener;
+use std::sync::Arc;
 
 use anyhow::Context;
 use camino::Utf8PathBuf;
@@ -164,8 +165,10 @@ async fn main() -> anyhow::Result<()> {
     let cryptoki_config = CryptokiConfigDirect {
         module_path: config.module_path,
         pin: AuthPin::new(config.pin),
-        serial: None,
-        uri: config.uri.filter(|s| !s.is_empty()),
+        uri: config.uri.filter(|s| !s.is_empty()).map(|s| {
+            let v = s.into_boxed_str();
+            Arc::<str>::from(v)
+        }),
     };
     let socket_path = config.socket_path;
 

--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -62,6 +62,7 @@ pub struct Args {
     /// [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
     #[arg(
         long,
+        env = "TEDGE_CONFIG_DIR",
         default_value = "/etc/tedge/",
         hide_env_values = true,
         hide_default_value = true,

--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -35,21 +35,29 @@ use tedge_p11_server::TedgeP11Server;
 #[command(version)]
 pub struct Args {
     /// A path where the UNIX socket listener will be created.
-    #[arg(long, env = "TEDGE_DEVICE_CRYPTOKI_SOCKET_PATH")]
+    #[arg(
+        long,
+        env = "TEDGE_DEVICE_CRYPTOKI_SOCKET_PATH",
+        hide_env_values = true
+    )]
     socket_path: Option<Utf8PathBuf>,
 
     /// The path to the PKCS#11 module.
-    #[arg(long, env = "TEDGE_DEVICE_CRYPTOKI_MODULE_PATH")]
+    #[arg(
+        long,
+        env = "TEDGE_DEVICE_CRYPTOKI_MODULE_PATH",
+        hide_env_values = true
+    )]
     module_path: Option<Utf8PathBuf>,
 
     /// The PIN for the PKCS#11 token.
-    #[arg(long, env = "TEDGE_DEVICE_CRYPTOKI_PIN")]
+    #[arg(long, env = "TEDGE_DEVICE_CRYPTOKI_PIN", hide_env_values = true)]
     pin: Option<String>,
 
     /// A URI of the token/object to use.
     ///
     /// See RFC #7512.
-    #[arg(long, env = "TEDGE_DEVICE_CRYPTOKI_URI")]
+    #[arg(long, env = "TEDGE_DEVICE_CRYPTOKI_URI", hide_env_values = true)]
     uri: Option<String>,
 
     /// Configures the logging level.

--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -71,7 +71,7 @@ pub struct Args {
     #[arg(
         long,
         env = "TEDGE_CONFIG_DIR",
-        default_value = "/etc/tedge/",
+        default_value = "/etc/tedge",
         hide_env_values = true,
         hide_default_value = true,
         hide_env = true,

--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -74,6 +74,7 @@ pub struct Args {
         default_value = "/etc/tedge/",
         hide_env_values = true,
         hide_default_value = true,
+        hide_env = true,
         global = true
     )]
     config_dir: Utf8PathBuf,

--- a/crates/extensions/tedge-p11-server/src/pkcs11.rs
+++ b/crates/extensions/tedge-p11-server/src/pkcs11.rs
@@ -35,7 +35,7 @@ pub struct CryptokiConfigDirect {
     pub module_path: Utf8PathBuf,
     pub pin: AuthPin,
     pub serial: Option<Arc<str>>,
-    pub uri: Option<Arc<str>>,
+    pub uri: Option<String>,
 }
 
 impl Debug for CryptokiConfigDirect {

--- a/crates/extensions/tedge-p11-server/src/pkcs11.rs
+++ b/crates/extensions/tedge-p11-server/src/pkcs11.rs
@@ -34,8 +34,7 @@ use std::sync::Mutex;
 pub struct CryptokiConfigDirect {
     pub module_path: Utf8PathBuf,
     pub pin: AuthPin,
-    pub serial: Option<Arc<str>>,
-    pub uri: Option<String>,
+    pub uri: Option<Arc<str>>,
 }
 
 impl Debug for CryptokiConfigDirect {
@@ -43,7 +42,7 @@ impl Debug for CryptokiConfigDirect {
         f.debug_struct("CryptokiConfigDirect")
             .field("module_path", &self.module_path)
             .field("pin", &"[REDACTED]")
-            .field("serial", &self.serial)
+            .field("uri", &self.uri)
             .finish()
     }
 }

--- a/tests/RobotFramework/tests/pkcs11/private_key_storage_aws.robot
+++ b/tests/RobotFramework/tests/pkcs11/private_key_storage_aws.robot
@@ -34,7 +34,8 @@ Custom Setup
     Remove Existing Certificates
 
     # initialize the soft hsm and create a self-signed certificate
-    Configure tedge-p11-server    module_path=/usr/lib/softhsm/libsofthsm2.so    pin=123456
+    Execute Command    tedge config set device.cryptoki.pin 123456
+    Execute Command    tedge config set device.cryptoki.module_path /usr/lib/softhsm/libsofthsm2.so
     Execute Command    sudo -u tedge /usr/bin/init_softhsm.sh --self-signed --device-id "${DEVICE_SN}" --pin 123456
 
     # configure tedge
@@ -46,11 +47,6 @@ Custom Setup
     # Upload the self-signed certificate
     ${cert_contents}=    Execute Command    cat $(tedge config get device.cert_path)
     ${aws}=    AWS.Create Thing With Self-Signed Certificate    name=${DEVICE_SN}    certificate_pem=${cert_contents}
-
-Configure tedge-p11-server
-    [Arguments]    ${module_path}    ${pin}
-    Execute Command
-    ...    cmd=printf 'TEDGE_DEVICE_CRYPTOKI_MODULE_PATH=%s\nTEDGE_DEVICE_CRYPTOKI_PIN=%s\n' "${module_path}" "${pin}" | sudo tee /etc/tedge/plugins/tedge-p11-server.conf
 
 Remove Existing Certificates
     Execute Command    cmd=rm -f "$(tedge config get device.key_path)" "$(tedge config get device.cert_path)"


### PR DESCRIPTION
## Proposed changes
Read tedge.toml in `tedge-p11-server` to avoid people having to supply the information via command-line arguments. This avoids using `tedge_config` to avoid unnecessary dependencies for `tedge-p11-server`.

During the refactoring the following additional changes were done (which are still configuration file related)

* [x] Allow uri to be configured via `tedge config set`
* [x] Remove unused pkcs11 serial value

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #3539 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

