### PR TITLE
fix: tedge-p11-server fails when configuration is missing

### DIFF
--- a/configuration/init/systemd/tedge-p11-server.service
+++ b/configuration/init/systemd/tedge-p11-server.service
@@ -7,7 +7,7 @@ Type=simple
 StandardError=journal
 ; Read environment variables from file as some PKCS11 modules require additional environment variables to function
 EnvironmentFile=-/etc/tedge/plugins/tedge-p11-server.conf
-ExecStart=/usr/bin/tedge-p11-server
+ExecStart=/usr/bin/tedge-p11-server --socket-path "%t/tedge-p11-server/tedge-p11-server.sock"
 Restart=on-failure
 
 [Install]

--- a/tests/RobotFramework/tests/pkcs11/private_key_storage.robot
+++ b/tests/RobotFramework/tests/pkcs11/private_key_storage.robot
@@ -52,6 +52,71 @@ Select Private key using PKCS#11 URI
     Set tedge-p11-server Uri    value=pkcs11:token=tedge;object=tedge
     Tedge Reconnect Should Succeed
 
+Ignore tedge.toml if missing
+    Execute Command    rm -f ./tedge.toml
+    ${stderr}=    Execute Command    tedge-p11-server --config-dir . --module-path xx.so    exp_exit_code=!0
+    # Don't log anything (this is normal behaviour as the user does not have to create a tedge.toml file)
+    Should Not Contain    ${stderr}    Failed to read ./tedge.toml: No such file
+    # And proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+    # Using default values
+    Should Contain    ${stderr}    tedge-p11-server.sock
+
+Ignore tedge.toml if empty
+    Execute Command    touch ./tedge.toml
+    ${stderr}=    Execute Command    tedge-p11-server --config-dir . --module-path xx.so    exp_exit_code=!0
+    # Don't log anything (this is normal behaviour, where the file is used for tedge and not tedge-p11-server)
+    Should Not Contain    ${stderr}    Failed to parse ./tedge.toml: invalid TOML
+    # And proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+    # Using default values
+    Should Contain    ${stderr}    tedge-p11-server.sock
+
+Ignore tedge.toml if incomplete
+    Execute Command    echo '[device]' >./tedge.toml
+    ${stderr}=    Execute Command    tedge-p11-server --config-dir . --module-path xx.so    exp_exit_code=!0
+    # Don't log anything (this is normal behaviour, where the file is used for tedge and not tedge-p11-server)
+    Should Not Contain    ${stderr}    Failed to parse ./tedge.toml: invalid TOML
+    Should Not Contain    ${stderr}    missing field `cryptoki`
+    # And proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+    # Using default values
+    Should Contain    ${stderr}    tedge-p11-server.sock
+
+Do not warn the user if tedge.toml is incomplete but not used
+    Execute Command    rm -f ./tedge.toml
+    ${stderr}=    Execute Command
+    ...    tedge-p11-server --config-dir . --module-path xx.so --pin 11.pin --socket-path yy.sock --uri zz.uri
+    ...    exp_exit_code=!0
+    # Don't warn as all values are provided on the command line
+    Should Not Contain    ${stderr}    Failed to read ./tedge.toml: No such file
+    # And proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+    # Using the values provided on the command lin
+    Should Contain    ${stderr}    xx.so
+    Should Contain    ${stderr}    yy.sock
+    Should Contain    ${stderr}    zz.uri
+
+Warn the user if tedge.toml exists but cannot be read
+    Execute Command    echo '[device.cryptoki]' >./tedge.toml
+    Execute Command    chmod a-rw ./tedge.toml
+    ${stderr}=    Execute Command
+    ...    sudo -u tedge tedge-p11-server --config-dir . --module-path xx.so
+    ...    exp_exit_code=!0
+    # Warn the user
+    Should Contain    ${stderr}    Failed to read ./tedge.toml: Permission denied
+    # But proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+
+Warn the user if tedge.toml cannot be parsed
+    Execute Command    rm -f ./tedge.toml
+    Execute Command    echo '[corrupted toml ...' >./tedge.toml
+    ${stderr}=    Execute Command    tedge-p11-server --config-dir . --module-path xx.so    exp_exit_code=!0
+    # Warn the user
+    Should Contain    ${stderr}    Failed to parse ./tedge.toml: invalid TOML
+    # But proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+
 
 *** Keywords ***
 Custom Setup


### PR DESCRIPTION
## Proposed changes

tedge-p11-server proceeds on missing tedge config

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3579

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

