### PR TITLE
docs: document support for using unix timestamps in telemetry data

### DIFF
--- a/docs/src/operate/telemetry/data-model.md
+++ b/docs/src/operate/telemetry/data-model.md
@@ -97,7 +97,7 @@ One MQTT message can contain a mixture of more than one single-value and multi-v
 | --------- | --------- |
 |`name`       |a string that identifies the measurement uniquely in context of the device|
 |`value`      |the value that was sampled; can be named (especially in context of a multi-value measurement) or unnamed; must be an integer or floating point number|
-|`timestamp`  |optional time that indicates when values were sampled; when not provided, %%te%% uses the current system time as the time of the sample; when provided must be conform to ISO 8601|
+|`timestamp`  |optional time that indicates when values were sampled; when not provided, %%te%% uses the current system time as the time of the sample; when provided must be conform to ISO 8601 or a unix timestamp (in seconds)|
 
 #### Behaviour of measurements
 - %%te%% does not store any historical sampled values for measurements
@@ -136,7 +136,7 @@ te/device/<child-id>///e/<event-type>
 | ------------------ | --------- |
 |`event-type`        |a string part of the MQTT topic, that identifies the event uniquely in context of the device|
 |`text`              |carries a human readable event-text; must be UTF-8 encoded|
-|`timestamp`         |optional time that indicates when the event has occurred; when not provided, %%te%% uses the current system time as the time of the event; when provided must be conform to ISO 8601|
+|`timestamp`         |optional time that indicates when the event has occurred; when not provided, %%te%% uses the current system time as the time of the event; when provided must be conform to ISO 8601 or a unix timestamp (in seconds)|
 |`custom fragments`  |additional fields are handled as custom specific information; if the connected cloud supports custom fragments its mapper transfers those accordingly to the cloud|
 
 #### Behaviour of events
@@ -178,7 +178,7 @@ te/device/<child-id>///a/<alarm-type>
 |`alarm-type`        |a string part of the MQTT topic, that identifies the alarm uniquely in context of the device|
 |`severity`          |a string part of the MQTT payload, that indicates the severity of the alarm; recommended to be `critical`, `major`, `minor` or `warning`|
 |`text`              |carries a human readable alarm-text; must be UTF-8 encoded|
-|`timestamp`         |optional time that indicates when the alarm has occurred; when not provided, %%te%% uses the current system time as the time of the alarm; when provided must be conform to ISO 8601|
+|`timestamp`         |optional time that indicates when the alarm has occurred; when not provided, %%te%% uses the current system time as the time of the alarm; when provided must be conform to ISO 8601 or a unix timestamp (in seconds)|
 |`custom fragments`  |additional fields are handled as custom specific information; if the connected cloud supports custom fragments its mapper transfers those accordingly to the cloud|
 
 #### Behaviour of alarms

--- a/docs/src/references/agent/device-management-api.md
+++ b/docs/src/references/agent/device-management-api.md
@@ -155,7 +155,7 @@ graph LR
 
 :::note
 The `command_id` is an arbitrary string however it should be unique.
-It is recommended to either use a unique id generator, or add a unix timestamp as a suffix, e.g. date +%s.
+It is recommended to either use a unique id generator, or add a unix timestamp as a suffix, e.g. `date +%s`.
 This unique id assigned by the requester, who is also responsible for creating the topic
 with an initial state and for finally removing it.
 :::

--- a/docs/src/start/raise-alarm.md
+++ b/docs/src/start/raise-alarm.md
@@ -35,7 +35,7 @@ The payload format must be as follows:
 {
   "text": "<alarm text>",
   "severity": "major",
-  "time": "<Timestamp in ISO-8601 format>"
+  "time": "<Timestamp in ISO-8601 format or a unix timestamp (in seconds)>"
 }
 ```
 

--- a/docs/src/start/send-events.md
+++ b/docs/src/start/send-events.md
@@ -31,7 +31,7 @@ The payload format must be as follows:
 ```json title="Payload"
 {
   "text": "<event text>",
-  "time": "<Timestamp in ISO-8601 format>"
+  "time": "<Timestamp in ISO-8601 format or a unix timestamp (in seconds)>"
 }
 ```
 
@@ -118,7 +118,7 @@ The payload format must be as follows:
 ```json title="Payload"
 {
   "text": "<event text>",
-  "time": "<Timestamp in ISO-8601 format>"
+  "time": "<Timestamp in ISO-8601 format or a unix timestamp (in seconds)>"
 }
 ```
 

--- a/docs/src/understand/tedge-mapper.md
+++ b/docs/src/understand/tedge-mapper.md
@@ -181,7 +181,7 @@ Here is an example if you publish invalid %%te%% JSON messages on `te/+/+/+/+/m/
 
 ```sh
 tedge mqtt pub te/device/main///m/ '{"temperature": 23,"pressure": 220'
-tedge mqtt pub te/device/main///m/ '{"temperature": 23,"time": 220}'
+tedge mqtt pub te/device/main///m/ '{"temperature": 23,"time": "oops"}'
 ```
 
 Then, you'll receive error messages from the mapper on the topic `te/errors`:
@@ -191,6 +191,6 @@ tedge mqtt sub te/errors
 ```
 
 ```log title="Output"
-[te/errors] Invalid JSON: Unexpected end of JSON: {"temperature":23,"pressure":220
-[te/errors] Not a timestamp: the time value must be an ISO8601 timestamp string in the YYYY-MM-DDThh:mm:ss.sss.±hh:mm format, not a number.
+[te/errors] Failed to convert a message on topic 'te/device/main///m/': Invalid JSON: EOF while parsing an object at line 1 column 34: `0`
+[te/errors] Failed to convert a message on topic 'te/device/main///m/': Invalid JSON: Invalid ISO8601 timestamp (expected YYYY-MM-DDThh:mm:ss.sss.±hh:mm): "oops": the 'year' component could not be parsed at line 1 column 33: `"}
 ```

--- a/docs/src/understand/thin-edge-json.md
+++ b/docs/src/understand/thin-edge-json.md
@@ -135,7 +135,7 @@ The grouping of measurements is usually done to represent measurements collected
 When %%te%% receives a measurement, it will add a timestamp to it before any further processing.
 If the user doesn't want to rely on %%te%% generated timestamps,
 an explicit timestamp can be provided in the measurement message itself by adding the time value as a string 
-in ISO 8601 format using `time` as the key name, as follows:
+in ISO 8601 format using `time`  or as a unix timestamp (in seconds) as the key name, as follows:
 
 ```sh te2mqtt formats=v1
 tedge mqtt pub te/device/main///m/example '{
@@ -160,7 +160,7 @@ and hence must not be used as measurement keys:
 
 | Key | Description |
 | --- | --- |
-| time | Timestamp in ISO 8601 string format |
+| time | Timestamp in ISO 8601 string format or as a unix timestamp (in seconds) |
 
 ## Events
 
@@ -186,7 +186,7 @@ tedge mqtt pub te/device/main///e/login '{
 |--------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `event_type` | Uniquely identifies the event in the context of the device; part of the MQTT topic                                                                                 |
 | `text`       | Text description of  the event; must be UTF-8 encoded                                                                                                              |
-| `time`  | Optional timestamp that indicates when the event occurred, in ISO 8601 string format; when not provided, %%te%% uses the current system time                      |
+| `time`  | Optional timestamp that indicates when the event occurred, in ISO 8601 string format or as a unix timestamp (in seconds); when not provided, %%te%% uses the current system time                      |
 | `*`          | Additional fields are handled as custom specific information; if the connected cloud supports custom fragments its mapper transfers those accordingly to the cloud |
 
 ## Alarms
@@ -215,6 +215,6 @@ tedge mqtt pub te/device/main///a/temperature_high '{
 | `alarm_type` | Uniquely identifies the alarm in the context of the device; part of the MQTT topic                                                                                 |
 | `severity`   | Severity of the alarm; recommended to be `critical`, `major`, `minor` or `warning`                                                                                           |
 | `text`       | Text description of the alarm; must be UTF-8 encoded                                                                                                               |
-| `timestamp`  | Optional time that indicates when the alarm has occurred, in ISO 8601 string format; when not provided, %%te%% uses the current system time                  |
+| `timestamp`  | Optional time that indicates when the alarm has occurred, in ISO 8601 string format or as a unix timestamp (in seconds); when not provided, %%te%% uses the current system time                  |
 | `*`          | Additional fields are handled as custom specific information; if the connected cloud supports custom fragments its mapper transfers those accordingly to the cloud |
 


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Document the support for providing the a timestamp in the thin-edge.io JSON payloads as either a ISO-8601 string or a unix timestamp (in seconds).

Support for unix timestamps was added a while ago but the docs weren't updated.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

