### PR TITLE
feat: tedge-p11-server log version on startup

### DIFF
--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use camino::Utf8PathBuf;
+use clap::crate_version;
 use clap::Parser;
 use serde::Deserialize;
 use tedge_p11_server::CryptokiConfigDirect;
@@ -241,6 +242,9 @@ async fn main() -> anyhow::Result<()> {
     yansi::whenever(USE_COLOR);
 
     let args = Args::parse();
+
+    info!("Starting tedge-p11-server {}", crate_version!());
+
     let config = try_read_config(args).await?;
     let cryptoki_config = CryptokiConfigDirect {
         module_path: config.module_path,

--- a/tests/RobotFramework/tests/pkcs11/tedge_p11_server.robot
+++ b/tests/RobotFramework/tests/pkcs11/tedge_p11_server.robot
@@ -88,6 +88,11 @@ Warn the user if tedge.toml cannot be parsed
     ...    error=PKCS #11 service failed: Failed to find a key
     Execute Command    cmd=tedge config unset c8y.device.key_uri
 
+Prints version on startup
+    Restart Service    tedge-p11-server
+    ${stdout}=    Execute Command    tedge-p11-server --version    strip=True
+    Logs Should Contain    Starting ${stdout}
+
 
 *** Keywords ***
 Custom Setup


### PR DESCRIPTION
## Proposed changes

tedge-p11-server will now print its cargo package version on startup. It's set in tedge/build.rs using $GIT_SEMVER environment variable, but can also be manually previewed using cargo run:

```
$ export GIT_SEMVER=$(git describe --always --tags --abbrev=8 --dirty)
$ cargo run --bin tedge-p11-server
...
[...] INFO tedge_p11_server: Starting tedge-p11-server 1.7.1-59-gd61187c8
```

Having version in the log makes debugging easier, since it doesn't have to be collected separately.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

