### PR TITLE
ci: free more disk space due to upcoming builds running out of space

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -41,9 +41,25 @@ jobs:
       - name: Reclaim some disk space
         run: |
           sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/lib/android
           sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/.ghcup
           sudo rm -rf "/usr/local/share/boost"
-          sudo rm -rf /opt/hostedtoolcache
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /opt/hostedtoolcache/
+          sudo rm -rf /usr/local/graalvm/
+          sudo rm -rf /usr/local/share/powershell
+          sudo rm -rf /usr/local/share/chromium
+          sudo rm -rf /usr/local/lib/node_modules
+          sudo docker image prune --all --force
+          
+          APT_PARAMS='sudo apt -y -qq -o=Dpkg::Use-Pty=0'
+          $APT_PARAMS remove '^dotnet-.*' '^php.*' '^mongodb-.*' '^llvm-.*' '^mysql-.*' azure-cli 'google-*' google-chrome-stable firefox powershell mono-devel
+          $APT_PARAMS autoremove --purge
+          $APT_PARAMS autoclean
+          $APT_PARAMS clean
+
           # Make sure /mnt has plenty of empty space,
           # but ignore the error we encounter on /mnt/swapfile
           # since we can't delete that


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Try and free more space on the Github runner due to encountering "No space left on device" in https://github.com/thin-edge/thin-edge.io/actions/runs/16578878898/job/46889886628?pr=3650.

The additional list of packages which are being deleted was taken from [this gist](https://gist.github.com/antiphishfish/1e3fbc3f64ef6f1ab2f47457d2da5d9d).

The new cleanup should free-up an additional ~26 GB (at least on the ubuntu-24.04 runner). Below shows a comparison with the previous clean step. Though the additional cleanup takes a lot longer, 2m30s (up from ~15 seconds).

**Before (previous cleanup strategy)**

```
Run df -BM
Filesystem     1M-blocks   Used Available Use% Mounted on
/dev/root         73326M 40281M    33030M  55% /
tmpfs              7998M     1M     7998M   1% /dev/shm
tmpfs              3200M     2M     3199M   1% /run
tmpfs                 5M     0M        5M   0% /run/lock
/dev/sdb16          881M    60M      760M   8% /boot
/dev/sdb15          105M     7M       99M   6% /boot/efi
/dev/sda1         75029M  4097M    67077M   6% /mnt
tmpfs              1600M     1M     1600M   1% /run/user/1001
```

**After (new cleanup strategy)**

```sh
Run df -BM
Filesystem     1M-blocks   Used Available Use% Mounted on
/dev/root         73326M 14055M    59255M  20% /
tmpfs              7998M     1M     7998M   1% /dev/shm
tmpfs              3200M     2M     3199M   1% /run
tmpfs                 5M     0M        5M   0% /run/lock
/dev/sda16          881M    60M      760M   8% /boot
/dev/sda15          105M     7M       99M   6% /boot/efi
/dev/sdb1         75029M  4097M    67077M   6% /mnt
tmpfs              1600M     1M     1600M   1% /run/user/1001
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

