### PR TITLE
feat: templates for builtin workflows

### DIFF
--- a/crates/common/tedge_utils/src/fs.rs
+++ b/crates/common/tedge_utils/src/fs.rs
@@ -1,3 +1,4 @@
+use crate::file;
 use std::fs as std_fs;
 use std::io::Read;
 use std::io::Write;
@@ -15,6 +16,9 @@ pub enum AtomFileError {
         context: String,
         source: std::io::Error,
     },
+
+    #[error(transparent)]
+    FromFileError(#[from] file::FileError),
 }
 
 pub trait ErrContext<T> {
@@ -174,10 +178,50 @@ fn parent_dir(file: &Path) -> PathBuf {
     }
 }
 
+/// Persists a file using the template pattern:
+///
+/// - `{name}` - active file (updated only if not overridden or disabled)
+/// - `{name}.template` - canonical template (always updated)
+/// - `{name}.disabled` - marker file indicating the file is disabled
+///
+/// If a user has modified the `name` file (making it differ from the `name.template`),
+/// or if a `.disabled` marker exists, the active file will not be updated.
+/// However, the template will always be refreshed with the latest definition.
+pub async fn persist_file_with_template(
+    dir: impl AsRef<Path>,
+    name: &str,
+    content: &str,
+) -> Result<(), AtomFileError> {
+    let dir = dir.as_ref();
+    let config_path = dir.join(name);
+    let template_path = dir.join(format!("{}.template", name));
+    let disabled_path = dir.join(format!("{}.disabled", name));
+
+    // Detect if user has customized the config by comparing with template
+    let prior_config: Option<Vec<u8>> = tokio_fs::read(&config_path).await.ok();
+    let prior_template: Option<Vec<u8>> = tokio_fs::read(&template_path).await.ok();
+    let overridden = prior_config != prior_template;
+    let disabled = tokio_fs::try_exists(&disabled_path).await.unwrap_or(false);
+
+    file::create_directory_with_defaults(dir).await?;
+
+    // Update the active config only if it hasn't been customized or disabled
+    if !overridden && !disabled {
+        atomically_write_file_async(&config_path, content.as_bytes()).await?;
+    }
+
+    // Always update the template file with the latest definition
+    atomically_write_file_async(&template_path, content.as_bytes()).await?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::fs::atomically_write_file_async;
     use crate::fs::atomically_write_file_sync;
+    use crate::fs::persist_file_with_template;
+    use crate::fs::AtomFileError;
 
     use tempfile::tempdir;
 
@@ -293,5 +337,124 @@ mod tests {
         } else {
             panic!("failed to read the new file");
         }
+    }
+
+    #[tokio::test]
+    async fn persist_file_with_template_creates_both_files_when_fresh() {
+        let temp_dir = tempdir().unwrap();
+        let content = "test config content";
+
+        let _: Result<(), AtomFileError> =
+            persist_file_with_template(temp_dir.path(), "test.toml", content).await;
+
+        let config_file = temp_dir.path().join("test.toml");
+        let template_file = temp_dir.path().join("test.toml.template");
+
+        assert!(config_file.exists(), "config file should exist");
+        assert!(template_file.exists(), "template file should exist");
+
+        let config_content = std::fs::read_to_string(&config_file).unwrap();
+        let template_content = std::fs::read_to_string(&template_file).unwrap();
+
+        assert_eq!(config_content, content, "config content should match");
+        assert_eq!(template_content, content, "template content should match");
+    }
+
+    #[tokio::test]
+    async fn persist_file_with_template_preserves_overriden_file() {
+        let temp_dir = tempdir().unwrap();
+        let original_content = "original config";
+        let custom_content = "custom user config";
+
+        // First call - creates both files
+        let _: Result<(), AtomFileError> =
+            persist_file_with_template(temp_dir.path(), "test.toml", original_content).await;
+
+        // User customizes the config file
+        let config_file = temp_dir.path().join("test.toml");
+        tokio::fs::write(&config_file, custom_content)
+            .await
+            .unwrap();
+
+        let new_content = "new content";
+        // Second call - config is customized, should only update template
+        let _: Result<(), AtomFileError> =
+            persist_file_with_template(temp_dir.path(), "test.toml", new_content).await;
+
+        // Config file should remain unchanged (user customization preserved)
+        let config_content = std::fs::read_to_string(&config_file).unwrap();
+        assert_eq!(
+            config_content, custom_content,
+            "config file should preserve user customization"
+        );
+
+        // Template file should be updated
+        let template_file = temp_dir.path().join("test.toml.template");
+        let template_content = std::fs::read_to_string(&template_file).unwrap();
+        assert_eq!(
+            template_content, new_content,
+            "template file should be updated"
+        );
+    }
+
+    #[tokio::test]
+    async fn persist_file_with_template_updates_both_when_unchanged() {
+        let temp_dir = tempdir().unwrap();
+        let original_content = "original config";
+
+        // First call - creates both files
+        let _: Result<(), AtomFileError> =
+            persist_file_with_template(temp_dir.path(), "test.toml", original_content).await;
+
+        let new_content = "updated config";
+        // Second call - config matches template, should update both
+        let _: Result<(), AtomFileError> =
+            persist_file_with_template(temp_dir.path(), "test.toml", new_content).await;
+
+        let config_file = temp_dir.path().join("test.toml");
+        let template_file = temp_dir.path().join("test.toml.template");
+
+        let config_content = std::fs::read_to_string(&config_file).unwrap();
+        let template_content = std::fs::read_to_string(&template_file).unwrap();
+
+        assert_eq!(config_content, new_content, "config file should be updated");
+        assert_eq!(
+            template_content, new_content,
+            "template file should be updated"
+        );
+    }
+
+    #[tokio::test]
+    async fn persist_file_with_template_preserves_original_if_disabled() {
+        let temp_dir = tempdir().unwrap();
+        let original_content = "original config";
+
+        // First call - creates both the config and the template files
+        let _ = persist_file_with_template(temp_dir.path(), "test.toml", original_content).await;
+
+        // Create disabled marker
+        tokio::fs::write(temp_dir.path().join("test.toml.disabled"), "")
+            .await
+            .unwrap();
+
+        let new_content = "new content";
+        // Second call - disabled marker exists, should only update template
+        let _ = persist_file_with_template(temp_dir.path(), "test.toml", new_content).await;
+
+        // Config file should remain unchanged because disabled
+        let config_file = temp_dir.path().join("test.toml");
+        let config_content = tokio::fs::read_to_string(&config_file).await.unwrap();
+        assert_eq!(
+            config_content, original_content,
+            "config file should remain unchanged when disabled"
+        );
+
+        // Template file should be updated
+        let template_file = temp_dir.path().join("test.toml.template");
+        let template_content = std::fs::read_to_string(&template_file).unwrap();
+        assert_eq!(
+            template_content, new_content,
+            "template file should be updated even when disabled"
+        );
     }
 }

--- a/crates/core/tedge_agent/src/device_profile_manager/mod.rs
+++ b/crates/core/tedge_agent/src/device_profile_manager/mod.rs
@@ -1,17 +1,17 @@
 use camino::Utf8PathBuf;
-use tedge_utils::file::create_file_with_defaults;
-use tedge_utils::file::FileError;
+use tedge_utils::fs::persist_file_with_template;
 
 pub struct DeviceProfileManagerBuilder {}
 
 impl DeviceProfileManagerBuilder {
-    pub async fn try_new(ops_dir: &Utf8PathBuf) -> Result<Self, FileError> {
-        let workflow_file = ops_dir.join("device_profile.toml");
-        if !workflow_file.exists() {
-            let workflow_definition = include_str!("../resources/device_profile.toml");
+    pub async fn try_new(ops_dir: &Utf8PathBuf) -> Result<Self, anyhow::Error> {
+        let workflow_definition = include_str!("../resources/device_profile.toml");
 
-            create_file_with_defaults(workflow_file, Some(workflow_definition)).await?;
-        }
+        // Initialize device_profile.toml with template pattern:
+        // - Always update device_profile.toml.template with the latest definition
+        // - Only update device_profile.toml if it doesn't exist or hasn't been customized by the user
+        persist_file_with_template(ops_dir, "device_profile.toml", workflow_definition).await?;
+
         Ok(Self {})
     }
 }

--- a/crates/extensions/tedge_config_manager/src/lib.rs
+++ b/crates/extensions/tedge_config_manager/src/lib.rs
@@ -47,12 +47,10 @@ use tedge_file_system_ext::FsWatchEvent;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::TopicFilter;
 use tedge_utils::file::create_directory_with_defaults;
-use tedge_utils::file::create_file_with_defaults;
 use tedge_utils::file::move_file;
-use tedge_utils::file::FileError;
 use tedge_utils::file::PermissionEntry;
 use tedge_utils::fs::atomically_write_file_sync;
-use tedge_utils::fs::AtomFileError;
+use tedge_utils::fs::persist_file_with_template;
 use toml::toml;
 
 /// An instance of the config manager
@@ -71,7 +69,7 @@ impl ConfigManagerBuilder {
         fs_notify: &mut impl MessageSource<FsWatchEvent, Vec<PathBuf>>,
         downloader_actor: &mut impl Service<ConfigDownloadRequest, ConfigDownloadResult>,
         uploader_actor: &mut impl Service<ConfigUploadRequest, ConfigUploadResult>,
-    ) -> Result<Self, FileError> {
+    ) -> Result<Self, anyhow::Error> {
         Self::init(&config).await?;
 
         let box_builder = SimpleMessageBoxBuilder::new("Tedge-Config-Manager", 16);
@@ -105,13 +103,14 @@ impl ConfigManagerBuilder {
         );
     }
 
-    pub async fn init(config: &ConfigManagerConfig) -> Result<(), FileError> {
-        let workflow_file = config.ops_dir.join("config_update.toml");
-        if !workflow_file.exists() {
-            let workflow_definition = include_str!("resources/config_update.toml");
+    pub async fn init(config: &ConfigManagerConfig) -> Result<(), anyhow::Error> {
+        // Initialize config_update.toml with template pattern:
+        // - Always update config_update.toml.template with the latest template definition
+        // - Only update config_update.toml if it doesn't exist or hasn't been customized by the user
+        let workflow_definition = include_str!("resources/config_update.toml");
 
-            create_file_with_defaults(workflow_file, Some(workflow_definition)).await?;
-        }
+        persist_file_with_template(&config.ops_dir, "config_update.toml", workflow_definition)
+            .await?;
 
         if config.plugin_config_path.exists() {
             return Ok(());
@@ -153,12 +152,7 @@ impl ConfigManagerBuilder {
             mode = 0o644
         }
         .to_string();
-        atomically_write_file_sync(&config.plugin_config_path, example_config.as_bytes()).map_err(
-            |AtomFileError::WriteError { source, .. }| FileError::FileCreateFailed {
-                file: config.plugin_config_path.to_string_lossy().to_string(),
-                from: source,
-            },
-        )?;
+        atomically_write_file_sync(&config.plugin_config_path, example_config.as_bytes())?;
 
         Ok(())
     }

--- a/crates/extensions/tedge_config_manager/src/tests.rs
+++ b/crates/extensions/tedge_config_manager/src/tests.rs
@@ -822,3 +822,125 @@ async fn execute_config_set_operation_step_file_not_found() -> Result<(), anyhow
 
     Ok(())
 }
+
+fn test_config(tempdir: &TempTedgeDir) -> ConfigManagerConfig {
+    ConfigManagerConfig {
+        config_dir: tempdir.path().to_path_buf(),
+        plugin_dirs: vec![],
+        plugin_config_dir: tempdir.path().join("plugins"),
+        plugin_config_path: tempdir
+            .path()
+            .join("plugins/tedge-configuration-plugin.toml"),
+        tmp_path: Arc::from(Utf8Path::from_path(&std::env::temp_dir()).unwrap()),
+        ops_dir: tempdir.dir("operations").utf8_path_buf(),
+        mqtt_schema: MqttSchema::default(),
+        config_snapshot_meta_topic: Topic::new_unchecked(
+            "te/device/main///cmd/config_snapshot/meta",
+        ),
+        config_update_meta_topic: Topic::new_unchecked("te/device/main///cmd/config_update/meta"),
+        config_update_topic: TopicFilter::new_unchecked("te/device/main///cmd/config_update/+"),
+        config_snapshot_topic: TopicFilter::new_unchecked("te/device/main///cmd/config_snapshot/+"),
+        tedge_http_host: Arc::from("localhost"),
+        config_snapshot_enabled: false,
+        config_update_enabled: false,
+        sudo_enabled: false,
+    }
+}
+
+#[tokio::test]
+async fn test_init_creates_config_and_template() -> anyhow::Result<()> {
+    let tempdir = TempTedgeDir::new();
+
+    let config = test_config(&tempdir);
+
+    ConfigManagerBuilder::init(&config).await?;
+
+    let toml_file = config.ops_dir.join("config_update.toml");
+    let template_file = config.ops_dir.join("config_update.toml.template");
+
+    assert!(toml_file.exists(), "config_update.toml should exist");
+    assert!(
+        template_file.exists(),
+        "config_update.toml.template should exist"
+    );
+
+    let toml_content = tokio::fs::read_to_string(&toml_file).await?;
+    let template_content = tokio::fs::read_to_string(&template_file).await?;
+
+    assert_eq!(
+        toml_content, template_content,
+        "Initial config and template should have identical content"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_init_preserves_customized_config() -> anyhow::Result<()> {
+    let tempdir = TempTedgeDir::new();
+
+    let config = test_config(&tempdir);
+
+    // Simulate an older template, which should be different from the latest template
+    let template_file = config.ops_dir.join("config_update.toml.template");
+    let older_template = "# Older template\noperation = \"config_update\"";
+    tokio::fs::write(&template_file, older_template).await?;
+
+    // User customizes the config file, making it different from the template
+    let toml_file = config.ops_dir.join("config_update.toml");
+    let original_content = "# User customized workflow\noperation = \"config_update\"";
+    tokio::fs::write(&toml_file, original_content).await?;
+
+    // Init simulates an upgrade from a previous version
+    ConfigManagerBuilder::init(&config).await?;
+
+    // Verify config was NOT overwritten
+    let toml_content = tokio::fs::read_to_string(&toml_file).await?;
+    assert_eq!(
+        toml_content, original_content,
+        "Customized config should remain unchanged"
+    );
+
+    // Verify template WAS updated with original content
+    let template_content = tokio::fs::read_to_string(&template_file).await?;
+    let latest_template = include_str!("resources/config_update.toml");
+    assert_eq!(
+        template_content, latest_template,
+        "Template should be updated to latest content"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_init_updates_both_when_identical() -> anyhow::Result<()> {
+    let tempdir = TempTedgeDir::new();
+
+    let config = test_config(&tempdir);
+
+    let old_template = "# Old workflow\noperation = \"config_update\"";
+    let template_file = config.ops_dir.join("config_update.toml.template");
+    tokio::fs::write(&template_file, old_template).await?;
+    let toml_file = config.ops_dir.join("config_update.toml");
+    tokio::fs::write(&toml_file, old_template).await?;
+
+    // Init should replace the old workflow definition with the latest one,
+    // since both config and template are identical, indicating that user has not customized it
+    ConfigManagerBuilder::init(&config).await?;
+
+    // Both files should have been overwritten
+    let latest_template = include_str!("resources/config_update.toml");
+    let toml_content_after = tokio::fs::read_to_string(&toml_file).await?;
+    let template_content = tokio::fs::read_to_string(&template_file).await?;
+
+    assert_eq!(
+        toml_content_after, latest_template,
+        "Config content should remain valid"
+    );
+    assert_eq!(
+        toml_content_after, template_content,
+        "Config and template should still be identical"
+    );
+
+    Ok(())
+}

--- a/crates/extensions/tedge_flows/src/registry.rs
+++ b/crates/extensions/tedge_flows/src/registry.rs
@@ -302,27 +302,7 @@ impl<T: FlowRegistry + Send> FlowRegistryExt for T {
         content: &str,
     ) -> Result<(), UpdateFlowRegistryError> {
         let dir = self.store().config_dir();
-        let flow_path = dir.join(name).with_extension("toml");
-        let disabled_flow_path = flow_path.with_extension("toml.disabled");
-        let template_path = flow_path.with_extension("toml.template");
-
-        // Don't update the flow definition if overridden or disabled
-        let prior_flow = tokio::fs::read(&flow_path).await.ok();
-        let prior_template = tokio::fs::read(&template_path).await.ok();
-        let overridden = prior_flow != prior_template;
-        let disabled = tokio::fs::try_exists(&disabled_flow_path)
-            .await
-            .unwrap_or(false);
-        let update_flow = !overridden && !disabled;
-
-        // Persist a copy of flow definition to be used by users as a template for their flows.
-        file::create_directory_with_defaults(dir).await?;
-        fs::atomically_write_file_async(template_path.as_std_path(), content.as_bytes()).await?;
-
-        if update_flow {
-            fs::atomically_write_file_async(flow_path.as_std_path(), content.as_bytes()).await?;
-        }
-
+        fs::persist_file_with_template(dir, &format!("{}.toml", name), content).await?;
         Ok(())
     }
 

--- a/crates/extensions/tedge_log_manager/src/lib.rs
+++ b/crates/extensions/tedge_log_manager/src/lib.rs
@@ -34,10 +34,8 @@ use tedge_api::workflow::SyncOnCommand;
 use tedge_file_system_ext::FsWatchEvent;
 use tedge_utils::file::create_directory_with_defaults;
 use tedge_utils::file::move_file;
-use tedge_utils::file::FileError;
 use tedge_utils::file::PermissionEntry;
 use tedge_utils::fs::atomically_write_file_sync;
-use tedge_utils::fs::AtomFileError;
 use toml::toml;
 
 #[cfg(test)]
@@ -61,7 +59,7 @@ impl LogManagerBuilder {
         plugin_config: PluginConfig,
         fs_notify: &mut impl MessageSource<FsWatchEvent, Vec<PathBuf>>,
         uploader_actor: &mut impl Service<LogUploadRequest, LogUploadResult>,
-    ) -> Result<Self, FileError> {
+    ) -> Result<Self, anyhow::Error> {
         Self::init(&config).await?;
 
         let box_builder = SimpleMessageBoxBuilder::new("Log Manager", 16);
@@ -80,7 +78,7 @@ impl LogManagerBuilder {
         })
     }
 
-    pub async fn init(config: &LogManagerConfig) -> Result<(), FileError> {
+    pub async fn init(config: &LogManagerConfig) -> Result<(), anyhow::Error> {
         if config.plugin_config_path.exists() {
             return Ok(());
         }
@@ -107,12 +105,7 @@ impl LogManagerBuilder {
             path = agent_logs_path
         }
         .to_string();
-        atomically_write_file_sync(&config.plugin_config_path, example_config.as_bytes()).map_err(
-            |AtomFileError::WriteError { source, .. }| FileError::FileCreateFailed {
-                file: config.plugin_config_path.to_string_lossy().to_string(),
-                from: source,
-            },
-        )?;
+        atomically_write_file_sync(&config.plugin_config_path, example_config.as_bytes())?;
 
         Ok(())
     }

--- a/crates/extensions/tedge_mqtt_bridge/src/persist.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/persist.rs
@@ -9,7 +9,6 @@ use tedge_config::tedge_toml::ProfileName;
 use tedge_config::TEdgeConfig;
 use tedge_utils::file::change_mode;
 use tedge_utils::file::change_user_and_group;
-use tedge_utils::file::{self};
 use tedge_utils::fs;
 use tracing::warn;
 
@@ -35,38 +34,23 @@ pub async fn persist_bridge_config_file(
     content: &str,
 ) -> anyhow::Result<()> {
     let config_path = dir.join(name).with_extension("toml");
-    let disabled_config_path = dir.join(name).with_extension("toml.disabled");
     let template_path = dir.join(name).with_extension("toml.template");
 
+    // Persist a copy of bridge config definition to be used by users as a template.
     // Don't update the flow definition if overridden or disabled
-    let prior_config = tokio::fs::read(&config_path).await.ok();
-    let prior_template = tokio::fs::read(&template_path).await.ok();
-    let overridden = prior_config != prior_template;
-    let disabled = tokio::fs::try_exists(&disabled_config_path)
+    let name_toml = format!("{}.toml", name);
+    fs::persist_file_with_template(dir, &name_toml, content)
         .await
-        .unwrap_or(false);
-    let update_flow = !overridden && !disabled;
+        .map_err(anyhow::Error::msg)?;
 
-    // Persist a copy of bridge config definition to be used by users as a template
-    file::create_directory_with_defaults(dir).await?;
-    fs::atomically_write_file_async(&template_path, content.as_bytes()).await?;
-
-    if let Err(err) = change_user_and_group(&template_path, "tedge", "tedge").await {
-        warn!("failed to set file ownership for '{template_path}': {err}");
-    }
-
-    if let Err(err) = change_mode(&template_path, 0o644).await {
-        warn!("failed to set file permissions for '{template_path}': {err}");
-    }
-
-    if update_flow {
-        fs::atomically_write_file_async(&config_path, content.as_bytes()).await?;
-        if let Err(err) = change_user_and_group(&config_path, "tedge", "tedge").await {
-            warn!("failed to set file ownership for '{config_path}': {err}");
+    // Set file ownership and permissions on both files
+    for path in [&config_path, &template_path] {
+        if let Err(err) = change_user_and_group(path, "tedge", "tedge").await {
+            warn!("failed to set file ownership for '{path}': {err}");
         }
 
-        if let Err(err) = change_mode(&config_path, 0o644).await {
-            warn!("failed to set file permissions for '{config_path}': {err}");
+        if let Err(err) = change_mode(path, 0o644).await {
+            warn!("failed to set file permissions for '{path}': {err}");
         }
     }
 

--- a/tests/RobotFramework/tests/cumulocity/configuration/config_operation_workflow/config_update_workflow.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/config_operation_workflow/config_update_workflow.robot
@@ -17,15 +17,38 @@ ${CONFIG_URL}       None
 
 *** Test Cases ***
 Default Workflow
+    ${original_config}    Execute Command    cat /etc/tedge/operations/config_update.toml
+    ${original_template}    Execute Command    cat /etc/tedge/operations/config_update.toml.template
+
+    Should Be Equal    ${original_config}    ${original_template}
+
     Update Config And Verify
 
 Workflow Override With Custom Set Script
+    ${original_config}    Execute Command    cat /etc/tedge/operations/config_update.toml
+    ${original_template}    Execute Command    cat /etc/tedge/operations/config_update.toml.template
+
     # Workflow with custom set script
     ThinEdgeIO.Transfer To Device
     ...    ${CURDIR}/config_update_custom_set.toml
     ...    /etc/tedge/operations/config_update.toml
 
+    ${updated_config}    Execute Command    cat /etc/tedge/operations/config_update.toml
+    Should Not Be Equal    ${original_config}    ${updated_config}
+
     Update Config And Verify
+
+    Execute Command    systemctl restart tedge-agent
+
+    ${config_after_restart}    Execute Command    cat /etc/tedge/operations/config_update.toml
+    ${template_after_restart}    Execute Command    cat /etc/tedge/operations/config_update.toml.template
+
+    # Verify customized config was preserved (not overwritten)
+    Should Be Equal    ${config_after_restart}    ${updated_config}
+    Should Be Equal    ${template_after_restart}    ${original_template}
+
+    # Verify the two files now have different content
+    Should Not Be Equal    ${config_after_restart}    ${template_after_restart}
 
 Legacy Workflow
     # Legacy workflow definition

--- a/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_initialization.robot
+++ b/tests/RobotFramework/tests/tedge_agent/device_profile/device_profile_initialization.robot
@@ -3,7 +3,7 @@ Resource            ../../../resources/common.resource
 Library             ThinEdgeIO
 Library             Cumulocity
 
-Test Setup          Custom Setup
+Suite Setup         Custom Setup
 Test Teardown       Get Logs
 
 Test Tags           theme:tedge_agent
@@ -11,12 +11,18 @@ Test Tags           theme:tedge_agent
 
 *** Test Cases ***
 Device profile is included in supported operations
-    Should Have MQTT Messages    te/device/main///cmd/device_profile    message_pattern=^{}$
+    Should Have MQTT Messages    te/device/main///cmd/device_profile    message_pattern=^{}$    date_from=-5s
     Should Contain Supported Operations    c8y_DeviceProfile
+
+Workflow definition is created along with template
+    ${original_config}    Execute Command    cat /etc/tedge/operations/device_profile.toml
+    ${original_template}    Execute Command    cat /etc/tedge/operations/device_profile.toml.template
+
+    Should Be Equal    ${original_config}    ${original_template}
 
 
 *** Keywords ***
 Custom Setup
-    ${DEVICE_SN}=    Setup
-    Set Suite Variable    $DEVICE_SN
+    ${DEVICE_SN}    Setup
+    Set Suite Variable    ${DEVICE_SN}
     Device Should Exist    ${DEVICE_SN}


### PR DESCRIPTION
## Proposed changes

Template files along with the workflow definitions for:
* `config_update.toml`
* `device_profile.toml`

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/4000

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

