### PR TITLE
refactor: handle renamed fields correctly in profiled configurations

### DIFF
--- a/crates/common/tedge_config_macros/impl/src/input/validate.rs
+++ b/crates/common/tedge_config_macros/impl/src/input/validate.rs
@@ -55,6 +55,17 @@ pub struct ConfigurationGroup {
     pub contents: Vec<FieldOrGroup>,
 }
 
+impl ConfigurationGroup {
+    pub fn name(&self) -> Cow<'_, str> {
+        self.rename()
+            .map_or_else(|| Cow::Owned(self.ident.to_string()), Cow::Borrowed)
+    }
+
+    pub fn rename(&self) -> Option<&str> {
+        Some(self.rename.as_ref()?.as_str())
+    }
+}
+
 impl TryFrom<super::parse::ConfigurationGroup> for ConfigurationGroup {
     type Error = syn::Error;
 


### PR DESCRIPTION
## Proposed changes
While trying to work on a new feature, I discovered renamed fields don't work as expected when stored inside renamed fields. They are read correctly, but we get unknown configuration key warnings when reading tedge-config, and (for the same underlying reason) the `group.profiles.name.field` syntax doesn't respect the renaming.

More concretely:
```rust
define_tedge_config! {
    #[tedge_config(multi)]
    mapper: {
        #[tedge_config(rename = "type")]
        ty: String,
    }
}
```

will successfully parse `mapper.profiles.c8y.ty` instead of `mapper.profiles.c8y.type`. Using the `--profile` flag works as expected though: `tedge config get --profile c8y mapper.type` succeeds (but emits the warning `Unknown configuration field "mapper.profiles.c8y.type" from toml file /etc/tedge/tedge.toml`).

Labelling this as an improvement rather than bugfix since the issue only affects possible future changes to configurations, not any existing configurations.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

