### PR TITLE
feat: default to existing device.id in tedge cert download c8y

### DIFF
--- a/crates/core/tedge/src/cli/certificate/cli.rs
+++ b/crates/core/tedge/src/cli/certificate/cli.rs
@@ -434,8 +434,13 @@ impl BuildCommand for TEdgeCertCli {
                             )))?
                             .into(),
                     ));
+                let device_id = if id.is_empty() {
+                    c8y_config.device.id().unwrap_or(id)
+                } else {
+                    id
+                };
                 let cmd = c8y::DownloadCertCmd {
-                    device_id: id,
+                    device_id,
                     one_time_password: token,
                     c8y_url,
                     root_certs: config.cloud_root_certs().await?,
@@ -603,7 +608,8 @@ pub enum DownloadCertCli {
     C8y {
         /// The device identifier to be used as the common name for the certificate
         ///
-        /// You will be prompted for input if the value is not provided or is empty
+        /// You will be prompted for input if an existing device id is not set,
+        /// or if the value is not provided or is empty
         #[clap(long = "device-id")]
         #[arg(
             env = "DEVICE_ID",

--- a/tests/RobotFramework/tests/cumulocity/registration/cumulocity_ca.robot
+++ b/tests/RobotFramework/tests/cumulocity/registration/cumulocity_ca.robot
@@ -25,6 +25,22 @@ Register Device Using Cumulocity CA with url flag
     Set Cumulocity URLs
     Execute Command    tedge connect c8y
 
+Reuse existing Device ID whilst downloading
+    [Documentation]    Re-registering the device shouldn't require providing the device-id again
+    [Setup]    Custom Setup
+    ${credentials}=    Bulk Register Device With Cumulocity CA    ${DEVICE_SN}
+    ${DOMAIN}=    Cumulocity.Get Domain
+    Execute Command
+    ...    tedge cert download c8y --device-id "${DEVICE_SN}" --one-time-password '${credentials.one_time_password}' --url ${DOMAIN} --retry-every 5s --max-timeout 30s
+    Set Cumulocity URLs
+    Execute Command    tedge connect c8y
+
+    # re-register the device (ensure that the DEVICE_ID env is also not set)
+    ${credentials}=    Bulk Register Device With Cumulocity CA    ${DEVICE_SN}
+    Execute Command
+    ...    cmd=env DEVICE_ID= tedge cert download c8y --one-time-password '${credentials.one_time_password}' --retry-every 5s --max-timeout 30s
+    Execute Command    tedge reconnect c8y
+
 Certificate Renewal Service Using Cumulocity Certificate Authority
     [Setup]    Setup With Self-Signed Certificate
     ${cert_before}=    Execute Command    tedge cert show | grep -v Status:


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Re-use the existing device.id if present during the `tedge cert download c8y` command.

This reduces user-error should the device need to be re-registered with the Cumulocity CA, where previously the user would be prompted for the device.id again (even when an existing certificate exists). Users can still overwrite the value by using the `--device-id <string>` flag.

This use-case occurred personally where I had to re-register devices, and wanted to be sure that I re-used the same device id.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

