### PR TITLE
docs(flows): document onStartup callback for flow steps

### DIFF
--- a/docs/src/references/mappers/flows.md
+++ b/docs/src/references/mappers/flows.md
@@ -61,16 +61,21 @@ which rule how to consume, transform and produce MQTT messages.
 
 A transformation *script* is a JavaScript or TypeScript module that exports:
 
+- optionally, a function `onStartup()`, invoked once when the flow or step starts to initialise state and optionally produce messages,
 - at least, a function `onMessage()`, aimed to transform one input message into zero, one or more output messages,
 - possibly, a function `onInterval()`, called at regular intervals to produce aggregated messages,
 
 ```ts
 interface FlowStep {
-    // transform one input message into zero, one or more output messages
-    onMessage(message: Message, context: Context): null | Message | Message[],
+  // called once when the flow (or the step) starts or when a step is reloaded
+  // it can be used to initialise state and optionally produce messages
+  onStartup(time: Date, context: Context): null | Message | Message[],
+
+  // transform one input message into zero, one or more output messages
+  onMessage(message: Message, context: Context): null | Message | Message[],
   
-    // called at regular intervals to produce aggregated messages
-    onInterval(time: Date, context: Context): null | Message | Message[]
+  // called at regular intervals to produce aggregated messages
+  onInterval(time: Date, context: Context): null | Message | Message[]
 }
 ```
 
@@ -168,6 +173,39 @@ A flow script can also export a `onInterval` function
     the flow script can implement aggregations over a time window.
     When messages are received they are pushed by the `onMessage` function into that state
     and the final outcome is extracted by the `onInterval` function at the end of the time window.
+
+A flow script can also export a `onStartup` function
+  - The `onStartup(time, context)` callback is invoked once when a flow is started and
+    also when an individual step module is reloaded while the mapper is running.
+  - Typical uses are: initialise `context` state, load or compute reference data, and
+    optionally produce one-time messages that should be emitted at startup.
+  - When a flow is initially loaded, `onStartup` callbacks for the involved steps are
+    invoked in the flow activation sequence. When a single step file is modified and
+    reloaded, the `onStartup` for that step is invoked (reload behaviour depends on the
+    mapper runtime and flow layout).
+  - Messages returned by `onStartup` are treated as regular output from the step, passed down to the
+    subsequent `onMessage` steps of the flow, and are emitted according to the flow's output
+    configuration (they are subject to the same loop-detection and output filtering safeguards as
+    other messages).
+
+    Example (simplified):
+
+    ```js
+    export function onStartup(_time, context) {
+      // initialize a shared value in the flow-level context
+      context.flow.set("units", JSON.stringify({ temp: "C" }))
+      // optionally return an initial message to be published by the flow
+      return { topic: "my/init", payload: "startup-complete" }
+    }
+
+    export function onMessage(message, context) {
+      // normal per-message processing
+    }
+    ```
+
+    For a more real-world example of how `onStartup` can be used, see
+    [`thingsboard-registration`](https://github.com/thin-edge/tedge-flows-examples/blob/10b4ac9560dde74f079efb3c9a46ea1167a0ded5/flows/thingsboard-registration/src/main.ts#L41-L48)
+    example.
 
 ## Flow configuration
 


### PR DESCRIPTION
## Proposed changes

Adds documentation for the `onStartup(time, context)` callback in flow step scripts.

- Adds API signature to `FlowStep`
- Documents semantics, reload behaviour, and example
- Points to test examples under `tests/RobotFramework/tests/tedge_flows/onstartup/`

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3998 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

