### PR TITLE
PKCS11 Extract uri module to another file and improve PKCS11 ECDSA signature formatting

### DIFF
--- a/crates/extensions/tedge-p11-server/src/pkcs11/mod.rs
+++ b/crates/extensions/tedge-p11-server/src/pkcs11/mod.rs
@@ -4,10 +4,8 @@
 //! - thin-edge: docs/src/references/hsm-support.md
 //! - PKCS#11: https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/os/pkcs11-base-v2.40-os.html
 
-use asn1_rs::FromDer as _;
-pub use cryptoki::types::AuthPin;
-
 use anyhow::Context;
+use asn1_rs::FromDer as _;
 use asn1_rs::ToDer;
 use camino::Utf8PathBuf;
 use cryptoki::context::CInitializeArgs;
@@ -34,6 +32,10 @@ use tracing::warn;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Mutex;
+
+pub use cryptoki::types::AuthPin;
+
+mod uri;
 
 // oIDs for curves defined here: https://datatracker.ietf.org/doc/html/rfc5480#section-2.1.1.1
 // other can be browsed here: https://oid-base.com/get/1.3.132.0.34
@@ -446,199 +448,5 @@ fn get_ec_mechanism(session: &Session, key: ObjectHandle) -> anyhow::Result<SigS
         SECP384R1_OID => Ok(SigScheme::EcdsaNistp384Sha384),
         SECP521R1_OID => Ok(SigScheme::EcdsaNistp521Sha512),
         _ => anyhow::bail!("Parsed oID({oid}) doesn't match any supported EC curve"),
-    }
-}
-
-pub mod uri {
-    use std::borrow::Cow;
-    use std::collections::HashMap;
-
-    /// Attributes decoded from a PKCS #11 URL.
-    ///
-    /// Attributes only relevant to us shall be put into fields and the rest is in `other` hashmap.
-    ///
-    /// https://www.rfc-editor.org/rfc/rfc7512.html
-    #[derive(Debug, Clone, Default)]
-    pub struct Pkcs11Uri<'a> {
-        pub token: Option<Cow<'a, str>>,
-        pub serial: Option<Cow<'a, str>>,
-        pub id: Option<Vec<u8>>,
-        pub object: Option<Cow<'a, str>>,
-        pub other: HashMap<&'a str, Cow<'a, str>>,
-    }
-
-    impl<'a> Pkcs11Uri<'a> {
-        pub fn parse(uri: &'a str) -> anyhow::Result<Self> {
-            let path = uri
-                .strip_prefix("pkcs11:")
-                .ok_or_else(|| anyhow::anyhow!("missing PKCS #11 URI scheme"))?;
-
-            // split of the query component
-            let path = path.split_once('?').map(|(l, _)| l).unwrap_or(path);
-
-            // parse attributes, duplicate attributes are an error (RFC section 2.3)
-            let pairs_iter = path.split(';').filter_map(|pair| pair.split_once('='));
-            let mut pairs: HashMap<&str, &str> = HashMap::new();
-            for (k, v) in pairs_iter {
-                let prev_value = pairs.insert(k, v);
-                if prev_value.is_some() {
-                    anyhow::bail!("PKCS#11 URI contains duplicate attribute ({k})");
-                }
-            }
-
-            let token = pairs
-                .remove("token")
-                .map(|v| percent_encoding::percent_decode_str(v).decode_utf8_lossy());
-            let serial = pairs
-                .remove("serial")
-                .map(|v| percent_encoding::percent_decode_str(v).decode_utf8_lossy());
-            let object = pairs
-                .remove("object")
-                .map(|v| percent_encoding::percent_decode_str(v).decode_utf8_lossy());
-
-            let id: Option<Vec<u8>> = pairs
-                .remove("id")
-                .map(|id| percent_encoding::percent_decode_str(id).collect());
-
-            let other = pairs
-                .into_iter()
-                .map(|(k, v)| {
-                    (
-                        k,
-                        percent_encoding::percent_decode_str(v).decode_utf8_lossy(),
-                    )
-                })
-                .collect();
-
-            Ok(Self {
-                token,
-                serial,
-                id,
-                object,
-                other,
-            })
-        }
-
-        /// Add new attributes from `other` to `self`.
-        ///
-        /// If other contains new attributes not present in self, add them to self. If these
-        /// attributes are already present in self, preserve value currently in self.
-        pub fn append_attributes(&mut self, other: Self) {
-            self.token = self.token.take().or(other.token);
-            self.serial = self.serial.take().or(other.serial);
-            self.id = self.id.take().or(other.id);
-            self.object = self.object.take().or(other.object);
-
-            for (attribute, value) in other.other {
-                if !self.other.contains_key(attribute) {
-                    self.other.insert(attribute, value);
-                }
-            }
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        #[test]
-        fn decodes_valid_pkcs11_uri() {
-            // test input URIs taken from RFC examples section and combined with properties we actually use
-            // https://www.rfc-editor.org/rfc/rfc7512.html#section-3
-            let input = "pkcs11:token=The%20Software%20PKCS%2311%20Softtoken;\
-            manufacturer=Snake%20Oil,%20Inc.;\
-            model=1.0;\
-            object=my-certificate;\
-            type=cert;\
-            id=%69%95%3E%5C%F4%BD%EC%91;\
-            serial=\
-            ?pin-source=file:/etc/token_pin";
-
-            let attributes = Pkcs11Uri::parse(input).unwrap();
-
-            assert_eq!(attributes.token.unwrap(), "The Software PKCS#11 Softtoken");
-            assert_eq!(
-                attributes.other.get("manufacturer").unwrap(),
-                "Snake Oil, Inc."
-            );
-            assert_eq!(attributes.other.get("model").unwrap(), "1.0");
-            assert_eq!(attributes.serial.unwrap(), "");
-            assert_eq!(attributes.object.unwrap(), "my-certificate");
-            assert_eq!(
-                attributes.id,
-                Some(vec![0x69, 0x95, 0x3e, 0x5c, 0xf4, 0xbd, 0xec, 0x91])
-            );
-        }
-
-        #[test]
-        fn fails_on_uris_with_duplicate_attributes() {
-            let input = "pkcs11:token=my-token;token=my-token";
-            let err = Pkcs11Uri::parse(input).unwrap_err();
-            assert!(err
-                .to_string()
-                .contains("PKCS#11 URI contains duplicate attribute (token)"));
-        }
-
-        #[test]
-        fn fails_on_uris_with_invalid_scheme() {
-            let input = "not a pkcs#11 uri";
-            let err = Pkcs11Uri::parse(input).unwrap_err();
-            assert!(err.to_string().contains("missing PKCS #11 URI scheme"));
-        }
-
-        #[test]
-        fn appends_attributes_correctly() {
-            let mut uri1 = Pkcs11Uri::parse("pkcs11:token=token1").unwrap();
-            let uri2 = Pkcs11Uri::parse(
-                "pkcs11:token=token2;serial=serial2;id=%01%02;object=object2;key1=value1",
-            )
-            .unwrap();
-
-            uri1.append_attributes(uri2);
-
-            assert_eq!(uri1.token.unwrap(), "token1");
-            assert_eq!(uri1.serial.unwrap(), "serial2");
-            assert_eq!(uri1.id, Some(vec![0x01, 0x02]));
-            assert_eq!(uri1.object.unwrap(), "object2");
-            assert_eq!(uri1.other.get("key1").unwrap(), "value1");
-        }
-
-        #[test]
-        fn appends_attributes_with_no_conflicts() {
-            let mut uri1 = Pkcs11Uri::parse("pkcs11:").unwrap();
-            let uri2 = Pkcs11Uri::parse(
-                "pkcs11:token=token2;serial=serial2;id=%01%02;object=object2;key1=value1",
-            )
-            .unwrap();
-
-            uri1.append_attributes(uri2);
-
-            assert_eq!(uri1.token.unwrap(), "token2");
-            assert_eq!(uri1.serial.unwrap(), "serial2");
-            assert_eq!(uri1.id, Some(vec![0x01, 0x02]));
-            assert_eq!(uri1.object.unwrap(), "object2");
-            assert_eq!(uri1.other.get("key1").unwrap(), "value1");
-        }
-
-        #[test]
-        fn does_not_override_existing_attributes() {
-            let mut uri1 = Pkcs11Uri::parse(
-                "pkcs11:token=token1;serial=serial1;id=%01;object=object1;key1=value1",
-            )
-            .unwrap();
-            let uri2 = Pkcs11Uri::parse(
-                "pkcs11:token=token2;serial=serial2;id=%02;object=object2;key2=value2",
-            )
-            .unwrap();
-
-            uri1.append_attributes(uri2);
-
-            assert_eq!(uri1.token.unwrap(), "token1");
-            assert_eq!(uri1.serial.unwrap(), "serial1");
-            assert_eq!(uri1.id, Some(vec![0x01]));
-            assert_eq!(uri1.object.unwrap(), "object1");
-            assert_eq!(uri1.other.get("key1").unwrap(), "value1");
-            assert_eq!(uri1.other.get("key2").unwrap(), "value2");
-        }
     }
 }

--- a/crates/extensions/tedge-p11-server/src/pkcs11/uri.rs
+++ b/crates/extensions/tedge-p11-server/src/pkcs11/uri.rs
@@ -1,0 +1,191 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+/// Attributes decoded from a PKCS #11 URL.
+///
+/// Attributes only relevant to us shall be put into fields and the rest is in `other` hashmap.
+///
+/// https://www.rfc-editor.org/rfc/rfc7512.html
+#[derive(Debug, Clone, Default)]
+pub struct Pkcs11Uri<'a> {
+    pub token: Option<Cow<'a, str>>,
+    pub serial: Option<Cow<'a, str>>,
+    pub id: Option<Vec<u8>>,
+    pub object: Option<Cow<'a, str>>,
+    pub other: HashMap<&'a str, Cow<'a, str>>,
+}
+
+impl<'a> Pkcs11Uri<'a> {
+    pub fn parse(uri: &'a str) -> anyhow::Result<Self> {
+        let path = uri
+            .strip_prefix("pkcs11:")
+            .ok_or_else(|| anyhow::anyhow!("missing PKCS #11 URI scheme"))?;
+
+        // split of the query component
+        let path = path.split_once('?').map(|(l, _)| l).unwrap_or(path);
+
+        // parse attributes, duplicate attributes are an error (RFC section 2.3)
+        let pairs_iter = path.split(';').filter_map(|pair| pair.split_once('='));
+        let mut pairs: HashMap<&str, &str> = HashMap::new();
+        for (k, v) in pairs_iter {
+            let prev_value = pairs.insert(k, v);
+            if prev_value.is_some() {
+                anyhow::bail!("PKCS#11 URI contains duplicate attribute ({k})");
+            }
+        }
+
+        let token = pairs
+            .remove("token")
+            .map(|v| percent_encoding::percent_decode_str(v).decode_utf8_lossy());
+        let serial = pairs
+            .remove("serial")
+            .map(|v| percent_encoding::percent_decode_str(v).decode_utf8_lossy());
+        let object = pairs
+            .remove("object")
+            .map(|v| percent_encoding::percent_decode_str(v).decode_utf8_lossy());
+
+        let id: Option<Vec<u8>> = pairs
+            .remove("id")
+            .map(|id| percent_encoding::percent_decode_str(id).collect());
+
+        let other = pairs
+            .into_iter()
+            .map(|(k, v)| {
+                (
+                    k,
+                    percent_encoding::percent_decode_str(v).decode_utf8_lossy(),
+                )
+            })
+            .collect();
+
+        Ok(Self {
+            token,
+            serial,
+            id,
+            object,
+            other,
+        })
+    }
+
+    /// Add new attributes from `other` to `self`.
+    ///
+    /// If other contains new attributes not present in self, add them to self. If these
+    /// attributes are already present in self, preserve value currently in self.
+    pub fn append_attributes(&mut self, other: Self) {
+        self.token = self.token.take().or(other.token);
+        self.serial = self.serial.take().or(other.serial);
+        self.id = self.id.take().or(other.id);
+        self.object = self.object.take().or(other.object);
+
+        for (attribute, value) in other.other {
+            if !self.other.contains_key(attribute) {
+                self.other.insert(attribute, value);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_valid_pkcs11_uri() {
+        // test input URIs taken from RFC examples section and combined with properties we actually use
+        // https://www.rfc-editor.org/rfc/rfc7512.html#section-3
+        let input = "pkcs11:token=The%20Software%20PKCS%2311%20Softtoken;\
+            manufacturer=Snake%20Oil,%20Inc.;\
+            model=1.0;\
+            object=my-certificate;\
+            type=cert;\
+            id=%69%95%3E%5C%F4%BD%EC%91;\
+            serial=\
+            ?pin-source=file:/etc/token_pin";
+
+        let attributes = Pkcs11Uri::parse(input).unwrap();
+
+        assert_eq!(attributes.token.unwrap(), "The Software PKCS#11 Softtoken");
+        assert_eq!(
+            attributes.other.get("manufacturer").unwrap(),
+            "Snake Oil, Inc."
+        );
+        assert_eq!(attributes.other.get("model").unwrap(), "1.0");
+        assert_eq!(attributes.serial.unwrap(), "");
+        assert_eq!(attributes.object.unwrap(), "my-certificate");
+        assert_eq!(
+            attributes.id,
+            Some(vec![0x69, 0x95, 0x3e, 0x5c, 0xf4, 0xbd, 0xec, 0x91])
+        );
+    }
+
+    #[test]
+    fn fails_on_uris_with_duplicate_attributes() {
+        let input = "pkcs11:token=my-token;token=my-token";
+        let err = Pkcs11Uri::parse(input).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("PKCS#11 URI contains duplicate attribute (token)"));
+    }
+
+    #[test]
+    fn fails_on_uris_with_invalid_scheme() {
+        let input = "not a pkcs#11 uri";
+        let err = Pkcs11Uri::parse(input).unwrap_err();
+        assert!(err.to_string().contains("missing PKCS #11 URI scheme"));
+    }
+
+    #[test]
+    fn appends_attributes_correctly() {
+        let mut uri1 = Pkcs11Uri::parse("pkcs11:token=token1").unwrap();
+        let uri2 = Pkcs11Uri::parse(
+            "pkcs11:token=token2;serial=serial2;id=%01%02;object=object2;key1=value1",
+        )
+        .unwrap();
+
+        uri1.append_attributes(uri2);
+
+        assert_eq!(uri1.token.unwrap(), "token1");
+        assert_eq!(uri1.serial.unwrap(), "serial2");
+        assert_eq!(uri1.id, Some(vec![0x01, 0x02]));
+        assert_eq!(uri1.object.unwrap(), "object2");
+        assert_eq!(uri1.other.get("key1").unwrap(), "value1");
+    }
+
+    #[test]
+    fn appends_attributes_with_no_conflicts() {
+        let mut uri1 = Pkcs11Uri::parse("pkcs11:").unwrap();
+        let uri2 = Pkcs11Uri::parse(
+            "pkcs11:token=token2;serial=serial2;id=%01%02;object=object2;key1=value1",
+        )
+        .unwrap();
+
+        uri1.append_attributes(uri2);
+
+        assert_eq!(uri1.token.unwrap(), "token2");
+        assert_eq!(uri1.serial.unwrap(), "serial2");
+        assert_eq!(uri1.id, Some(vec![0x01, 0x02]));
+        assert_eq!(uri1.object.unwrap(), "object2");
+        assert_eq!(uri1.other.get("key1").unwrap(), "value1");
+    }
+
+    #[test]
+    fn does_not_override_existing_attributes() {
+        let mut uri1 = Pkcs11Uri::parse(
+            "pkcs11:token=token1;serial=serial1;id=%01;object=object1;key1=value1",
+        )
+        .unwrap();
+        let uri2 = Pkcs11Uri::parse(
+            "pkcs11:token=token2;serial=serial2;id=%02;object=object2;key2=value2",
+        )
+        .unwrap();
+
+        uri1.append_attributes(uri2);
+
+        assert_eq!(uri1.token.unwrap(), "token1");
+        assert_eq!(uri1.serial.unwrap(), "serial1");
+        assert_eq!(uri1.id, Some(vec![0x01]));
+        assert_eq!(uri1.object.unwrap(), "object1");
+        assert_eq!(uri1.other.get("key1").unwrap(), "value1");
+        assert_eq!(uri1.other.get("key2").unwrap(), "value2");
+    }
+}


### PR DESCRIPTION
## Proposed changes

Notable ECDSA signature formatting changes:
- replace an unwrap when serializing ASN.1 with a returned error
- add documentation
- add test checking if we're not misinterpreting `r` or `s` as negative values when MSB is set

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

