### PR TITLE
fix: broken 1.89.0-nightly build

### DIFF
--- a/crates/core/tedge_agent/src/restart_manager/actor.rs
+++ b/crates/core/tedge_agent/src/restart_manager/actor.rs
@@ -191,8 +191,10 @@ impl RestartManagerActor {
         let mut not_interrupted = true;
         for mut command in commands {
             let cmd = command.as_std().get_program().to_string_lossy();
-            let args = command.as_std().get_args();
-            info!("Restarting: {cmd} {args:?}");
+            {
+                let args = command.as_std().get_args();
+                info!("Restarting: {cmd} {args:?}");
+            }
 
             match command.status().await {
                 Ok(status) => {


### PR DESCRIPTION

## Proposed changes

Cargo +nightly check is failing with error: future cannot be sent between threads safely because `args` of type `CommandArgs<'_>` is not `Send`

This is weird because `args` is not used by the future `command.status().await`. 

Fixed, by dropping `args` before the call to await.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

