### PR TITLE
test: robust teardown for Cumulocity CA cloud profile test

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/registration/cumulocity_ca.robot
+++ b/tests/RobotFramework/tests/cumulocity/registration/cumulocity_ca.robot
@@ -76,7 +76,7 @@ Certificate Renewal with Cloud Profiles
 
     ${cert_after}=    Execute Command    tedge cert show c8y --profile customer | grep Thumbprint
     Should Not Be Equal    ${cert_before}    ${cert_after}
-    [Teardown]    Cumulocity.Delete Managed Object And Device User    external_id=${DEVICE_SN_2}
+    [Teardown]    Disconnect And Delete Device From Cumulocity    profile=customer    external_id=${DEVICE_SN_2}
 
 
 *** Keywords ***
@@ -91,3 +91,8 @@ Setup With Self-Signed Certificate
 Setup With Cumulocity CA Certificate
     ${DEVICE_SN}=    Setup    register_using=c8y-ca
     Set Test Variable    $DEVICE_SN
+
+Disconnect And Delete Device From Cumulocity
+    [Arguments]    ${profile}    ${external_id}
+    Execute Command    tedge disconnect c8y --profile ${profile}    ignore_exit_code=${True}
+    Cumulocity.Delete Managed Object And Device User    ${external_id}


### PR DESCRIPTION
## Proposed changes

Disconnect the device before deleting it from Cumulocity. Otherwise the mapper that's left running can re-create the deleted device, with the availability messages that's sent periodically.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

