### PR TITLE
refactor: Update tests to check for maximum message counts only when appropriate

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command/custom_operation_command.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_command/custom_operation_command.robot
@@ -22,10 +22,7 @@ Run shell custom operation for main device and publish the status
     ...    c8y/s/us
     ...    message_pattern=^(504|505|506),[0-9]+($|,\\"helloworld1\n\\")
     ...    minimum=2
-    # FIXME: Don't assert the maximum number of duplicate MQTT operation messages
-    # are sometimes received from the cloud. Remove once the following ticket is addressed:
-    # https://github.com/thin-edge/thin-edge.io/issues/3403
-    # ...    maximum=2
+    ...    maximum=2
 
 Run shell custom operation for main device and do not publish the status
     ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command_2    /etc/tedge/operations/c8y/c8y_Command
@@ -65,10 +62,7 @@ Run shell custom operation for main device with custom topic
     ...    c8y/s/us
     ...    message_pattern=^(504|505|506),1234($|,\\"helloworld4\n\\")
     ...    minimum=2
-    # FIXME: Don't assert the maximum number of duplicate MQTT operation messages
-    # are sometimes received from the cloud. Remove once the following ticket is addressed:
-    # https://github.com/thin-edge/thin-edge.io/issues/3403
-    # ...    maximum=2
+    ...    maximum=2
 
 
 *** Keywords ***

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_smartrest_template/smartrest_template.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_smartrest_template/smartrest_template.robot
@@ -22,7 +22,6 @@ smartrest template custom operation successful
     ${c8y_messages}=    Should Have MQTT Messages
     ...    c8y/s/dc/${DEVICE_SN}
     ...    minimum=1
-    ...    maximum=1
     ...    message_contains=dm101,${DEVICE_SN},Factory Wifi,factory-onboarding-wifi,WPA3-Personal
 
 

--- a/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device_retry.robot
+++ b/tests/RobotFramework/tests/cumulocity/firmware/firmware_operation_child_device_retry.robot
@@ -22,7 +22,6 @@ Firmware plugin supports restart via service manager #1932
     ...    topic=tedge/${CHILD_SN}/commands/req/firmware_update
     ...    date_from=${operation_start}
     ...    minimum=1
-    ...    maximum=1
 
     # Restart firmware plugin
     ${restart_pre}=    ThinEdgeIO.Get Unix Timestamp


### PR DESCRIPTION
## Proposed changes
- Re-enable some maximum message count assertions that were skipped while #3402 was awaiting a fix
- Remove the maximum message count assertion in the custom smartrest operation test. In the case of custom smartrest operations, the mapper makes no attempt to de-duplicate incoming operations, so we can't guarantee that an operation won't be executed twice, particularly in the case of system tests which run just after tedge has started up.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

