### PR TITLE
improve: PKCS11 slots/tokens/objects logging

### DIFF
--- a/crates/extensions/tedge-p11-server/src/pkcs11/mod.rs
+++ b/crates/extensions/tedge-p11-server/src/pkcs11/mod.rs
@@ -136,7 +136,7 @@ impl Cryptoki {
     /// again ([C_GetSlotList]).
     ///
     /// [C_GetSlotList]: https://docs.oasis-open.org/pkcs11/pkcs11-base/v2.40/errata01/os/pkcs11-base-v2.40-errata01-os-complete.html#_Toc441755804
-    fn reinit(&self) -> anyhow::Result<()> {
+    fn _reinit(&self) -> anyhow::Result<()> {
         // load a new client before locking so if error we don't poison the mutex
         let new_client = Self::load(&self.config.module_path)?;
 
@@ -195,7 +195,9 @@ impl Cryptoki {
         let wanted_label = uri_attributes.token.as_ref();
         let wanted_serial = uri_attributes.serial.as_ref();
 
-        self.reinit()?;
+        // avoid reinitializing for now because of Nitrokey slowness
+        // self.reinit()?;
+
         let context = match self.context.lock() {
             Ok(c) => c,
             Err(e) => e.into_inner(),

--- a/crates/extensions/tedge-p11-server/src/pkcs11/uri.rs
+++ b/crates/extensions/tedge-p11-server/src/pkcs11/uri.rs
@@ -85,6 +85,22 @@ impl<'a> Pkcs11Uri<'a> {
     }
 }
 
+const PKCS11_ASCII_SET: &percent_encoding::AsciiSet =
+    &percent_encoding::NON_ALPHANUMERIC.remove(b'-');
+
+/// Percent-encode PKCS11 attribute values.
+///
+/// In contrast to more general URL percent-encoding, some characters like `-` don't need to be
+/// percent-encoded in PKCS11 URIs[1], so we don't encode them. Note that if we did, encoding these
+/// characters that don't have to be encoded is not a mistake, as any URI parser would eagerly
+/// decode all percent-encode sequences, the difference is just better/worse readability for the
+/// user.
+///
+/// [1]: https://www.rfc-editor.org/rfc/rfc7512.html#section-2.3
+pub fn percent_encode(input: &str) -> String {
+    percent_encoding::utf8_percent_encode(input, PKCS11_ASCII_SET).to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/RobotFramework/tests/pkcs11/private_key_storage_runtime_changes.robot
+++ b/tests/RobotFramework/tests/pkcs11/private_key_storage_runtime_changes.robot
@@ -3,7 +3,7 @@ Resource            ./pkcs11_common.resource
 
 Test Teardown       Get Suite Logs
 
-Test Tags           adapter:docker    theme:cryptoki
+Test Tags           adapter:docker    theme:cryptoki    test:on_demand
 
 
 *** Test Cases ***


### PR DESCRIPTION
## Proposed changes

When opening a session to a token as part of a request, all slots and tokens visible by the system will be printed.
We will also print URIs of all objects that we can see on the token.

NOTE: this PR also reverts "https://github.com/thin-edge/thin-edge.io/pull/3772", because this fix introduces TLS timeouts. For details see the commit message https://github.com/thin-edge/thin-edge.io/commit/7bcf8a91d7da11a4c5e7491063ff1ae48bda0190

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This is a follow-up to #3766 that we thought was solved but is not. The issue can't be reliably reproduced, so we need to improve diagnostics for when it eventually reappears.

