### PR TITLE
feat(tedge-p11-server): Improve frame parse error message

### DIFF
--- a/crates/extensions/tedge-p11-server/src/proxy/connection.rs
+++ b/crates/extensions/tedge-p11-server/src/proxy/connection.rs
@@ -31,10 +31,7 @@ impl Connection {
         let mut buf = Vec::new();
         self.stream.read_to_end(&mut buf)?;
 
-        // will fail if not version 1
-        let frame: Frame =
-            postcard::from_bytes(&buf).context("Failed to parse the received frame")?;
-
+        let frame = Frame::from_bytes(&buf).context("Failed to parse the received frame")?;
         let Frame::Version1(frame) = frame;
 
         // by that time the sender should've already closed this connection half, so we ignore


### PR DESCRIPTION
## Proposed changes

When tedge-p11-server fails to parse received message, error message now contains if frame version is unsupported or if request type is unrecognized. This should provide more of a hint when tedge-p11-server is used with an incompatible version of tedge.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

