### PR TITLE
fix: Don't take ownership of existing operations directory in remote access plugin init

### DIFF
--- a/crates/core/tedge/src/cli/init.rs
+++ b/crates/core/tedge/src/cli/init.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use tedge_config::TEdgeConfig;
 use tedge_utils::file::change_user_and_group;
-use tedge_utils::file::create_directory;
+use tedge_utils::file::create_directory_and_update_ownership;
 use tedge_utils::file::PermissionEntry;
 use tracing::debug;
 
@@ -83,18 +83,25 @@ impl TEdgeInitCmd {
                 Some(0o775),
             )
         };
-        create_directory(&config_dir, &permissions).await?;
-        create_directory(config_dir.join("mosquitto-conf"), &permissions).await?;
-        create_directory(config_dir.join("operations"), &permissions).await?;
-        create_directory(config_dir.join("operations").join("c8y"), &permissions).await?;
-        create_directory(config_dir.join("plugins"), &permissions).await?;
-        create_directory(config_dir.join("sm-plugins"), &permissions).await?;
-        create_directory(config_dir.join("device-certs"), &permissions).await?;
-        create_directory(config_dir.join("mappers"), &permissions).await?;
-        create_directory(config_dir.join(".tedge-mapper-c8y"), &permissions).await?;
+        create_directory_and_update_ownership(&config_dir, &permissions).await?;
+        create_directory_and_update_ownership(config_dir.join("mosquitto-conf"), &permissions)
+            .await?;
+        create_directory_and_update_ownership(config_dir.join("operations"), &permissions).await?;
+        create_directory_and_update_ownership(
+            config_dir.join("operations").join("c8y"),
+            &permissions,
+        )
+        .await?;
+        create_directory_and_update_ownership(config_dir.join("plugins"), &permissions).await?;
+        create_directory_and_update_ownership(config_dir.join("sm-plugins"), &permissions).await?;
+        create_directory_and_update_ownership(config_dir.join("device-certs"), &permissions)
+            .await?;
+        create_directory_and_update_ownership(config_dir.join("mappers"), &permissions).await?;
+        create_directory_and_update_ownership(config_dir.join(".tedge-mapper-c8y"), &permissions)
+            .await?;
 
-        create_directory(&config.logs.path, &permissions).await?;
-        create_directory(&config.data.path, &permissions).await?;
+        create_directory_and_update_ownership(&config.logs.path, &permissions).await?;
+        create_directory_and_update_ownership(&config.data.path, &permissions).await?;
 
         let entity_store_file = config_dir.join(".agent").join("entity_store.jsonl");
 

--- a/plugins/tedge_file_config_plugin/src/config.rs
+++ b/plugins/tedge_file_config_plugin/src/config.rs
@@ -81,11 +81,11 @@ impl FileEntry {
             path: path.into(),
             config_type: config_type.into(),
             file_permissions,
-            parent_permissions: PermissionEntry {
-                user: parent_user,
-                group: parent_group,
-                mode: parent_permissions.mode,
-            },
+            parent_permissions: PermissionEntry::new(
+                parent_user,
+                parent_group,
+                parent_permissions.mode,
+            ),
         }
     }
 }
@@ -285,11 +285,11 @@ type = "other.conf"
 
     #[test]
     fn test_file_entry_new_inherits_parent_permissions() {
-        let file_perms = PermissionEntry {
-            user: Some("tedge".to_string()),
-            group: Some("tedge".to_string()),
-            mode: Some(0o644),
-        };
+        let file_perms = PermissionEntry::new(
+            Some("tedge".to_string()),
+            Some("tedge".to_string()),
+            Some(0o644),
+        );
         let parent_perms = PermissionEntry::default();
 
         let entry = FileEntry::new("/etc/test.conf", "test.conf", file_perms, parent_perms);
@@ -302,16 +302,16 @@ type = "other.conf"
 
     #[test]
     fn test_file_entry_new_respects_explicit_parent_permissions() {
-        let file_perms = PermissionEntry {
-            user: Some("user1".to_string()),
-            group: Some("group1".to_string()),
-            mode: Some(0o644),
-        };
-        let parent_perms = PermissionEntry {
-            user: Some("parent_user".to_string()),
-            group: Some("parent_group".to_string()),
-            mode: Some(0o755),
-        };
+        let file_perms = PermissionEntry::new(
+            Some("user1".to_string()),
+            Some("group1".to_string()),
+            Some(0o644),
+        );
+        let parent_perms = PermissionEntry::new(
+            Some("parent_user".to_string()),
+            Some("parent_group".to_string()),
+            Some(0o755),
+        );
 
         let entry = FileEntry::new("/etc/test.conf", "test.conf", file_perms, parent_perms);
 

--- a/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
+++ b/tests/RobotFramework/tests/cumulocity/remote-access/test_remote_access.robot
@@ -27,8 +27,11 @@ Install/uninstall c8y-remote-access-plugin
 Init c8y-remote-access-plugin with the custom user and group
     Device Should Have Installed Software    c8y-remote-access-plugin
 
+    Execute Command    sudo tedge init
     Execute Command    sudo c8y-remote-access-plugin --init --user petertest --group petertest
-    Path Should Have Permissions    /etc/tedge/operations/c8y    mode=775    owner_group=petertest:petertest
+
+    # remote-access-plugin shouldn't take ownership of directory
+    Path Should Have Permissions    /etc/tedge/operations/c8y    mode=775    owner_group=tedge:tedge
     Path Should Have Permissions
     ...    /etc/tedge/operations/c8y/c8y_RemoteAccessConnect
     ...    mode=644


### PR DESCRIPTION
## Proposed changes
Fix an issue where the `c8y-remote-access-plugin --init` command changes ownership of the `/etc/tedge/operations/c8y` directory when it already exists.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

