### PR TITLE
fix: pkcs11 signing with a wrong key and a ready check when `TedgeP11Client` is created

### DIFF
--- a/crates/extensions/tedge-p11-server/src/client.rs
+++ b/crates/extensions/tedge-p11-server/src/client.rs
@@ -13,10 +13,41 @@ use super::service::SignRequest;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TedgeP11Client {
-    pub socket_path: Arc<Path>,
+    socket_path: Arc<Path>,
 }
 
 impl TedgeP11Client {
+    /// Returns the client after performing a ready check to the server.
+    ///
+    /// Before returning the client, a request is made to the server to "warm it up", discarding the
+    /// response.
+    ///
+    /// In some environments, starting up `tedge-p11-server` can take an unreasonable amount of
+    /// time, which is a problem because if we wait for it to start up while we're making a TLS 1.3
+    /// handshake, the TCP connection can get dropped due to hitting a timeout. What's worse, the
+    /// application layer protocol (MQTT) doesn't seem to send a required [TLS `close_notify`
+    /// message before EOF][unexp-eof], which results in an additional error from rustls:
+    ///
+    /// > peer closed connection without sending TLS close_notify:
+    /// > https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof
+    ///
+    /// To remedy this for now, we're making this additional request when creating the client to
+    /// hopefully make the server the most ready it can be for handling the real requests.
+    ///
+    /// This is not ideal because the server can still get restarted between creating the client and
+    /// making the sign request, but we're making a best-effort here not to add too much complexity
+    /// to cater to environments which are not very sane and should be relatively rare.
+    ///
+    /// [unexp-eof]: https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof
+    pub fn with_ready_check(socket_path: Arc<Path>) -> Self {
+        let client = Self { socket_path };
+
+        // make any request to make sure the service is online and it will respond
+        let _ = client.choose_scheme(&[], None);
+
+        client
+    }
+
     pub fn choose_scheme(
         &self,
         offered: &[rustls::SignatureScheme],

--- a/crates/extensions/tedge-p11-server/src/server.rs
+++ b/crates/extensions/tedge-p11-server/src/server.rs
@@ -135,11 +135,8 @@ mod tests {
         // wait until the server calls accept()
         tokio::time::sleep(Duration::from_millis(2)).await;
 
-        let client = TedgeP11Client {
-            socket_path: socket_path.into(),
-        };
-
         tokio::task::spawn_blocking(move || {
+            let client = TedgeP11Client::with_ready_check(socket_path.into());
             assert_eq!(client.choose_scheme(&[], None).unwrap().unwrap(), SCHEME);
             assert_eq!(&client.sign(&[], None).unwrap(), &SIGNATURE[..]);
         })

--- a/crates/extensions/tedge-p11-server/src/service.rs
+++ b/crates/extensions/tedge-p11-server/src/service.rs
@@ -1,7 +1,5 @@
 use crate::pkcs11::Cryptoki;
 use crate::pkcs11::CryptokiConfigDirect;
-
-use crate::pkcs11::Pkcs11SigningKey;
 use crate::pkcs11::PkcsSigner;
 
 use anyhow::Context;
@@ -73,11 +71,7 @@ impl SigningService for TedgeP11Service {
             .signing_key(uri.as_deref())
             .context("Failed to find a signing key")?;
 
-        let session = match signing_key {
-            Pkcs11SigningKey::Ecdsa(key) => key.pkcs11,
-            Pkcs11SigningKey::Rsa(key) => key.pkcs11,
-        };
-        let signer = PkcsSigner::from_session(session.clone());
+        let signer = PkcsSigner::from_key(signing_key);
         let signature = signer
             .sign(&request.to_sign)
             .context("Failed to sign using PKCS #11")?;


### PR DESCRIPTION
## Proposed changes

This PR has 2 parts:

1. Fix a bug where we didn't keep the handle to the key we found using the URI if it was declared, but used another search to find a new key capable of signing. Sometimes it worked, because the library could technically return the least recently used key as "first", which worked sometimes but not always. Now, within the session we keep track of the object handle in the key struct so the key is guaranteed to be correct.
2. Add a ready ready check when creating the `TedgeP11Client`. During a shared debugging session with @reubenmiller, we discovered that on certain setups loading the PKCS11 library can be unreasonably slow, so we decided to make a request that starts the server before the actual handshake to ensure the server is warm. More rationale in the method doc comment.   

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #3601 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

