### PR TITLE
refactor: split private_key_storage.robot

### DIFF
--- a/tests/RobotFramework/tests/pkcs11/create_key.robot
+++ b/tests/RobotFramework/tests/pkcs11/create_key.robot
@@ -1,0 +1,151 @@
+*** Settings ***
+Documentation       Tests for the `tedge cert create-key-hsm` command.
+
+Resource            pkcs11_common.resource
+
+Suite Setup         Custom Setup
+Suite Teardown      Get Suite Logs
+
+Test Tags           adapter:docker    theme:cryptoki
+
+
+*** Variables ***
+${KEY_URI}      ${EMPTY}
+${TOKEN_URI}    pkcs11:token=create-key-token
+
+
+*** Test Cases ***
+Can create a private key on the PKCS11 token
+    Execute Command    cmd=softhsm2-util --init-token --free --label create-key-token --pin=123456 --so-pin=123456
+
+    ${output}=    Execute Command
+    ...    cmd=p11tool --login --set-pin=123456 --list-privkeys "${TOKEN_URI}"
+    ...    exp_exit_code=!0
+    ...    strip=True
+    ...    stdout=False
+    ...    stderr=True
+    Should Be Equal    ${output}    No matching objects found
+
+    Create private key    label=rsa-2048    type=rsa    p11tool_keytype=RSA-2048
+    Create private key
+    ...    label=rsa-3072
+    ...    type=rsa
+    ...    bits=3072
+    ...    p11tool_keytype=RSA-3072
+    Create private key
+    ...    label=rsa-4096
+    ...    type=rsa
+    ...    bits=4096
+    ...    p11tool_keytype=RSA-4096
+
+    Create private key
+    ...    label=ec-256
+    ...    type=ecdsa
+    ...    curve=p256
+    ...    p11tool_keytype=EC/ECDSA-SECP256R1
+    Create private key
+    ...    label=ec-384
+    ...    type=ecdsa
+    ...    curve=p384
+    ...    p11tool_keytype=EC/ECDSA-SECP384R1
+    # ECDSA P521 not supported by rcgen
+
+Shows connected initialized tokens when token argument is not provided
+    # setup multiple tokens
+    Execute Command    cmd=softhsm2-util --init-token --free --label create-key-token1 --pin=123456 --so-pin=123456
+    Execute Command    cmd=softhsm2-util --init-token --free --label create-key-token2 --pin=123456 --so-pin=123456
+
+    # unset key_uri so there there's no hint where to generate the keypair
+    Execute Command    cmd=tedge config unset device.key_uri
+    ${stderr}=    Execute Command
+    ...    cmd=tedge cert create-key-hsm --type ecdsa --label my-key
+    ...    strip=True
+    ...    stdout=False
+    ...    stderr=True
+    ...    exp_exit_code=1
+    Should Contain    ${stderr}    No token URL was provided for this operation; the available tokens are:
+    Should Contain    ${stderr}    token=create-key-token1
+    Should Contain    ${stderr}    token=create-key-token2
+
+Can set key ID using --id flag
+    ${output}=    Execute Command
+    ...    cmd=tedge cert create-key-hsm --type ecdsa --label my-key --id 010203 "${TOKEN_URI}"
+    ...    strip=True
+    ...    stdout=False
+    ...    stderr=True
+    Should Contain    ${output}    id=%01%02%03
+
+    ${output}=    Execute Command
+    ...    cmd=tedge cert create-key-hsm --type ecdsa --label my-key --id 010203 "${TOKEN_URI}"
+    ...    strip=True
+    ...    stdout=False
+    ...    stderr=True
+    ...    exp_exit_code=!0
+    Should Contain    ${output}    Object with this id already exists on the token
+
+Can provide PIN using --pin flag
+    ${output}=    Execute Command
+    ...    cmd=tedge cert create-key-hsm --label my-key --pin 000000 "${TOKEN_URI}"
+    ...    strip=True
+    ...    stdout=False
+    ...    stderr=True
+    ...    exp_exit_code=!0
+    Should Contain    ${output}    The specified PIN is incorrect
+
+Saves public key to file using --outfile-pubkey flag
+    ${output}=    Execute Command
+    ...    cmd=tedge cert create-key-hsm --label my-key --outfile-pubkey pubkey.pem "${TOKEN_URI}"
+    ...    strip=True
+    ...    stdout=False
+    ...    stderr=True
+    ${pubkey}=    Execute Command    cat pubkey.pem    strip=True
+    Should Contain    ${output}    ${pubkey}
+
+
+*** Keywords ***
+Create private key
+    [Arguments]    ${type}    ${label}    ${bits}=${EMPTY}    ${curve}=${EMPTY}    ${p11tool_keytype}=${EMPTY}
+    # create the private key on token and write CSR to device.csr_path
+    VAR    ${command}=    tedge cert create-key-hsm --label ${label} --type ${type} "${TOKEN_URI}"
+    IF    $bits
+        VAR    ${command}=    ${command} --bits ${bits}
+    END
+    IF    $curve
+        VAR    ${command}=    ${command} --curve ${curve}
+    END
+    ${create_key_output}=    Execute Command    ${command}    strip=True    stderr=True    stdout=False
+
+    # check if key is created
+    ${output}=    Execute Command
+    ...    cmd=p11tool --login --set-pin=123456 --list-privkeys "${TOKEN_URI}"
+    IF    $p11tool_keytype
+        Should Contain    ${output}    Type: Private key (${p11tool_keytype})
+    ELSE
+        Should Contain    ${output}    Type: Private key
+    END
+    Should Contain    ${output}    Label: ${label}
+
+    ${key_uri}=    Execute Command    tedge config get device.key_uri    strip=True
+    Should Contain    ${create_key_output}    ${key_uri}
+
+Custom Setup
+    ${DEVICE_SN}=    Setup    register=${False}
+    Set Suite Variable    ${DEVICE_SN}
+
+    # Allow the tedge user to access softhsm
+    Execute Command    sudo usermod -a -G softhsm tedge
+    Transfer To Device    ${CURDIR}/data/init_softhsm.sh    /usr/bin/
+
+    # initialize the soft hsm and create a certificate signing request
+    Execute Command    tedge config set device.cryptoki.pin 123456
+    Execute Command    tedge config set device.cryptoki.module_path /usr/lib/softhsm/libsofthsm2.so
+    Execute Command    sudo -u tedge /usr/bin/init_softhsm.sh --device-id "${DEVICE_SN}" --pin 123456
+
+    # configure tedge
+    ${domain}=    Cumulocity.Get Domain
+    Execute Command    tedge config set c8y.url "${domain}"
+    Execute Command    tedge config set mqtt.bridge.built_in true
+    Execute Command    tedge config set device.cryptoki.mode socket
+
+    ${csr_path}=    Execute Command    cmd=tedge config get device.csr_path    strip=${True}
+    ThinEdgeIO.Register Device With Cumulocity CA    ${DEVICE_SN}    csr_path=${csr_path}

--- a/tests/RobotFramework/tests/pkcs11/tedge_p11_server.robot
+++ b/tests/RobotFramework/tests/pkcs11/tedge_p11_server.robot
@@ -1,0 +1,102 @@
+*** Settings ***
+Documentation       Test suite for tedge-p11-server functionality.
+
+Resource            pkcs11_common.resource
+
+Suite Setup         Custom Setup
+Suite Teardown      Get Suite Logs
+
+Test Tags           adapter:docker    theme:cryptoki
+
+
+*** Test Cases ***
+Ignore tedge.toml if missing
+    Execute Command    rm -f ./tedge.toml
+    ${stderr}=    Execute Command    tedge-p11-server --config-dir . --module-path xx.so    exp_exit_code=!0
+    # Don't log anything (this is normal behaviour as the user does not have to create a tedge.toml file)
+    Should Not Contain    ${stderr}    Failed to read ./tedge.toml: No such file
+    # And proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+    # Using default values
+    Should Contain    ${stderr}    tedge-p11-server.sock
+
+Ignore tedge.toml if empty
+    Execute Command    touch ./tedge.toml
+    ${stderr}=    Execute Command    tedge-p11-server --config-dir . --module-path xx.so    exp_exit_code=!0
+    # Don't log anything (this is normal behaviour, where the file is used for tedge and not tedge-p11-server)
+    Should Not Contain    ${stderr}    Failed to parse ./tedge.toml: invalid TOML
+    # And proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+    # Using default values
+    Should Contain    ${stderr}    tedge-p11-server.sock
+
+Ignore tedge.toml if incomplete
+    Execute Command    echo '[device]' >./tedge.toml
+    ${stderr}=    Execute Command    tedge-p11-server --config-dir . --module-path xx.so    exp_exit_code=!0
+    # Don't log anything (this is normal behaviour, where the file is used for tedge and not tedge-p11-server)
+    Should Not Contain    ${stderr}    Failed to parse ./tedge.toml: invalid TOML
+    Should Not Contain    ${stderr}    missing field `cryptoki`
+    # And proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+    # Using default values
+    Should Contain    ${stderr}    tedge-p11-server.sock
+
+Do not warn the user if tedge.toml is incomplete but not used
+    Execute Command    rm -f ./tedge.toml
+    ${stderr}=    Execute Command
+    ...    tedge-p11-server --config-dir . --module-path xx.so --pin 11.pin --socket-path yy.sock --uri zz.uri
+    ...    exp_exit_code=!0
+    # Don't warn as all values are provided on the command line
+    Should Not Contain    ${stderr}    Failed to read ./tedge.toml: No such file
+    # And proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+    # Using the values provided on the command lin
+    Should Contain    ${stderr}    xx.so
+    Should Contain    ${stderr}    yy.sock
+    Should Contain    ${stderr}    zz.uri
+
+Warn the user if tedge.toml exists but cannot be read
+    Execute Command    echo '[device.cryptoki]' >./tedge.toml
+    Execute Command    chmod a-rw ./tedge.toml
+    ${stderr}=    Execute Command
+    ...    sudo -u tedge tedge-p11-server --config-dir . --module-path xx.so
+    ...    exp_exit_code=!0
+    # Warn the user
+    Should Contain    ${stderr}    Failed to read ./tedge.toml: Permission denied
+    # But proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+
+Warn the user if tedge.toml cannot be parsed
+    Execute Command    rm -f ./tedge.toml
+    Execute Command    echo '[corrupted toml ...' >./tedge.toml
+    ${stderr}=    Execute Command    tedge-p11-server --config-dir . --module-path xx.so    exp_exit_code=!0
+    # Warn the user
+    Should Contain    ${stderr}    Failed to parse ./tedge.toml: invalid TOML
+    # But proceed
+    Should Contain    ${stderr}    Using cryptoki configuration
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}=    Setup    register=${False}
+    Set Suite Variable    ${DEVICE_SN}
+
+    # Allow the tedge user to access softhsm
+    Execute Command    sudo usermod -a -G softhsm tedge
+    Transfer To Device    ${CURDIR}/data/init_softhsm.sh    /usr/bin/
+
+    # initialize the soft hsm and create a certificate signing request
+    Execute Command    tedge config set device.cryptoki.pin 123456
+    Execute Command    tedge config set device.cryptoki.module_path /usr/lib/softhsm/libsofthsm2.so
+    Execute Command    sudo -u tedge /usr/bin/init_softhsm.sh --device-id "${DEVICE_SN}" --pin 123456
+
+    # configure tedge
+    ${domain}=    Cumulocity.Get Domain
+    Execute Command    tedge config set c8y.url "${domain}"
+    Execute Command    tedge config set mqtt.bridge.built_in true
+    Execute Command    tedge config set device.cryptoki.mode socket
+
+    ${csr_path}=    Execute Command    cmd=tedge config get device.csr_path    strip=${True}
+    ThinEdgeIO.Register Device With Cumulocity CA    ${DEVICE_SN}    csr_path=${csr_path}
+
+    Unset tedge-p11-server Uri


### PR DESCRIPTION
## Proposed changes

private_key_storage.robot suite was split into 3 suites:

- create_key.robot which tests only key creation
- tedge_p11_server.robot which tests only tedge-p11-server config handling
- private_key_storage.robot which now only tests tedge selecting and connecting using private keys from the tokens

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

