### PR TITLE
fix: suppress logging during tedge completions to avoid shell startup warnings

### DIFF
--- a/crates/core/tedge/src/main.rs
+++ b/crates/core/tedge/src/main.rs
@@ -89,12 +89,17 @@ async fn main() -> anyhow::Result<()> {
                 .context("failed to run tedge file log plugin")?
         }
         TEdgeOptMulticall::Tedge(TEdgeCli { cmd, common }) => {
-            log_init_with_default_level(
-                "tedge",
-                &common.log_args,
-                &common.config_dir,
-                tracing::Level::WARN,
-            )?;
+            // Skip log initialisation for `tedge completions` — the command is
+            // sourced from shell startup files and any warnings (e.g. about
+            // unrecognised config keys) would be printed on every new shell session.
+            if !matches!(cmd, TEdgeOpt::Completions { .. }) {
+                log_init_with_default_level(
+                    "tedge",
+                    &common.log_args,
+                    &common.config_dir,
+                    tracing::Level::WARN,
+                )?;
+            }
 
             let tedge_config = tedge_config::TEdgeConfig::load(&common.config_dir).await?;
 

--- a/crates/core/tedge/tests/main.rs
+++ b/crates/core/tedge/tests/main.rs
@@ -632,4 +632,46 @@ mod tests {
         ];
         vec
     }
+
+    // `tedge completions` is sourced from shell startup files, so any warnings
+    // printed to stderr would appear on every new shell session. Verify that
+    // even when the config file contains an unrecognised key (which would
+    // normally produce a warning), running `tedge completions` stays silent.
+    #[test_case("bash")]
+    #[test_case("zsh")]
+    #[test_case("fish")]
+    fn completions_produces_no_stderr_even_with_unknown_config_key(
+        shell: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let config_dir = temp_dir.path().to_str().unwrap();
+
+        // Write a config file with an unrecognised key so that, if logging were
+        // active, a warning would be emitted.
+        std::fs::write(
+            temp_dir.path().join("tedge.toml"),
+            "[unknown_section]\nunknown_key = \"value\"\n",
+        )?;
+
+        // Another tedge command with the same config *does* emit the warning —
+        // this confirms the config really does trigger one.
+        tedge_command([
+            "--config-dir",
+            config_dir,
+            "config",
+            "get",
+            "device.cert_path",
+        ])?
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Unknown configuration field"));
+
+        // `tedge completions` must remain completely silent on stderr.
+        tedge_command(["--config-dir", config_dir, "completions", shell])?
+            .assert()
+            .success()
+            .stderr(predicate::str::is_empty());
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Proposed changes
`tedge completions` is sourced from shell startup files, so any warnings (e.g. about unrecognised config keys) would appear on every new shell session. Skip `log_init` for this command so no subscriber is installed and tracing events are silently dropped, matching the suppression already in place for the tab-completion phase.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #4021

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

