### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -334,7 +334,9 @@ impl ConnectCommand {
                 let c8y_config = self.config.c8y.try_get(profile_name.as_deref())?;
                 let mut mqtt_auth_config = self.config.mqtt_auth_config_cloud_broker(c8y_config)?;
                 if let Some(client_config) = mqtt_auth_config.client.as_mut() {
-                    client_config.cert_file = _certificate_shift.new_cert_path.to_owned()
+                    _certificate_shift
+                        .new_cert_path
+                        .clone_into(&mut client_config.cert_file)
                 }
 
                 create_device_with_direct_connection(

--- a/crates/extensions/tedge-p11-server/src/server.rs
+++ b/crates/extensions/tedge-p11-server/src/server.rs
@@ -157,7 +157,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(2)).await;
 
         let response = tokio::task::spawn_blocking(move || {
-            let mut client_connection = Connection::new(UnixStream::connect(&socket_path).unwrap());
+            let mut client_connection = Connection::new(UnixStream::connect(socket_path).unwrap());
             client_connection
                 .write_frame(&Frame1::SignResponse(SignResponse(vec![])))
                 .unwrap();
@@ -184,7 +184,7 @@ mod tests {
 
         // the reader should exit
         tokio::task::spawn_blocking(move || {
-            let mut stream = UnixStream::connect(&socket_path).unwrap();
+            let mut stream = UnixStream::connect(socket_path).unwrap();
             write!(stream, "garbage").unwrap();
             stream.shutdown(std::net::Shutdown::Write).unwrap();
             let mut response = Vec::new();


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix minor clippy warnings that were visible when running `just check`.

Below are examples of the warnings:

```
warning: the borrowed expression implements the required traits
   --> crates/extensions/tedge-p11-server/src/server.rs:160:77
    |
160 |             let mut client_connection = Connection::new(UnixStream::connect(&socket_path).unwrap());
    |                                                                             ^^^^^^^^^^^^ help: change this to: `socket_path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
    = note: `#[warn(clippy::needless_borrows_for_generic_args)]` on by default
```

```
warning: the borrowed expression implements the required traits
   --> crates/extensions/tedge-p11-server/src/server.rs:188:50
    |
188 |             let mut stream = UnixStream::connect(&socket_path).unwrap();
    |                                                  ^^^^^^^^^^^^ help: change this to: `socket_path`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
    = note: `#[warn(clippy::needless_borrows_for_generic_args)]` on by default
```

```
warning: assigning the result of `ToOwned::to_owned()` may be inefficient
   --> crates/core/tedge/src/cli/connect/command.rs:337:21
    |
337 |                     client_config.cert_file = _certificate_shift.new_cert_path.to_owned()
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_into()`: `_certificate_shift.new_cert_path.clone_into(&mut client_config.cert_file)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `#[warn(clippy::assigning_clones)]` on by default
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

