### PR TITLE
fix: tedge connect c8y --test works with basic auth

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/smartrest_one/smartrest_one.robot
+++ b/tests/RobotFramework/tests/cumulocity/smartrest_one/smartrest_one.robot
@@ -25,6 +25,12 @@ Supports SmartREST 1.0 Templates - mosquitto
     [Tags]    test:retry(1)    workaround    # rarely no message arrives on c8y/s/dl/template
     Register and Use SmartREST 1.0. Templates    use_builtin_bridge=false
 
+tedge connect c8y --test works with basic auth
+    [Tags]    \#3791
+    Register and Use SmartREST 1.0. Templates    use_builtin_bridge=true
+    Execute Command    tedge connect c8y --test
+    Should Have MQTT Messages    c8y/s/ds    message_contains=124
+
 
 *** Keywords ***
 Register and Use SmartREST 1.0. Templates


### PR DESCRIPTION
## Proposed changes
`tedge connect c8y --test` uses SmartREST `123` and expects to receive `124` when using basic auth.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3791 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

