### PR TITLE
docs: Fill in fallback values for sh command blocks

### DIFF
--- a/docs/src/references/hsm-support.md
+++ b/docs/src/references/hsm-support.md
@@ -32,9 +32,34 @@ to private key stored in the HSM (a step that depends on the actual key).
 This feature has the following related configuration options:
 
 ```sh command="tedge config list --doc device.cryptoki" title="tedge config list --doc device.cryptoki"
+       device.cryptoki.mode  Whether to use a Hardware Security Module for authenticating the MQTT connection with the cloud.  "off" to not use the HSM, "module" to use the provided cryptoki dynamic module, "socket" to access the HSM via tedge-p11-server signing service.
+                             Examples: off, module, socket
+
+device.cryptoki.module_path  A path to the PKCS#11 module used for interaction with the HSM.  Needs to be set when `device.cryptoki.mode` is set to `module`.
+                             Example: /usr/lib/x86_64-linux-gnu/opensc-pkcs11.so
+
+        device.cryptoki.pin  Pin value for logging into the HSM.
+                             Example: 123456
+
+        device.cryptoki.uri  A URI of the token/object to be used by tedge-p11-server.  See RFC #7512.
+                             Example: pkcs11:token=my-pkcs11-token;object=my-key
+
+device.cryptoki.socket_path  A path to the tedge-p11-server socket.  Needs to be set when `device.cryptoki.mode` is set to `socket`.
+                             Example: /run/tedge-p11-server/tedge-p11-server.sock
 ```
 
 ```sh command="tedge config list --doc key_uri" title="tedge config list --doc key_uri"
+    device.key_uri  A PKCS#11 URI of the private key.  See RFC #7512.
+                    Example: pkcs11:token=my-pkcs11-token;object=my-key
+
+c8y.device.key_uri  A PKCS#11 URI of the private key.  See RFC #7512.
+                    Example: pkcs11:token=my-pkcs11-token;object=my-key
+
+ az.device.key_uri  A PKCS#11 URI of the private key.  See RFC #7512.
+                    Example: pkcs11:token=my-pkcs11-token;object=my-key
+
+aws.device.key_uri  A PKCS#11 URI of the private key.  See RFC #7512.
+                    Example: pkcs11:model=PKCS%2315%20emulated
 ```
 
 ## Setup guide

--- a/docs/src/references/tedge-p11-server.md
+++ b/docs/src/references/tedge-p11-server.md
@@ -85,6 +85,20 @@ token will be considered for a key.
 ## Relevant configuration
 
 ```sh command="tedge config list --doc device.cryptoki" title="tedge config list --doc device.cryptoki"
+       device.cryptoki.mode  Whether to use a Hardware Security Module for authenticating the MQTT connection with the cloud.  "off" to not use the HSM, "module" to use the provided cryptoki dynamic module, "socket" to access the HSM via tedge-p11-server signing service.
+                             Examples: off, module, socket
+
+device.cryptoki.module_path  A path to the PKCS#11 module used for interaction with the HSM.  Needs to be set when `device.cryptoki.mode` is set to `module`.
+                             Example: /usr/lib/x86_64-linux-gnu/opensc-pkcs11.so
+
+        device.cryptoki.pin  Pin value for logging into the HSM.
+                             Example: 123456
+
+        device.cryptoki.uri  A URI of the token/object to be used by tedge-p11-server.  See RFC #7512.
+                             Example: pkcs11:token=my-pkcs11-token;object=my-key
+
+device.cryptoki.socket_path  A path to the tedge-p11-server socket.  Needs to be set when `device.cryptoki.mode` is set to `socket`.
+                             Example: /run/tedge-p11-server/tedge-p11-server.sock
 ```
 
 ## Command help

--- a/docs/src/references/tedge-write.md
+++ b/docs/src/references/tedge-write.md
@@ -74,4 +74,46 @@ provided new values will be ignored.
 ## Command help
 
 ```sh command="tedge-write --help" title="tedge-write --help"
+tee-like helper for writing to files which `tedge` user does not have write permissions to.
+
+To be used in combination with sudo, passing the file content via standard input.
+
+Usage: tedge-write [OPTIONS] <DESTINATION_PATH>
+
+Arguments:
+  <DESTINATION_PATH>
+          A canonical path to a file to which standard input will be written.
+
+          If the file does not exist, it will be created with the specified owner/group/permissions. If the file does exist, it will be overwritten, but its owner/group/permissions will remain unchanged.
+
+Options:
+      --mode <MODE>
+          Permission mode for the file, in octal form
+
+      --user <USER>
+          User which will become the new owner of the file
+
+      --group <GROUP>
+          Group which will become the new owner of the file
+
+      --config-dir <CONFIG_DIR>
+          [env: TEDGE_CONFIG_DIR, default: /etc/tedge]
+
+      --debug
+          Turn-on the DEBUG log level.
+
+          If off only reports ERROR, WARN, and INFO, if on also reports DEBUG
+
+      --log-level <LOG_LEVEL>
+          Configures the logging level.
+
+          One of error/warn/info/debug/trace. Logs with verbosity lower or equal to the selected level will be printed, i.e. warn prints ERROR and WARN logs and trace prints logs of all levels.
+
+          Overrides `--debug`
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 ```


### PR DESCRIPTION
## Proposed changes

Fills in missing fallback text for `sh command="tedge ..."` blocks, which were generating fine locally, but were empty in the live docs because of missing thin-edge binaries.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/tedge-docs/issues/110

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

