### PR TITLE
fix: Ensure tedge-flows dumps statistics even if there are no registered interval handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5156,6 +5156,7 @@ dependencies = [
  "tokio",
  "toml 0.8.22",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/extensions/tedge_flows/Cargo.toml
+++ b/crates/extensions/tedge_flows/Cargo.toml
@@ -37,6 +37,7 @@ tracing = { workspace = true }
 tedge_mqtt_ext = { workspace = true, features = ["test-helpers"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [lints]
 workspace = true

--- a/crates/extensions/tedge_flows/src/lib.rs
+++ b/crates/extensions/tedge_flows/src/lib.rs
@@ -9,6 +9,7 @@ mod runtime;
 mod stats;
 
 use crate::actor::FlowsMapper;
+use crate::actor::STATS_DUMP_INTERVAL;
 pub use crate::runtime::MessageProcessor;
 use camino::Utf8Path;
 use std::convert::Infallible;
@@ -28,6 +29,7 @@ use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::MqttRequest;
 use tedge_mqtt_ext::SubscriptionDiff;
 use tedge_mqtt_ext::TopicFilter;
+use tokio::time::Instant;
 use tracing::error;
 
 fan_in_message_type!(InputMessage[MqttMessage, FsWatchEvent]: Clone, Debug, Eq, PartialEq);
@@ -98,6 +100,7 @@ impl Builder<FlowsMapper> for FlowsMapperBuilder {
             messages: self.message_box.build(),
             subscriptions,
             processor: self.processor,
+            next_dump: Instant::now() + STATS_DUMP_INTERVAL,
         }
     }
 }

--- a/crates/extensions/tedge_flows/tests/stats_dump.rs
+++ b/crates/extensions/tedge_flows/tests/stats_dump.rs
@@ -1,0 +1,317 @@
+use camino::Utf8Path;
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::time::Duration;
+use tedge_actors::Actor as _;
+use tedge_actors::Builder;
+use tedge_actors::CloneSender as _;
+use tedge_actors::DynSender;
+use tedge_actors::MappingSender;
+use tedge_actors::MessageSink;
+use tedge_actors::MessageSource as ActorMessageSource;
+use tedge_actors::NoConfig;
+use tedge_actors::SimpleMessageBox;
+use tedge_actors::SimpleMessageBoxBuilder;
+use tedge_flows::FlowsMapperBuilder;
+use tedge_mqtt_ext::DynSubscriptions;
+use tedge_mqtt_ext::MqttMessage;
+use tedge_mqtt_ext::MqttRequest;
+use tempfile::TempDir;
+use tracing::Subscriber;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::Layer;
+
+struct TestCaptureLayer {
+    captured: Arc<StdMutex<Vec<String>>>,
+}
+
+impl TestCaptureLayer {
+    fn new(captured: Arc<StdMutex<Vec<String>>>) -> Self {
+        Self { captured }
+    }
+}
+
+impl<S> Layer<S> for TestCaptureLayer
+where
+    S: Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut visitor = MessageVisitor::default();
+        event.record(&mut visitor);
+        if let Some(message) = visitor.message {
+            self.captured.lock().unwrap().push(message);
+        }
+    }
+}
+
+#[derive(Default)]
+struct MessageVisitor {
+    message: Option<String>,
+}
+
+impl tracing::field::Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.message = Some(format!("{:?}", value));
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn stats_are_dumped_when_no_interval_handlers_registered() {
+    let captured_logs = Arc::new(StdMutex::new(Vec::new()));
+    let captured_logs_clone = captured_logs.clone();
+
+    let _guard = tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_test_writer())
+        .with(TestCaptureLayer::new(captured_logs_clone))
+        .set_default();
+
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let config_dir = temp_dir.path();
+
+    let js_content = r#"
+        export function onMessage(message) {
+            return [message];
+        }
+    "#;
+    std::fs::write(config_dir.join("passthrough.js"), js_content).expect("Failed to write JS file");
+
+    let config = r#"
+        input.mqtt.topics = ["te/device/main///m/test"]
+        steps = [{ script = "passthrough.js" }]
+        output.mqtt.topics = ["te/device/main///m/output"]
+    "#;
+    std::fs::write(config_dir.join("mqtt_only_flow.toml"), config).expect("Failed to write config");
+
+    let mut flows_builder = FlowsMapperBuilder::try_new(Utf8Path::from_path(config_dir).unwrap())
+        .await
+        .expect("Failed to create FlowsMapperBuilder");
+
+    let mut mock_mqtt = MockMqttBuilder::new();
+    flows_builder.connect(&mut mock_mqtt);
+
+    let flows_actor = flows_builder.build();
+    let _mqtt_mock = mock_mqtt.build();
+
+    let actor_handle = tokio::spawn(async move { flows_actor.run().await });
+
+    tokio::time::advance(Duration::from_secs(300)).await;
+    tokio::task::yield_now().await;
+
+    actor_handle.abort();
+    let _ = actor_handle.await;
+
+    let logs = captured_logs.lock().unwrap();
+    let log_text = logs.join("\n");
+
+    assert!(
+        log_text.contains("Memory usage:"),
+        "Expected memory stats to be dumped after 300+ seconds. Captured logs:\n{}",
+        log_text
+    );
+    assert!(
+        log_text.contains("Processing statistics:"),
+        "Expected processing stats to be dumped after 300+ seconds. Captured logs:\n{}",
+        log_text
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn stats_dumped_when_interval_handlers_present() {
+    let captured_logs = Arc::new(StdMutex::new(Vec::new()));
+    let captured_logs_clone = captured_logs.clone();
+
+    let _guard = tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_test_writer())
+        .with(TestCaptureLayer::new(captured_logs_clone))
+        .set_default();
+
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let config_dir = temp_dir.path();
+
+    let js_content = r#"
+        export function onMessage(message) {
+            return [message];
+        }
+
+        export function onInterval() {
+            return [];
+        }
+    "#;
+    std::fs::write(config_dir.join("interval_script.js"), js_content)
+        .expect("Failed to write JS file");
+
+    let config = r#"
+        input.mqtt.topics = ["te/device/main///m/test"]
+        steps = [{ script = "interval_script.js", interval = "37s" }]
+        output.mqtt.topics = ["te/device/main///m/output"]
+    "#;
+    std::fs::write(config_dir.join("interval_flow.toml"), config).expect("Failed to write config");
+
+    let mut flows_builder = FlowsMapperBuilder::try_new(Utf8Path::from_path(config_dir).unwrap())
+        .await
+        .expect("Failed to create FlowsMapperBuilder");
+
+    let mut mock_mqtt = MockMqttBuilder::new();
+    flows_builder.connect(&mut mock_mqtt);
+
+    let flows_actor = flows_builder.build();
+    let _mqtt_mock = mock_mqtt.build();
+
+    let actor_handle = tokio::spawn(async move { flows_actor.run().await });
+
+    tokio::time::advance(Duration::from_secs(300)).await;
+    tokio::task::yield_now().await;
+
+    actor_handle.abort();
+    let _ = actor_handle.await;
+
+    let logs = captured_logs.lock().unwrap();
+    let log_text = logs.join("\n");
+
+    assert!(
+        log_text.contains("Memory usage:"),
+        "Expected memory stats to be dumped after 300+ seconds. Captured logs:\n{}",
+        log_text
+    );
+    assert!(
+        log_text.contains("Processing statistics:"),
+        "Expected processing stats to be dumped after 300+ seconds. Captured logs:\n{}",
+        log_text
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn stats_not_dumped_before_300_seconds() {
+    let captured_logs = Arc::new(StdMutex::new(Vec::new()));
+    let captured_logs_clone = captured_logs.clone();
+
+    let _guard = tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_test_writer())
+        .with(TestCaptureLayer::new(captured_logs_clone))
+        .set_default();
+
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let config_dir = temp_dir.path();
+
+    let js_content = r#"
+        export function onMessage(message) {
+            return [message];
+        }
+    "#;
+    std::fs::write(config_dir.join("passthrough.js"), js_content).expect("Failed to write JS file");
+
+    let config = r#"
+        input.mqtt.topics = ["te/device/main///m/test"]
+        steps = [{ script = "passthrough.js" }]
+        output.mqtt.topics = ["te/device/main///m/output"]
+    "#;
+    std::fs::write(config_dir.join("mqtt_only_flow.toml"), config).expect("Failed to write config");
+
+    let mut flows_builder = FlowsMapperBuilder::try_new(Utf8Path::from_path(config_dir).unwrap())
+        .await
+        .expect("Failed to create FlowsMapperBuilder");
+
+    let mut mock_mqtt = MockMqttBuilder::new();
+    flows_builder.connect(&mut mock_mqtt);
+
+    let flows_actor = flows_builder.build();
+    let _mqtt_mock = mock_mqtt.build();
+
+    let actor_handle = tokio::spawn(async move { flows_actor.run().await });
+
+    tokio::time::advance(Duration::from_secs(299)).await;
+    tokio::task::yield_now().await;
+
+    actor_handle.abort();
+    let _ = actor_handle.await;
+
+    let logs = captured_logs.lock().unwrap();
+    let log_text = logs.join("\n");
+
+    assert!(
+        !log_text.contains("Memory usage:"),
+        "Stats should not be dumped before 300 seconds. Captured logs:\n{}",
+        log_text
+    );
+    assert!(
+        !log_text.contains("Processing statistics:"),
+        "Stats should not be dumped before 300 seconds. Captured logs:\n{}",
+        log_text
+    );
+}
+
+type MockMqttActor = SimpleMessageBox<MqttMessage, MqttMessage>;
+
+struct MockMqttBuilder {
+    messages: SimpleMessageBoxBuilder<MqttMessage, MqttMessage>,
+    sender_cache: Arc<StdMutex<Option<DynSender<MqttRequest>>>>,
+    captured_messages: Arc<StdMutex<Vec<MqttMessage>>>,
+}
+
+impl MockMqttBuilder {
+    fn new() -> Self {
+        Self {
+            messages: SimpleMessageBoxBuilder::new("MockMQTT", 32),
+            sender_cache: Arc::new(StdMutex::new(None)),
+            captured_messages: Arc::new(StdMutex::new(Vec::new())),
+        }
+    }
+}
+
+impl ActorMessageSource<MqttMessage, &mut DynSubscriptions> for MockMqttBuilder {
+    fn connect_sink(
+        &mut self,
+        config: &mut DynSubscriptions,
+        sink: &impl MessageSink<MqttMessage>,
+    ) {
+        config.set_client_id_usize(0);
+        self.messages.connect_sink(NoConfig, sink);
+    }
+}
+
+impl MessageSink<MqttRequest> for MockMqttBuilder {
+    fn get_sender(&self) -> DynSender<MqttRequest> {
+        let mut cached_sender = self.sender_cache.lock().unwrap();
+        if let Some(sender) = &*cached_sender {
+            return sender.sender_clone();
+        }
+
+        let captured_messages = self.captured_messages.clone();
+        let sender = Box::new(MappingSender::new(
+            self.messages.get_sender(),
+            move |req: MqttRequest| match req {
+                MqttRequest::Publish(msg) => {
+                    captured_messages.lock().unwrap().push(msg.clone());
+                    Some(msg)
+                }
+                MqttRequest::Subscribe(_) => None,
+                MqttRequest::RetrieveRetain(_, _) => {
+                    unimplemented!()
+                }
+            },
+        ));
+
+        *cached_sender = Some(sender.sender_clone());
+        sender
+    }
+}
+
+impl Builder<MockMqttActor> for MockMqttBuilder {
+    type Error = Infallible;
+
+    fn try_build(self) -> Result<MockMqttActor, Self::Error> {
+        Ok(self.build())
+    }
+
+    fn build(self) -> MockMqttActor {
+        self.messages.build()
+    }
+}


### PR DESCRIPTION
## Proposed changes
In #3801, I accidentally broke the statistics dumping. Previously we executed the interval handling every second, but with the refactoring we now only execute interval handling when necessary. The statistics dumping wasn't taken into account with this logic, however, so if no interval handlers/only long running interval handlers were used, the statistics would potentially never be dumped, and certainly not reliably.

This PR modifies the actor to ensure it calls on_interval when statistics are due to be dumped. In addition, it exchanges the potentially flaky `seconds % 300 == 0` test with a check to see if at least 300 seconds have passed since we last dumped stats, making the behaviour more reliable.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

