### PR TITLE
refactor: remove redundant use_basic_auth checks

### DIFF
--- a/crates/core/tedge/src/cli/connect/c8y.rs
+++ b/crates/core/tedge/src/cli/connect/c8y.rs
@@ -27,6 +27,7 @@ use rumqttc::QoS;
 use rumqttc::QoS::AtLeastOnce;
 use rumqttc::TlsError;
 use rumqttc::Transport;
+use tedge_config::models::auth_method::AuthType;
 use tedge_config::tedge_toml::MqttAuthConfigCloudBroker;
 use tedge_config::tedge_toml::ProfileName;
 use tedge_config::TEdgeConfig;
@@ -35,7 +36,6 @@ const CONNECTION_ERROR_CONTEXT: &str = "Connection error while creating device i
 
 // Connect directly to the c8y cloud over mqtt and publish device create message.
 pub async fn create_device_with_direct_connection(
-    use_basic_auth: bool,
     bridge_config: &BridgeConfig,
     device_type: &str,
     // TODO: put into general authentication struct
@@ -53,7 +53,7 @@ pub async fn create_device_with_direct_connection(
     );
     mqtt_options.set_keep_alive(std::time::Duration::from_secs(5));
 
-    let tls_config = if use_basic_auth {
+    let tls_config = if bridge_config.auth_type == AuthType::Basic {
         mqtt_options.set_credentials(
             bridge_config
                 .remote_username


### PR DESCRIPTION
## Proposed changes
At some point, `bridge_config` started holding `auth_type`.  This allows us to simplify the `tedge connect` implementation.  

This PR is purely a refactoring; no behavioral changes are expected.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

