### PR TITLE
feat: sync signal support for agent

### DIFF
--- a/crates/core/tedge_agent/src/operation_workflows/builder.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/builder.rs
@@ -28,7 +28,7 @@ use tedge_api::mqtt_topics::ChannelFilter;
 use tedge_api::mqtt_topics::EntityFilter;
 use tedge_api::mqtt_topics::EntityTopicId;
 use tedge_api::mqtt_topics::MqttSchema;
-use tedge_api::mqtt_topics::SignalType;
+use tedge_api::mqtt_topics::OperationType;
 use tedge_api::workflow::GenericCommandData;
 use tedge_api::workflow::GenericCommandState;
 use tedge_api::workflow::OperationName;
@@ -74,7 +74,11 @@ impl WorkflowActorBuilder {
 
         let mqtt_publisher = mqtt_actor.get_sender();
         mqtt_actor.connect_sink(
-            Self::subscriptions(&config.mqtt_schema, &config.device_topic_id),
+            Self::subscriptions(
+                &config.mqtt_schema,
+                &config.device_topic_id,
+                &config.service_topic_id,
+            ),
             &input_sender,
         );
         let mqtt_publisher = LoggingSender::new("MqttPublisher".into(), mqtt_publisher);
@@ -111,25 +115,34 @@ impl WorkflowActorBuilder {
     }
 
     /// Register an actor to receive sync signals on completion of other commands
-    pub fn register_sync_signal_sink<OperationActor>(&mut self, actor: &OperationActor)
-    where
+    pub fn register_sync_signal_sink<OperationActor>(
+        &mut self,
+        op_type: OperationType,
+        actor: &OperationActor,
+    ) where
         OperationActor: MessageSink<CmdMetaSyncSignal> + SyncOnCommand,
     {
         let sender = actor.get_sender();
+        self.sync_signal_dispatcher
+            .register_operation_handler(op_type, sender.sender_clone());
         for operation in actor.sync_on_commands() {
             self.sync_signal_dispatcher
-                .register_sync_signal_sender(operation, sender.sender_clone());
+                .register_operation_listener(operation, sender.sender_clone());
         }
     }
 
-    pub fn subscriptions(mqtt_schema: &MqttSchema, device_topic_id: &EntityTopicId) -> TopicFilter {
+    pub fn subscriptions(
+        mqtt_schema: &MqttSchema,
+        device_topic_id: &EntityTopicId,
+        service_topic_id: &EntityTopicId,
+    ) -> TopicFilter {
         let mut topics = mqtt_schema.topics(
             EntityFilter::Entity(device_topic_id),
             ChannelFilter::AnyCommand,
         );
         topics.add_all(mqtt_schema.topics(
-            EntityFilter::Entity(device_topic_id),
-            ChannelFilter::Signal(SignalType::Sync),
+            EntityFilter::Entity(service_topic_id),
+            ChannelFilter::AnySignal,
         ));
         topics
     }

--- a/crates/core/tedge_agent/src/operation_workflows/config.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/config.rs
@@ -7,6 +7,7 @@ use tedge_config::TEdgeConfig;
 pub struct OperationConfig {
     pub mqtt_schema: MqttSchema,
     pub device_topic_id: EntityTopicId,
+    pub service_topic_id: EntityTopicId,
     pub log_dir: Utf8PathBuf,
     pub config_dir: Utf8PathBuf,
     pub state_dir: Utf8PathBuf,
@@ -17,6 +18,7 @@ impl OperationConfig {
     pub async fn from_tedge_config(
         topic_root: String,
         device_topic_id: &EntityTopicId,
+        service_topic_id: EntityTopicId,
         tedge_config: &TEdgeConfig,
     ) -> Result<OperationConfig, tedge_config::TEdgeConfigError> {
         let config_dir = tedge_config.root_dir();
@@ -24,6 +26,7 @@ impl OperationConfig {
         Ok(OperationConfig {
             mqtt_schema: MqttSchema::with_root(topic_root),
             device_topic_id: device_topic_id.clone(),
+            service_topic_id,
             log_dir: tedge_config.logs.path.join("agent"),
             config_dir: config_dir.to_owned(),
             state_dir: tedge_config.agent.state.path.clone().into(),

--- a/crates/core/tedge_agent/src/operation_workflows/message_box.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/message_box.rs
@@ -49,21 +49,38 @@ impl CommandDispatcher {
 
 #[derive(Default)]
 pub(crate) struct SyncSignalDispatcher {
-    senders: HashMap<OperationType, Vec<DynSender<CmdMetaSyncSignal>>>,
+    op_handler_senders: HashMap<OperationType, DynSender<CmdMetaSyncSignal>>,
+    op_listener_senders: HashMap<OperationType, Vec<DynSender<CmdMetaSyncSignal>>>,
 }
 
 impl SyncSignalDispatcher {
-    /// Register where to send sync signals for the given command type
-    pub(crate) fn register_sync_signal_sender(
+    /// Register sender for the operation handler to receive sync signals for that operation
+    pub(crate) fn register_operation_handler(
         &mut self,
         operation: OperationType,
         sender: DynSender<CmdMetaSyncSignal>,
     ) {
-        self.senders.entry(operation).or_default().push(sender);
+        self.op_handler_senders.insert(operation, sender);
     }
 
-    pub(crate) async fn send(&mut self, operation: OperationType) -> Result<(), ChannelError> {
-        let Some(senders) = self.senders.get_mut(&operation) else {
+    /// Register senders for operation listeners that must be notified when the given operation completes
+    pub(crate) fn register_operation_listener(
+        &mut self,
+        operation: OperationType,
+        sender: DynSender<CmdMetaSyncSignal>,
+    ) {
+        self.op_listener_senders
+            .entry(operation)
+            .or_default()
+            .push(sender);
+    }
+
+    /// Send sync signal to all registered listeners for the given operation
+    pub(crate) async fn sync_listener(
+        &mut self,
+        operation: OperationType,
+    ) -> Result<(), ChannelError> {
+        let Some(senders) = self.op_listener_senders.get_mut(&operation) else {
             return Ok(());
         };
         for sender in senders {
@@ -72,12 +89,18 @@ impl SyncSignalDispatcher {
         Ok(())
     }
 
-    /// Send sync signal to all registered actors
+    /// Send sync signal to the operation handler actor registered for the given operation
+    pub(crate) async fn sync(&mut self, operation: OperationType) -> Result<(), ChannelError> {
+        if let Some(sender) = self.op_handler_senders.get_mut(&operation) {
+            sender.send(()).await?;
+        };
+        Ok(())
+    }
+
+    /// Send sync signal to all registered operation handler actors
     pub(crate) async fn sync_all(&mut self) -> Result<(), ChannelError> {
-        for senders in self.senders.values_mut() {
-            for sender in senders {
-                sender.send(()).await?;
-            }
+        for sender in self.op_handler_senders.values_mut() {
+            sender.send(()).await?;
         }
         Ok(())
     }

--- a/crates/core/tedge_agent/src/operation_workflows/tests.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/tests.rs
@@ -361,9 +361,16 @@ async fn spawn_mqtt_operation_converter(device_topic_id: &str) -> Result<TestHan
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
     let tmp_path = Utf8Path::from_path(tmp_dir.path()).unwrap();
+    let device_topic_id = device_topic_id
+        .parse::<EntityTopicId>()
+        .expect("Invalid topic id");
+    let service_topic_id = device_topic_id
+        .default_service_for_device("tedge-agent")
+        .expect("Invalid service topic id");
     let config = OperationConfig {
         mqtt_schema: MqttSchema::new(),
-        device_topic_id: device_topic_id.parse().expect("Invalid topic id"),
+        device_topic_id,
+        service_topic_id,
         log_dir: tmp_path.into(),
         config_dir: tmp_path.into(),
         state_dir: tmp_path.join("running-operations"),

--- a/crates/core/tedge_api/src/mqtt_topics.rs
+++ b/crates/core/tedge_api/src/mqtt_topics.rs
@@ -798,6 +798,7 @@ impl OperationType {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SignalType {
     Sync,
+    SyncOperation(OperationType),
     Custom(String),
 }
 
@@ -833,6 +834,14 @@ impl<'a> From<&'a str> for SignalType {
     fn from(s: &'a str) -> SignalType {
         match s {
             "sync" => SignalType::Sync,
+            "sync_restart" => SignalType::SyncOperation(OperationType::Restart),
+            "sync_firmware_update" => SignalType::SyncOperation(OperationType::FirmwareUpdate),
+            "sync_software_update" => SignalType::SyncOperation(OperationType::SoftwareUpdate),
+            "sync_software_list" => SignalType::SyncOperation(OperationType::SoftwareList),
+            "sync_config_update" => SignalType::SyncOperation(OperationType::ConfigUpdate),
+            "sync_config_snapshot" => SignalType::SyncOperation(OperationType::ConfigSnapshot),
+            "sync_log_upload" => SignalType::SyncOperation(OperationType::LogUpload),
+            "sync_device_profile" => SignalType::SyncOperation(OperationType::DeviceProfile),
             custom => SignalType::Custom(custom.to_string()),
         }
     }
@@ -842,6 +851,7 @@ impl Display for SignalType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             SignalType::Sync => write!(f, "sync"),
+            SignalType::SyncOperation(operation) => write!(f, "sync_{}", operation),
             SignalType::Custom(custom) => write!(f, "{custom}"),
         }
     }

--- a/crates/extensions/c8y_mapper_ext/src/signals.rs
+++ b/crates/extensions/c8y_mapper_ext/src/signals.rs
@@ -26,7 +26,7 @@ impl CumulocityConverter {
                     }
                 }
             }
-            SignalType::Custom(_) => {}
+            SignalType::SyncOperation(_) | SignalType::Custom(_) => {}
         }
 
         Ok(messages)

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_plugins.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_plugins.robot
@@ -56,12 +56,23 @@ Supported log types updated on sync signal
     Install Package Using APT    haveged
 
     ${start_time}=    Get Unix Timestamp
-    Execute Command    tedge mqtt pub te/device/main///signal/sync '{}'
+    Execute Command    tedge mqtt pub te/device/main/service/tedge-agent/signal/sync '{}'
 
     Should Have MQTT Messages
     ...    topic=te/device/main///cmd/log_upload
     ...    date_from=${start_time}
     ...    message_contains=haveged::journald
+
+Supported log types updated on sync log_upload signal
+    Install Package Using APT    anacron
+
+    ${start_time}=    Get Unix Timestamp
+    Execute Command    tedge mqtt pub te/device/main/service/tedge-agent/signal/sync_log_upload '{}'
+
+    Should Have MQTT Messages
+    ...    topic=te/device/main///cmd/log_upload
+    ...    date_from=${start_time}
+    ...    message_contains=anacron::journald
 
 Log operation journald plugin can return logs for all units
     Should Contain Supported Log Types    all-units::journald


### PR DESCRIPTION
## Proposed changes

Agent to react to a `signal/sync` message by notifying all built-in actors to sync their states. Currently only the log manager actor reacts to this signal by resending the supported log types. Operation specific sync messages like `sync_log_upload` can be used to trigger a sync of that specific actor.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

