### PR TITLE
fix: allow concurrent `tedge connect <cloud> --test` processes

### DIFF
--- a/crates/common/mqtt_channel/src/config.rs
+++ b/crates/common/mqtt_channel/src/config.rs
@@ -294,6 +294,18 @@ impl Config {
         }
     }
 
+    /// Set the random session name with prefix and clear the session
+    pub fn with_session_prefix(self, prefix: impl Into<String>) -> Self {
+        let random: String = std::iter::repeat_with(fastrand::lowercase)
+            .take(10)
+            .collect();
+        Self {
+            session_name: Some(format!("{}-{}", prefix.into(), random)),
+            clean_session: true,
+            ..self
+        }
+    }
+
     /// Unset the session name and clear the session
     pub fn with_no_session(self) -> Self {
         Self {

--- a/crates/core/tedge/src/cli/connect/aws.rs
+++ b/crates/core/tedge/src/cli/connect/aws.rs
@@ -27,7 +27,7 @@ pub async fn check_device_status_aws(
 
     let mut mqtt_options = tedge_config
         .mqtt_config()?
-        .with_session_name(CLIENT_ID)
+        .with_session_prefix(CLIENT_ID)
         .rumqttc_options()?;
     mqtt_options.set_keep_alive(RESPONSE_TIMEOUT);
 

--- a/crates/core/tedge/src/cli/connect/azure.rs
+++ b/crates/core/tedge/src/cli/connect/azure.rs
@@ -33,7 +33,7 @@ pub(crate) async fn check_device_status_azure(
 
     let mut mqtt_options = tedge_config
         .mqtt_config()?
-        .with_session_name(CLIENT_ID)
+        .with_session_prefix(CLIENT_ID)
         .rumqttc_options()?;
 
     mqtt_options.set_keep_alive(RESPONSE_TIMEOUT);

--- a/crates/core/tedge/src/cli/connect/c8y.rs
+++ b/crates/core/tedge/src/cli/connect/c8y.rs
@@ -199,8 +199,7 @@ pub(crate) async fn check_device_status_c8y(
 
     let mut mqtt_options = tedge_config
         .mqtt_config()?
-        .with_session_name(CLIENT_ID)
-        .with_clean_session(true)
+        .with_session_prefix(CLIENT_ID)
         .rumqttc_options()?;
 
     mqtt_options.set_keep_alive(RESPONSE_TIMEOUT);
@@ -323,8 +322,7 @@ pub(crate) async fn get_connected_c8y_url(
 
     let mut mqtt_options = tedge_config
         .mqtt_config()?
-        .with_session_name(CLIENT_ID)
-        .with_clean_session(true)
+        .with_session_prefix(CLIENT_ID)
         .rumqttc_options()?;
     mqtt_options.set_keep_alive(RESPONSE_TIMEOUT);
 

--- a/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
+++ b/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
@@ -18,6 +18,10 @@ tedge_connect_test_positive
     ${output}=    Execute Command    sudo tedge connect c8y --test    stdout=${False}    stderr=${True}
     Should Contain    ${output}    Connection check to c8y cloud is successful.
 
+Multiple tedge connect test processes can run concurrently
+    [Tags]    \#3907
+    Execute Command    sudo tedge connect c8y --test & sudo tedge connect c8y --test    timeout=5
+
 Non-root users should be able to read the mosquitto configuration files #2154
     [Tags]    \#2154
     Execute Command    sudo tedge connect c8y || true


### PR DESCRIPTION
## Proposed changes

To support running multiple tedge connect test processes simultaneously, this change introduces a random suffix to the session name. This prevents naming conflicts when concurrent processes are executed.

Note: Although removing `.with_session_name(CLIENT_ID)` would technically resolve the issue, I chose to introduce `.with_session_prefix()` for a specific reason: keeping the prefix in the session name improves debuggability in MQTT logs, as the session name clearly identifies the source of each MQTT session.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3907 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

