### PR TITLE
tests: update flow for measurement unit transformation to always output c8y compatible measurements

### DIFF
--- a/tests/RobotFramework/tests/tedge_flows/flows/measurements.samples
+++ b/tests/RobotFramework/tests/tedge_flows/flows/measurements.samples
@@ -1,6 +1,6 @@
 # The default is to have no units
-INPUT: [te/device/main///m/] {"temperature": 25, "time":"2025-06-27T13:33:53.493Z"}
-OUTPUT: [c8y/measurement/measurements/create] {"type":"ThinEdgeMeasurement","temperature":{"temperature":25},"time":"2025-06-27T13:33:53.493Z"}
+INPUT: [te/device/main///m/] {"temperature": 25,"outside":{"humidity":85}, "time":"2025-06-27T13:33:53.493Z"}
+OUTPUT: [c8y/measurement/measurements/create] {"type":"ThinEdgeMeasurement","temperature":{"temperature":{"value":25}},"outside":{"humidity":{"value":85}},"time":"2025-06-27T13:33:53.493Z"}
 
 # Units can be set using the meta topic
 INPUT: [te/device/main///m//meta] {"temperature": { "unit": "°C" }}
@@ -17,7 +17,7 @@ OUTPUT: [c8y/measurement/measurements/create] {"type":"ThinEdgeMeasurement","tem
 # Units can be set to across measurement types
 INPUT: [te/device/main///m/environment/meta] { "temperature": { "unit": "°C" }, "location": { "altitude": { "unit": "m" } }, "pressure": { "unit": "pascal" } }
 INPUT: [te/device/main///m/environment] {"time":"2025-06-27T08:11:05.301804125Z", "temperature": 25, "location": {"latitude": 32.54, "longitude": -117.67, "altitude": 98.6 }, "pressure": 98}
-OUTPUT: [c8y/measurement/measurements/create] {"type":"environment","time":"2025-06-27T08:11:05.301804125Z","temperature":{"temperature":{"value":25,"unit":"°C"}},"location":{"latitude":32.54,"longitude":-117.67,"altitude":{"value":98.6,"unit":"m"}},"pressure":{"pressure":{"value":98,"unit":"pascal"}}}
+OUTPUT: [c8y/measurement/measurements/create] {"type":"environment","time":"2025-06-27T08:11:05.301804125Z","temperature":{"temperature":{"value":25,"unit":"°C"}},"location":{"latitude":{"value":32.54},"longitude":{"value":-117.67},"altitude":{"value":98.6,"unit":"m"}},"pressure":{"pressure":{"value":98,"unit":"pascal"}}}
 
 # For the default type °F are still used, while changed to °C for environment measurements
 INPUT: [te/device/main///m/] {"temperature": 77, "time":"2025-06-27T12:40:24.122Z"}

--- a/tests/RobotFramework/tests/tedge_flows/flows/te_to_c8y.js
+++ b/tests/RobotFramework/tests/tedge_flows/flows/te_to_c8y.js
@@ -66,6 +66,8 @@ export function onMessage(message, config) {
     else if (typeof(v) === "number") {
       if (Object.keys(k_meta).length>0) {
         v = { value: v, ...k_meta }
+      } else {
+        v = { value: v }
       }
       let fragment = { [k]: { [k]: v } }
       Object.assign(c8y_msg, fragment)
@@ -76,6 +78,8 @@ export function onMessage(message, config) {
         if (typeof(sub_v) === "number") {
           if (sub_k_meta) {
             sub_v = { value: sub_v, ...sub_k_meta }
+          } else {
+            sub_v = { value: sub_v }
           }
           let sub_fragment = { [sub_k]: sub_v }
           Object.assign(fragment, sub_fragment)

--- a/tests/RobotFramework/tests/tedge_flows/tedge_flows.robot
+++ b/tests/RobotFramework/tests/tedge_flows/tedge_flows.robot
@@ -47,7 +47,7 @@ Translate complex tedge json to c8y json
     ...    strip=True
     Should Be Equal
     ...    ${transformed_msg}
-    ...    [c8y/measurement/measurements/create] {"type":"environment","time":"2025-06-27T08:11:05.301804125Z","temperature":{"temperature":258},"location":{"latitude":32.54,"longitude":-117.67,"altitude":98.6},"pressure":{"pressure":98}}
+    ...    [c8y/measurement/measurements/create] {"type":"environment","time":"2025-06-27T08:11:05.301804125Z","temperature":{"temperature":{"value":258}},"location":{"latitude":{"value":32.54},"longitude":{"value":-117.67},"altitude":{"value":98.6}},"pressure":{"pressure":{"value":98}}}
 
 Using base64 to encode tedge flows input
     ${encoded_input}    Execute Command
@@ -57,11 +57,11 @@ Using base64 to encode tedge flows input
     ...    strip=True
     Should Be Equal
     ...    ${transformed_msg}
-    ...    [c8y/measurement/measurements/create] {"type":"env","time":"2025-06-27T08:11:05.301804125Z","temperature":{"temperature":258}}
+    ...    [c8y/measurement/measurements/create] {"type":"env","time":"2025-06-27T08:11:05.301804125Z","temperature":{"temperature":{"value":258}}}
 
 Using base64 to encode tedge flows output
     ${encoded_output}    Execute Command
-    ...    echo -n '{"type":"env","time":"2025-06-27T08:11:05.301804125Z","temperature":{"temperature":258}}' | base64 --wrap\=0
+    ...    echo -n '{"type":"env","time":"2025-06-27T08:11:05.301804125Z","temperature":{"temperature":{"value":258}}}' | base64 --wrap\=0
     ${transformed_msg}    Execute Command
     ...    tedge flows test --base64-output te/device/main///m/env '{"time":"2025-06-27T08:11:05.301804125Z", "temperature": 258}'
     ...    strip=True


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Update the te_to_c8y.js flow example where it converts thin-edge.io measurements to Cumulocity measurements and optionally adds the registered units to the outgoing Cumulocity measurement.

The problem was with the output measurements when there was no registered unit and it would not transform the number to a nested object, e.g. `{"value": 123}`, which meant that the value would be rejected by Cumulocity (if it would be sent to Cumulocity).

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

