### PR TITLE
fix: missing operation file c8y-remote-access-plugin when installed on Alpine Linux

### DIFF
--- a/configuration/contrib/operations/c8y_RemoteAccessConnect
+++ b/configuration/contrib/operations/c8y_RemoteAccessConnect
@@ -1,0 +1,4 @@
+[exec]
+command = "c8y-remote-access-plugin"
+topic = "c8y/s/ds"
+on_message = "530"

--- a/configuration/package_manifests/nfpm.c8y-remote-access-plugin.yaml
+++ b/configuration/package_manifests/nfpm.c8y-remote-access-plugin.yaml
@@ -49,6 +49,19 @@ contents:
       mode: 0644
     packager: rpm
 
+  # Some package manager (e.g. apk) require at least one file to included
+  # in the package in order to run the maintainer scripts (preinstall, postinstall)
+  # so include the configuration file by default in all packages for consistency across
+  # the different package managers.
+  # Note: the contents of the file should align with what is generated when running
+  # c8y-remote-access-plugin --init (for consistency)
+  - src: ./configuration/contrib/operations/c8y_RemoteAccessConnect
+    dst: /etc/tedge/operations/c8y/c8y_RemoteAccessConnect
+    file_info:
+      mode: 0644
+      owner: tedge
+    type: config
+
 overrides:
   apk:
     scripts:


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix an issue where the c8y-remote-access-plugin's maintainer scripts are not executed on Alpine Linux due to the apk package only containing a post-installation script (no actual files) which calls the `c8y-remote-access-plugin --init` which creates the required operation handler file. This resulted in the Remote Access not appearing in Cumulocity as the operation definition was missing.

To avoid this problem, the `c8y_RemoteAccessConnect` operation definition is being added to each of the linux packages (for consistency across deb, rpm and apk), to avoid this problem. The init command can still be run as it can correct any potential file ownership issues that may have changed over time on the user's device.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3667

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

