### PR TITLE
fix: create tedge-p11-server socket parent directory if it does not exist

### DIFF
--- a/crates/extensions/tedge-p11-server/Cargo.toml
+++ b/crates/extensions/tedge-p11-server/Cargo.toml
@@ -21,6 +21,7 @@ rustls.workspace = true
 sd-listen-fds.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = [
+    "fs",
     "rt",
     "macros",
     "net",

--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -99,6 +99,16 @@ async fn main() -> anyhow::Result<()> {
             (listener, None)
         } else {
             debug!("No sockets from systemd, creating a standalone socket");
+            let socket_dir = socket_path.parent();
+            if let Some(socket_dir) = socket_dir {
+                if !socket_dir.exists() {
+                    tokio::fs::create_dir_all(socket_dir)
+                        .await
+                        .context(format!(
+                            "error creating parent directories for {socket_dir:?}"
+                        ))?;
+                }
+            }
             let listener = UnixListener::bind(&socket_path)
                 .with_context(|| format!("Failed to bind to socket at '{socket_path}'"))?;
             (


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

When tedge-p11-server is creating the socket itself (e.g. not using the systemd socket binding), then it should also create the required parent directories if they do not already exist.

Now the following `--socket-path` does not have to exist prior to starting the tedge-p11-server:

```
tedge-p11-server \
  --pin 123456 \
  --module-path /opt/homebrew/lib/libykcs11.dylib \
  --socket-path /tmp/tedge-p11-server/example.sock
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

