### PR TITLE
test: wait for agent to be ready before restarting mapper

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/inventory/inventory_update_bootstrap.robot
+++ b/tests/RobotFramework/tests/cumulocity/inventory/inventory_update_bootstrap.robot
@@ -28,6 +28,7 @@ Main device name and type not updated on mapper and agent restart
     Execute Command
     ...    cmd=printf '{"name":"Super Advanced Device","type":"advancedV2"}\n' > /etc/tedge/device/inventory.json
     Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
     Execute Command    tedge reconnect c8y
     Sleep    3s
     Device Should Have Fragment Values    name\="Super Advanced Device"
@@ -40,6 +41,7 @@ Main device name and type not updated on mapper and agent restart
     Device Should Have Fragment Values    name\="RaspberryPi 0001"
     Device Should Have Fragment Values    type\="RaspberryPi5"
     Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
     Execute Command    tedge reconnect c8y
     Sleep    3s
     Device Should Have Fragment Values    name\="RaspberryPi 0001"


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix a flaky test which was introduced in https://github.com/thin-edge/thin-edge.io/pull/3742.

The root case seems to be a race condition where if the mapper is restarted whilst the tedge-agent is still starting up, when results in inventory name/type values being non-deterministic. It is unclear whether there is something can be done in the mapper to make this more reliable, however the test needs to be patched so it does not block other PRs.

Below are multiple failures which occurred on the CI runner.

* https://github.com/thin-edge/thin-edge.io/actions/runs/16679498844
* https://github.com/thin-edge/thin-edge.io/actions/runs/16678104887
* https://github.com/thin-edge/thin-edge.io/actions/runs/16677349088

The failures can be easily re-produced by reducing the CPU quota for the system tests using the following env variables:

```
DOCKER_OPTIONS_CPU_QUOTA=5000
DOCKER_OPTIONS_CPU_PERIOD=20000
```

Below shows a comparison before and after the change using the `flake-finder` task:

**Before**

```sh
$ invoke flake-finder --test-name 'Main device name and type not updated on mapper and agent restart' --iterations 50 --clean

Overall: FAILED
Results: 5 iterations, 1 passed, 4 failed
Elapsed time: 0:09:55.613560
Failed iterations: [2, 3, 4, 5]
```

**After**

```
$ invoke flake-finder --test-name 'Main device name and type not updated on mapper and agent restart' --iterations 50 --clean

Overall: PASSED
Results: 50 iterations, 50 passed, 0 failed
Elapsed time: 1:21:56.979814
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

