### PR TITLE
tests: Fix tedge-p11-server blocking test

### DIFF
--- a/crates/extensions/tedge-p11-server/src/server.rs
+++ b/crates/extensions/tedge-p11-server/src/server.rs
@@ -156,16 +156,15 @@ mod tests {
         // wait until the server calls accept()
         tokio::time::sleep(Duration::from_millis(2)).await;
 
-        let mut client_connection = Connection::new(UnixStream::connect(&socket_path).unwrap());
-        let mut client_connection = tokio::task::spawn_blocking(move || {
+        let response = tokio::task::spawn_blocking(move || {
+            let mut client_connection = Connection::new(UnixStream::connect(&socket_path).unwrap());
             client_connection
                 .write_frame(&Frame1::SignResponse(SignResponse(vec![])))
                 .unwrap();
-            client_connection
+            client_connection.read_frame().unwrap()
         })
         .await
         .unwrap();
-        let response = client_connection.read_frame().unwrap();
         assert!(matches!(response, Frame1::Error(_)));
     }
 


### PR DESCRIPTION
## Proposed changes

A blocking sync operation that blocked the tokio executor was previously missed. All of the blocking operations were moved to spawn_blocking where they shouldn't block anymore.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

* https://github.com/thin-edge/thin-edge.io/issues/3606

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

