### PR TITLE
feat: enable cert renewal when using cloud profiles with Cumulocity

### DIFF
--- a/configuration/init/systemd/tedge-cert-renewer-c8y.target
+++ b/configuration/init/systemd/tedge-cert-renewer-c8y.target
@@ -1,0 +1,2 @@
+[Unit]
+Description=thin-edge.io certificate renewal for c8y cloud profiles

--- a/configuration/init/systemd/tedge-cert-renewer-c8y@.service
+++ b/configuration/init/systemd/tedge-cert-renewer-c8y@.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=thin-edge.io certificate renewer for c8y (profile=%i)
+After=network-online.target
+StartLimitIntervalSec=0
+PartOf=tedge-cert-renewer-c8y.target
+
+[Service]
+Type=oneshot
+User=root
+
+Environment=RENEW_WITH_CA=c8y
+
+; Only run service is if the certificate needs renewal
+ExecCondition=/usr/bin/tedge cert needs-renewal c8y --profile %i
+
+; Run renewal
+ExecStartPre=/usr/bin/tedge cert renew c8y --ca ${RENEW_WITH_CA} --profile %i
+
+; Reconnect
+ExecStart=/usr/bin/tedge reconnect c8y --profile %i
+
+; Cleanup
+ExecStopPost=sh -c 'rm -f "$(tedge config get c8y.device.cert_path --profile %i).new"'
+
+[Install]
+WantedBy=multi-user.target

--- a/configuration/init/systemd/tedge-cert-renewer-c8y@.timer
+++ b/configuration/init/systemd/tedge-cert-renewer-c8y@.timer
@@ -1,0 +1,19 @@
+[Unit]
+Description=Timer for thin-edge.io certificate renewal for c8y (profile=%i)
+Documentation=https://thin-edge.io
+PartOf=tedge-cert-renewer-c8y.target
+
+[Timer]
+Persistent=true
+
+; Timer interval
+OnCalendar=hourly
+
+; Always run the timer on time
+AccuracySec=1us
+
+; Add jitter to prevent a "thundering herd" of simultaneous certificate renewals
+RandomizedDelaySec=5m
+
+[Install]
+WantedBy=timers.target

--- a/configuration/init/systemd/tedge-mapper-c8y@.service
+++ b/configuration/init/systemd/tedge-mapper-c8y@.service
@@ -2,7 +2,7 @@
 Description=tedge-mapper-c8y converts Thin Edge JSON measurements to Cumulocity JSON format.
 After=syslog.target network.target mosquitto.service
 PartOf=tedge-mapper-c8y.target
-Wants=tedge-cert-renewer@%i.timer
+Wants=tedge-cert-renewer-c8y@%i.timer
 
 [Service]
 User=tedge

--- a/configuration/package_manifests/nfpm.tedge-mapper.yaml
+++ b/configuration/package_manifests/nfpm.tedge-mapper.yaml
@@ -177,6 +177,40 @@ contents:
       mode: 0644
     packager: rpm
 
+  # Cumulocity cloud profile cert renewal service
+  - src: ./configuration/init/systemd/tedge-cert-renewer-c8y.target
+    dst: /lib/systemd/system/tedge-cert-renewer-c8y.target
+    file_info:
+      mode: 0644
+    packager: deb
+  - src: ./configuration/init/systemd/tedge-cert-renewer-c8y.target
+    dst: /lib/systemd/system/tedge-cert-renewer-c8y.target
+    file_info:
+      mode: 0644
+    packager: rpm
+
+  - src: ./configuration/init/systemd/tedge-cert-renewer-c8y@.service
+    dst: /lib/systemd/system/tedge-cert-renewer-c8y@.service
+    file_info:
+      mode: 0644
+    packager: deb
+  - src: ./configuration/init/systemd/tedge-cert-renewer-c8y@.service
+    dst: /lib/systemd/system/tedge-cert-renewer-c8y@.service
+    file_info:
+      mode: 0644
+    packager: rpm
+
+  - src: ./configuration/init/systemd/tedge-cert-renewer-c8y@.timer
+    dst: /lib/systemd/system/tedge-cert-renewer-c8y@.timer
+    file_info:
+      mode: 0644
+    packager: deb
+  - src: ./configuration/init/systemd/tedge-cert-renewer-c8y@.timer
+    dst: /lib/systemd/system/tedge-cert-renewer-c8y@.timer
+    file_info:
+      mode: 0644
+    packager: rpm
+
   - src: ./configuration/contrib/collectd/collectd.conf
     dst: /etc/tedge/contrib/collectd/
     file_info:

--- a/docs/src/operate/c8y/cloud-profiles.md
+++ b/docs/src/operate/c8y/cloud-profiles.md
@@ -188,3 +188,129 @@ $ TEDGE_C8Y_PROFILES_$C8Y_PROFILE_NAME_PROXY_BIND_PORT=1234 tedge config get c8y
 If you are configuring %%te%% entirely with environment variables, e.g. in a
 containerised deployment, you probably don't need to make use of cloud profiles
 as you can set the relevant configurations directly on each mapper instance.
+
+## Examples
+
+### Example: Connect to a second Cumulocity Tenant
+
+Assuming you have %%te%% device that is already connected to one Cumulocity tenant, and you now want to connect the device to a second Cumulocity tenant so that you can expose the second tenant to customer of yours. In this scenario, you don't want to expose all of the device management aspects like firmware/software installation, but you want the customer to be able to view telemetry data being sent by the device. This setup is enabled by using cloud profiles, which setups up two instances of the tedge-mapper-c8y service, one per Cumulocity tenant connection.
+
+The following diagram illustrates the target setup where the same device is connected to two different Cumulocity tenants, where each connection is using a different device certificate (however the same the private key is used for both connections).
+
+```mermaid
+flowchart TD
+    A[Tenant 1] <--Connect with Cert 1--> Device
+    B[Tenant 2] <--Connect with Cert 2--> Device
+```
+
+The above setup can be achieved with the following steps:
+
+1. Set the Cumulocity URL of the second tenant you wish connect the device to
+
+    <UserContext>
+
+    ```sh
+    sudo tedge config set c8y.url $C8Y_PROFILE_URL --profile $C8Y_PROFILE_NAME
+    ```
+
+    </UserContext>
+
+    :::note
+    The `--profile <name>` argument is used to indicate that you wish to change the settings for the cloud profile of the given name.
+    :::
+
+1. Change the public certificate path which will be used by the second connection (though it doesn't exist just yet)
+
+    <UserContext>
+
+    ```sh
+    sudo tedge config set c8y.device.cert_path /etc/tedge/device-certs/tedge-certificate-$C8Y_PROFILE_NAME.pem --profile $C8Y_PROFILE_NAME
+    ```
+
+    </UserContext>
+
+1. Change the bridge related settings to avoid conflicts with the default Cumulocity connection
+
+    <UserContext>
+
+    ```sh
+    sudo tedge config set c8y.bridge.topic_prefix c8y-$C8Y_PROFILE_NAME --profile $C8Y_PROFILE_NAME
+    sudo tedge config set c8y.proxy.bind.port 8002 --profile $C8Y_PROFILE_NAME
+    ```
+
+    </UserContext>
+
+1. Optional: Set which telemetry data is pushed to the second connection by changing which %%te%% topics the mapper instance subscribes to
+
+    <UserContext>
+
+    ```sh
+    # default connection: send all data
+    tedge config set c8y.topics "te/+/+/+/+,te/+/+/+/+/twin/+,te/+/+/+/+/m/+,te/+/+/+/+/m/+/meta,te/+/+/+/+/e/+,te/+/+/+/+/a/+,te/+/+/+/+/status/health" --profile $C8Y_PROFILE_NAME
+
+    # second connection: only send measurements and twin information but not alarms and events
+    tedge config set c8y.topics "te/+/+/+/+,te/+/+/+/+/twin/+,te/+/+/+/+/m/+,te/+/+/+/+/m/+/meta,te/+/+/+/+/status/health" --profile $C8Y_PROFILE_NAME
+    ```
+
+    </UserContext>
+
+    :::note
+    If you modify these settings after %%te%% is already connected, then you will have to restart the mapper afterwards.
+    :::
+
+    You can also control which operation should be enabled for the connection by setting the following settings to `false`.
+
+    <UserContext>
+
+    ```sh
+    # enable fetch style operations
+    tedge config set c8y.enable.log_upload false --profile $C8Y_PROFILE_NAME
+    tedge config set c8y.enable.config_snapshot false  --profile $C8Y_PROFILE_NAME
+
+    # disable operations which change things
+    tedge config set c8y.enable.config_update false --profile $C8Y_PROFILE_NAME
+    tedge config set c8y.enable.firmware_update false --profile $C8Y_PROFILE_NAME
+    tedge config set c8y.enable.device_profile false --profile $C8Y_PROFILE_NAME
+    ```
+
+    </UserContext>
+
+1. Navigate to the Cumulocity Device Registration application, and register a single device using the Cumulocity CA feature where you can set the one-time password that the device will use to download it.
+
+1. Download the device certificate from the Cumulocity CA
+
+    <UserContext>
+
+    ```sh
+    sudo tedge cert download c8y --profile $C8Y_PROFILE_NAME --one-time-password "<one_time_password>" --device-id "$(tedge config get device.id)"
+    ```
+
+    </UserContext>
+
+    :::note
+    You can use your own Certificate Authority to issue a certificate, but then you will have to retrieve the certificate yourself and place in the configured path.
+    :::
+
+1. Connect the device to the second Cumulocity tenant
+
+    <UserContext>
+
+    ```sh
+    sudo tedge connect c8y --profile $C8Y_PROFILE_NAME
+    ```
+
+    </UserContext>
+
+    If you are using systemd on your device, then a certificate renewal service which will automatically renew the certificate for you. You can inspect the timer which triggers the `tedge-cert-renewer-c8y@` service periodically using the following command:
+
+    <UserContext>
+    
+    ```sh
+    # check the timer
+    sudo systemctl status tedge-cert-renewer-c8y@$C8Y_PROFILE_NAME.timer
+
+    # check the service called by the timer
+    sudo systemctl status tedge-cert-renewer-c8y@$C8Y_PROFILE_NAME.service
+    ```
+
+    </UserContext>


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Add a new systemd service template to handle the certificate renewal when using a Cumulocity mapper with cloud profiles. The previous service `tedge-cert-renewer@.service` isn't able to support cloud profiles as the template variable (the part after the `@` sign) is used for the mapper type, and not the cloud profile name.

The new `tedge-cert-renewer-c8y@.timer` unit (not the `-c8y` before the `@` sign!) will be automatically activated when the `tedge-mapper-c8y@.service` is enabled/created. The timer then will trigger the corresponding `tedge-cert-renewer-c8y@.service` which then does the actual certificate renewal commands for the given cloud profile.

Note: You can manually enable and start the renewal process for a given Cumulocity cloud profile using the following commands:

```sh
systemctl enable tedge-cert-renewer-c8y@second.timer
systemctl start tedge-cert-renewer-c8y@second.timer
```

The PR also included an extension to the existing cloud profiles documentation to provide an end-to-end example of how to setup a second connection and going into some details about why (to reflect a customer scenario).

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

