### PR TITLE
Configure supported cloud backends at compile time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ mqtt_tests = { path = "crates/tests/mqtt_tests" }
 plugin_sm = { path = "crates/core/plugin_sm" }
 tedge-agent = { path = "crates/core/tedge_agent" }
 tedge-apt-plugin = { path = "plugins/tedge_apt_plugin" }
-tedge-mapper = { path = "crates/core/tedge_mapper" }
+tedge-mapper = { path = "crates/core/tedge_mapper", default-features = false }
 tedge-p11-server = { path = "crates/extensions/tedge-p11-server" }
 tedge-watchdog = { path = "crates/core/tedge_watchdog" }
 tedge-write = { path = "crates/core/tedge_write" }

--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -77,8 +77,9 @@ x509-parser = { workspace = true }
 
 
 [features]
-default = ["aws"]
+default = ["aws", "azure"]
 aws = ["tedge-mapper/aws"]
+azure = ["tedge-mapper/azure"]
 integration-test = []
 
 [lints]

--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -77,9 +77,10 @@ x509-parser = { workspace = true }
 
 
 [features]
-default = ["aws", "azure"]
+default = ["aws", "azure", "c8y"]
 aws = ["tedge-mapper/aws"]
 azure = ["tedge-mapper/azure"]
+c8y = ["tedge-mapper/c8y"]
 integration-test = []
 
 [lints]

--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -47,7 +47,7 @@ serde_json = { workspace = true }
 strum_macros = { workspace = true }
 tedge-agent = { workspace = true }
 tedge-apt-plugin = { workspace = true }
-tedge-mapper = { workspace = true }
+tedge-mapper = { workspace = true, default-features = false }
 tedge-watchdog = { workspace = true }
 tedge-write = { workspace = true }
 tedge_api = { workspace = true }
@@ -77,6 +77,8 @@ x509-parser = { workspace = true }
 
 
 [features]
+default = ["aws"]
+aws = ["tedge-mapper/aws"]
 integration-test = []
 
 [lints]

--- a/crates/core/tedge/src/bridge/mod.rs
+++ b/crates/core/tedge/src/bridge/mod.rs
@@ -3,6 +3,7 @@
 mod common_mosquitto_config;
 mod config;
 
+#[cfg(feature = "aws")]
 pub mod aws;
 pub mod azure;
 pub mod c8y;

--- a/crates/core/tedge/src/bridge/mod.rs
+++ b/crates/core/tedge/src/bridge/mod.rs
@@ -5,6 +5,7 @@ mod config;
 
 #[cfg(feature = "aws")]
 pub mod aws;
+#[cfg(feature = "azure")]
 pub mod azure;
 pub mod c8y;
 

--- a/crates/core/tedge/src/bridge/mod.rs
+++ b/crates/core/tedge/src/bridge/mod.rs
@@ -7,6 +7,7 @@ mod config;
 pub mod aws;
 #[cfg(feature = "azure")]
 pub mod azure;
+#[cfg(feature = "c8y")]
 pub mod c8y;
 
 pub use common_mosquitto_config::*;

--- a/crates/core/tedge/src/cli/certificate/cli.rs
+++ b/crates/core/tedge/src/cli/certificate/cli.rs
@@ -337,6 +337,7 @@ impl BuildCommand for TEdgeCertCli {
                     };
                     let c8y = match cloud {
                         None => C8yEndPoint::local_proxy(&config, None)?,
+                        #[cfg(feature = "c8y")]
                         Some(Cloud::C8y(profile)) => C8yEndPoint::local_proxy(
                             &config,
                             profile.as_deref().map(|p| p.as_ref()),

--- a/crates/core/tedge/src/cli/certificate/cli.rs
+++ b/crates/core/tedge/src/cli/certificate/cli.rs
@@ -341,6 +341,7 @@ impl BuildCommand for TEdgeCertCli {
                             &config,
                             profile.as_deref().map(|p| p.as_ref()),
                         )?,
+                        #[cfg(any(feature = "aws", feature = "azure"))]
                         Some(cloud) => {
                             return Err(
                                 anyhow!("Certificate renewal is not supported for {cloud}").into()

--- a/crates/core/tedge/src/cli/common.rs
+++ b/crates/core/tedge/src/cli/common.rs
@@ -161,7 +161,9 @@ impl MaybeBorrowedCloud<'_> {
 
     pub fn profile_name(&self) -> Option<&ProfileName> {
         match self {
-            Self::Aws(profile) | Self::Azure(profile) | Self::C8y(profile) => profile.as_deref(),
+            Self::C8y(profile) => profile.as_deref(),
+            Self::Aws(profile) => profile.as_deref(),
+            Self::Azure(profile) => profile.as_deref(),
         }
     }
 }

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "aws")]
 use crate::bridge::aws::BridgeConfigAwsParams;
 use crate::bridge::azure::BridgeConfigAzureParams;
 use crate::bridge::c8y::BridgeConfigC8yParams;
@@ -7,6 +8,7 @@ use crate::bridge::CommonMosquittoConfig;
 use crate::bridge::TEDGE_BRIDGE_CONF_DIR_PATH;
 use crate::cli::common::Cloud;
 use crate::cli::common::MaybeBorrowedCloud;
+#[cfg(feature = "aws")]
 use crate::cli::connect::aws::check_device_status_aws;
 use crate::cli::connect::azure::check_device_status_azure;
 use crate::cli::connect::c8y::*;
@@ -221,6 +223,7 @@ impl ConnectCommand {
                 }
                 enable_software_management(&bridge_config, &*self.service_manager).await;
             }
+            #[cfg(feature = "aws")]
             Cloud::Aws(_) => (),
             Cloud::Azure(_) => (),
         }
@@ -324,6 +327,7 @@ impl ConnectCommand {
                 )
                 .await
             }
+            #[cfg(feature = "aws")]
             Cloud::Aws(_) => Ok(()),
             Cloud::Azure(_) => Ok(()),
         }
@@ -339,6 +343,7 @@ fn credentials_path_for<'a>(
             let c8y_config = config.c8y.try_get(profile.as_deref())?;
             Ok(Some(&c8y_config.credentials_path))
         }
+        #[cfg(feature = "aws")]
         Cloud::Aws(_) => Ok(None),
         Cloud::Azure(_) => Ok(None),
     }
@@ -375,6 +380,7 @@ impl ConnectCommand {
                     Ok(None)
                 }
             }
+            #[cfg(feature = "aws")]
             Cloud::Aws(_) => Ok(None),
             Cloud::Azure(_) => Ok(None),
         }
@@ -403,6 +409,7 @@ impl ConnectCommand {
         let spinner = Spinner::start("Verifying device is connected to cloud");
         let res = match &self.cloud {
             Cloud::Azure(profile) => check_device_status_azure(config, profile.as_deref()).await,
+            #[cfg(feature = "aws")]
             Cloud::Aws(profile) => check_device_status_aws(config, profile.as_deref()).await,
             Cloud::C8y(profile) => check_device_status_c8y(config, profile.as_deref()).await,
         };
@@ -433,6 +440,7 @@ impl ConnectCommand {
 
 fn validate_config(config: &TEdgeConfig, cloud: &MaybeBorrowedCloud<'_>) -> anyhow::Result<()> {
     match cloud {
+        #[cfg(feature = "aws")]
         MaybeBorrowedCloud::Aws(_) => {
             let profiles = config
                 .aws
@@ -602,6 +610,7 @@ pub fn bridge_config(
 
             Ok(BridgeConfig::from(params))
         }
+        #[cfg(feature = "aws")]
         MaybeBorrowedCloud::Aws(profile) => {
             let aws_config = config.aws.try_get(profile.as_deref())?;
 
@@ -718,6 +727,7 @@ impl ConnectCommand {
                     spinner.finish(res)?;
                 }
             }
+            #[cfg(feature = "aws")]
             Cloud::Aws(_) => (),
             Cloud::Azure(_) => (),
         }

--- a/crates/core/tedge/src/cli/connect/mod.rs
+++ b/crates/core/tedge/src/cli/connect/mod.rs
@@ -6,6 +6,7 @@ pub use self::error::*;
 mod aws;
 #[cfg(feature = "azure")]
 mod azure;
+#[cfg(feature = "c8y")]
 mod c8y;
 mod cli;
 mod command;

--- a/crates/core/tedge/src/cli/connect/mod.rs
+++ b/crates/core/tedge/src/cli/connect/mod.rs
@@ -4,6 +4,7 @@ pub use self::error::*;
 
 #[cfg(feature = "aws")]
 mod aws;
+#[cfg(feature = "azure")]
 mod azure;
 mod c8y;
 mod cli;

--- a/crates/core/tedge/src/cli/connect/mod.rs
+++ b/crates/core/tedge/src/cli/connect/mod.rs
@@ -2,6 +2,7 @@ pub use self::cli::*;
 pub use self::command::*;
 pub use self::error::*;
 
+#[cfg(feature = "aws")]
 mod aws;
 mod azure;
 mod c8y;

--- a/crates/core/tedge/src/cli/refresh_bridges.rs
+++ b/crates/core/tedge/src/cli/refresh_bridges.rs
@@ -109,6 +109,7 @@ fn possible_clouds(config: &TEdgeConfig) -> impl Iterator<Item = CloudBorrow<'_>
     let iter = ::std::iter::empty();
     let iter = iter.chain(config.c8y.keys().map(CloudBorrow::c8y_borrowed));
     let iter = iter.chain(config.az.keys().map(CloudBorrow::az_borrowed));
+    #[cfg(feature = "aws")]
     let iter = iter.chain(config.aws.keys().map(CloudBorrow::aws_borrowed));
 
     iter

--- a/crates/core/tedge/src/cli/refresh_bridges.rs
+++ b/crates/core/tedge/src/cli/refresh_bridges.rs
@@ -107,6 +107,7 @@ async fn established_bridges<'a>(
 
 fn possible_clouds(config: &TEdgeConfig) -> impl Iterator<Item = CloudBorrow<'_>> {
     let iter = ::std::iter::empty();
+    #[cfg(feature = "c8y")]
     let iter = iter.chain(config.c8y.keys().map(CloudBorrow::c8y_borrowed));
     #[cfg(feature = "azure")]
     let iter = iter.chain(config.az.keys().map(CloudBorrow::az_borrowed));

--- a/crates/core/tedge/src/cli/refresh_bridges.rs
+++ b/crates/core/tedge/src/cli/refresh_bridges.rs
@@ -106,12 +106,12 @@ async fn established_bridges<'a>(
 }
 
 fn possible_clouds(config: &TEdgeConfig) -> impl Iterator<Item = CloudBorrow<'_>> {
-    config
-        .c8y
-        .keys()
-        .map(CloudBorrow::c8y_borrowed)
-        .chain(config.az.keys().map(CloudBorrow::az_borrowed))
-        .chain(config.aws.keys().map(CloudBorrow::aws_borrowed))
+    let iter = ::std::iter::empty();
+    let iter = iter.chain(config.c8y.keys().map(CloudBorrow::c8y_borrowed));
+    let iter = iter.chain(config.az.keys().map(CloudBorrow::az_borrowed));
+    let iter = iter.chain(config.aws.keys().map(CloudBorrow::aws_borrowed));
+
+    iter
 }
 
 pub async fn refresh_bridge(

--- a/crates/core/tedge/src/cli/refresh_bridges.rs
+++ b/crates/core/tedge/src/cli/refresh_bridges.rs
@@ -108,6 +108,7 @@ async fn established_bridges<'a>(
 fn possible_clouds(config: &TEdgeConfig) -> impl Iterator<Item = CloudBorrow<'_>> {
     let iter = ::std::iter::empty();
     let iter = iter.chain(config.c8y.keys().map(CloudBorrow::c8y_borrowed));
+    #[cfg(feature = "azure")]
     let iter = iter.chain(config.az.keys().map(CloudBorrow::az_borrowed));
     #[cfg(feature = "aws")]
     let iter = iter.chain(config.aws.keys().map(CloudBorrow::aws_borrowed));

--- a/crates/core/tedge/src/lib.rs
+++ b/crates/core/tedge/src/lib.rs
@@ -8,3 +8,6 @@ mod system_services;
 pub type ConfigError = crate::error::TEdgeError;
 const BROKER_USER: &str = "mosquitto";
 const BROKER_GROUP: &str = "mosquitto";
+
+#[cfg(not(any(feature = "aws", feature = "azure", feature = "c8y")))]
+compile_error!("Either feature \"aws\", \"azure\", or \"c8y\" must be enabled.");

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -15,9 +15,9 @@ async-trait = { workspace = true }
 aws_mapper_ext = { workspace = true, optional = true }
 az_mapper_ext = { workspace = true, optional = true }
 batcher = { workspace = true }
-c8y_api = { workspace = true }
-c8y_auth_proxy = { workspace = true }
-c8y_mapper_ext = { workspace = true }
+c8y_api = { workspace = true, optional = true }
+c8y_auth_proxy = { workspace = true, optional = true }
+c8y_mapper_ext = { workspace = true, optional = true }
 clap = { workspace = true }
 clock = { workspace = true }
 collectd_ext = { workspace = true }
@@ -38,9 +38,10 @@ tedge_uploader_ext = { workspace = true }
 tracing = { workspace = true }
 
 [features]
-default = ["aws", "azure"]
+default = ["aws", "azure", "c8y"]
 aws = ["dep:aws_mapper_ext"]
 azure = ["dep:az_mapper_ext"]
+c8y = ["dep:c8y_mapper_ext", "dep:c8y_api", "dep:c8y_auth_proxy"]
 integration-test = []
 
 [lints]

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -13,7 +13,7 @@ repository = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 aws_mapper_ext = { workspace = true, optional = true }
-az_mapper_ext = { workspace = true }
+az_mapper_ext = { workspace = true, optional = true }
 batcher = { workspace = true }
 c8y_api = { workspace = true }
 c8y_auth_proxy = { workspace = true }
@@ -38,8 +38,9 @@ tedge_uploader_ext = { workspace = true }
 tracing = { workspace = true }
 
 [features]
-default = ["aws"]
+default = ["aws", "azure"]
 aws = ["dep:aws_mapper_ext"]
+azure = ["dep:az_mapper_ext"]
 integration-test = []
 
 [lints]

--- a/crates/core/tedge_mapper/Cargo.toml
+++ b/crates/core/tedge_mapper/Cargo.toml
@@ -12,7 +12,7 @@ repository = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-aws_mapper_ext = { workspace = true }
+aws_mapper_ext = { workspace = true, optional = true }
 az_mapper_ext = { workspace = true }
 batcher = { workspace = true }
 c8y_api = { workspace = true }
@@ -38,6 +38,8 @@ tedge_uploader_ext = { workspace = true }
 tracing = { workspace = true }
 
 [features]
+default = ["aws"]
+aws = ["dep:aws_mapper_ext"]
 integration-test = []
 
 [lints]

--- a/crates/core/tedge_mapper/src/lib.rs
+++ b/crates/core/tedge_mapper/src/lib.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 #[cfg(feature = "aws")]
 use crate::aws::mapper::AwsMapper;
+#[cfg(feature = "azure")]
 use crate::az::mapper::AzureMapper;
 use crate::c8y::mapper::CumulocityMapper;
 use crate::collectd::mapper::CollectdMapper;
@@ -16,6 +17,7 @@ use tracing::log::warn;
 
 #[cfg(feature = "aws")]
 mod aws;
+#[cfg(feature = "azure")]
 mod az;
 mod c8y;
 mod collectd;
@@ -42,6 +44,7 @@ macro_rules! read_and_set_var {
 
 fn lookup_component(component_name: MapperName) -> Box<dyn TEdgeComponent> {
     match component_name {
+        #[cfg(feature = "azure")]
         MapperName::Az { profile } => Box::new(AzureMapper {
             profile: read_and_set_var!(profile, "TEDGE_CLOUD_PROFILE"),
         }),
@@ -83,6 +86,7 @@ pub struct MapperOpt {
 #[derive(Debug, clap::Subcommand, Clone)]
 #[clap(rename_all = "snake_case")]
 pub enum MapperName {
+    #[cfg(feature = "azure")]
     Az {
         /// The cloud profile to use
         #[clap(long)]
@@ -105,7 +109,9 @@ pub enum MapperName {
 impl fmt::Display for MapperName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            #[cfg(feature = "azure")]
             MapperName::Az { profile: None } => write!(f, "tedge-mapper-az"),
+            #[cfg(feature = "azure")]
             MapperName::Az {
                 profile: Some(profile),
             } => write!(f, "tedge-mapper-az@{profile}"),

--- a/crates/core/tedge_mapper/src/lib.rs
+++ b/crates/core/tedge_mapper/src/lib.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+#[cfg(feature = "aws")]
 use crate::aws::mapper::AwsMapper;
 use crate::az::mapper::AzureMapper;
 use crate::c8y::mapper::CumulocityMapper;
@@ -13,6 +14,7 @@ use tedge_config::log_init;
 use tedge_config::tedge_toml::ProfileName;
 use tracing::log::warn;
 
+#[cfg(feature = "aws")]
 mod aws;
 mod az;
 mod c8y;
@@ -43,6 +45,7 @@ fn lookup_component(component_name: MapperName) -> Box<dyn TEdgeComponent> {
         MapperName::Az { profile } => Box::new(AzureMapper {
             profile: read_and_set_var!(profile, "TEDGE_CLOUD_PROFILE"),
         }),
+        #[cfg(feature = "aws")]
         MapperName::Aws { profile } => Box::new(AwsMapper {
             profile: read_and_set_var!(profile, "TEDGE_CLOUD_PROFILE"),
         }),
@@ -85,6 +88,7 @@ pub enum MapperName {
         #[clap(long)]
         profile: Option<ProfileName>,
     },
+    #[cfg(feature = "aws")]
     Aws {
         /// The cloud profile to use
         #[clap(long)]
@@ -105,7 +109,9 @@ impl fmt::Display for MapperName {
             MapperName::Az {
                 profile: Some(profile),
             } => write!(f, "tedge-mapper-az@{profile}"),
+            #[cfg(feature = "aws")]
             MapperName::Aws { profile: None } => write!(f, "tedge-mapper-aws"),
+            #[cfg(feature = "aws")]
             MapperName::Aws {
                 profile: Some(profile),
             } => write!(f, "tedge-mapper-aws@{profile}"),

--- a/crates/core/tedge_mapper/src/lib.rs
+++ b/crates/core/tedge_mapper/src/lib.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use crate::aws::mapper::AwsMapper;
 #[cfg(feature = "azure")]
 use crate::az::mapper::AzureMapper;
+#[cfg(feature = "c8y")]
 use crate::c8y::mapper::CumulocityMapper;
 use crate::collectd::mapper::CollectdMapper;
 use crate::core::component::TEdgeComponent;
@@ -19,6 +20,7 @@ use tracing::log::warn;
 mod aws;
 #[cfg(feature = "azure")]
 mod az;
+#[cfg(feature = "c8y")]
 mod c8y;
 mod collectd;
 mod core;
@@ -53,6 +55,7 @@ fn lookup_component(component_name: MapperName) -> Box<dyn TEdgeComponent> {
             profile: read_and_set_var!(profile, "TEDGE_CLOUD_PROFILE"),
         }),
         MapperName::Collectd => Box::new(CollectdMapper),
+        #[cfg(feature = "c8y")]
         MapperName::C8y { profile } => Box::new(CumulocityMapper {
             profile: read_and_set_var!(profile, "TEDGE_CLOUD_PROFILE"),
         }),
@@ -98,6 +101,7 @@ pub enum MapperName {
         #[clap(long)]
         profile: Option<ProfileName>,
     },
+    #[cfg(feature = "c8y")]
     C8y {
         /// The cloud profile to use
         #[clap(long)]
@@ -121,7 +125,9 @@ impl fmt::Display for MapperName {
             MapperName::Aws {
                 profile: Some(profile),
             } => write!(f, "tedge-mapper-aws@{profile}"),
+            #[cfg(feature = "c8y")]
             MapperName::C8y { profile: None } => write!(f, "tedge-mapper-c8y"),
+            #[cfg(feature = "c8y")]
             MapperName::C8y {
                 profile: Some(profile),
             } => write!(f, "tedge-mapper-c8y@{profile}"),


### PR DESCRIPTION
## Proposed changes

Use Cargo features to configure the supported cloud backends in the thin-edge mapper and the supported bridges.

An integrator who wants to use thin-edge in a product can use the features to explicitly disable supported cloud backends at compile time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3584

<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)