### PR TITLE
fix: wrong message being shown on `system.toml` parse error

### DIFF
--- a/crates/core/tedge/src/system_services/managers/general_manager.rs
+++ b/crates/core/tedge/src/system_services/managers/general_manager.rs
@@ -193,48 +193,26 @@ impl ServiceCommand<'_> {
         service_manager: &GeneralServiceManager,
     ) -> Result<ExecCommand, SystemServiceError> {
         let config_path = service_manager.config_path.clone();
+        let config = match self {
+            Self::CheckManager => &service_manager.init_config.is_available,
+            Self::Stop(_) => &service_manager.init_config.stop,
+            Self::Restart(_) => &service_manager.init_config.restart,
+            Self::Start(_) => &service_manager.init_config.start,
+            Self::Enable(_) => &service_manager.init_config.enable,
+            Self::Disable(_) => &service_manager.init_config.disable,
+            Self::IsActive(_) => &service_manager.init_config.is_active,
+        };
+
         match self {
-            Self::CheckManager => ExecCommand::try_new(
-                service_manager.init_config.is_available.clone(),
-                ServiceCommand::CheckManager,
-                config_path,
-            ),
-            Self::Stop(service) => ExecCommand::try_new_with_placeholder(
-                service_manager.init_config.stop.clone(),
-                ServiceCommand::Stop(service),
-                config_path,
-                service,
-            ),
-            Self::Restart(service) => ExecCommand::try_new_with_placeholder(
-                service_manager.init_config.restart.clone(),
-                ServiceCommand::Restart(service),
-                config_path,
-                service,
-            ),
-            Self::Start(service) => ExecCommand::try_new_with_placeholder(
-                service_manager.init_config.start.clone(),
-                ServiceCommand::Enable(service),
-                config_path,
-                service,
-            ),
-            Self::Enable(service) => ExecCommand::try_new_with_placeholder(
-                service_manager.init_config.enable.clone(),
-                ServiceCommand::Enable(service),
-                config_path,
-                service,
-            ),
-            Self::Disable(service) => ExecCommand::try_new_with_placeholder(
-                service_manager.init_config.disable.clone(),
-                ServiceCommand::Disable(service),
-                config_path,
-                service,
-            ),
-            Self::IsActive(service) => ExecCommand::try_new_with_placeholder(
-                service_manager.init_config.is_active.clone(),
-                ServiceCommand::IsActive(service),
-                config_path,
-                service,
-            ),
+            Self::CheckManager => ExecCommand::try_new(config.clone(), self, config_path),
+            Self::Stop(service)
+            | Self::Restart(service)
+            | Self::Start(service)
+            | Self::Enable(service)
+            | Self::Disable(service)
+            | Self::IsActive(service) => {
+                ExecCommand::try_new_with_placeholder(config.clone(), self, config_path, service)
+            }
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

A wrong variant of ServiceCommand was used which caused an error message to wrongly report that `ServiceCommand::Enable` instead of `ServiceCommand::Start` failed when `start` command in `system.toml` did not contain a placeholder for an argument.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Some of the service manager code could be further improved:

1. Many arguments are passed down unnecessarily just for sake of error reporting, we could instead not pass them down and instead attach the context up the call stack.
2. Could use docs comments describing why we use `system.toml` file and why handling it takes quite a bit of code