### PR TITLE
docs: add info how to display custom fragments in Cumulocity Dev-Mgmt UI

### DIFF
--- a/docs/src/operate/c8y/custom-fragments.md
+++ b/docs/src/operate/c8y/custom-fragments.md
@@ -37,6 +37,10 @@ sudo tedge config set device.type edge_gateway
 
 Additional fragments can be added to the device by either publishing to a give MQTT topic, or via a file based method. Each section describes what data and when to use it.
 
+:::tip
+In order to display your custom fragments in Cumulocity's Device Management UI, you have to add them to the "Device Data" Widget of your Device's Info Page. See the [Device Details Info](https://cumulocity.com/docs/device-management-application/viewing-device-details/#info) for reference.
+:::
+
 ### MQTT Dynamic Fragments {#dynamic-fragments}
 
 %%te%% offers an MQTT topic which can be used to publish data to custom fragments for a device, child devices or services.


### PR DESCRIPTION
## Proposed changes

I've received feedback that it should be more obvious that Users need to Edit Widgets / Adapt the UI before seeing the custom fragments they created via thin-edge.io. 
For all other actions (create measurements, events, alarms, create child-devices/services, etc.) no changes are needed on cloud side, for custom fragments there is. This PR introduces a short note about it to the docs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [X] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

