### PR TITLE
fix: flush stdout before exiting tedge http command

### DIFF
--- a/crates/core/tedge/src/cli/http/command.rs
+++ b/crates/core/tedge/src/cli/http/command.rs
@@ -97,6 +97,7 @@ impl HttpCommand {
             while let Some(bytes) = body.next().await {
                 stdout.write_all(&bytes?).await?;
             }
+            stdout.flush().await?;
             Ok(())
         } else {
             let kind = if status.is_client_error() {

--- a/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
+++ b/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
@@ -1101,11 +1101,7 @@ class ThinEdgeIO(DeviceLibrary):
         }
         json_payload = json.dumps(payload)
         
-        command = (
-            "curl -X POST http://localhost:8000/te/v1/entities "
-            "-H 'Content-Type: application/json' "
-            f"-d '{json_payload}'"
-        )
+        command = f"tedge http post /te/v1/entities --data '{json_payload}'"
         output = device.execute_command(command)
         json_output = json.loads(output.stdout)
         return json_output
@@ -1141,7 +1137,7 @@ class ThinEdgeIO(DeviceLibrary):
             )
         
         command = (
-            f"curl -X DELETE http://localhost:8000/te/v1/entities/{topic_id}"
+            f"tedge http delete /te/v1/entities/{topic_id}"
         )
         output = device.execute_command(command)
         json_output = json.loads(output.stdout)
@@ -1186,7 +1182,7 @@ class ThinEdgeIO(DeviceLibrary):
                 f"Unable to query the entity store as the device: '{device_name}' has not been setup"
             )
 
-        url = "http://localhost:8000/te/v1/entities"
+        url = "/te/v1/entities"
         params = {}
         if root:
             params["root"] = root
@@ -1199,7 +1195,7 @@ class ThinEdgeIO(DeviceLibrary):
             query_string = "&".join(f"{key}={value}" for key, value in params.items())
             url += f"?{query_string}"
 
-        output = device.execute_command(f"curl -f '{url}'")
+        output = device.execute_command(f"tedge http get '{url}'")
         entities = json.loads(output.stdout)
         return entities
 

--- a/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
+++ b/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
@@ -1103,7 +1103,7 @@ class ThinEdgeIO(DeviceLibrary):
         
         command = f"tedge http post /te/v1/entities --data '{json_payload}'"
         output = device.execute_command(command)
-        json_output = json.loads(output.stdout)
+        json_output = json.loads(output.stdout) if output.stdout else ""
         return json_output
 
     @keyword("Deregister Entity")
@@ -1140,7 +1140,7 @@ class ThinEdgeIO(DeviceLibrary):
             f"tedge http delete /te/v1/entities/{topic_id}"
         )
         output = device.execute_command(command)
-        json_output = json.loads(output.stdout)
+        json_output = json.loads(output.stdout) if output.stdout else ""
         return json_output
 
     @keyword("List Entities")
@@ -1196,7 +1196,7 @@ class ThinEdgeIO(DeviceLibrary):
             url += f"?{query_string}"
 
         output = device.execute_command(f"tedge http get '{url}'")
-        entities = json.loads(output.stdout)
+        entities = json.loads(output.stdout) if output.stdout else ""
         return entities
 
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix a bug where the `tedge http` command would not flush the stdout before exiting which would result empty stdout.

This behaviour caused some system tests to fail as a result, most notably https://github.com/thin-edge/thin-edge.io/issues/3559.

With this change linked flaky test ticket now passes 100% of the time (from a 100 run sample).

```
$ invoke flake-finder --test-name "Updating entities from a child device" --iterations 100 --clean
Overall: PASSED
Results: 100 iterations, 100 passed, 0 failed
Elapsed time: 0:16:13.157208
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3559

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

