### PR TITLE
fix: prevent URI percent-decoding in c8y_auth_proxy path handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,7 @@ dependencies = [
  "tedge_actors",
  "tedge_config",
  "tedge_config_macros",
+ "test-case",
  "tokio",
  "tokio-tungstenite",
  "tracing",

--- a/crates/extensions/c8y_auth_proxy/Cargo.toml
+++ b/crates/extensions/c8y_auth_proxy/Cargo.toml
@@ -42,6 +42,7 @@ env_logger = { workspace = true }
 httparse = { workspace = true }
 mockito = { workspace = true }
 rcgen = { workspace = true }
+test-case = { workspace = true }
 
 [lints]
 workspace = true

--- a/tests/RobotFramework/tests/cumulocity/http_proxy/http_proxy_support.robot
+++ b/tests/RobotFramework/tests/cumulocity/http_proxy/http_proxy_support.robot
@@ -45,6 +45,12 @@ Install thin-edge.io behind a Proxy using curl
     ...    cmd=export https_proxy=http://127.0.0.1:8080; curl -fsSL https://thin-edge.io/install.sh | sh -s
     Configure and Connect to Cumulocity
 
+C8Y HTTP proxy supports percent encoded characters
+    [Tags]    \#3884
+    [Setup]    Setup
+    Execute Command    tedge mqtt pub c8y/s/us 101,"test;device"
+    Execute Command    tedge http get /c8y/identity/externalIds/c8y_Serial/test%3Bdevice
+
 
 *** Keywords ***
 Setup Device With thin-edge.io


### PR DESCRIPTION
## Proposed changes
[`axum::extract::Path`](https://docs.rs/axum/latest/axum/extract/struct.Path.html) forces any percent encoded parameters decoded, that causes a url containing encoded semicolon `%3B` changed into decoded `;`, and c8y responses with an error.

 > Any percent encoded parameters will be automatically decoded. The decoded parameters must be valid UTF-8, otherwise Path will fail and return a 400 Bad Request response.

This PR uses a workaround to avoid using `axum::extract::Path`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3884

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

