### PR TITLE
fix: support HTTP proxy in c8y remote access plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ name = "c8y-remote-access-plugin"
 version = "1.5.0"
 dependencies = [
  "async-compat",
+ "async-http-proxy",
  "async-tungstenite 0.28.0",
  "axum 0.8.1",
  "base64 0.22.1",
@@ -811,6 +812,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-rustls 0.26.1",
  "url",
  "ws_stream_tungstenite 0.14.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ assert-json-diff = "2.0"
 assert_cmd = "2.0"
 assert_matches = "1.5"
 async-compat = "0.2.1"
+async-http-proxy = "1.2"
 async-tempfile = "0.7"
 async-trait = "0.1"
 async-tungstenite = { version = "0.28", features = [

--- a/plugins/c8y_remote_access_plugin/Cargo.toml
+++ b/plugins/c8y_remote_access_plugin/Cargo.toml
@@ -11,6 +11,7 @@ repository = { workspace = true }
 
 [dependencies]
 async-compat = { workspace = true }
+async-http-proxy = { workspace = true }
 async-tungstenite = { workspace = true }
 base64 = { workspace = true }
 c8y_api = { workspace = true }
@@ -35,6 +36,7 @@ tokio = { workspace = true, features = [
     "time",
     "process",
 ] }
+tokio-rustls = { workspace = true }
 url = { workspace = true }
 ws_stream_tungstenite = { workspace = true }
 

--- a/plugins/c8y_remote_access_plugin/src/lib.rs
+++ b/plugins/c8y_remote_access_plugin/src/lib.rs
@@ -322,9 +322,14 @@ async fn proxy(
         .await.context("Failed when requesting JWT from Cumulocity or invalid username/password credentials are given")?;
     let client_config = config.cloud_client_tls_config();
 
-    let proxy =
-        WebsocketSocketProxy::connect(&url, command.target_address(), auth, Some(client_config))
-            .await?;
+    let proxy = WebsocketSocketProxy::connect(
+        &url,
+        command.target_address(),
+        auth,
+        Some(client_config),
+        &config.proxy,
+    )
+    .await?;
 
     proxy.run().await;
     Ok(())

--- a/tests/RobotFramework/tests/cumulocity/http_proxy/http_proxy_support.robot
+++ b/tests/RobotFramework/tests/cumulocity/http_proxy/http_proxy_support.robot
@@ -21,6 +21,13 @@ tedge can connect to Cumulocity using HTTP Connect Tunnelling
     ${operation}=    Get Configuration    tedge-configuration-plugin
     Operation Should Be SUCCESSFUL    ${operation}
 
+Remote Access Uses the HTTP Proxy
+    [Tags]    theme:c8y    theme:http_proxy    theme:remoteaccess
+    [Setup]    Setup Device With thin-edge.io
+    Execute Command    tedge connect c8y
+    Device Should Exist    ${DEVICE_SN}
+    Execute SSH Command Using Remote Access
+
 Install thin-edge.io behind a Proxy using wget
     [Setup]    Setup Device Without thin-edge.io
     Execute Command
@@ -68,3 +75,13 @@ Add iptables Rules
     Execute Command    sudo iptables -A OUTPUT -o lo -j ACCEPT
     # Allow traffic from the gost user
     Execute Command    sudo iptables -A OUTPUT -m owner --uid-owner "$(id -u gost)" -j ACCEPT
+
+Execute SSH Command Using Remote Access
+    ${KEY_FILE}=    ThinEdgeIO.Configure SSH
+    ThinEdgeIO.Add Remote Access Passthrough Configuration
+    ${stdout}=    ThinEdgeIO.Execute Remote Access Command
+    ...    command=tedge --version
+    ...    exp_exit_code=0
+    ...    user=root
+    ...    key_file=${KEY_FILE}
+    Should Match Regexp    ${stdout}    tedge .+

--- a/tests/RobotFramework/tests/cumulocity/http_proxy/http_proxy_support.robot
+++ b/tests/RobotFramework/tests/cumulocity/http_proxy/http_proxy_support.robot
@@ -28,6 +28,11 @@ Remote Access Uses the HTTP Proxy
     Device Should Exist    ${DEVICE_SN}
     Execute SSH Command Using Remote Access
 
+C8Y HTTP proxy uses HTTP tunnelling
+    [Setup]    Setup Device With thin-edge.io
+    Execute Command    tedge connect c8y
+    Execute Command    tedge http get /c8y/inventory/managedObjects
+
 Install thin-edge.io behind a Proxy using wget
     [Setup]    Setup Device Without thin-edge.io
     Execute Command


### PR DESCRIPTION
## Proposed changes
Support the HTTP proxy configuration in the c8y remote access plugin. This was an accidental omission with the proxy feature.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #3598 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

