### PR TITLE
fix: improve operation handler error message when tmp.path doesn't exist

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -884,14 +884,22 @@ impl CumulocityConverter {
         let command = script.command.as_str();
         let cmd_id = self.command_id.new_id();
 
-        let mut logged =
-            LoggedCommand::new(command, self.config.tmp_dir.as_ref()).map_err(|e| {
-                CumulocityMapperError::ExecuteFailed {
-                    error_message: e.to_string(),
-                    command: command.to_string(),
-                    operation_name: operation_name.to_string(),
-                }
-            })?;
+        let tmp_dir = self.config.tmp_dir.as_ref();
+        if !tmp_dir.exists() {
+            return Err(CumulocityMapperError::ExecuteFailed {
+                error_message: format!("the configured tmp.path '{}' does not exist", tmp_dir),
+                command: command.to_string(),
+                operation_name: operation_name.clone(),
+            });
+        }
+
+        let mut logged = LoggedCommand::new(command, tmp_dir).map_err(|e| {
+            CumulocityMapperError::ExecuteFailed {
+                error_message: e.to_string(),
+                command: command.to_string(),
+                operation_name: operation_name.to_string(),
+            }
+        })?;
 
         logged.args(script.args);
 

--- a/tests/RobotFramework/tests/cumulocity/shell/shell_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/shell/shell_operation.robot
@@ -36,6 +36,15 @@ Shell command succeeds if output is too large
     ${result}=    Set Variable    ${operation.to_json()["c8y_Command"]["result"]}
     Should End With    ${result}    ...<trimmed>
 
+Commands fail if the tmp.dir does not exist and include the path in the failure reason
+    [Tags]    \#3796
+    Execute Command    cmd=tedge config set tmp.path /dummy
+    Disconnect Then Connect Mapper    mapper=c8y
+    ${operation}=    Cumulocity.Execute Shell Command    echo helloworld
+    Operation Should Be FAILED
+    ...    ${operation}
+    ...    failure_reason=.*Operation execution failed: the configured tmp.path '/dummy' does not exist*
+
 
 *** Keywords ***
 Custom Setup


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Improve the operation handler error message when the tmp.path does exists (as it uses it as the working directory of the process being spawned). Previously the error message would not contain the path making it unclear to users that it was the tmp.path that doesn't exist and not the script itself being executed.

Example of the improved error message:

```
Operation execution failed: the configured tmp.path '/dummy' does not exist. Command: /etc/tedge/operations/command. Operation name: c8y_Command
```


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3796

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

