### PR TITLE
fix: accept values starting with hypen in flags related to passwords

### DIFF
--- a/crates/core/tedge/src/cli/certificate/cli.rs
+++ b/crates/core/tedge/src/cli/certificate/cli.rs
@@ -385,7 +385,7 @@ pub enum UploadCertCli {
         /// You will be prompted for input if the value is not provided or is empty
         username: String,
 
-        #[clap(long = "password")]
+        #[clap(long = "password", allow_hyphen_values = true)]
         #[arg(env = "C8Y_PASSWORD", hide_env_values = true, hide_default_value = true, default_value_t = std::env::var("C8YPASS").unwrap_or_default().to_string())]
         // Note: Prefer C8Y_PASSWORD over the now deprecated C8YPASS env variable as the former is also supported by other tooling such as go-c8y-cli
         /// Cumulocity Password.
@@ -443,7 +443,7 @@ pub enum DownloadCertCli {
         )]
         id: String,
 
-        #[clap(short = 'p', long = "one-time-password")]
+        #[clap(short = 'p', long = "one-time-password", allow_hyphen_values = true)]
         #[arg(
             env = "DEVICE_ONE_TIME_PASSWORD",
             hide_env_values = true,


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Accept values provided to flags, which are related to passwords, to start with a hypen (to prevent cli parsing errors).

Only the password related flags were allowed for this, as other fields didn't make much sense starting with a hypen anyway.

The following commands should now work:

```sh
tedge cert download c8y --one-time-password "-example1234"
tedge cert upload c8y --password "-example1234"
```


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

* https://github.com/thin-edge/thin-edge.io/issues/3618

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

