### PR TITLE
Resolve RUSTSEC-2026-0009 (stack exhaustion in `time` crate)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,7 +15,8 @@ ignore = [
     # the timings of the decryption operation. We only use the crate to construct the public key
     # from components, so this doesn't affect us. To make sure we don't use affected API,
     # appropriate entries should be added to clippy.toml to disallow these methods.
-    "RUSTSEC-2023-0071"
+    "RUSTSEC-2023-0071",
+    "RUSTSEC-2026-0009"
 ] 
 informational_warnings = ["unmaintained"] # warn for categories of informational advisories
 severity_threshold = "low" # CVSS severity ("none", "low", "medium", "high", "critical")

--- a/clippy.toml
+++ b/clippy.toml
@@ -13,5 +13,12 @@ disallowed-methods = [
     { path = "reqwest::Client::new", reason = "Use `certificate::CloudRootCerts` type instead to take root_cert_path configurations into account" },
     { path = "hyper_rustls::HttpsConnectorBuilder::with_native_roots", reason = "Use .with_tls_config(tedge_config.cloud_client_tls_config()) instead to use configured root certificate paths for the connected cloud" },
     {path = "rsa::RsaPrivateKey::decrypt"},
+    { path = "time::Date::parse", reason = "RUSTSEC-2026-0009" },
+    { path = "time::OffsetDateTime::parse", reason = "RUSTSEC-2026-0009" },
+    { path = "time::PrimitiveDateTime::parse", reason = "RUSTSEC-2026-0009" },
+    { path = "time::Time::parse", reason = "RUSTSEC-2026-0009" },
+    { path = "time::UtcDateTime::parse", reason = "RUSTSEC-2026-0009" },
+    { path = "time::UtcOffset::parse", reason = "RUSTSEC-2026-0009" },
+    { path = "time::parsing::Parsed::parse_item", reason = "RUSTSEC-2026-0009" },
 ]
 large-error-threshold = 256

--- a/crates/common/tedge_utils/src/timestamp.rs
+++ b/crates/common/tedge_utils/src/timestamp.rs
@@ -140,6 +140,10 @@ impl de::Visitor<'_> for IsoOrUnixVisitor {
     where
         E: de::Error,
     {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "Not vulnerable to RUSTSEC-2026-0009 as not RFC-2822 format"
+        )]
         OffsetDateTime::parse(timestamp_str, &Rfc3339)
             .map(IsoOrUnix)
             .map_err(|err| de::Error::custom(invalid_iso8601(timestamp_str, err)))

--- a/crates/core/c8y_api/src/smartrest/smartrest_deserializer.rs
+++ b/crates/core/c8y_api/src/smartrest/smartrest_deserializer.rs
@@ -48,7 +48,13 @@ where
         date_string = date_part;
     }
 
-    match OffsetDateTime::parse(&date_string, &format_description::well_known::Rfc3339) {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "Not vulnerable to RUSTSEC-2026-0009 as not RFC-2822 format"
+    )]
+    let time = OffsetDateTime::parse(&date_string, &format_description::well_known::Rfc3339);
+
+    match time {
         Ok(result) => Ok(result),
         Err(e) => Err(D::Error::custom(format!("Error: {}", e))),
     }

--- a/crates/core/tedge_api/src/measurement/parser.rs
+++ b/crates/core/tedge_api/src/measurement/parser.rs
@@ -358,11 +358,7 @@ mod tests {
         use crate::measurement::builder::ThinEdgeJsonBuilder;
 
         let input = "{\n\"time\" : 1701949168,\n\"test\": 1023}";
-        let expected_timestamp = OffsetDateTime::parse(
-            "2023-12-07T11:39:28Z",
-            &time::format_description::well_known::Rfc3339,
-        )
-        .unwrap();
+        let expected_timestamp = parse_timestamp("2023-12-07T11:39:28Z");
 
         let mut builder = ThinEdgeJsonBuilder::default();
 
@@ -376,11 +372,7 @@ mod tests {
         use crate::measurement::builder::ThinEdgeJsonBuilder;
 
         let input = "{\n\"time\" : 1701949168.001,\n\"test\": 1023}";
-        let expected_timestamp = OffsetDateTime::parse(
-            "2023-12-07T11:39:28.001Z",
-            &time::format_description::well_known::Rfc3339,
-        )
-        .unwrap();
+        let expected_timestamp = parse_timestamp("2023-12-07T11:39:28.001Z");
 
         let mut builder = ThinEdgeJsonBuilder::default();
 
@@ -417,5 +409,13 @@ mod tests {
         let mut builder = ThinEdgeJsonBuilder::default();
 
         parse_str(input, &mut builder).unwrap();
+    }
+
+    fn parse_timestamp(timestamp: &str) -> OffsetDateTime {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "Not vulnerable to RUSTSEC-2026-0009 as not RFC-2822 format"
+        )]
+        OffsetDateTime::parse(timestamp, &time::format_description::well_known::Rfc3339).unwrap()
     }
 }

--- a/crates/core/tedge_watchdog/src/systemd_watchdog.rs
+++ b/crates/core/tedge_watchdog/src/systemd_watchdog.rs
@@ -364,11 +364,8 @@ mod tests {
         let (mut sender, mut receiver) = mpsc::unbounded::<MqttMessage>();
         let health_topic =
             Topic::new("te/device/main/service/test-service/status/health").expect("Valid topic");
-        let request_timestamp = OffsetDateTime::parse(
-            "2023-12-15T14:31:03.234Z",
-            &time::format_description::well_known::Rfc3339,
-        )
-        .unwrap();
+
+        let request_timestamp = parse_timestamp("2023-12-15T14:31:03.234Z");
         let incremented_datetime = request_timestamp + Duration::from_secs(3);
         let payload_timestamp = TimeFormat::Unix.to_json(incremented_datetime).unwrap();
 
@@ -385,5 +382,13 @@ mod tests {
         let health_status =
             get_latest_health_status_message(request_timestamp, &mut receiver).await;
         assert_eq!(health_status.unwrap().time, Some(payload_timestamp));
+    }
+
+    fn parse_timestamp(timestamp: &str) -> OffsetDateTime {
+        #[expect(
+            clippy::disallowed_methods,
+            reason = "Not vulnerable to RUSTSEC-2026-0009 as not RFC-2822 format"
+        )]
+        OffsetDateTime::parse(timestamp, &time::format_description::well_known::Rfc3339).unwrap()
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -74,6 +74,7 @@ ignore = [
     { id = "RUSTSEC-2025-0012", reason = "crate: backoff. Needs refactoring to remove dependency" },
     { id = "RUSTSEC-2024-0436", reason = "crate: paste. Used by cryptoki dependency" },
     { id = "RUSTSEC-2023-0071", reason = "crate: rsa. No patch available, not using affected API, added rules to clippy to forbid using these APIs" },
+    { id = "RUSTSEC-2026-0009", reason = "crate: time. Patching requires updating MSRV, applied workaround in one usage, added rules to clippy to forbid using these APIs elsewhere" },
 
     #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish


### PR DESCRIPTION
## Proposed changes
Resolves [RUSTSEC-2026-0009](https://rustsec.org/advisories/RUSTSEC-2026-0009) (Denial of Service via Stack Exhaustion in the `time` crate) by:
1. Preventing usages of the affected parsing functions
2. Allowing the existing usages through - these only use the RFC-3339 format and not RFC-2822 format, therefore they are unaffected by the vulnerability
3. Ignoring the vulnerability in the cargo-audit/cargo-deny configurations, since this is now covered by the clippy configuration

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

