### PR TITLE
feat: create parent directories when apply configuration from the cloud

### DIFF
--- a/crates/common/tedge_utils/src/atomic.rs
+++ b/crates/common/tedge_utils/src/atomic.rs
@@ -39,6 +39,14 @@ pub fn write_file_atomic_set_permissions_if_doesnt_exist(
     let target_permissions = target_permissions(dest, permissions)
         .context("failed to compute target permissions of the file")?;
 
+    // Create parent directories of the file
+    std::fs::create_dir_all(dest.parent().unwrap()).with_context(|| {
+        format!(
+            "could not create parent directories of file '{}'",
+            dest.to_string_lossy()
+        )
+    })?;
+
     // TODO: create tests to ensure writes we expect are atomic
     let mut tempfile = tempfile::Builder::new()
         .permissions(std::fs::Permissions::from_mode(0o600))

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -69,6 +69,17 @@ Set Configuration when tedge-write is in another location
     Text file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1    /etc/config1.json    ${CURDIR}/config1-version2.json    664    root:root    delete_file_before=${false}
     Binary file (Child Device)    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1_BINARY    /etc/binary-config1.tar.gz    ${CURDIR}/binary-config1.tar.gz    664    root:root    delete_file_before=${false}
 
+Set Configuration Should Create Parent Directories
+    Cumulocity.Set Device    ${PARENT_SN}
+
+    ${config_url}=    Cumulocity.Create Inventory Binary    temp_file    harbor-certificate    contents=DUMMY CONTENTS
+    ${operation}=    Cumulocity.Set Configuration    harbor-certificate    url=${config_url}
+    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}    timeout=120
+
+    ThinEdgeIO.Set Device Context    ${PARENT_SN}
+    ${contents}=    Execute Command    cat /etc/containers/certs.d/example/ca.crt    strip=${True}
+    Should Be Equal    ${contents}    DUMMY CONTENTS
+
 Set configuration with broken url
     [Template]    Set Configuration from URL
     Main Device    ${PARENT_SN}    ${PARENT_SN}    CONFIG1    /etc/config1.json    invalid://hellö.zip
@@ -378,8 +389,25 @@ Set Configuration from URL
     Log    Test Description: ${test_desc}
 
     ThinEdgeIO.Set Device Context    ${device}
-    ${hash_before}=    Execute Command    md5sum ${device_file}
-    ${stat_before}=    Execute Command    stat ${device_file}
+    ${hash_before}=    Execute Command    md5sum ${device_file} ||true
+    ${stat_before}=    Execute Command    stat ${device_file} ||true
+
+    Cumulocity.Set Device    ${external_id}
+    ${operation}=    Cumulocity.Set Configuration    ${config_type}    url=${config_url}
+    ${operation}=    Operation Should Be FAILED    ${operation}    timeout=120
+
+    ${hash_after}=    Execute Command    md5sum ${device_file}
+    ${stat_after}=    Execute Command    stat ${device_file}
+    Should Be Equal    ${hash_before}    ${hash_after}
+    Should Be Equal    ${stat_before}    ${stat_after}
+
+Set Configuration
+    [Arguments]    ${test_desc}    ${device}    ${external_id}    ${config_type}    ${device_file}    ${config_url}
+    Log    Test Description: ${test_desc}
+
+    ThinEdgeIO.Set Device Context    ${device}
+    ${hash_before}=    Execute Command    md5sum ${device_file} ||true
+    ${stat_before}=    Execute Command    stat ${device_file} ||true
 
     Cumulocity.Set Device    ${external_id}
     ${operation}=    Cumulocity.Set Configuration    ${config_type}    url=${config_url}
@@ -443,6 +471,7 @@ Update configuration plugin config via cloud
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG-ROOT
@@ -468,6 +497,7 @@ Modify configuration plugin config via local filesystem modify inplace
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG-ROOT
@@ -477,6 +507,7 @@ Modify configuration plugin config via local filesystem modify inplace
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG3
     ...    CONFIG3_BINARY
@@ -492,6 +523,7 @@ Modify configuration plugin config via local filesystem overwrite
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY
@@ -502,6 +534,7 @@ Modify configuration plugin config via local filesystem overwrite
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG3
     ...    CONFIG3_BINARY
@@ -517,6 +550,7 @@ Update configuration plugin config via local filesystem copy
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY
@@ -542,6 +576,7 @@ Update configuration plugin config via local filesystem move (different director
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG-ROOT
@@ -567,6 +602,7 @@ Update configuration plugin config via local filesystem move (same directory)
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG-ROOT

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -113,6 +113,7 @@ Update Configuration Should Fail
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY
@@ -137,6 +138,7 @@ Update Configuration Should Succeed
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY

--- a/tests/RobotFramework/tests/cumulocity/configuration/tedge-configuration-plugin.toml
+++ b/tests/RobotFramework/tests/cumulocity/configuration/tedge-configuration-plugin.toml
@@ -4,4 +4,5 @@ files = [
     { path = '/etc/config1.json', type = 'CONFIG1', user = 'tedge', group = 'tedge', mode = 0o640 },
     { path = '/etc/binary-config1.tar.gz', type = 'CONFIG1_BINARY', user = 'tedge', group = 'tedge', mode = 0o640 },
     { path = '/etc/config-root.json', type = 'CONFIG-ROOT', user = 'root', group = 'root', mode = 0o600 },
+    { path = '/etc/containers/certs.d/example/ca.crt', type = 'harbor-certificate', user = 'tedge', group = 'tedge', mode = 0o640 },
 ]


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

When applying a configuration from the cloud (via the tedge-configuration-plugin.toml), the parent directories will be automatically created if they do not already exist.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3693

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

