### PR TITLE
fix: remove useless error messages

### DIFF
--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -453,7 +453,7 @@ impl Agent {
             let mut entity_store_actor_builder =
                 ServerActorBuilder::new(entity_store_server, &ServerConfig::default(), Sequential);
             mqtt_actor_builder.connect_mapped_sink(
-                entity_manager::server::subscriptions(self.config.mqtt_topic_root.as_ref()),
+                entity_manager::server::subscriptions(&mqtt_schema),
                 &entity_store_actor_builder,
                 |message| {
                     Some(RequestEnvelope {

--- a/crates/core/tedge_agent/src/entity_manager/server.rs
+++ b/crates/core/tedge_agent/src/entity_manager/server.rs
@@ -426,7 +426,26 @@ impl EntityStoreServer {
     }
 }
 
-pub fn subscriptions(topic_root: &str) -> TopicFilter {
-    let topic = format!("{}/+/+/+/+/#", topic_root);
-    vec![topic].try_into().unwrap()
+pub fn subscriptions(mqtt_schema: &MqttSchema) -> TopicFilter {
+    let mut topics = TopicFilter::empty();
+
+    // Subscribing only to northbound topics published *from* the device,
+    // and not the southbound topics published *to* the device,
+    // as those are the only ones relevant for entity store and auto-registration
+    for channel_filter in [
+        ChannelFilter::EntityMetadata,
+        ChannelFilter::EntityTwinData,
+        ChannelFilter::Measurement,
+        ChannelFilter::MeasurementMetadata,
+        ChannelFilter::Event,
+        ChannelFilter::EventMetadata,
+        ChannelFilter::Alarm,
+        ChannelFilter::AlarmMetadata,
+        ChannelFilter::AnyCommandMetadata,
+        ChannelFilter::AnyStatus,
+    ] {
+        topics.add_all(mqtt_schema.topics(EntityFilter::AnyEntity, channel_filter));
+    }
+
+    topics
 }

--- a/crates/core/tedge_api/src/mqtt_topics.rs
+++ b/crates/core/tedge_api/src/mqtt_topics.rs
@@ -183,6 +183,7 @@ impl MqttSchema {
             ChannelFilter::Signal(signal_type) => format!("/signal/{signal_type}"),
             ChannelFilter::Health => "/status/health".to_string(),
             ChannelFilter::Status(component) => format!("/status/{component}"),
+            ChannelFilter::AnyStatus => "/status/+".to_string(),
         };
 
         TopicFilter::new_unchecked(&format!("{}/{entity}{channel}", self.root))
@@ -903,6 +904,7 @@ pub enum ChannelFilter {
     CommandMetadata(OperationType),
     Health,
     Status(String),
+    AnyStatus,
 }
 
 impl From<&Channel> for ChannelFilter {


### PR DESCRIPTION
## Proposed changes

Remove useless error messages emitted  by `tedge-agent` each time flow metrics are published over MQTT.

```
2026-03-10T09:57:39.356869315Z ERROR tedge_agent::entity_manager::server: Ignoring the message: [te/device/main/service/tedge-mapper-c8y/status/metrics/units.toml qos=1] {"cpu-max":"71.871µs","cpu-min":"13.541µs","error":0,"input":7,"output":0,"type":"flow"} received on unsupported topic

```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

