### PR TITLE
feat: Connect summary cryptoki show mode and key URI

### DIFF
--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -982,6 +982,14 @@ impl TEdgeConfigReader {
         .unwrap()
     }
 
+    pub fn as_cloud_config(&self, cloud: Cloud<'_>) -> Result<&dyn CloudConfig, MultiError> {
+        Ok(match cloud {
+            Cloud::C8y(profile) => self.c8y.try_get(profile)?,
+            Cloud::Az(profile) => self.az.try_get(profile)?,
+            Cloud::Aws(profile) => self.aws.try_get(profile)?,
+        })
+    }
+
     pub fn device_key_path<'a>(
         &self,
         cloud: Option<impl Into<Cloud<'a>>>,

--- a/crates/core/tedge/src/cli/log.rs
+++ b/crates/core/tedge/src/cli/log.rs
@@ -256,7 +256,7 @@ pub struct ConfigLogger<'a> {
     mosquitto_version: Option<&'a str>,
     cloud: &'a MaybeBorrowedCloud<'a>,
     credentials_path: Option<&'a Utf8Path>,
-    cryptoki: bool,
+    cryptoki: &'a str,
     proxy_url: Option<&'a ProxyUrl>,
     proxy_username: Option<&'a str>,
 }
@@ -270,7 +270,7 @@ impl<'a> ConfigLogger<'a> {
         service_manager: &'a dyn SystemServiceManager,
         cloud: &'a MaybeBorrowedCloud<'a>,
         credentials_path: Option<&'a Utf8Path>,
-        use_cryptoki: bool,
+        cryptoki: &'a str,
         proxy_url: Option<&'a ProxyUrl>,
         proxy_username: Option<&'a str>,
     ) {
@@ -287,7 +287,7 @@ impl<'a> ConfigLogger<'a> {
                 service_manager,
                 mosquitto_version: config.mosquitto_version.as_deref(),
                 cloud,
-                cryptoki: use_cryptoki,
+                cryptoki,
                 proxy_url,
                 proxy_username,
             }


### PR DESCRIPTION
## Proposed changes

Change `cryptoki:` line in connection summary from simple `true/false` to display mode and key URI:

- If mode is off: `cryptoki: off`
- If mode is not off and `key_uri` is not set: `cryptoki: MODE`
- If mode is not off and `key_uri` is set: `cryptoki: MODE (key: KEY)`

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I'm not sure if this is the best way to format the information in the summary, I'm open to suggestions for changes.

An alternative would be to instead of separate `cryptoki:` line, to add a `private key:` line, and put there `key_uri` and `key_path` config settings, depending whether cryptoki is enabled or not.
