### PR TITLE
fix: don't retry http server 500/501 errors when uploading files

### DIFF
--- a/crates/common/upload/src/upload.rs
+++ b/crates/common/upload/src/upload.rs
@@ -261,9 +261,15 @@ impl Uploader {
                 })?
                 .error_for_status()
                 .map_err(|err| match err.status() {
-                    Some(status_error) if status_error.is_client_error() => {
+                    // 4xx and 500/501 server-side errors are permanent and retrying won't help
+                    Some(status)
+                        if status.is_client_error()
+                            || status == reqwest::StatusCode::INTERNAL_SERVER_ERROR
+                            || status == reqwest::StatusCode::NOT_IMPLEMENTED =>
+                    {
                         backoff::Error::Permanent(UploadError::Network(err))
                     }
+                    // 502/503/504 are gateway/overload conditions that may resolve on retry.
                     _ => backoff::Error::transient(UploadError::Network(err)),
                 })
         };
@@ -453,7 +459,7 @@ mod tests {
             put(|body: axum::body::Body| async move {
                 let res = async {
                     if is_first_attempt.fetch_and(false, Ordering::SeqCst) {
-                        Ok(StatusCode::INTERNAL_SERVER_ERROR)
+                        Ok(StatusCode::SERVICE_UNAVAILABLE)
                     } else {
                         let mut file = BufWriter::new(
                             File::create(target_path_clone.as_path())

--- a/tests/RobotFramework/tests/cumulocity/configuration/config_snapshot_error_handling.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/config_snapshot_error_handling.robot
@@ -1,0 +1,53 @@
+*** Settings ***
+Resource            ../../../resources/common.resource
+Library             ThinEdgeIO
+Library             Cumulocity
+
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:configuration
+
+
+*** Variables ***
+${DEVICE_SN}            ${EMPTY}
+${FILE_TRANSFER_DIR}    /var/tedge/file-transfer
+
+
+*** Test Cases ***
+Config snapshot fails immediately when file-transfer storage is not writable
+    [Documentation]    When the local file-transfer service cannot write the uploaded file (e.g. due
+    ...    to a permissions problem on its storage directory) it returns HTTP 500.
+    ...    The config snapshot operation should immediately transition to the FAILED state instead of
+    ...    retrying indefinitely (which would leave it stuck in EXECUTING for up to 5 minutes).
+    [Tags]    \#3374
+    [Setup]    Remove Write Permissions From File-Transfer Directory
+
+    Cumulocity.Set Device    ${DEVICE_SN}
+
+    # The timeout here is intentionally short: if the fix is in place the operation
+    # should fail within a few seconds; without the fix it would keep retrying for
+    # ~5 minutes (the default max_elapsed_time in the upload backoff) before giving up.
+    ${operation}=    Cumulocity.Get Configuration    tedge-configuration-plugin
+    Operation Should Be FAILED
+    ...    ${operation}
+    ...    failure_reason=config-manager failed uploading configuration snapshot.*
+    ...    timeout=30
+    [Teardown]    Run Keywords
+    ...    Restore File-Transfer Directory Permissions
+    ...    AND    Get Logs
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    ${DEVICE_SN}
+    Cumulocity.Device Should Exist    ${DEVICE_SN}
+
+Remove Write Permissions From File-Transfer Directory
+    # Remove all permissions from the file-transfer storage directory so that any
+    # PUT request to the file-transfer service results in a 500 Internal Server Error.
+    Execute Command    sudo chmod 000 ${FILE_TRANSFER_DIR}
+
+Restore File-Transfer Directory Permissions
+    Execute Command    sudo chmod 755 ${FILE_TRANSFER_DIR}


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

When uploading files, treat server errors (status codes, 500 and 501) as non-transient errors so they aren't retried as generally a retry won't help. Status Codes 502/503 are still retried as before as generally these errors are transient.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3374

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

