### PR TITLE
refactor: Revert "disable problematic tests to allow the CI changes to be merged"

### DIFF
--- a/crates/extensions/tedge_downloader_ext/src/tests.rs
+++ b/crates/extensions/tedge_downloader_ext/src/tests.rs
@@ -10,7 +10,6 @@ use tokio::time::timeout;
 const TEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[tokio::test]
-#[ignore = "to get #3726 merged"]
 async fn download_without_auth() {
     let ttd = TempTedgeDir::new();
     let mut server = mockito::Server::new_async().await;
@@ -42,7 +41,6 @@ async fn download_without_auth() {
 }
 
 #[tokio::test]
-#[ignore = "to get #3726 merged"]
 async fn download_with_auth() {
     let ttd = TempTedgeDir::new();
     let mut server = mockito::Server::new_async().await;
@@ -89,7 +87,6 @@ async fn spawn_downloader_actor(
 }
 
 #[tokio::test]
-#[ignore = "to get #3726 merged"]
 async fn download_if_download_key_is_struct() {
     let ttd = TempTedgeDir::new();
     let mut server = mockito::Server::new_async().await;


### PR DESCRIPTION
This reverts commit dd5a8e0abc42c00ae69746154ad92b79d10d575d.

## Proposed changes
Re-enable the download tests following the merging of #3726.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

