### PR TITLE
chore: tedge diag's tarball path prints out to stdout

### DIFF
--- a/crates/core/tedge/src/cli/diag/collect.rs
+++ b/crates/core/tedge/src/cli/diag/collect.rs
@@ -201,6 +201,7 @@ impl DiagCollectCommand {
 
         // Cannot write this message to summary.log since the tarball has already been created
         eprintln!("Diagnostic information saved to {tarball_path}");
+        println!("{tarball_path}");
         Ok(tarball_path)
     }
 }

--- a/tests/RobotFramework/tests/tedge/diag/tedge_diag_collect.robot
+++ b/tests/RobotFramework/tests/tedge/diag/tedge_diag_collect.robot
@@ -11,9 +11,10 @@ Test Tags           theme:troubleshooting    theme:cli    theme:plugins
 
 *** Test Cases ***
 Run tedge diag collect
-    Execute Command    tedge diag collect --name default
+    ${stdout}=    Execute Command    tedge diag collect --name default    strip=${True}
     File Should Exist    /tmp/default.tar.gz
     Directory Should Not Exist    /tmp/default
+    Should Be Equal    ${stdout}    /tmp/default.tar.gz
 
     Execute Command    tar -xvzf /tmp/default.tar.gz -C /tmp
     Validate preset plugins    default


### PR DESCRIPTION
## Proposed changes
Only the tarball path prints out to `stdout` to make the following usecase work.

```sh
OUTPUT_PATH=$(tedge diag collect --name some_file_name)
tedge upload c8y --file "$OUTPUT_PATH"

# or in a one-liner
tedge upload c8y --file "$(tedge diag collect)"
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3646 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

