### PR TITLE
fix: the name of a flow is derived from its source file path

### DIFF
--- a/crates/extensions/tedge_flows/src/config.rs
+++ b/crates/extensions/tedge_flows/src/config.rs
@@ -25,7 +25,6 @@ use tracing::info;
 #[derive(Deserialize)]
 pub struct FlowConfig {
     // meta info
-    name: Option<String>,
     version: Option<String>,
     description: Option<String>,
     tags: Option<Vec<String>>,
@@ -110,6 +109,9 @@ pub enum OutputConfig {
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConfigError {
+    #[error("Not a valid filename for a flow")]
+    IncorrectFlowFilename,
+
     #[error("Not a valid MQTT topic: {0}")]
     IncorrectTopic(String),
 
@@ -133,15 +135,43 @@ pub enum ConfigError {
     FileInfiniteLoop { name: String, path: String },
 }
 
+/// ```
+/// use tedge_flows::derive_flow_name;
+/// assert_eq!(derive_flow_name("/flows".into(), "/flows/flow.toml".into()), Some("flow".into()));
+/// assert_eq!(derive_flow_name("/flows".into(), "/flows/hello.toml".into()), Some("hello".into()));
+/// assert_eq!(derive_flow_name("/flows".into(), "/flows/hello/flow.toml".into()), Some("hello".into()));
+/// assert_eq!(derive_flow_name("/flows".into(), "/flows/hello/world.toml".into()), Some("hello/world".into()));
+/// assert_eq!(derive_flow_name("/flows".into(), "/flows/hello/world/flow.toml".into()), Some("hello/world".into()));
+/// assert_eq!(derive_flow_name("/flows".into(), "/flows/.toml".into()), None);
+/// assert_eq!(derive_flow_name("/flows".into(), "/flows/hello/params.toml".into()), None);
+/// assert_eq!(derive_flow_name("/flows".into(), "/flows/hello/world.js".into()), None);
+/// assert_eq!(derive_flow_name("/flows".into(), "/unrelated/flows/hello.toml".into()), None);
+/// ```
+pub fn derive_flow_name(flows_dir: &Utf8Path, flow_path: &Utf8Path) -> Option<String> {
+    let path = flow_path.strip_prefix(flows_dir).ok()?;
+    if path.extension() != Some("toml") {
+        return None;
+    };
+    if path.file_name()? == Params::filename() {
+        return None;
+    }
+    match (path.parent()?.as_str(), path.file_stem()?) {
+        ("", "flow") => Some("flow".to_string()),
+        (dir_name, "flow") => Some(dir_name.into()),
+        ("", file_stem) => Some(file_stem.into()),
+        (dir_name, file_stem) => Some(format!("{dir_name}/{file_stem}")),
+    }
+}
+
 impl FlowConfig {
     /// Loads all the flow definitions
     ///
     /// Return the collection of loaded flow configs
     /// as well as the list of files that cannot be read as flow specs
     pub async fn load_all_flows(
-        config_dir: &Utf8Path,
+        flows_dir: &Utf8Path,
     ) -> (HashMap<Utf8PathBuf, FlowConfig>, Vec<Utf8PathBuf>) {
-        let pattern = format!("{}/**/*.toml", config_dir);
+        let pattern = format!("{}/**/*.toml", flows_dir);
         let paths = tokio::task::spawn_blocking(move || {
             let mut paths = Vec::new();
             match glob(&pattern) {
@@ -215,7 +245,6 @@ impl FlowConfig {
             interval: None,
         };
         Self {
-            name: None,
             version: None,
             description: None,
             tags: None,
@@ -235,6 +264,7 @@ impl FlowConfig {
         self,
         rs_transformers: &BuiltinTransformers,
         js_runtime: &mut JsRuntime,
+        flows_dir: &Utf8Path,
         source: Utf8PathBuf,
     ) -> Result<Flow, ConfigError> {
         let input = self.input.try_into()?;
@@ -249,9 +279,10 @@ impl FlowConfig {
                 .await?;
             steps.push(step);
         }
-        let name = self
-            .name
-            .unwrap_or_else(|| source.file_name().unwrap_or_default().to_string());
+
+        let Some(name) = derive_flow_name(flows_dir, &source) else {
+            return Err(ConfigError::IncorrectFlowFilename);
+        };
 
         detect_loop(&name, &input, &output, self.expect_loop)?;
 

--- a/crates/extensions/tedge_flows/src/flow.rs
+++ b/crates/extensions/tedge_flows/src/flow.rs
@@ -415,7 +415,7 @@ impl Flow {
                     error!(
                         target: "flows",
                         "Flow '{}' is dropping output message to '{}' to prevent an infinite loop",
-                        self.name,
+                        self.name(),
                         msg.topic
                     );
                     false

--- a/crates/extensions/tedge_flows/src/lib.rs
+++ b/crates/extensions/tedge_flows/src/lib.rs
@@ -15,6 +15,7 @@ mod steps;
 mod transformers;
 
 use crate::actor::FlowsMapper;
+pub use crate::config::derive_flow_name;
 pub use crate::config::ConfigError;
 pub use crate::config::FlowConfig;
 pub use crate::connected_flow::ConnectedFlowRegistry;

--- a/crates/extensions/tedge_flows/src/registry.rs
+++ b/crates/extensions/tedge_flows/src/registry.rs
@@ -84,7 +84,6 @@ pub enum RegistrationStatus {
 #[async_trait]
 pub trait FlowRegistryExt: FlowRegistry {
     fn config_dir(&self) -> Utf8PathBuf;
-
     fn registration_status(&self, path: &Utf8Path) -> RegistrationStatus;
     fn flow(&self, path: &Utf8Path) -> Option<&Self::Flow>;
     fn flow_mut(&mut self, path: &Utf8Path) -> Option<&mut Self::Flow>;
@@ -189,7 +188,8 @@ impl<T: FlowRegistry + Send> FlowRegistryExt for T {
 
     async fn load_single_script(&mut self, js_runtime: &mut JsRuntime, script: &Utf8Path) {
         let config = FlowConfig::wrap_script_into_flow(script);
-        self.load_config(js_runtime, script, config).await;
+        let flow = script.with_extension("toml");
+        self.load_config(js_runtime, &flow, config).await;
     }
 
     async fn add_flow(&mut self, js_runtime: &mut JsRuntime, path: &Utf8Path) {
@@ -277,7 +277,12 @@ impl<T: FlowRegistry + Send> FlowRegistryExt for T {
         config: FlowConfig,
     ) {
         match config
-            .compile(self.builtins(), js_runtime, path.to_owned())
+            .compile(
+                self.builtins(),
+                js_runtime,
+                self.config_dir().as_ref(),
+                path.to_owned(),
+            )
             .await
             .and_then(Self::compile)
         {

--- a/tests/RobotFramework/tests/tedge_flows/tedge_flows.robot
+++ b/tests/RobotFramework/tests/tedge_flows/tedge_flows.robot
@@ -444,13 +444,13 @@ Params are dynamically reloaded
 
 Flow with static mqtt topic loop is rejected at load time
     Install Flow    infinite-loop-flows    mqtt-static-loop.toml
-    Service Logs Should Contain    tedge-mapper-local    Flow 'mqtt-static-loop.toml' defines an infinite loop
+    Service Logs Should Contain    tedge-mapper-local    Flow 'mqtt-static-loop' defines an infinite loop
 
     ${errors}    Execute Command
     ...    tedge flows test te/loop/test '{}'
     ...    stdout=${False}
     ...    stderr=${True}
-    Should Contain    ${errors}    Flow 'mqtt-static-loop.toml' defines an infinite loop
+    Should Contain    ${errors}    Flow 'mqtt-static-loop' defines an infinite loop
     [Teardown]    Uninstall Flow    mqtt-static-loop.toml
 
 Flow with mqtt runtime loop drops messages
@@ -458,7 +458,7 @@ Flow with mqtt runtime loop drops messages
     Execute Command    tedge mqtt pub te/loop/test '{}'
     Service Logs Should Contain
     ...    tedge-mapper-local
-    ...    Flow 'mqtt-runtime-loop.toml' is dropping output message to 'te/loop/test' to prevent an infinite loop
+    ...    Flow 'mqtt-runtime-loop' is dropping output message to 'te/loop/test' to prevent an infinite loop
 
     ${errors}    Execute Command
     ...    tedge flows test te/loop/test '{}'
@@ -466,18 +466,18 @@ Flow with mqtt runtime loop drops messages
     ...    stderr=${True}
     Should Contain
     ...    ${errors}
-    ...    Flow 'mqtt-runtime-loop.toml' is dropping output message to 'te/loop/test' to prevent an infinite loop
+    ...    Flow 'mqtt-runtime-loop' is dropping output message to 'te/loop/test' to prevent an infinite loop
     [Teardown]    Uninstall Flow    mqtt-runtime-loop.toml
 
 Flow with static file path loop is rejected at load time
     Install Flow    infinite-loop-flows    file-loop.toml
-    Service Logs Should Contain    tedge-mapper-local    Flow 'file-loop.toml' defines an infinite loop
+    Service Logs Should Contain    tedge-mapper-local    Flow 'file-loop' defines an infinite loop
 
     ${errors}    Execute Command
     ...    tedge flows test te/anything '{}'
     ...    stdout=${False}
     ...    stderr=${True}
-    Should Contain    ${errors}    Flow 'file-loop.toml' defines an infinite loop
+    Should Contain    ${errors}    Flow 'file-loop' defines an infinite loop
     [Teardown]    Uninstall Flow    file-loop.toml
 
 Loop detection skipped for single script test


### PR DESCRIPTION
## Proposed changes

The name of a flow is no more given by the flow definition metadata but derived from its source file path.

see crates/extensions/tedge_flows and https://github.com/thin-edge/thin-edge.io/pull/4037#issuecomment-4074367221

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- https://github.com/thin-edge/thin-edge.io/issues/4056

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

