### PR TITLE
fix: do not overwrite latest twin data from inventory.json values on mapper restart

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -41,7 +41,6 @@ const SUPPORTED_OPERATIONS_DIRECTORY: &str = "operations";
 pub struct C8yMapperConfig {
     pub device_id: String,
     pub device_topic_id: EntityTopicId,
-    pub device_type: String,
     pub service: TEdgeConfigReaderService,
     pub c8y_host: String,
     pub c8y_mqtt: String,
@@ -84,7 +83,6 @@ impl C8yMapperConfig {
 
         device_id: String,
         device_topic_id: EntityTopicId,
-        device_type: String,
         service: TEdgeConfigReaderService,
         c8y_host: String,
         c8y_mqtt: String,
@@ -124,7 +122,6 @@ impl C8yMapperConfig {
             data_dir,
             device_id,
             device_topic_id,
-            device_type,
             service,
             c8y_host,
             c8y_mqtt,
@@ -170,7 +167,6 @@ impl C8yMapperConfig {
 
         let c8y_config = tedge_config.c8y.try_get(c8y_profile)?;
         let device_id = c8y_config.device.id()?.to_string();
-        let device_type = tedge_config.device.ty.clone();
         let device_topic_id = EntityTopicId::from_str(&tedge_config.mqtt.device_topic_id)?;
         let service = tedge_config.service.clone();
         let c8y_host = c8y_config.http.or_config_not_set()?.to_string();
@@ -241,7 +237,6 @@ impl C8yMapperConfig {
             tmp_dir,
             device_id,
             device_topic_id,
-            device_type,
             service,
             c8y_host,
             c8y_mqtt,

--- a/docs/src/operate/c8y/custom-fragments.md
+++ b/docs/src/operate/c8y/custom-fragments.md
@@ -83,11 +83,11 @@ An example `inventory.json` looks something like this:
 }
 ```
 
-To see the changes you need to restart the tedge-mapper.
+To see the changes you need to restart the tedge-agent.
 If you're using systemctl you can do: 
 
 ```sh
-sudo systemctl restart tedge-mapper-c8y
+sudo systemctl restart tedge-agent
 ```
 
 In the Cumulocity UI this will looks something like this:
@@ -100,6 +100,23 @@ In the Cumulocity UI this will looks something like this:
     />
 </p>
 
+The `tedge-agent` publishes fragments in this file to their corresponding twin topics as retained messages.
+For example, the above `inventory.json` file is processed as follows:
+
+```sh te2mqtt
+tedge mqtt pub --retained te/device/main///twin/c8y_Hardware '{
+  "model": "BCM2708",
+  "revision": "000e",
+  "serialNumber": "00000000e2f5ad4d"
+}'
+```
+
+Since these entries are persistent retained messages, when entries are removed from the `inventory.json` file,
+the corresponding twin entries must also be cleared explicitly from the broker as follows:
+
+```sh te2mqtt
+tedge mqtt pub --retained  te/device/main///twin/c8y_Hardware ''
+```
 
 For information on which fragments Cumulocity supports please see the
 [Cumulocity API docs](https://cumulocity.com/docs/device-integration/fragment-library/).

--- a/tests/RobotFramework/tests/cumulocity/inventory/inventory_update_bootstrap.robot
+++ b/tests/RobotFramework/tests/cumulocity/inventory/inventory_update_bootstrap.robot
@@ -1,0 +1,56 @@
+*** Settings ***
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:telemetry
+
+
+*** Test Cases ***
+Main device name and type not updated on mapper and agent restart
+    Execute Command    tedge connect c8y
+    Device Should Exist    ${DEVICE_SN}
+
+    # Check initial values from registration
+    Device Should Have Fragment Values    name\="Advanced ${DEVICE_SN}"
+    Device Should Have Fragment Values    type\="advancedV1"
+
+    # The original values should also be retained after restarting
+    Execute Command    tedge reconnect c8y
+    Sleep    3s
+    Device Should Have Fragment Values    name\="Advanced ${DEVICE_SN}"
+    Device Should Have Fragment Values    type\="advancedV1"
+
+    # Change the values via the inventory.json
+    Execute Command
+    ...    cmd=printf '{"name":"Super Advanced Device","type":"advancedV2"}\n' > /etc/tedge/device/inventory.json
+    Restart Service    tedge-agent
+    Execute Command    tedge reconnect c8y
+    Sleep    3s
+    Device Should Have Fragment Values    name\="Super Advanced Device"
+    Device Should Have Fragment Values    type\="advancedV2"
+
+    # Override the cloud values by explicitly publishing new values on the local broker
+    Execute Command    tedge mqtt pub --retain "te/device/main///twin/name" '"RaspberryPi 0001"'
+    Execute Command    tedge mqtt pub --retain "te/device/main///twin/type" '"RaspberryPi5"'
+    Sleep    3s
+    Device Should Have Fragment Values    name\="RaspberryPi 0001"
+    Device Should Have Fragment Values    type\="RaspberryPi5"
+    Restart Service    tedge-agent
+    Execute Command    tedge reconnect c8y
+    Sleep    3s
+    Device Should Have Fragment Values    name\="RaspberryPi 0001"
+    Device Should Have Fragment Values    type\="RaspberryPi5"
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}=    Setup    register=${False}
+    ThinEdgeIO.Register Device With Cumulocity CA
+    ...    external_id=${DEVICE_SN}
+    ...    name=Advanced ${DEVICE_SN}
+    ...    device_type=advancedV1
+    Set Suite Variable    $DEVICE_SN

--- a/tests/RobotFramework/tests/tedge/diag/predefined_plugins.robot
+++ b/tests/RobotFramework/tests/tedge/diag/predefined_plugins.robot
@@ -40,7 +40,9 @@ Test Tags           theme:troubleshooting    theme:cli    theme:plugins
         File Size Is Not Zero    ${log_name}
     END
     Log Should Contain    tedge-mqtt-sub.log    [te/device/main///cmd/restart] {}
-    Log Should Contain    tedge-mqtt-sub-retained-only.log    [te/device/main///twin/type] "thin-edge.io"
+    Log Should Contain
+    ...    tedge-mqtt-sub-retained-only.log
+    ...    [te/device/main/service/tedge-agent] {"@parent":"device/main//","@type":"service","name":"tedge-agent","type":"service"}
 
 04_workflow
     File Size Is Not Zero    output.log


### PR DESCRIPTION
## Proposed changes

- [x] move inventory.json processing from `tedge-mapper-c8y` to `tedge-agent` 
- [x] Publish the contents of `inventory.json` file to `twin` topics only after all the existing retained twin messages are processed by the agent, so that already published `twin` keys are skipped (to avoid overwriting them with old values in the file).

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

* https://github.com/thin-edge/thin-edge.io/issues/3734
* https://github.com/thin-edge/thin-edge.io/issues/3666

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

