### PR TITLE
feat: publish properties along tedge measurements

### DIFF
--- a/crates/common/json_writer/src/lib.rs
+++ b/crates/common/json_writer/src/lib.rs
@@ -58,6 +58,13 @@ impl JsonWriter {
         }
     }
 
+    pub fn write_value(&mut self, s: &serde_json::Value) -> Result<(), JsonWriterError> {
+        self.maybe_separate();
+        serde_json::to_writer(&mut self.buffer, s)?;
+        self.needs_separator = true;
+        Ok(())
+    }
+
     pub fn write_open_obj(&mut self) {
         self.maybe_separate();
         self.buffer.push(b'{');

--- a/crates/core/tedge_api/src/measurement/builder.rs
+++ b/crates/core/tedge_api/src/measurement/builder.rs
@@ -79,6 +79,14 @@ impl MeasurementVisitor for ThinEdgeJsonBuilder {
     fn visit_text_property(&mut self, _name: &str, _value: &str) -> Result<(), Self::Error> {
         Ok(())
     }
+
+    fn visit_json_property(
+        &mut self,
+        _name: &str,
+        _value: serde_json::Value,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/core/tedge_api/src/measurement/group.rs
+++ b/crates/core/tedge_api/src/measurement/group.rs
@@ -190,6 +190,14 @@ impl MeasurementVisitor for MeasurementGrouper {
     fn visit_text_property(&mut self, _name: &str, _value: &str) -> Result<(), Self::Error> {
         Ok(())
     }
+
+    fn visit_json_property(
+        &mut self,
+        _name: &str,
+        _value: serde_json::Value,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -218,6 +226,7 @@ mod tests {
             fn visit_start_group(&mut self, group: &str) -> Result<(), TestError>;
             fn visit_end_group(&mut self) -> Result<(), TestError>;
             fn visit_text_property(&mut self, _name: &str, _value:&str)-> Result<(), TestError>;
+            fn visit_json_property(&mut self, _name: &str, _value: serde_json::Value) -> Result<(), TestError>;
         }
     }
 

--- a/crates/core/tedge_api/src/measurement/mod.rs
+++ b/crates/core/tedge_api/src/measurement/mod.rs
@@ -81,6 +81,10 @@ pub use serialize::*;
 ///    fn visit_text_property(&mut self, _name: &str, _value: &str) -> Result<(), Self::Error>{
 ///         Ok(())
 ///    }
+///
+///    fn visit_json_property(&mut self, _name: &str, _value: serde_json::Value) -> Result<(), Self::Error>{
+///         Ok(())
+///    }
 /// }
 /// ```
 pub trait MeasurementVisitor {
@@ -95,6 +99,13 @@ pub trait MeasurementVisitor {
 
     /// Add a text property, attached to the current group if any.
     fn visit_text_property(&mut self, _name: &str, _value: &str) -> Result<(), Self::Error>;
+
+    /// Add a free form property that is not a measurement nor a text.
+    fn visit_json_property(
+        &mut self,
+        name: &str,
+        value: serde_json::Value,
+    ) -> Result<(), Self::Error>;
 
     /// Start to gather measurements for a group.
     fn visit_start_group(&mut self, group: &str) -> Result<(), Self::Error>;

--- a/crates/core/tedge_api/src/measurement/parser.rs
+++ b/crates/core/tedge_api/src/measurement/parser.rs
@@ -98,6 +98,12 @@ where
                         .visit_timestamp(timestamp.into())
                         .map_err(de::Error::custom)?;
                 }
+                "properties" => {
+                    let properties = map.next_value()?;
+                    self.visitor
+                        .visit_json_property("properties", properties)
+                        .map_err(de::Error::custom)?;
+                }
                 _key => {
                     let parser = ThinEdgeValueParser {
                         depth: 0,

--- a/crates/core/tedge_api/src/measurement/serialize.rs
+++ b/crates/core/tedge_api/src/measurement/serialize.rs
@@ -9,6 +9,7 @@ pub struct ThinEdgeJsonSerializer {
     is_within_group: bool,
     default_timestamp: Option<OffsetDateTime>,
     timestamp_present: bool,
+    properties: Option<serde_json::Value>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -59,6 +60,7 @@ impl ThinEdgeJsonSerializer {
             is_within_group: false,
             default_timestamp,
             timestamp_present: false,
+            properties: None,
         }
     }
 
@@ -71,6 +73,11 @@ impl ThinEdgeJsonSerializer {
             if let Some(default_timestamp) = self.default_timestamp {
                 self.visit_timestamp(default_timestamp)?;
             }
+        }
+
+        if let Some(properties) = &self.properties {
+            self.json.write_key("properties")?;
+            self.json.write_value(properties)?;
         }
 
         self.json.write_close_obj();
@@ -139,6 +146,15 @@ impl MeasurementVisitor for ThinEdgeJsonSerializer {
     }
 
     fn visit_text_property(&mut self, _name: &str, _value: &str) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn visit_json_property(
+        &mut self,
+        _name: &str,
+        value: serde_json::Value,
+    ) -> Result<(), Self::Error> {
+        self.properties = Some(value);
         Ok(())
     }
 }

--- a/crates/extensions/c8y_mapper_ext/src/serializer.rs
+++ b/crates/extensions/c8y_mapper_ext/src/serializer.rs
@@ -193,6 +193,23 @@ impl MeasurementVisitor for C8yJsonSerializer {
         Ok(())
     }
 
+    fn visit_json_property(
+        &mut self,
+        key: &str,
+        value: serde_json::Value,
+    ) -> Result<(), Self::Error> {
+        if key == "properties" && value.is_object() {
+            if let Some(properties) = value.as_object() {
+                for (k, v) in properties {
+                    self.json.write_key(k)?;
+                    self.json.write_value(v)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn visit_start_group(&mut self, group: &str) -> Result<(), Self::Error> {
         if self.is_within_group {
             return Err(MeasurementStreamError::UnexpectedStartOfGroup.into());

--- a/docs/src/understand/thin-edge-json.md
+++ b/docs/src/understand/thin-edge-json.md
@@ -162,6 +162,44 @@ and hence must not be used as measurement keys:
 | --- | --- |
 | time | Timestamp in ISO 8601 string format or as a unix timestamp (in seconds) |
 
+### Measurement properties
+
+A measurement can contain additional properties to contextualize the measurement.
+
+These properties are free-form and only have to be grouped under a `properties` sub-object.
+
+```sh te2mqtt formats=v1
+tedge mqtt pub te/device/main///m/example '{
+  "time": "2020-10-15T05:30:47+00:00",
+  "temperature": 25,
+
+  "properties": {
+    "sensor": "DS18B20",
+    "has_alarm": false,
+    "samples": [ 25.1, 25.0, 24.9],
+    "range": {
+       "min": "-55°C",
+       "max": "+125°C"
+    }
+  }
+}'
+```
+
+These additional properties are not interpreted by %%te%% as measurement values and are passed unchanged to the target cloud.
+For instance, the example is translated into the following when forwarded to Cumulocity:
+
+```json
+{
+  "time":"2020-10-15T05:30:47Z",
+  "temperature":{"temperature":{"value":25.0}},
+  "sensor":"DS18B20",
+  "has_alarm":false,
+  "samples":[25.1,25.0,24.9],
+  "range":{"min":"-55°C","max":"+125°C"},
+  "type":"example"
+}
+```
+
 ## Events
 
 *Events* are notifications that something happened on the device, its environment, the domain application or the software system.

--- a/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry.robot
+++ b/tests/RobotFramework/tests/cumulocity/telemetry/thin-edge_device_telemetry.robot
@@ -61,6 +61,34 @@ Thin-edge devices support sending custom measurements
     ...    series=L1
     Log    ${measurements}
 
+Thin-edge devices sending metadata properties along measurements
+    Execute Command
+    ...    tedge mqtt pub 'te/device/main///m/g1' '{"robot_mech_energy":{"accumulated_energy": 0.1},"properties":{"measurement_context":{"status": "nominal","cycle_id": "cycle-98765"}}}'
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=g1
+    ...    value=robot_mech_energy
+    ...    series=accumulated_energy
+    Log    ${measurements}
+    Should Be Equal    ${measurements[0]["measurement_context"]["status"]}    nominal
+    Should Be Equal    ${measurements[0]["measurement_context"]["cycle_id"]}    cycle-98765
+
+Thin-edge devices sending arbitrary metadata properties along measurements
+    Execute Command
+    ...    tedge mqtt pub 'te/device/main///m/g3' '{"robot_mech_energy": 0.1,"properties":{"prop1":"foo","prop2":false,"prop3":["foo", "bar"]}}'
+    ${measurements}=    Device Should Have Measurements
+    ...    minimum=1
+    ...    maximum=1
+    ...    type=g3
+    ...    value=robot_mech_energy
+    ...    series=robot_mech_energy
+    Log    ${measurements}
+    Should Be Equal    ${measurements[0]["prop1"]}    foo
+    Should Be Equal As Strings    ${measurements[0]["prop2"]}    False
+    Should Be Equal    ${measurements[0]["prop3"][0]}    foo
+    Should Be Equal    ${measurements[0]["prop3"][1]}    bar
+
 Thin-edge devices support sending custom events
     Execute Command
     ...    tedge mqtt pub te/device/main///e/myCustomType1 '{ "text": "Some test event", "someOtherCustomFragment": {"nested":{"value": "extra info"}} }'


### PR DESCRIPTION
## Proposed changes

Allow  meta properties to be published along tedge measurements, and forward these properties unchanged to Cumulocity.

```
tedge mqtt pub te/device/main///m/example '{
  "time": "2020-10-15T05:30:47+00:00",
  "temperature": 25,
  "properties": {
    "sensor": "DS18B20",
    "has_alarm": false,
    "samples": [ 25.1, 25.0, 24.9],
    "range": {
       "min": "-55°C",
       "max": "+125°C"
    }
  }
}'
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3768

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

