### PR TITLE
feat: switch to musl when building for riscv64gc

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -142,7 +142,7 @@ jobs:
           - armv5te-unknown-linux-musleabi
           - x86_64-unknown-linux-musl
           - i686-unknown-linux-musl
-          - riscv64gc-unknown-linux-gnu
+          - riscv64gc-unknown-linux-musl
           - aarch64-apple-darwin
           - x86_64-apple-darwin
 
@@ -184,11 +184,10 @@ jobs:
             host_os: ubuntu-24.04
             cargo_options: --no-run
 
-          # Note: riscv64gc-unknown-linux-musl is meant to be supported from 1.82
-          # but there are still some build problems which prevent it from being used.
-          # So stick to gnu build only
-          - target: riscv64gc-unknown-linux-gnu
-            build_with: auto
+          # Note: riscv64gc-unknown-linux-musl currently fails to build
+          # when using clang, but cargo-zigbuild works
+          - target: riscv64gc-unknown-linux-musl
+            build_with: zig
             host_os: ubuntu-24.04
             cargo_options: --no-run
 
@@ -372,7 +371,7 @@ jobs:
           - { target: i686-unknown-linux-musl,        repo_suffix: '',          component: main }
           # Debian also calls this "armel" (conflict with arm-unknown-linux-musleabi)
           # - { target: armv5te-unknown-linux-musleabi, repo_suffix: '',          component: main }
-          - { target: riscv64gc-unknown-linux-gnu,    repo_suffix: '',          component: main }
+          - { target: riscv64gc-unknown-linux-musl,    repo_suffix: '',          component: main }
           - { target: aarch64-apple-darwin,      repo_suffix: '',          component: main }
           - { target: x86_64-apple-darwin,       repo_suffix: '',          component: main }
 

--- a/ci/build_scripts/check_bindgen_feature.sh
+++ b/ci/build_scripts/check_bindgen_feature.sh
@@ -43,7 +43,7 @@ TARGETS_WITH_BINDGEN=(
     "arm-unknown-linux-musleabihf"
     "arm-unknown-linux-musleabi"
     "armv5te-unknown-linux-musleabi"
-    "riscv64gc-unknown-linux-gnu"
+    "riscv64gc-unknown-linux-musl"
     "i686-unknown-linux-musl"
 )
 

--- a/mk/install-build-tools-all-targets.sh
+++ b/mk/install-build-tools-all-targets.sh
@@ -9,7 +9,7 @@ TARGETS=(
     arm-unknown-linux-musleabihf
     arm-unknown-linux-musleabi
     armv5te-unknown-linux-musleabi
-    riscv64gc-unknown-linux-gnu
+    riscv64gc-unknown-linux-musl
 )
 
 for TARGET in "${TARGETS[@]}"; do


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Switch from `riscv64gc-unknown-linux-gnu` to `riscv64gc-unknown-linux-musl` (statically linked) to reduce dependency on a specific libc version. Currently `riscv64gc-unknown-linux-gnu` is being used but being linked against the glibc version on the build machine which is very new, GLIBC 2.39.

Previously `riscv64gc-unknown-linux-gnu` was only used as Rust only added musl support in 1.82. Unfortunately the tedge binary doesn't build when using clang, however cargo-zigbuild works fine.

Note: tedge-p11-server is still built using cargo-ziglang using `riscv64gc-unknown-linux-gnu` as it needs to be dynamically linked so that it can load the cryptoki library

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

