### PR TITLE
test: start tedge-agent after the inventory.json file

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/inventory/inventory_update.robot
+++ b/tests/RobotFramework/tests/cumulocity/inventory/inventory_update.robot
@@ -60,11 +60,11 @@ Update main device inventory fragments via twin topics using built-in bridge
 
 *** Keywords ***
 Custom Setup
-    ${DEVICE_SN}=    Setup
+    ${DEVICE_SN}=    Setup    connect=${False}
     Set Suite Variable    $DEVICE_SN
-    Device Should Exist    ${DEVICE_SN}
     ThinEdgeIO.Transfer To Device    ${CURDIR}/inventory.json    /etc/tedge/device/
-    ThinEdgeIO.Disconnect Then Connect Mapper    c8y
+    ThinEdgeIO.Connect Mapper    c8y
+    Device Should Exist    ${DEVICE_SN}
 
 Validate inventory fragment updates via twin topics
     [Arguments]    ${device_xid}=${DEVICE_SN}    ${device_tid}=${device_xid}


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix a flaky test due a race condition where the tedge-agent is starting up at the same time the inventory.json is being edited which results in the inventory.json being sometimes ignored.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3764

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

