### PR TITLE
tests: uses qos 2 for mqtt-logger to improve accuracy of logs in system tests

### DIFF
--- a/tests/images/debian-systemd/files/mqtt-logger
+++ b/tests/images/debian-systemd/files/mqtt-logger
@@ -117,6 +117,8 @@ subscribe() {
             --cafile "$MQTT_CA_FILE" \
             --key "$MQTT_KEY_FILE" \
             --cert "$MQTT_CERT_FILE" \
+            -i "mqtt-logger" \
+            -c \
             -t '#' \
             -q 2 \
             -F '{"timestamp":%U,"message":%j,"payload_hex":"%x"}'
@@ -125,6 +127,8 @@ subscribe() {
             --nodelay \
             -h "$MQTT_HOST" \
             -p "$MQTT_PORT" \
+            -i "mqtt-logger" \
+            -c \
             -t '#' \
             -q 2 \
             -F '{"timestamp":%U,"message":%j,"payload_hex":"%x"}'


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Using QoS for MQTT subscriptions within the `mqtt-service` test component (used within the RobotFramework tests), to ensure the accuracy of the log output which is used for assertions in the `Should Have MQTT Messages` keyword.

During a flake-finder run, multiple failures were observed in the `Full supported operations message has no duplicates` test case, where the `Should Have MQTT Messages` assertion failed, however the c8y_SupportedOperations fragment was correctly set in the server. This is still a theory, however switching to QoS 2 subscriptions for a test component anyway makes sense.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

