### PR TITLE
feat: add offline mode to tedge reconnect command

### DIFF
--- a/crates/core/tedge/src/cli/reconnect/cli.rs
+++ b/crates/core/tedge/src/cli/reconnect/cli.rs
@@ -6,6 +6,10 @@ use tedge_config::TEdgeConfig;
 
 #[derive(clap::Args, Debug)]
 pub struct TEdgeReconnectCli {
+    /// Ignore connection registration and connection check
+    #[clap(long = "offline", global = true)]
+    offline_mode: bool,
+
     #[clap(subcommand)]
     cloud: CloudArg,
 }
@@ -16,6 +20,7 @@ impl BuildCommand for TEdgeReconnectCli {
             config_dir: config.root_dir().to_owned(),
             service_manager: service_manager(config.root_dir())?,
             cloud: self.cloud.try_into()?,
+            offline_mode: self.offline_mode,
             use_mapper: true,
         }
         .into_boxed())

--- a/crates/core/tedge/src/cli/reconnect/command.rs
+++ b/crates/core/tedge/src/cli/reconnect/command.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 pub struct ReconnectBridgeCommand {
     pub config_dir: Utf8PathBuf,
     pub cloud: Cloud,
+    pub offline_mode: bool,
     pub use_mapper: bool,
     pub service_manager: Arc<dyn SystemServiceManager>,
 }
@@ -50,7 +51,7 @@ impl From<&ReconnectBridgeCommand> for ConnectCommand {
         ConnectCommand {
             cloud: reconnect_cmd.cloud.clone(),
             is_test_connection: false,
-            offline_mode: false,
+            offline_mode: reconnect_cmd.offline_mode,
             service_manager: reconnect_cmd.service_manager.clone(),
             is_reconnect: true,
         }

--- a/tests/RobotFramework/tests/tedge_connect/tedge_connect_offline.robot
+++ b/tests/RobotFramework/tests/tedge_connect/tedge_connect_offline.robot
@@ -20,3 +20,15 @@ Check offline bootstrapping
 
     ThinEdgeIO.Connect To Network
     ThinEdgeIO.Execute Command    sudo tedge connect c8y --test
+
+Check offline bootstrapping using reconnect
+    ThinEdgeIO.Execute Command    sudo tedge disconnect c8y
+    ThinEdgeIO.Service Should Be Stopped    tedge-mapper-c8y
+
+    ThinEdgeIO.Disconnect From Network
+    ThinEdgeIO.Execute Command    sudo tedge reconnect c8y --offline
+    ThinEdgeIO.Service Should Be Running    tedge-mapper-c8y
+    ThinEdgeIO.Execute Command    sudo tedge connect c8y --test    exp_exit_code=!0
+
+    ThinEdgeIO.Connect To Network
+    ThinEdgeIO.Execute Command    sudo tedge connect c8y --test    timeout=60


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Improve cli consistency by adding the `--offline` flag to the `tedge reconnect` command to allow users to reconfigure the mapper even if the device does not have cloud connectivity.

The `offline` mode is useful when the device has already been pre-registered with Cumulocity (via the Bulk Registration API), and the device is being setup in the factory without internet connection, and `tedge connect/reconnect` is used to recreate the bridge settings, and enable/start the required services (which is extremely helpful when dealing with non-systemd based OS's). 

This aligns the `tedge reconnect` command with the `tedge connect` command, and allows users to seemlessly switch between the two commands,

**Before**

```
tedge disconnect c8y
tedge connect c8y --offline
```

**After**

```sh
tedge reconnect c8y --offline
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

