### PR TITLE
build: Make build tools build to different dirs so `just release` doesn't rebuild from scratch every time

### DIFF
--- a/ci/build_scripts/build.sh
+++ b/ci/build_scripts/build.sh
@@ -203,16 +203,21 @@ build() {
     shift
     case "$build_tool" in
         zig|ziglang|cargo-zigbuild)
+            # make different tools build to different directories so they don't trash each other's cache
+            BUILD_SUBDIR=target/cargo-zigbuild
+            BUILD_DIR=${BUILD_DIR/target/$BUILD_SUBDIR}
             # shellcheck disable=SC2086
-            cargo-zigbuild $TOOLCHAIN zigbuild "$@"
+            cargo-zigbuild $TOOLCHAIN zigbuild --target-dir "$BUILD_SUBDIR" "$@"
             ;;
         clang)
+            BUILD_SUBDIR=target/clang
+            BUILD_DIR=${BUILD_DIR/target/$BUILD_SUBDIR}
             # shellcheck disable=SC2086
-            mk/cargo.sh $TOOLCHAIN build "$@"
+            mk/cargo.sh $TOOLCHAIN build --target-dir "$BUILD_SUBDIR" "$@"
             ;;
         native|*)
             # shellcheck disable=SC2086
-            cargo $TOOLCHAIN build "$@"
+            cargo $TOOLCHAIN build --target-dir "$BINARY_TARGET" "$@"
             ;;
     esac
 }


### PR DESCRIPTION
## Proposed changes

Until now, when build.sh script used different build tools, e.g. cargo-zigbuild or clang, all these tools built to the same directory. Because their output is different, they generated different cachedir tags, so this resulted in no artifact caching when running `just release` multiple times on the same code: cargo zigbuild first run and wrote its tag, then clang and overwrote zigbuild's cache tag and on next `just release` invocation zigbuild would have to build from scratch becuase its stuff was overwritten by clang, and vice versa.

Now they output to different directories so they don't overwrite each other's cache. This might increase the size of the build directory.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Feel free to amend the commit since the change is maybe not the cleanest (mutating a variable defined outside the function, may easily break), but not sure how to do it better.

