### PR TITLE
feat: single connection to either mqtt service or core mqtt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4731,6 +4731,7 @@ dependencies = [
  "pad",
  "pem",
  "predicates 2.1.5",
+ "pretty_assertions",
  "rasn",
  "rasn-cms",
  "rcgen",

--- a/crates/common/tedge_config/src/tedge_toml/models/c8y.rs
+++ b/crates/common/tedge_config/src/tedge_toml/models/c8y.rs
@@ -1,0 +1,2 @@
+pub const MQTT_CORE_TLS_PORT: u16 = 8883;
+pub const MQTT_SERVICE_TLS_PORT: u16 = 9883;

--- a/crates/common/tedge_config/src/tedge_toml/models/host_port.rs
+++ b/crates/common/tedge_config/src/tedge_toml/models/host_port.rs
@@ -58,6 +58,12 @@ impl<const P: u16> HostPort<P> {
     pub fn port(&self) -> Port {
         self.port
     }
+
+    /// Sets the port for this HostPort and updates the stored input string as well
+    pub fn set_port(&mut self, port: u16) {
+        self.port = Port(port);
+        self.input = format!("{}:{}", self.hostname, self.port);
+    }
 }
 
 impl<const P: u16> From<HostPort<P>> for String {

--- a/crates/common/tedge_config/src/tedge_toml/models/mod.rs
+++ b/crates/common/tedge_config/src/tedge_toml/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod apt_config;
 pub mod auth_method;
 pub mod auto;
+pub mod c8y;
 pub mod c8y_software_management;
 pub mod connect_url;
 pub mod cryptoki;
@@ -24,10 +25,10 @@ use strum::Display;
 
 pub const HTTPS_PORT: u16 = 443;
 pub const MQTT_TLS_PORT: u16 = 8883;
-pub const MQTT_SVC_TLS_PORT: u16 = 9883;
 
 pub use self::apt_config::*;
 pub use self::auto::*;
+pub use self::c8y::*;
 pub use self::c8y_software_management::*;
 pub use self::connect_url::*;
 pub use self::cryptoki::Cryptoki;

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -20,7 +20,6 @@ use super::models::SoftwareManagementApiFlag;
 use super::models::TemplatesSet;
 use super::models::TopicPrefix;
 use super::models::HTTPS_PORT;
-use super::models::MQTT_SVC_TLS_PORT;
 use super::models::MQTT_TLS_PORT;
 use super::tedge_config_location::TEdgeConfigLocation;
 use crate::models::AbsolutePath;
@@ -475,20 +474,9 @@ define_tedge_config! {
             #[tedge_config(example = "true", default(value = false))]
             enabled: bool,
 
-            /// MQTT service endpoint for the Cumulocity tenant, with optional port.
-            #[tedge_config(example = "mqtt.your-tenant.cumulocity.com:9883")]
-            #[tedge_config(default(from_optional_key = "c8y.mqtt"))]
-            url: HostPort<MQTT_SVC_TLS_PORT>,
-
-            /// The topic prefix that will be used for the Cumulocity MQTT service endpoint connection.
-            /// For instance, if set to "c8y-mqtt", then messages published to `c8y-mqtt/xyz`
-            /// will be forwarded to the MQTT service endpoint on the `xyz` topic
-            #[tedge_config(example = "c8y-mqtt", default(function = "c8y_mqtt_service_topic_prefix"))]
-            topic_prefix: TopicPrefix,
-
             /// Set of MQTT topics the bridge should subscribe to on the Cumulocity MQTT service endpoint
             #[tedge_config(example = "incoming/topic,another/topic,test/topic")]
-            #[tedge_config(default(value = "$demo/$error"))]
+            #[tedge_config(default(function = "TemplatesSet::default"))]
             topics: TemplatesSet,
         }
     },
@@ -1218,16 +1206,6 @@ impl CloudConfig for TEdgeConfigReaderAws {
 
 fn c8y_topic_prefix() -> TopicPrefix {
     TopicPrefix::try_new("c8y").unwrap()
-}
-
-fn c8y_mqtt_service_topic_prefix() -> TopicPrefix {
-    TopicPrefix::try_new("c8y-mqtt").unwrap()
-}
-
-impl From<HostPort<MQTT_TLS_PORT>> for HostPort<MQTT_SVC_TLS_PORT> {
-    fn from(value: HostPort<MQTT_TLS_PORT>) -> Self {
-        HostPort::try_from(value.host().to_string()).expect("Source hostname must have been valid")
-    }
 }
 
 fn az_topic_prefix() -> TopicPrefix {

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config/append_remove.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config/append_remove.rs
@@ -41,7 +41,6 @@ impl_append_remove_for_single_value!(
     EntityTopicId,
     HostPort<HTTPS_PORT>,
     HostPort<MQTT_TLS_PORT>,
-    HostPort<MQTT_SVC_TLS_PORT>,
     bool,
     IpAddr,
     u16,

--- a/crates/core/tedge/Cargo.toml
+++ b/crates/core/tedge/Cargo.toml
@@ -77,6 +77,7 @@ mockall = { workspace = true }
 mockito = { workspace = true }
 mqtt_tests = { workspace = true }
 predicates = { workspace = true }
+pretty_assertions = { workspace = true }
 rcgen = { workspace = true }
 tedge_config = { workspace = true, features = ["test"] }
 tedge_test_utils = { workspace = true }

--- a/crates/core/tedge/src/bridge/c8y.rs
+++ b/crates/core/tedge/src/bridge/c8y.rs
@@ -1,8 +1,6 @@
 use super::config::ProxyWrapper;
 use super::BridgeConfig;
 use crate::bridge::config::BridgeLocation;
-use crate::ConfigError;
-use c8y_api::http_proxy::read_c8y_credentials;
 use camino::Utf8PathBuf;
 use std::borrow::Cow;
 use std::process::Command;
@@ -15,10 +13,8 @@ use tedge_config::models::AutoFlag;
 use tedge_config::models::HostPort;
 use tedge_config::models::TemplatesSet;
 use tedge_config::models::TopicPrefix;
-use tedge_config::models::MQTT_SVC_TLS_PORT;
 use tedge_config::models::MQTT_TLS_PORT;
 use tedge_config::tedge_toml::ProfileName;
-use tedge_config::TEdgeConfig;
 use which::which;
 
 #[derive(Debug)]
@@ -40,6 +36,8 @@ pub struct BridgeConfigC8yParams {
     pub mqtt_schema: MqttSchema,
     pub keepalive_interval: Duration,
     pub proxy: Option<rumqttc::Proxy>,
+    pub use_mqtt_service: bool,
+    pub custom_topics: TemplatesSet,
 }
 
 impl From<BridgeConfigC8yParams> for BridgeConfig {
@@ -62,6 +60,8 @@ impl From<BridgeConfigC8yParams> for BridgeConfig {
             mqtt_schema,
             keepalive_interval,
             proxy,
+            use_mqtt_service,
+            custom_topics,
         } = params;
 
         let mut topics: Vec<String> = vec![
@@ -152,6 +152,16 @@ impl From<BridgeConfigC8yParams> for BridgeConfig {
             topics.extend(templates_set);
         }
 
+        if use_mqtt_service {
+            // Custom outgoing topics to MQTT service
+            topics.push(format!(r#"# out 1 {topic_prefix}/mqtt/out/ """#));
+
+            // Custom incoming topics subscribed on MQTT service
+            for topic in custom_topics.0.iter() {
+                topics.push(format!(r#"{topic} in 1 {topic_prefix}/mqtt/in/ """#));
+            }
+        }
+
         let (include_local_clean_session, mosquitto_version) = match include_local_clean_session {
             AutoFlag::True => (true, None),
             AutoFlag::False => (false, None),
@@ -205,170 +215,6 @@ impl From<BridgeConfigC8yParams> for BridgeConfig {
     }
 }
 
-#[derive(Debug)]
-pub struct BridgeConfigC8yMqttServiceParams {
-    pub mqtt_host: HostPort<MQTT_SVC_TLS_PORT>,
-    pub config_file: Cow<'static, str>,
-    pub remote_clientid: String,
-    pub remote_username: Option<String>,
-    pub remote_password: Option<String>,
-    pub bridge_root_cert_path: Utf8PathBuf,
-    pub bridge_certfile: Utf8PathBuf,
-    pub bridge_keyfile: Utf8PathBuf,
-    pub include_local_clean_session: AutoFlag,
-    pub bridge_location: BridgeLocation,
-    pub topic_prefix: TopicPrefix,
-    pub profile_name: Option<ProfileName>,
-    pub mqtt_schema: MqttSchema,
-    pub keepalive_interval: Duration,
-    pub sub_topics: TemplatesSet,
-}
-
-impl TryFrom<(&TEdgeConfig, Option<&ProfileName>)> for BridgeConfigC8yMqttServiceParams {
-    type Error = ConfigError;
-
-    fn try_from(value: (&TEdgeConfig, Option<&ProfileName>)) -> Result<Self, Self::Error> {
-        let (config, profile) = value;
-
-        let bridge_location = match config.mqtt.bridge.built_in {
-            true => BridgeLocation::BuiltIn,
-            false => BridgeLocation::Mosquitto,
-        };
-        let mqtt_schema = MqttSchema::with_root(config.mqtt.topic_root.clone());
-        let c8y_config = config.c8y.try_get(profile)?;
-
-        let (remote_username, remote_password) =
-            match c8y_config.auth_method.to_type(&c8y_config.credentials_path) {
-                AuthType::Certificate => (None, None),
-                AuthType::Basic => {
-                    let (username, password) = read_c8y_credentials(&c8y_config.credentials_path)?;
-                    (Some(username), Some(password))
-                }
-            };
-
-        let config_file = if let Some(profile_name) = &profile {
-            format!("c8y-mqtt-svc@{profile_name}-bridge.conf")
-        } else {
-            "c8y-mqtt-svc-bridge.conf".to_string()
-        };
-
-        let params = BridgeConfigC8yMqttServiceParams {
-            mqtt_host: c8y_config.mqtt_service.url.or_config_not_set()?.clone(),
-            config_file: config_file.into(),
-            bridge_root_cert_path: c8y_config.root_cert_path.clone().into(),
-            remote_clientid: c8y_config.device.id()?.clone(),
-            remote_username,
-            remote_password,
-            bridge_certfile: c8y_config.device.cert_path.clone().into(),
-            bridge_keyfile: c8y_config.device.key_path.clone().into(),
-            include_local_clean_session: c8y_config.bridge.include.local_cleansession.clone(),
-            bridge_location,
-            topic_prefix: c8y_config.mqtt_service.topic_prefix.clone(),
-            profile_name: profile.cloned(),
-            mqtt_schema,
-            keepalive_interval: c8y_config.bridge.keepalive_interval.duration(),
-            sub_topics: c8y_config.mqtt_service.topics.clone(),
-        };
-
-        Ok(params)
-    }
-}
-
-impl From<BridgeConfigC8yMqttServiceParams> for BridgeConfig {
-    fn from(params: BridgeConfigC8yMqttServiceParams) -> Self {
-        let BridgeConfigC8yMqttServiceParams {
-            mqtt_host,
-            config_file,
-            bridge_root_cert_path,
-            remote_username,
-            remote_password,
-            remote_clientid,
-            bridge_certfile,
-            bridge_keyfile,
-            include_local_clean_session,
-            bridge_location,
-            topic_prefix,
-            profile_name,
-            mqtt_schema,
-            keepalive_interval,
-            sub_topics,
-        } = params;
-
-        let address = mqtt_host
-            .to_string()
-            .parse::<HostPort<MQTT_TLS_PORT>>()
-            .expect("MQTT service address must be in the expected format");
-
-        let mut topics: Vec<String> = vec![
-            // Outgoing
-            format!(r#"# out 1 {topic_prefix}/"#),
-        ];
-
-        // Topics to subscribe to
-        for topic in sub_topics.0.iter() {
-            topics.push(format!(r#"{topic} in 1 {topic_prefix}/"#));
-        }
-
-        let auth_type = if remote_password.is_some() {
-            AuthType::Basic
-        } else {
-            AuthType::Certificate
-        };
-
-        let (include_local_clean_session, mosquitto_version) = match include_local_clean_session {
-            AutoFlag::True => (true, None),
-            AutoFlag::False => (false, None),
-            AutoFlag::Auto => is_mosquitto_version_above_2(),
-        };
-
-        let service_name = format!("mosquitto-{topic_prefix}-bridge");
-        let health = mqtt_schema.topic_for(
-            &EntityTopicId::default_main_service(&service_name).unwrap(),
-            &Channel::Health,
-        );
-
-        Self {
-            cloud_name: "c8y-mqtt".into(),
-            config_file,
-            connection: if let Some(profile) = &profile_name {
-                format!("edge_to_c8y_mqtt_service@{profile}")
-            } else {
-                "edge_to_c8y_mqtt_service".into()
-            },
-            address,
-            remote_username,
-            remote_password,
-            bridge_root_cert_path,
-            remote_clientid,
-            local_clientid: if let Some(profile) = &profile_name {
-                format!("CumulocityMqttService@{profile}")
-            } else {
-                "CumulocityMqttService".into()
-            },
-            bridge_certfile,
-            bridge_keyfile,
-            use_mapper: true,
-            use_agent: true,
-            try_private: false,
-            start_type: "automatic".into(),
-            clean_session: true,
-            include_local_clean_session,
-            local_clean_session: false,
-            notifications: true,
-            notifications_local_only: true,
-            notification_topic: health.name,
-            bridge_attempt_unsubscribe: false,
-            topics,
-            bridge_location,
-            connection_check_attempts: 3,
-            auth_type,
-            mosquitto_version,
-            keepalive_interval,
-            proxy: None,
-        }
-    }
-}
-
 /// Return whether or not mosquitto version is >= 2.0.0
 ///
 /// As mosquitto doesn't provide a `--version` flag, this is a guess.
@@ -404,11 +250,11 @@ pub fn is_mosquitto_version_above_2() -> (bool, Option<String>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
     use std::convert::TryFrom;
 
     #[test]
     fn test_bridge_config_from_c8y_params() -> anyhow::Result<()> {
-        use std::convert::TryFrom;
         let params = BridgeConfigC8yParams {
             mqtt_host: HostPort::<MQTT_TLS_PORT>::try_from("test.test.io")?,
             config_file: "c8y-bridge.conf".into(),
@@ -427,6 +273,8 @@ mod tests {
             mqtt_schema: MqttSchema::with_root("te".into()),
             keepalive_interval: Duration::from_secs(60),
             proxy: None,
+            use_mqtt_service: false,
+            custom_topics: TemplatesSet::default(),
         };
 
         let bridge = BridgeConfig::from(params);
@@ -526,6 +374,8 @@ mod tests {
             mqtt_schema: MqttSchema::with_root("te".into()),
             keepalive_interval: Duration::from_secs(60),
             proxy: None,
+            use_mqtt_service: false,
+            custom_topics: TemplatesSet::default(),
         };
 
         let bridge = BridgeConfig::from(params);
@@ -613,45 +463,88 @@ mod tests {
     }
 
     #[test]
-    fn test_bridge_config_from_c8y_mqtt_service_params_certificate_auth() -> anyhow::Result<()> {
-        let params = BridgeConfigC8yMqttServiceParams {
-            mqtt_host: HostPort::<MQTT_SVC_TLS_PORT>::try_from("test.test.io").unwrap(),
-            config_file: "c8y-mqtt-svc-bridge.conf".into(),
+    fn test_bridge_config_mqtt_service_enabled() -> anyhow::Result<()> {
+        let params = BridgeConfigC8yParams {
+            mqtt_host: HostPort::<MQTT_TLS_PORT>::try_from("test.test.io")?,
+            config_file: "c8y-bridge.conf".into(),
             remote_clientid: "alpha".into(),
             remote_username: None,
             remote_password: None,
             bridge_root_cert_path: Utf8PathBuf::from("./test_root.pem"),
             bridge_certfile: "./test-certificate.pem".into(),
             bridge_keyfile: "./test-private-key.pem".into(),
+            smartrest_templates: TemplatesSet::from(vec!["abc", "def"]),
+            smartrest_one_templates: TemplatesSet::default(),
             include_local_clean_session: AutoFlag::False,
             bridge_location: BridgeLocation::Mosquitto,
-            topic_prefix: "c8y-mqtt".try_into().unwrap(),
+            topic_prefix: "c8y".try_into().unwrap(),
             profile_name: None,
             mqtt_schema: MqttSchema::with_root("te".into()),
-            keepalive_interval: Duration::from_secs(45),
-            sub_topics: TemplatesSet::from(vec!["test/topic", "demo/topic"]),
+            keepalive_interval: Duration::from_secs(60),
+            proxy: None,
+            use_mqtt_service: true,
+            custom_topics: TemplatesSet::from(vec!["test", "demo"]),
         };
 
         let bridge = BridgeConfig::from(params);
 
         let expected = BridgeConfig {
-            cloud_name: "c8y-mqtt".into(),
-            config_file: "c8y-mqtt-svc-bridge.conf".into(),
-            connection: "edge_to_c8y_mqtt_service".into(),
-            address: HostPort::<MQTT_TLS_PORT>::try_from("test.test.io:9883")?,
+            cloud_name: "c8y".into(),
+            config_file: "c8y-bridge.conf".into(),
+            connection: "edge_to_c8y".into(),
+            address: HostPort::<MQTT_TLS_PORT>::try_from("test.test.io")?,
             remote_username: None,
             remote_password: None,
-            remote_clientid: "alpha".into(),
-            local_clientid: "CumulocityMqttService".into(),
             bridge_root_cert_path: Utf8PathBuf::from("./test_root.pem"),
+            remote_clientid: "alpha".into(),
+            local_clientid: "Cumulocity".into(),
             bridge_certfile: "./test-certificate.pem".into(),
             bridge_keyfile: "./test-private-key.pem".into(),
             use_mapper: true,
             use_agent: true,
             topics: vec![
-                "# out 1 c8y-mqtt/".into(),
-                "test/topic in 1 c8y-mqtt/".into(),
-                "demo/topic in 1 c8y-mqtt/".into(),
+                // Templates
+                r#"s/dt in 1 c8y/ """#.into(),
+                r#"s/ut/# out 1 c8y/ """#.into(),
+                // Static templates
+                r#"s/us/# out 1 c8y/ """#.into(),
+                r#"t/us/# out 1 c8y/ """#.into(),
+                r#"q/us/# out 1 c8y/ """#.into(),
+                r#"c/us/# out 1 c8y/ """#.into(),
+                r#"s/ds in 1 c8y/ """#.into(),
+                // Debug
+                r#"s/e in 0 c8y/ """#.into(),
+                // SmartRest2
+                r#"s/uc/# out 1 c8y/ """#.into(),
+                r#"t/uc/# out 1 c8y/ """#.into(),
+                r#"q/uc/# out 1 c8y/ """#.into(),
+                r#"c/uc/# out 1 c8y/ """#.into(),
+                r#"s/dc/# in 1 c8y/ """#.into(),
+                // c8y JSON
+                r#"inventory/managedObjects/update/# out 1 c8y/ """#.into(),
+                r#"measurement/measurements/create out 1 c8y/ """#.into(),
+                r#"measurement/measurements/createBulk out 1 c8y/ """#.into(),
+                r#"event/events/create out 1 c8y/ """#.into(),
+                r#"event/events/createBulk out 1 c8y/ """#.into(),
+                r#"alarm/alarms/create out 1 c8y/ """#.into(),
+                r#"alarm/alarms/createBulk out 1 c8y/ """#.into(),
+                r#"devicecontrol/notifications in 1 c8y/ """#.into(),
+                r#"error in 1 c8y/ """#.into(),
+                // c8y JWT token retrieval
+                r#"s/uat out 0 c8y/ """#.into(),
+                r#"s/dat in 0 c8y/ """#.into(),
+                // Smartrest templates should be deserialized as:
+                // s/uc/template-1 (in from localhost), s/uc/template-1
+                // s/dc/template-1 (out to localhost), s/dc/template-1
+                r#"s/uc/abc out 1 c8y/ """#.into(),
+                r#"s/dc/abc in 1 c8y/ """#.into(),
+                r#"s/uc/def out 1 c8y/ """#.into(),
+                r#"s/dc/def in 1 c8y/ """#.into(),
+                // MQTT service custom outgoing topics
+                r#"# out 1 c8y/mqtt/out/ """#.into(),
+                // MQTT service custom incoming topics
+                r#"test in 1 c8y/mqtt/in/ """#.into(),
+                r#"demo in 1 c8y/mqtt/in/ """#.into(),
             ],
             try_private: false,
             start_type: "automatic".into(),
@@ -660,61 +553,99 @@ mod tests {
             local_clean_session: false,
             notifications: true,
             notifications_local_only: true,
-            notification_topic: "te/device/main/service/mosquitto-c8y-mqtt-bridge/status/health"
-                .into(),
+            notification_topic: "te/device/main/service/mosquitto-c8y-bridge/status/health".into(),
             bridge_attempt_unsubscribe: false,
             bridge_location: BridgeLocation::Mosquitto,
             connection_check_attempts: 3,
             auth_type: AuthType::Certificate,
             mosquitto_version: None,
-            keepalive_interval: Duration::from_secs(45),
+            keepalive_interval: Duration::from_secs(60),
             proxy: None,
         };
 
         assert_eq!(bridge, expected);
+
         Ok(())
     }
 
     #[test]
-    fn test_bridge_config_from_c8y_mqtt_service_params_basic_auth() -> anyhow::Result<()> {
-        let params = BridgeConfigC8yMqttServiceParams {
-            mqtt_host: HostPort::<MQTT_SVC_TLS_PORT>::try_from("test.test.io")?,
-            config_file: "c8y-mqtt-svc-bridge.conf".into(),
+    fn test_bridge_config_custom_topics_ignored_when_mqtt_service_disabled() -> anyhow::Result<()> {
+        let params = BridgeConfigC8yParams {
+            mqtt_host: HostPort::<MQTT_TLS_PORT>::try_from("test.test.io")?,
+            config_file: "c8y-bridge.conf".into(),
             remote_clientid: "alpha".into(),
-            remote_username: Some("octocat".into()),
-            remote_password: Some("abcd1234".into()),
+            remote_username: None,
+            remote_password: None,
             bridge_root_cert_path: Utf8PathBuf::from("./test_root.pem"),
             bridge_certfile: "./test-certificate.pem".into(),
             bridge_keyfile: "./test-private-key.pem".into(),
+            smartrest_templates: TemplatesSet::from(vec!["abc", "def"]),
+            smartrest_one_templates: TemplatesSet::default(),
             include_local_clean_session: AutoFlag::False,
             bridge_location: BridgeLocation::Mosquitto,
-            topic_prefix: "c8y-mqtt".try_into().unwrap(),
+            topic_prefix: "c8y".try_into().unwrap(),
             profile_name: None,
             mqtt_schema: MqttSchema::with_root("te".into()),
-            keepalive_interval: Duration::from_secs(45),
-            sub_topics: TemplatesSet::from(vec!["test/topic", "demo/topic"]),
+            keepalive_interval: Duration::from_secs(60),
+            proxy: None,
+            use_mqtt_service: false, // MQTT service disabled
+            custom_topics: TemplatesSet::from(vec!["test", "demo"]),
         };
 
         let bridge = BridgeConfig::from(params);
 
         let expected = BridgeConfig {
-            cloud_name: "c8y-mqtt".into(),
-            config_file: "c8y-mqtt-svc-bridge.conf".into(),
-            connection: "edge_to_c8y_mqtt_service".into(),
-            address: HostPort::<MQTT_TLS_PORT>::try_from("test.test.io:9883")?,
-            remote_username: Some("octocat".into()),
-            remote_password: Some("abcd1234".into()),
-            remote_clientid: "alpha".into(),
-            local_clientid: "CumulocityMqttService".into(),
+            cloud_name: "c8y".into(),
+            config_file: "c8y-bridge.conf".into(),
+            connection: "edge_to_c8y".into(),
+            address: HostPort::<MQTT_TLS_PORT>::try_from("test.test.io")?,
+            remote_username: None,
+            remote_password: None,
             bridge_root_cert_path: Utf8PathBuf::from("./test_root.pem"),
+            remote_clientid: "alpha".into(),
+            local_clientid: "Cumulocity".into(),
             bridge_certfile: "./test-certificate.pem".into(),
             bridge_keyfile: "./test-private-key.pem".into(),
             use_mapper: true,
             use_agent: true,
             topics: vec![
-                "# out 1 c8y-mqtt/".into(),
-                "test/topic in 1 c8y-mqtt/".into(),
-                "demo/topic in 1 c8y-mqtt/".into(),
+                // Templates
+                r#"s/dt in 1 c8y/ """#.into(),
+                r#"s/ut/# out 1 c8y/ """#.into(),
+                // Static templates
+                r#"s/us/# out 1 c8y/ """#.into(),
+                r#"t/us/# out 1 c8y/ """#.into(),
+                r#"q/us/# out 1 c8y/ """#.into(),
+                r#"c/us/# out 1 c8y/ """#.into(),
+                r#"s/ds in 1 c8y/ """#.into(),
+                // Debug
+                r#"s/e in 0 c8y/ """#.into(),
+                // SmartRest2
+                r#"s/uc/# out 1 c8y/ """#.into(),
+                r#"t/uc/# out 1 c8y/ """#.into(),
+                r#"q/uc/# out 1 c8y/ """#.into(),
+                r#"c/uc/# out 1 c8y/ """#.into(),
+                r#"s/dc/# in 1 c8y/ """#.into(),
+                // c8y JSON
+                r#"inventory/managedObjects/update/# out 1 c8y/ """#.into(),
+                r#"measurement/measurements/create out 1 c8y/ """#.into(),
+                r#"measurement/measurements/createBulk out 1 c8y/ """#.into(),
+                r#"event/events/create out 1 c8y/ """#.into(),
+                r#"event/events/createBulk out 1 c8y/ """#.into(),
+                r#"alarm/alarms/create out 1 c8y/ """#.into(),
+                r#"alarm/alarms/createBulk out 1 c8y/ """#.into(),
+                r#"devicecontrol/notifications in 1 c8y/ """#.into(),
+                r#"error in 1 c8y/ """#.into(),
+                // c8y JWT token retrieval
+                r#"s/uat out 0 c8y/ """#.into(),
+                r#"s/dat in 0 c8y/ """#.into(),
+                // Smartrest templates should be deserialized as:
+                // s/uc/template-1 (in from localhost), s/uc/template-1
+                // s/dc/template-1 (out to localhost), s/dc/template-1
+                r#"s/uc/abc out 1 c8y/ """#.into(),
+                r#"s/dc/abc in 1 c8y/ """#.into(),
+                r#"s/uc/def out 1 c8y/ """#.into(),
+                r#"s/dc/def in 1 c8y/ """#.into(),
             ],
             try_private: false,
             start_type: "automatic".into(),
@@ -723,18 +654,18 @@ mod tests {
             local_clean_session: false,
             notifications: true,
             notifications_local_only: true,
-            notification_topic: "te/device/main/service/mosquitto-c8y-mqtt-bridge/status/health"
-                .into(),
+            notification_topic: "te/device/main/service/mosquitto-c8y-bridge/status/health".into(),
             bridge_attempt_unsubscribe: false,
             bridge_location: BridgeLocation::Mosquitto,
             connection_check_attempts: 3,
-            auth_type: AuthType::Basic,
+            auth_type: AuthType::Certificate,
             mosquitto_version: None,
-            keepalive_interval: Duration::from_secs(45),
+            keepalive_interval: Duration::from_secs(60),
             proxy: None,
         };
 
         assert_eq!(bridge, expected);
+
         Ok(())
     }
 }

--- a/crates/core/tedge/src/cli/connect/aws.rs
+++ b/crates/core/tedge/src/cli/connect/aws.rs
@@ -20,9 +20,7 @@ pub async fn check_device_status_aws(
     let topic_prefix = &aws_config.bridge.topic_prefix;
     let aws_topic_pub_check_connection = format!("{topic_prefix}/test-connection");
     let aws_topic_sub_check_connection = format!("{topic_prefix}/connection-success");
-    let built_in_bridge_health = bridge_health_topic(topic_prefix, tedge_config)
-        .unwrap()
-        .name;
+    let built_in_bridge_health = bridge_health_topic(topic_prefix, tedge_config).name;
     const CLIENT_ID: &str = "check_connection_aws";
     const REGISTRATION_PAYLOAD: &[u8] = b"";
 

--- a/crates/core/tedge/src/cli/connect/azure.rs
+++ b/crates/core/tedge/src/cli/connect/azure.rs
@@ -23,9 +23,7 @@ pub(crate) async fn check_device_status_azure(
 ) -> Result<DeviceStatus, ConnectError> {
     let az_config = tedge_config.az.try_get(profile)?;
     let topic_prefix = &az_config.bridge.topic_prefix;
-    let built_in_bridge_health = bridge_health_topic(topic_prefix, tedge_config)
-        .unwrap()
-        .name;
+    let built_in_bridge_health = bridge_health_topic(topic_prefix, tedge_config).name;
     let azure_topic_device_twin_downstream = format!(r##"{topic_prefix}/twin/res/#"##);
     let azure_topic_device_twin_upstream = format!(r#"{topic_prefix}/twin/GET/?$rid=1"#);
     const CLIENT_ID: &str = "check_connection_az";

--- a/crates/core/tedge/src/cli/connect/c8y.rs
+++ b/crates/core/tedge/src/cli/connect/c8y.rs
@@ -174,12 +174,7 @@ pub(crate) async fn check_device_status_c8y(
 
     let prefix = &c8y_config.bridge.topic_prefix;
     let built_in_bridge = tedge_config.mqtt.bridge.built_in;
-    let mqtt_service_enabled = c8y_config.mqtt_service.enabled;
-    let core_mqtt_bridge_health_topic = bridge_health_topic(prefix, tedge_config).unwrap().name;
-    let mqtt_service_bridge_health_topic =
-        bridge_health_topic(&c8y_config.mqtt_service.topic_prefix, tedge_config)
-            .unwrap()
-            .name;
+    let bridge_health_topic = bridge_health_topic(prefix, tedge_config).name;
 
     let (downstream_topic, upstream_topic, payload) = if c8y_config
         .auth_method
@@ -214,18 +209,10 @@ pub(crate) async fn check_device_status_c8y(
         .set_connection_timeout(CONNECTION_TIMEOUT.as_secs());
     let mut acknowledged = false;
 
-    client
-        .subscribe(&core_mqtt_bridge_health_topic, AtLeastOnce)
-        .await?;
+    client.subscribe(&bridge_health_topic, AtLeastOnce).await?;
     client.subscribe(&downstream_topic, AtLeastOnce).await?;
-    if mqtt_service_enabled {
-        client
-            .subscribe(&mqtt_service_bridge_health_topic, AtLeastOnce)
-            .await?;
-    }
 
-    let mut mqtt_service_bridge_healthy = false;
-    let mut core_mqtt_connected = false;
+    let mut bridge_connected = false;
 
     let mut err = None;
     loop {
@@ -242,12 +229,12 @@ pub(crate) async fn check_device_status_c8y(
                     if message_id.parse() == Ok(GET_DEVICE_MANAGED_OBJECT_ID_RESPONSE)
                         || message_id.parse() == Ok(JWT_TOKEN)
                     {
-                        core_mqtt_connected = true;
+                        bridge_connected = true;
                         break;
                     }
                 } else if is_bridge_health_up_message(
                     &response,
-                    &core_mqtt_bridge_health_topic,
+                    &bridge_health_topic,
                     built_in_bridge,
                 ) {
                     client
@@ -258,12 +245,6 @@ pub(crate) async fn check_device_status_c8y(
                             payload.clone(),
                         )
                         .await?;
-                } else if is_bridge_health_up_message(
-                    &response,
-                    &mqtt_service_bridge_health_topic,
-                    built_in_bridge,
-                ) {
-                    mqtt_service_bridge_healthy = true;
                 }
             }
             Ok(Event::Outgoing(Outgoing::PingReq)) => {
@@ -296,19 +277,8 @@ pub(crate) async fn check_device_status_c8y(
         }
     }
 
-    if core_mqtt_connected {
-        if mqtt_service_enabled && !mqtt_service_bridge_healthy {
-            err = Some(anyhow!(
-                "Cumulocity Core MQTT connection is healthy but MQTT service connection is not healthy"
-            ));
-        }
-    } else {
-        let err_msg = if mqtt_service_enabled && !mqtt_service_bridge_healthy {
-            "Connection to Cumulocity Core MQTT and MQTT service are not healthy"
-        } else {
-            "Connection to Cumulocity Core MQTT is not healthy"
-        };
-        err = Some(anyhow!(err_msg));
+    if !bridge_connected {
+        err = Some(anyhow!("Connection to Cumulocity is not healthy"));
     }
 
     match err {

--- a/docs/src/operate/c8y/connect-mqtt-service.md
+++ b/docs/src/operate/c8y/connect-mqtt-service.md
@@ -22,34 +22,39 @@ The user context will be persisted in your web browser's local storage.
 
 ## MQTT Service
 
-:::caution
-The Cumulocity MQTT service is still in Public Preview, and as such, the interface is subject to change.
-It is strongly advised to avoid using it in production scenarios until the interface has stabilized. If you do decide
-to use it in production systems, then expect to have to do run some migration activities to update the %%te%% version
-and modify interfaces, configuration, and update the %%te%% version, once the feature goes into General Availability.
-:::
-
-The [Cumulocity MQTT service](https://cumulocity.com/docs/device-integration/mqtt-service) is the next-gen MQTT broker offered by Cumulocity. In contrast to the existing [Cumulocity Core MQTT](https://cumulocity.com/docs/device-integration/mqtt/), the [Cumulocity MQTT service](https://cumulocity.com/docs/device-integration/mqtt-service) allows devices to publish and receive data using user-defined topics and payloads. The feature is currently in [Public Preview](https://cumulocity.com/docs/2024/glossary/p/#public-preview) which means that the interface is subject to change and some of the functionality is not yet implemented.
-
-%%te%% currently uses [Cumulocity's Core MQTT](https://cumulocity.com/docs/device-integration/mqtt/) to establish a connection to the cloud, however it is planned that once the
-MQTT Service reaches the [General Availability](https://cumulocity.com/docs/2024/glossary/g/#ga) status, it will support both the required subset of functionality currently provided
-by the Core MQTT (e.g. SmartREST and JSON over MQTT communication) in addition to the user-defined topics and payloads. However, until this functionality is provided by the new service,
-if you wish to use Cumulocity MQTT Service, %%te%% will have to maintain two active MQTT connections, one to the Core MQTT, and one to the MQTT Service.
+%%te%%, when connected to Cumulocity, connects to its [Core MQTT](https://cumulocity.com/docs/device-integration/mqtt/) 
+endpoint by default, which only supports a predefined set of topics that the device can publish data to
+and receive data from in predefined data formats (e.g: SmartREST or JSON over MQTT).
+The [Cumulocity MQTT service](https://cumulocity.com/docs/device-integration/mqtt-service) on the other hand,
+is the next-gen MQTT endpoint offered by Cumulocity,
+which allows devices to publish and receive data using user-defined custom topic and payload formats as well.
 
 More information about the two MQTT interfaces offered by Cumulocity in the following table.
 
 |Name|Port|Description|Status|
 |----|----|-----------|------|
-|[Cumulocity Core MQTT](https://cumulocity.com/docs/device-integration/mqtt/)|8883|Allows devices to send messages directly into Cumulocity, provided that the device implements the pre-defined topic schema and payload formats of Core MQTT|[General Availability](https://cumulocity.com/docs/2024/glossary/g/#ga)|
-|[Cumulocity MQTT Service](https://cumulocity.com/docs/device-integration/mqtt-service)|9883|Allows devices to send and receive arbitrary payloads on any MQTT topic|[Public Preview](https://cumulocity.com/docs/2024/glossary/p/#public-preview) (subject to change)|
+|Core MQTT|8883|Allows devices to send messages directly into Cumulocity, provided that the device implements the pre-defined topic schema and payload formats of Core MQTT|[General Availability](https://cumulocity.com/docs/2024/glossary/g/#ga)|
+|MQTT Service|9883|Allows devices to send and receive arbitrary payloads on any MQTT topic|[Public Preview](https://cumulocity.com/docs/2024/glossary/p/#public-preview) (subject to change)|
 
+:::caution
+The Cumulocity MQTT service is still in Public Preview, and as such, the interface is subject to change.
+It is strongly advised to avoid using it in production scenarios until the interface has stabilized.
+If you do decide to use it in production systems, then expect to have to do run some migration activities
+to update the %%te%% version and modify interfaces, configuration etc once the feature goes into General Availability.
+:::
 
 ### Configure the device
+
+:::note
+The examples in this section demonstrate a device using a custom topic scheme to
+publish temperature measurements to the `sensors/temperature/measurement` topic in the cloud and
+receive commands to adjust the sampling interval from the cloud on the `sensors/temperature/set-config` topic.
+:::
 
 Most of the configuration used to connect to the Cumulocity MQTT service endpoint are the same as
 the ones used to connect to the Cumulocity Core MQTT endpoint.
 
-1. Configure Cumulocity URL
+1. Configure Cumulocity URL, if not already set.
 
    <UserContext>
    
@@ -60,13 +65,11 @@ the ones used to connect to the Cumulocity Core MQTT endpoint.
    </UserContext>
 
    :::note
-   Though you're setting the `c8y.url` config, the `c8y.mqtt_service.url` config is used under-the-hood for the connection,
-   as this config is derived from the `c8y.mqtt` config, which is further derived from `c8y.url`, by default.
-   For example, when `c8y.url` is `example.cumulocity.com`, `c8y.mqtt` would be `example.cumulocity.com:8883`
-   and `c8y.mqtt_service.url` would be `example.cumulocity.com:9883`.
+   Though the `c8y.url` config is set in this step, the `c8y.mqtt` config is used under-the-hood for the connection,
+   as this config is derived from `c8y.url`, by default.
 
-   If the MQTT service url is different from the one that would be derived from `c8y.url` or `c8y.mqtt`,
-   set`c8y.mqtt_service.url` explicitly.
+   If the MQTT service url is different from the one that would be derived from `c8y.url`,
+   then set`c8y.mqtt` explicitly.
    :::
 
 1. Enable connection to MQTT service endpoint
@@ -75,10 +78,18 @@ the ones used to connect to the Cumulocity Core MQTT endpoint.
    sudo tedge config set c8y.mqtt_service.enabled true
    ```
 
-1. Provide a topic to subscribe to
+   :::note
+   The `c8y.mqtt` value is derived differently based on whether mqtt service is enabled or not.
+   For example, when `c8y.url` is `example.cumulocity.com` and when `mqtt_service` is enabled,
+   `c8y.mqtt` would be derived as `example.cumulocity.com:9883` (the default mqtt service endpoint).
+   else it would be `example.cumulocity.com:8883` (the default core mqtt endpoint).
+   :::
+
+
+1. Provide the topics to subscribe to (e.g: topic to receive sensor config updates)
 
    ```sh
-   sudo tedge config set c8y.mqtt_service.topics demo/topic
+   sudo tedge config set c8y.mqtt_service.topics sensors/temperature/set-config
    ```
 
 1. Make Cumulocity trust the device certificate as described [here](./connect.md#making-the-cloud-trust-the-device),
@@ -90,16 +101,31 @@ the ones used to connect to the Cumulocity Core MQTT endpoint.
    sudo tedge connect c8y
    ```
 
-   This step establishes the bridge connection to both the core endpoint as well as the mqtt service endpoints simultaneously.
-
-1. Once connected, all messages published to `c8y-mqtt/#` topics are forwarded to the MQTT service endpoint.
-
-   ```sh
-   tedge mqtt pub c8y-mqtt/test/topic '{ "hello": "world" }'
-   ```
-
-   The receipt of the published message can be validated on Cumulocity.
+   This step establishes the bridge connection to the mqtt service endpoint instead of the core mqtt endpoint.
+   All MQTT traffic using both the built-in topics (e.g: SmartREST) as well as the user-provided custom topics
+   are routed to the MQTT service endpoint, completely bypassing the core MQTT endpoint.
 
    :::note
-   The bridge topic prefix `c8y-mqtt` can be changed using the tedge configuration: `c8y.mqtt_service.topic_prefix`.
+   If the device was previously connected to Cumulocity (the Core MQTT endpoint),
+   doing a `sudo tedge reconnect c8y` after steps 2 and 3 would have sufficed.
    :::
+
+1. Once connected, all messages published to `c8y/mqtt/out/#` topics are forwarded to the MQTT service endpoint,
+   without the `c8y/mqtt/out/` prefix.
+
+   For example, to publish the temperature measurement:
+
+   ```sh
+   tedge mqtt pub c8y/mqtt/out/sensors/temperature/measurement 25
+   ```
+
+   The message will be published to the `sensors/temperature/measurement` topic on the MQTT service,
+   and its receipt can be validated on Cumulocity.
+2. Similarly, any messages published to the subscribed `sensors/temperature/set-config` topic on Cumulocity
+   are published to the corresponding local bridge topic with a `c8y/mqtt/in/` topic prefix.
+
+   To see the set configuration commands received from the cloud:
+
+   ```sh
+   tedge mqtt sub c8y/mqtt/in/sensors/temperature/set-config
+   ```


### PR DESCRIPTION
## Proposed changes

When `c8y.mqtt_service.enabled` is set to `true`, just connect to MQTT service endpoint on port 9883 instead of establishing two connections, one to core mqtt and another one to mqtt service. This feature can only be tested against a tenant with the SmartREST proxy feature of MQTT service enabled, so that the same connection can interact with the device over SmartREST or JSON over MQTT.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3858

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

