### PR TITLE
fix: de-duplicate custom operations on c8y/devicecontrol/notifications

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -641,9 +641,7 @@ impl CumulocityConverter {
                 )
                 .await;
             let result = self.handle_c8y_operation_result(&result, Some(operation.op_id.clone()));
-            if !result.is_empty() {
-                self.active_commands.insert(cmd_id, Some(Instant::now()));
-            }
+            self.active_commands.insert(cmd_id, Some(Instant::now()));
             output.extend(result);
         }
 
@@ -758,9 +756,7 @@ impl CumulocityConverter {
             .await;
 
         let output = self.handle_c8y_operation_result(&result, Some(operation.op_id));
-        if !output.is_empty() {
-            self.active_commands.insert(cmd_id, Some(Instant::now()));
-        }
+        self.active_commands.insert(cmd_id, Some(Instant::now()));
 
         Ok(output)
     }


### PR DESCRIPTION
## Proposed changes
Ensure `tedge-mapper-c8y` doesn't handle incoming custom operations if received multiple times from Cumulocity.

The specific case this fixes is for custom operations from Cumulocity JSON fragements (e.g. on `c8y/devicecontrol/notifications`) where these execute using a `command` from the mapper. Since these don't use a workflow to execute, these operations didn't generate any `te/...` messages, so we didn't track them in `active_commands`. This PR changes this so that any operation with an ID is included in `active_commands`, and it will be removed after a 12 hour timeout elapses.

This won't fix any cases where we are using smartrest to receive the operation payload, since those messages do not have an ID included in the payload.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #3399 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

