### PR TITLE
fix: align c8y-remote-access-plugin operations folder creation with tedge init

### DIFF
--- a/plugins/c8y_remote_access_plugin/src/lib.rs
+++ b/plugins/c8y_remote_access_plugin/src/lib.rs
@@ -97,7 +97,7 @@ async fn declare_supported_operation(
         supported_operation_path.parent().unwrap(),
         user,
         group,
-        0o755,
+        0o775,
     )
     .await
     .into_diagnostic()

--- a/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
+++ b/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
@@ -28,7 +28,7 @@ Init c8y-remote-access-plugin with the custom user and group
     Device Should Have Installed Software    c8y-remote-access-plugin
 
     Execute Command    sudo c8y-remote-access-plugin --init --user petertest --group petertest
-    Path Should Have Permissions    /etc/tedge/operations/c8y    mode=755    owner_group=petertest:petertest
+    Path Should Have Permissions    /etc/tedge/operations/c8y    mode=775    owner_group=petertest:petertest
     Path Should Have Permissions
     ...    /etc/tedge/operations/c8y/c8y_RemoteAccessConnect
     ...    mode=644


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

A failed [merge-queue run](https://github.com/thin-edge/thin-edge.io/actions/runs/21601966591) highlighted a system test failure which shows there was a difference between the `c8y-remote-access-plugin --init` command and the `tedge init` when it comes to the permissions assigned to the `/etc/tedge/operations` folder. The former used `0755`, whilst the latter used `0775`.

This PR change parent folder creation to use `0775` which to align with `tedge init`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

CI Run where the error was identified: 

https://github.com/thin-edge/thin-edge.io/actions/runs/21601966591

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

