### PR TITLE
test: PKCS11 connect using RSA keys of all sizes

### DIFF
--- a/tests/RobotFramework/tests/pkcs11/private_key_storage.robot
+++ b/tests/RobotFramework/tests/pkcs11/private_key_storage.robot
@@ -82,22 +82,13 @@ Select Private key using a request URI
     Should Contain    ${stdout}    item=cryptoki: socket (key: pkcs11:token=tedge;object=tedge)
 
 Connects to C8y using an RSA key
-    [Documentation]    Test that we can connect to C8y using an RSA private key. At the time of writing the test
-    ...    `tedge cert create` by default uses an ECDSA keypair, so we have to generate it manually and upload it.
-    # set up an RSA key for tedge and upload it
-    Execute Command    softhsm2-util --init-token --free --label c8y-token-rsa --pin "123456" --so-pin "123456"
-    Execute Command
-    ...    cmd=p11tool --set-pin=123456 --login --generate-privkey RSA --bits 4096 --label "c8y-key-rsa" "pkcs11:token=c8y-token-rsa" --outfile pubkey.pem
-    Execute Command
-    ...    cmd=GNUTLS_PIN=123456 certtool --generate-self-signed --template ${CERT_TEMPLATE} --outfile /etc/tedge/device-certs/tedge-certificate.pem --load-privkey "pkcs11:token=c8y-token-rsa;object=c8y-key-rsa"
-
-    Execute Command
-    ...    cmd=sudo env C8Y_USER='${C8Y_CONFIG.username}' C8Y_PASSWORD='${C8Y_CONFIG.password}' tedge cert upload c8y
-    ...    log_output=${False}
-
-    Set tedge-p11-server Uri    value=pkcs11:token=c8y-token-rsa;object=c8y-key-rsa
-
-    Execute Command    tedge reconnect c8y
+    [Documentation]    Test that we can connect to C8y using an RSA private keys of all sizes.
+    [Setup]    Set tedge-p11-server Uri    value=${EMPTY}
+    [Template]    Connect to C8y using new keypair
+    type=rsa    bits=4096
+    type=rsa    bits=3072
+    type=rsa    bits=2048
+    type=rsa    bits=1024
 
 Connects to C8y supporting all TLS13 ECDSA signature algorithms
     [Documentation]    Check that we support all ECDSA sigschemes used in TLS1.3, i.e: ecdsa_secp256r1_sha256,


### PR DESCRIPTION
## Proposed changes

Add a test checking that we can connect to Cumulocity using PKCS11 RSA private keys of size: 1024 bits, 2048 bits, 3072 bits and 4096 bits.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

