### PR TITLE
Reenable connect checks for aws and azure

### DIFF
--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -227,9 +227,7 @@ impl ConnectCommand {
             self.start_mapper().await;
         }
 
-        #[cfg(feature = "c8y")]
         let mut connection_check_success = true;
-        #[cfg(feature = "c8y")]
         if !self.offline_mode {
             match self
                 .check_connection_with_retries(
@@ -445,7 +443,6 @@ impl ConnectCommand {
         }
     }
 
-    #[cfg(feature = "c8y")]
     async fn check_connection_with_retries(
         &self,
         tedge_config: &TEdgeConfig,


### PR DESCRIPTION
## Proposed changes

Reenable connect checks for aws and azure.

It was disabled in f40a93c90, possibly by mistake because we set a variable used only when connecting to c8y. However, aside from setting that variable we emit a warning if the check is not successful, which is desired. As such, connection checks for these clouds were reenabled.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

