### PR TITLE
fix: respect sudo.enable setting when running log plugins

### DIFF
--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -403,6 +403,7 @@ impl Agent {
                 mqtt_schema: mqtt_schema.clone(),
                 mqtt_device_topic_id: device_topic_id.clone(),
                 plugin_dirs: self.config.log_plugin_dirs,
+                is_sudo_enabled: self.config.is_sudo_enabled,
             })?;
 
             let plugin_config =

--- a/crates/extensions/tedge_log_manager/src/config.rs
+++ b/crates/extensions/tedge_log_manager/src/config.rs
@@ -45,6 +45,7 @@ pub struct LogManagerOptions {
     pub mqtt_schema: MqttSchema,
     pub mqtt_device_topic_id: EntityTopicId,
     pub plugin_dirs: Vec<Utf8PathBuf>,
+    pub is_sudo_enabled: bool,
 }
 
 impl LogManagerConfig {
@@ -89,7 +90,7 @@ impl LogManagerConfig {
             logtype_reload_topic,
             logfile_request_topic,
             log_metadata_sync_topics,
-            sudo_enabled: true,
+            sudo_enabled: cliopts.is_sudo_enabled,
         })
     }
 }

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_plugins.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_plugins.robot
@@ -232,6 +232,27 @@ Reporting sudo misconfiguration
     ...    current_only=${True}
     ...    text=ERROR log plugins: Skipping /etc/share/tedge/log-plugins/dummy_plugin: not properly configured to run with sudo
 
+Supported log types loaded when sudo disabled
+    [Documentation]    Log plugins should be discovered and listed even when sudo.enable is false.
+    ...    Verifies that the agent does not unconditionally invoked sudo during plugin detection.
+    [Tags]    adapter:docker
+    Sleep    1s    reason=Allow the agent to complete startup actions before stopping
+    Stop Service    tedge-agent
+
+    # remove tedge sudo rules to prevent any command from working
+    Execute Command    cmd=rm -f /etc/sudoers.d/tedge
+
+    Execute Command    tedge config set sudo.enable false
+
+    # install a new plugin
+    ThinEdgeIO.Transfer To Device
+    ...    ${CURDIR}/plugins/dummy_plugin
+    ...    /usr/share/tedge/log-plugins/dummy_plugin2
+    Execute Command    chmod a+x /usr/share/tedge/log-plugins/dummy_plugin2
+
+    Start Service    tedge-agent
+    Should Contain Supported Log Types    dummy_log::dummy_plugin2
+
 Agent resilient to plugin dirs removal
     ${date_from}=    Get Unix Timestamp
     Execute Command    rm -rf /usr/share/tedge/log-plugins


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix a bug where the log plugin was not respecting the `sudo.enable` setting, so it would always run the plugins using sudo.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

