### PR TITLE
fix: support `--help` for `apt` and `file-log` plugins.

### DIFF
--- a/plugins/tedge_file_log_plugin/src/bin.rs
+++ b/plugins/tedge_file_log_plugin/src/bin.rs
@@ -13,6 +13,7 @@ use time::OffsetDateTime;
 #[derive(clap::Parser, Debug)]
 #[clap(
     name = "tedge-file-log-plugin",
+    alias = "file",
     version = clap::crate_version!(),
     about = clap::crate_description!(),
     arg_required_else_help(true)


### PR DESCRIPTION
## Proposed changes
We handle `apt` plugin parsing errors to ensure the exit code is 1, to adhere to the plugin interface. However, in doing so, we accidentally mishandled clap error output.

This PR leans more heavily on the clap APIs for printing error information, and ensures we exit as expected (0 if the user requests `--help`, 1 if a plugin encounters an error parsing arguments, 2 if another tedge binary encounters an error parsing arguments). It also adds support for unit testing the exit codes.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

