### PR TITLE
fix: clear all retained entity messages on entity deregistration

### DIFF
--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -58,6 +58,7 @@ use tedge_log_manager::LogManagerConfig;
 use tedge_log_manager::LogManagerOptions;
 use tedge_mqtt_ext::MqttActorBuilder;
 use tedge_mqtt_ext::MqttConfig;
+use tedge_mqtt_ext::MqttDynamicConnector;
 use tedge_mqtt_ext::TopicFilter;
 use tedge_script_ext::ScriptActor;
 use tedge_signal_ext::SignalActor;
@@ -271,7 +272,7 @@ impl Agent {
         let mut restart_actor_builder = RestartManagerBuilder::new(self.config.restart_config);
 
         // Mqtt actor
-        let mut mqtt_actor_builder = MqttActorBuilder::new(self.config.mqtt_config);
+        let mut mqtt_actor_builder = MqttActorBuilder::new(self.config.mqtt_config.clone());
 
         // Software update actor
         let mut software_update_builder = SoftwareManagerBuilder::new(self.config.sw_update_config);
@@ -387,6 +388,7 @@ impl Agent {
             let entity_store_server = EntityStoreServer::new(
                 entity_store,
                 mqtt_schema.clone(),
+                Box::new(MqttDynamicConnector::new(self.config.mqtt_config)),
                 &mut mqtt_actor_builder,
                 self.config.entity_auto_register,
             );

--- a/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
+++ b/tests/RobotFramework/libraries/ThinEdgeIO/ThinEdgeIO.py
@@ -748,7 +748,7 @@ class ThinEdgeIO(DeviceLibrary):
             self,
             topic: str,
             device_name: str = None 
-    ) -> str:
+    ):
         """
         Assert that there are no retained messages on the given topic
 
@@ -756,7 +756,7 @@ class ThinEdgeIO(DeviceLibrary):
             topic (str): Filter by topic. Supports MQTT wildcard patterns
 
         *Example:*
-        | ${messages}= | `Should Not Have Retained MQTT Messages` | te/device/child01/# |
+        | `Should Not Have Retained MQTT Messages` | te/device/child01/# |
         """
         device = self.current
         if device_name:
@@ -768,10 +768,13 @@ class ThinEdgeIO(DeviceLibrary):
                 f"Unable to execute the command as the device: '{device_name}' has not been setup"
             )
         
-        command = f"tedge mqtt sub {topic} --retained-only --no-topic --duration 1s"
-        output = device.execute_command(command).stdout
-        assert output == "", f"Expected no messages, but received: {output}"
-        return output
+        for _ in range(5):
+            command = f"tedge mqtt sub {topic} --retained-only --no-topic --duration 1s"
+            output = device.execute_command(command).stdout
+            if output == "":
+                return ""
+            time.sleep(1)
+        raise AssertionError(f"Expected no messages, but received: {output}")
 
     @keyword("Register Child Device")
     def register_child(

--- a/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
+++ b/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_api.robot
@@ -486,7 +486,7 @@ Entity twin api errors
     ...    ${resp}
     ...    Failed to buffer the request body: length limit exceeded|413
 
-Delete entity clears entity registration and twin messages
+Delete entity clears entity registration and all retained data messages
     Register Entity    device/child0//    child-device    device/main//
     Register Entity    device/child1//    child-device    device/main//
     Register Entity    device/child2//    child-device    device/main//
@@ -496,9 +496,13 @@ Delete entity clears entity registration and twin messages
 
     Execute Command    tedge http put /te/v1/entities/device/child0///twin '{"x": 1, "y": 2, "z": 3}'
     Execute Command    tedge mqtt pub --retain 'te/device/child0///twin/foo' '"bar"'
+    Execute Command    tedge mqtt pub --retain 'te/device/child0///a/high_temp' '{"severity": "critical"}'
     Execute Command    tedge mqtt pub --retain 'te/device/child0/service/service0/twin/foo' '"bar"'
+    Execute Command    tedge mqtt pub --retain 'te/device/child0/service/service0/status/health' '{"status": "up"}'
     Execute Command    tedge mqtt pub --retain 'te/device/child00///twin/foo' '"bar"'
+    Execute Command    tedge mqtt pub --retain 'te/device/child00///cmd/log_upload/123' '{"status": "init"}'
     Execute Command    tedge mqtt pub --retain 'te/device/child000///twin/foo' '"bar"'
+    Execute Command    tedge mqtt pub --retain 'te/device/child000///cmd/restart' '{}'
 
     Should Have Retained MQTT Messages    te/device/child0///twin/foo    message_contains="bar"
     Should Have Retained MQTT Messages    te/device/child0///twin/x    message_contains=1
@@ -509,9 +513,9 @@ Delete entity clears entity registration and twin messages
 
     ${deleted}=    Deregister Entity    device/child0//
 
-    Should Not Have Retained MQTT Messages    te/device/child0//#
-    Should Not Have Retained MQTT Messages    te/device/child00//#
     Should Not Have Retained MQTT Messages    te/device/child000//#
+    Should Not Have Retained MQTT Messages    te/device/child00//#
+    Should Not Have Retained MQTT Messages    te/device/child0//#
 
 
 *** Keywords ***


### PR DESCRIPTION
## Proposed changes

On entity deregistration, fetch all retained messages associated with that entity and its children and then clear them all.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

