### PR TITLE
docs: fix incorrect note format in Entity Management REST API guide

### DIFF
--- a/docs/src/operate/entity-management/rest_api.md
+++ b/docs/src/operate/entity-management/rest_api.md
@@ -23,7 +23,7 @@ The payload must contain at least the `@topic-id` and `@type` of the entity: whe
 :::note
 The topic id of the entity is not specified in the URL path, but in the payload itself,
 unlike the MQTT API where it is specified in the MQTT topic.
-:::note
+:::
 
 Other supported (optional) fields in the registration payload include:
 - `@parent`: Topic ID of the parent entity.


### PR DESCRIPTION
## Proposed changes

Fix the `NOTE` format in https://thin-edge.github.io/thin-edge.io/operate/entity-management/rest_api/

**Wrong:**
<img width="962" height="686" alt="image" src="https://github.com/user-attachments/assets/110d5ed5-1728-4fb6-8e16-59f96f39812d" />

**Corrected:**
<img width="985" height="646" alt="image" src="https://github.com/user-attachments/assets/0660ab9d-f590-43b9-ada5-83bace09105d" />


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

