### PR TITLE
fix: Handle more possible cases in JS exception handling due to OOM

### DIFF
--- a/crates/extensions/tedge_flows/src/js_runtime.rs
+++ b/crates/extensions/tedge_flows/src/js_runtime.rs
@@ -367,10 +367,24 @@ impl<'js> JsModules<'js> {
 
 impl LoadError {
     fn from_js(ctx: &Ctx<'_>, err: Error) -> Self {
-        if let Some(ex) = ctx.catch().as_exception() {
+        let caught = ctx.catch();
+        if let Some(ex) = caught.as_exception() {
             LoadError::JsException {
                 message: ex.message().unwrap_or_default(),
                 stack: ex.stack().unwrap_or_default(),
+            }
+        } else if let Some(s) = caught.as_string() {
+            // OOM: QuickJS couldn't allocate the Exception object and fell back to
+            // storing "out of memory" as a string atom.
+            LoadError::JsException {
+                message: s.to_string().unwrap_or_default(),
+                stack: String::new(),
+            }
+        } else if caught.is_null() && matches!(err, Error::Exception) {
+            // Severe OOM: QuickJS couldn't allocate any exception value at all.
+            LoadError::JsException {
+                message: "out of memory".to_owned(),
+                stack: String::new(),
             }
         } else {
             err.into()


### PR DESCRIPTION
## Proposed changes
I was observing some flakiness in the OOM unit test for the flows runtime locally.

I threw the problem in Claude's direction and this is what it produced, and that seems to have resolved the flakiness.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

