### PR TITLE
fix: Make log level overrides for `tedge` binary work again

### DIFF
--- a/crates/common/tedge_config/src/cli.rs
+++ b/crates/common/tedge_config/src/cli.rs
@@ -43,15 +43,6 @@ pub struct LogConfigArgs {
     pub log_level: Option<tracing::Level>,
 }
 
-impl LogConfigArgs {
-    pub fn with_default_level(self, log_level: tracing::Level) -> Self {
-        Self {
-            log_level: self.log_level.or(Some(log_level)),
-            ..self
-        }
-    }
-}
-
 fn log_level_completions() -> Vec<CompletionCandidate> {
     use tracing::Level as L;
     let options = [L::TRACE, L::DEBUG, L::INFO, L::WARN, L::ERROR];

--- a/crates/core/tedge/src/main.rs
+++ b/crates/core/tedge/src/main.rs
@@ -17,7 +17,7 @@ use tedge::TEdgeCli;
 use tedge::TEdgeOpt;
 use tedge::TEdgeOptMulticall;
 use tedge_config::cli::CommonArgs;
-use tedge_config::log_init;
+use tedge_config::log_init_with_default_level;
 use tedge_config::unconfigured_logger;
 use tedge_file_log_plugin::bin::TEdgeConfigView;
 use tracing::log;
@@ -91,10 +91,11 @@ async fn main() -> anyhow::Result<()> {
                 .context("failed to run tedge file log plugin")?
         }
         TEdgeOptMulticall::Tedge(TEdgeCli { cmd, common }) => {
-            log_init(
+            log_init_with_default_level(
                 "tedge",
-                &common.log_args.with_default_level(tracing::Level::WARN),
+                &common.log_args,
                 &common.config_dir,
+                tracing::Level::WARN,
             )?;
 
             let tedge_config = tedge_config::TEdgeConfig::load(&common.config_dir).await?;


### PR DESCRIPTION
## Proposed changes

Fix an issue where setting log level using some methods (e.g. `RUST_LOG`, `--debug`) didn't have an effect for `tedge` binary because a variable containing log level selected by CLI flags was being set if empty as a way to override the default log level, but caused other user-controlled log level overrides to stop working.

Instead, another parameter was introduced for caller to select a default log level that will be selected if no overrides are used.

### How to check

Before the PR, using a flag like `--debug` had no effect, no `DEBUG` logs are printed:

```
$ tedge reconnect c8y --debug
Disconnecting from Cumulocity:
Removing bridge config file... ✓

[...]

Checking Cumulocity is connected to intended tenant... ✓
Enabling tedge-agent... ✓
```

With the fix, `DEBUG` logs are printed:

```
$ cargo run --bin tedge -- reconnect c8y --debug
2026-02-05T17:40:22.868861455Z DEBUG tedge_config::tedge_toml::tedge_config_location: Loading configuration from "/etc/tedge/tedge.toml"

[...]

2026-02-05T17:40:25.734396371Z DEBUG rumqttc::state: Disconnect
Checking Cumulocity is connected to intended tenant... ✓
Enabling tedge-agent... ✓
```


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

