### PR TITLE
fix: hanging workflow awaiting a sub-operation resumed on agent restart

### DIFF
--- a/crates/core/tedge_agent/src/operation_workflows/actor.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/actor.rs
@@ -742,6 +742,16 @@ impl WorkflowActor {
                     .load_pending_commands(pending_commands)
                     .await
                 {
+                    // Skip the commands which have been finalized and cleared
+                    // as a side effect of resuming a previous command
+                    if self
+                        .workflow_repository
+                        .get_state(command.command_topic())
+                        .is_none()
+                    {
+                        continue;
+                    }
+
                     // Make sure the latest state is visible over MQTT
                     self.mqtt_publisher
                         .send(command.clone().into_message())

--- a/crates/core/tedge_agent/src/operation_workflows/persist.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/persist.rs
@@ -446,6 +446,10 @@ impl WorkflowRepository {
         self.workflows.get_action(command_state)
     }
 
+    pub fn get_state(&self, command: &str) -> Option<&GenericCommandState> {
+        self.workflows.get_state(command)
+    }
+
     pub fn root_invoking_command_state(
         &self,
         leaf_command: &GenericCommandState,

--- a/crates/core/tedge_api/src/workflow/supervisor.rs
+++ b/crates/core/tedge_api/src/workflow/supervisor.rs
@@ -3,6 +3,7 @@ use crate::workflow::*;
 use on_disk::OnDiskCommandBoard;
 use serde::Serialize;
 use std::string::ToString;
+use tracing::error;
 use tracing::info;
 
 /// Dispatch actions to operation participants
@@ -78,10 +79,25 @@ impl WorkflowSupervisor {
     /// Update on start the set of pending commands
     pub fn load_pending_commands(&mut self, commands: CommandBoard) -> Vec<GenericCommandState> {
         self.commands = commands;
-        self.commands
+        let resumed_commands: Vec<GenericCommandState> = self
+            .commands
             .iter()
             .filter_map(|(t, s)| self.resume_command(t, s.clone()))
-            .collect()
+            .collect();
+
+        // The commands should be updated with the resumed states,
+        // and not only the caller notified of these new states.
+        //
+        // A resumed command can be the sub-command of another resumed command
+        // which has then to observe the actual state of its sub-command
+        // and not the state persisted before the agent was interrupted.
+        for command in resumed_commands.iter() {
+            if let Err(err) = self.commands.update(command.clone()) {
+                error!("Fail to resume command: {err}");
+            }
+        }
+
+        resumed_commands
     }
 
     /// List the capabilities provided by the registered workflows
@@ -607,5 +623,122 @@ mod tests {
             workflows.root_invoking_command_state(&level_2_cmd),
             Some(&level_1_cmd)
         );
+    }
+
+    /// On restart, the state of a command awaiting the agent restart must be moved
+    /// to its `on_success` state and not only in the returned states.
+    #[test]
+    fn agent_restart_is_persisted_on_the_command_board() {
+        let mut workflows = restart_workflows();
+        let cmd_topic = "te/device/main///cmd/restart-agent/robot-1";
+        let board = command_board(vec![pending_command(cmd_topic, "restarting")]);
+
+        let resumed = workflows.load_pending_commands(board);
+
+        assert_eq!(resumed.len(), 1);
+        assert_eq!(resumed[0].status, "successful");
+        assert_eq!(
+            workflows.get_state(cmd_topic).map(|s| s.status.as_ref()),
+            Some("successful")
+        );
+    }
+
+    /// On restart, a command awaiting the completion of a sub-command which was itself
+    /// awaiting the agent restart, must observe the resumed state of that sub-command.
+    #[test]
+    fn agent_restart_is_visible_from_the_invoking_command() {
+        let mut workflows = restart_workflows();
+        let wrapper_topic = "te/device/main///cmd/restart-agent-wrapper/robot-1";
+        let sub_cmd_topic = "te/device/main///cmd/restart-agent/sub:restart-agent-wrapper:robot-1";
+        let wrapper_cmd = pending_command(wrapper_topic, "restarting");
+        let board = command_board(vec![
+            wrapper_cmd.clone(),
+            pending_command(sub_cmd_topic, "restarting"),
+        ]);
+
+        workflows.load_pending_commands(board);
+
+        // The invoking command must see its sub-command as successful, whatever the order
+        // in which the pending commands have been resumed.
+        let sub_cmd_state = workflows.sub_command_state(&wrapper_cmd);
+        assert_eq!(
+            sub_cmd_state.map(|s| s.status.as_ref()),
+            Some("successful"),
+            "the invoking command still sees a sub-command awaiting the agent restart"
+        );
+    }
+
+    /// A workflow awaiting the agent restart, moving on success to a state which is not a step
+    /// of this workflow but the final state of a `cleanup` action.
+    const RESTART_WORKFLOW: &str = r#"
+operation = "restart-agent"
+
+[init]
+action = "proceed"
+on_success = "restarting"
+
+[restarting]
+action = "await-agent-restart"
+on_success = "successful"
+on_timeout = "failed"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"
+"#;
+
+    /// A workflow awaiting the completion of the restart-agent sub-operation
+    const WRAPPER_WORKFLOW: &str = r#"
+operation = "restart-agent-wrapper"
+
+[init]
+operation = "restart-agent"
+on_exec = "restarting"
+
+[restarting]
+action = "await-operation-completion"
+on_success = "successful"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"
+"#;
+
+    const VERSION: &str = "1.0";
+
+    fn pending_command(topic: &str, status: &str) -> GenericCommandState {
+        GenericCommandState::from_command_message(&MqttMessage::new(
+            &Topic::new_unchecked(topic),
+            format!(r#"{{ "@version": "{VERSION}", "status": "{status}" }}"#),
+        ))
+        .unwrap()
+    }
+
+    fn restart_workflows() -> WorkflowSupervisor {
+        let mut workflows = WorkflowSupervisor::default();
+        for definition in [RESTART_WORKFLOW, WRAPPER_WORKFLOW] {
+            let workflow: OperationWorkflow = toml::from_str(definition).unwrap();
+            let operation = workflow.operation.to_string();
+            workflows
+                .register_custom_workflow(UserDefined(VERSION.to_string()), workflow)
+                .unwrap();
+            // Mark the version as in-use, as done when a command is created
+            workflows.use_current_version(&operation);
+        }
+        workflows
+    }
+
+    fn command_board(commands: Vec<GenericCommandState>) -> CommandBoard {
+        let now = time::OffsetDateTime::now_utc();
+        CommandBoard::new(
+            commands
+                .into_iter()
+                .map(|command| (command.topic.name.clone(), (now, command)))
+                .collect(),
+        )
     }
 }

--- a/tests/RobotFramework/tests/tedge_agent/workflows/custom_operation.robot
+++ b/tests/RobotFramework/tests/tedge_agent/workflows/custom_operation.robot
@@ -253,6 +253,22 @@ The max log file count can be configured per operation
     Should Contain    ${log_files}    workflow-lite_software_update-n205.log
     Should Contain    ${log_files}    workflow-lite_software_update-n206.log
 
+Trigger wrapped workflow without an intermediate state
+    [Documentation]    A sub-operation awaiting the agent restart and moving on success directly to a
+    ...    final state, must be seen as successful by the operation awaiting its completion.
+    ${pid_before}    Get Service PID    tedge-agent
+    Execute Command
+    ...    tedge mqtt pub --retain te/device/main///cmd/restart-tedge-agent-wrapper/robot-4 '{"status":"init"}'
+    Should Have MQTT Messages
+    ...    te/device/main///cmd/restart-tedge-agent-wrapper/robot-4
+    ...    message_pattern=.*successful.*
+    ...    timeout=120
+    ${pid_after}    Get Service PID    tedge-agent
+    Should Not Be Equal    ${pid_before}    ${pid_after}    msg=tedge-agent should have been restarted
+    [Teardown]    Run Keywords
+    ...    Execute Command    tedge mqtt pub --retain te/device/main///cmd/restart-tedge-agent-wrapper/robot-4 ''
+    ...    AND    Get Logs
+
 
 *** Keywords ***
 Custom Test Setup
@@ -277,6 +293,8 @@ Copy Configuration Files
     ThinEdgeIO.Transfer To Device    ${CURDIR}/restart-tedge-agent.toml    /etc/tedge/operations/
     ThinEdgeIO.Transfer To Device    ${CURDIR}/tedge-agent-pid.sh    /etc/tedge/operations/
     ThinEdgeIO.Transfer To Device    ${CURDIR}/native-reboot.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/restart-tedge-agent-wrapper.toml    /etc/tedge/operations/
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/restart-tedge-agent-internal.toml    /etc/tedge/operations/
     ThinEdgeIO.Transfer To Device    ${CURDIR}/gp_command.toml    /etc/tedge/operations/
     ThinEdgeIO.Transfer To Device    ${CURDIR}/super_command.toml    /etc/tedge/operations/
     ThinEdgeIO.Transfer To Device    ${CURDIR}/sub_command.toml    /etc/tedge/operations/

--- a/tests/RobotFramework/tests/tedge_agent/workflows/restart-tedge-agent-internal.toml
+++ b/tests/RobotFramework/tests/tedge_agent/workflows/restart-tedge-agent-internal.toml
@@ -1,0 +1,21 @@
+operation = "restart-tedge-agent-internal"
+
+[init]
+action = "proceed"
+on_success = "restart"
+
+[restart]
+background_script = "sudo systemctl restart tedge-agent"
+on_exec = "restarting"
+
+[restarting]
+action = "await-agent-restart"
+on_success = "successful"
+timeout_second = 30
+on_timeout = "failed"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"

--- a/tests/RobotFramework/tests/tedge_agent/workflows/restart-tedge-agent-wrapper.toml
+++ b/tests/RobotFramework/tests/tedge_agent/workflows/restart-tedge-agent-wrapper.toml
@@ -1,0 +1,19 @@
+operation = "restart-tedge-agent-wrapper"
+
+[init]
+action = "proceed"
+on_success = "restart"
+
+[restart]
+operation = "restart-tedge-agent-internal"
+on_exec = "restarting"
+
+[restarting]
+action = "await-operation-completion"
+on_success = "successful"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

`await-agent-restart` never completes when its `on_success` target is a final state, and the operation is invoked as a sub-operation. The invoking workflow stays stuck in `await-operation-completion` until it is timed out.

On restart, `WorkflowSupervisor::load_pending_commands` resumes every pending command — moving those in an `await-agent-restart` step to their `on_success` state — but it only returned the resumed states to the caller: the command board itself kept the states persisted before the agent was interrupted.

This goes unnoticed as long as the resumed state triggers an action that persists a new state on its way (e.g. an intermediate `action = "proceed"` step). It is fatal when `on_success` points directly at a final state, because the resulting `cleanup` action updates no state at all. The invoking command is then resumed, reads its sub-command from the board, still sees the stale `await-agent-restart` status, concludes the sub-operation is running, and waits
forever.

The fix stores the resumed states on the command board, so a command awaiting a sub-command observes the actual state of that sub-command and not the state persisted before the interruption. The agent also skips the resumed commands that have been cleared in the meantime — the pending commands are resumed in a non deterministic order, and a sub-command may be finalized and cleared while resuming its invoking command; without the check its retained state would be published again and left stuck on the broker.

This also fixes the same class of hang for the built-in `config_update` workflow when it is wrapped by a custom or device-profile operation.

**Verification**

The system test was added first and confirmed to fail in the [CI Run](https://github.com/thin-edge/thin-edge.io/actions/runs/30989686873) before the fix was applied.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

* https://github.com/thin-edge/thin-edge.io/issues/3848

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

