### PR TITLE
feat: create parent directories if missing for config_update operation

### DIFF
--- a/crates/core/tedge_write/src/lib.rs
+++ b/crates/core/tedge_write/src/lib.rs
@@ -30,3 +30,4 @@ pub mod bin;
 mod api;
 
 pub use api::CopyOptions;
+pub use api::CreateDirsOptions;

--- a/docs/src/operate/c8y/configuration-management.md
+++ b/docs/src/operate/c8y/configuration-management.md
@@ -26,13 +26,25 @@ files = [
   { path = '/etc/tedge/mosquitto-conf/c8y-bridge.conf', type = 'c8y-bridge.conf' },
   { path = '/etc/tedge/mosquitto-conf/tedge-mosquitto.conf', type = 'tedge-mosquitto.conf' },
   { path = '/etc/mosquitto/mosquitto.conf', type = 'mosquitto.conf' },
-  { path = '/etc/tedge/c8y/example.txt', type = 'example', user = 'tedge', group = 'tedge', mode = 0o644 }
+  { path = '/etc/tedge/c8y/example.txt', type = 'example', user = 'tedge', group = 'tedge', mode = 0o644 },
+  { path = '/etc/containers/certs.d/example/ca.crt', type = 'harbor-certificate', user = 'tedge', group = 'tedge', mode = 0o640, parent_user = 'root', parent_group = 'root', parent_mode = 0o755 },
 ]
 ```
 
 * `path` is the full path to the configuration file.
 * `type` is a unique alias for each file entry which will be used to represent that file in Cumulocity UI.
-* `user`, `group` and `mode` are UNIX file permission settings to be used to create a configuration file. If not provided, the files will be created with `root` user. If the file exists already, its ownership will be retained.
+* `user`, `group` and `mode` are UNIX file permission settings to be used to create a configuration file. 
+  If not provided, the files will be created with the current user and group, and, if not feasible, using `root`.
+  If the file exists already, its ownership will be retained.
+* `parent_user`, `parent_group` and `parent_mode` are UNIX file permission settings to be used to create the immediate
+  parent directory of the configuration file. It is recommended to set these values if the parent directories are
+  expected to be missing initially.
+    * If these values are not explicitly provided,
+        * the values from `user` and `group` will be used as a fallback.
+        * if `user` and `group` are also not specified,
+            * the directories will be created with the `root` user if `tedge-write` is enabled.
+            * otherwise, the current system user and group will be used.
+    * If the directories already exist, its existing ownership and permissions will be preserved.
 
 :::note
 The Cumulocity legacy configuration operations (e.g. non file-type operations) will be automatically given the "default" type. This will enable you to configure the file location as you would with any other configuration file.

--- a/docs/src/references/agent/tedge-configuration-management.md
+++ b/docs/src/references/agent/tedge-configuration-management.md
@@ -71,13 +71,22 @@ Each configuration file is defined by a record with:
   and a new one is created with these ownership parameters.
   When a configuration file is already present on the device,
   the agent preserves its existing ownership, ignoring these parameters.
+* Optional unix directory ownership of the immediate parent of the file: `parent_user`, `parent_group` and octal `parent_mode`.
+  These parameters apply only when the configuration file and its parent directories do not already exist on the device.
+  In such cases, the immediate parent directory is created with the specified ownership and mode.
+  Any missing directories above the immediate parent are created using the current user and group.
+  If the file’s `user` is specified but `parent_user` is not, `parent_user` will default to the value of `user`.
+  Similarly, if the file’s `group` is specified but `parent_group` is not, `parent_group` will default to the value of `group`.
+  If the parent directories already exist, the agent preserves their existing ownership and ignores these parameters.
 
 ```toml title="file: /etc/tedge/plugins/tedge-configuration-plugin.toml"
 files = [
   { path = '/etc/tedge/tedge.toml', type = 'tedge.toml' },
   { path = '/etc/tedge/mosquitto-conf/c8y-bridge.conf', type = 'c8y-bridge' },
   { path = '/etc/tedge/mosquitto-conf/tedge-mosquitto.conf', type = 'tedge-mosquitto' },
-  { path = '/etc/mosquitto/mosquitto.conf', type = 'mosquitto', user = 'mosquitto', group = 'mosquitto', mode = 0o644 }
+  { path = '/etc/mosquitto/mosquitto.conf', type = 'mosquitto', user = 'mosquitto', group = 'mosquitto', mode = 0o644 },
+  { path = '/etc/containers/certs.d/example/ca.crt', type = 'harbor-certificate', user = 'tedge', group = 'tedge', mode = 0o640, parent_user = 'root', parent_group = 'root', parent_mode = 0o755 },
+
 ]
 ```
 

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -113,6 +113,7 @@ Update Configuration Should Fail
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY
@@ -126,6 +127,7 @@ Update Configuration Should Fail
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY
@@ -137,6 +139,7 @@ Update Configuration Should Succeed
     Cumulocity.Should Support Configurations
     ...    tedge-configuration-plugin
     ...    /etc/tedge/tedge.toml
+    ...    harbor-certificate
     ...    system.toml
     ...    CONFIG1
     ...    CONFIG1_BINARY

--- a/tests/RobotFramework/tests/cumulocity/configuration/tedge-configuration-plugin.toml
+++ b/tests/RobotFramework/tests/cumulocity/configuration/tedge-configuration-plugin.toml
@@ -4,4 +4,5 @@ files = [
     { path = '/etc/config1.json', type = 'CONFIG1', user = 'tedge', group = 'tedge', mode = 0o640 },
     { path = '/etc/binary-config1.tar.gz', type = 'CONFIG1_BINARY', user = 'tedge', group = 'tedge', mode = 0o640 },
     { path = '/etc/config-root.json', type = 'CONFIG-ROOT', user = 'root', group = 'root', mode = 0o600 },
+    { path = '/etc/containers/certs.d/example/ca.crt', type = 'harbor-certificate', user = 'tedge', group = 'tedge', mode = 0o640, parent_user = 'root', parent_group = 'root', parent_mode = 0o700 },
 ]


### PR DESCRIPTION
## Proposed changes
Previously, the `config_update` operation would fail if any parent directories of the target file were missing.

This change ensures that missing parent directories are automatically created when the operation is executed.

The mode, user, and group of the immediate parent directory can be configured via `tedge-configuration-plugin.toml` using the following keys:
- `parent_mode`
- `parent_user`
- `parent_group`

If `parent_user` and `parent_group` are not explicitly specified, but the target file's ownership is provided, the parent directory will inherit the file's user and group.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3693 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

