### PR TITLE
fix: `--flows-dir` resolve paths

### DIFF
--- a/crates/core/tedge/src/cli/flows/cli.rs
+++ b/crates/core/tedge/src/cli/flows/cli.rs
@@ -208,7 +208,10 @@ impl TEdgeFlowsCli {
         flows_dir: &Utf8PathBuf,
         js_config: JsRuntimeConfig,
     ) -> Result<MessageProcessor<BaseFlowRegistry>, Error> {
-        let mut processor = Self::init_processor(flows_dir, js_config)
+        let flows_dir = flows_dir
+            .canonicalize_utf8()
+            .context("Invalid flows-dir path")?;
+        let mut processor = Self::init_processor(&flows_dir, js_config)
             .await
             .with_context(|| format!("loading flows and steps from {flows_dir}"))?;
         processor.load_all_flows().await;

--- a/tests/RobotFramework/tests/cumulocity/flows/cli_flows_list.robot
+++ b/tests/RobotFramework/tests/cumulocity/flows/cli_flows_list.robot
@@ -34,6 +34,25 @@ Passes when all flows in a folder are valid
     Execute Command    cmd=printf 'input.mqtt.topics = ["foo"]\nsteps = [{script = "main.js"}]\n' > ${tmpdir}/flow.toml
     ${output}=    Execute Command    cmd=tedge flows list --flows-dir ${tmpdir} 2>&1    exp_exit_code=0
 
+Normalizes flows-dir path
+    [Documentation]    Checks flows are printed correctly when using relative paths, e.g. `.`, `../` or when using symlinks
+    ${tmpdir}=    Create Temp Directory
+    Execute Command    cmd=echo 'export function onMessage(message, context) { return []; }' > ${tmpdir}/main.js
+    Execute Command    cmd=printf 'input.mqtt.topics = ["foo"]\nsteps = [{script = "main.js"}]\n' > ${tmpdir}/flow.toml
+    VAR    ${child_dir}=    ${tmpdir}/childdir
+    Execute Command    cmd=mkdir ${child_dir}
+    VAR    ${symlink}=    ${tmpdir}.link
+    Execute Command    cmd=ln -s ${tmpdir} ${symlink}
+
+    # flows list shouldn't fail
+    ${out1}=    Execute Command    cmd=cd ${tmpdir} && tedge flows list --flows-dir . 2>&1    exp_exit_code=0
+    ${out2}=    Execute Command    cmd=cd ${child_dir} && tedge flows list --flows-dir ../ 2>&1    exp_exit_code=0
+    ${out3}=    Execute Command    cmd=tedge flows list --flows-dir ${symlink} 2>&1    exp_exit_code=0
+
+    # paths in output should be the same in all cases (be canonicalized)
+    Should Be Equal    ${out1}    ${out2}
+    Should Be Equal    ${out1}    ${out3}
+
 
 *** Keywords ***
 Custom Setup

--- a/tests/RobotFramework/tests/tedge_flows/tedge_flows.robot
+++ b/tests/RobotFramework/tests/tedge_flows/tedge_flows.robot
@@ -10,6 +10,27 @@ Test Tags           theme:tedge_flows
 
 
 *** Test Cases ***
+Normalizes flows-dir path
+    [Documentation]    Checks flows are printed correctly when using relative paths, e.g. `.`, `../` or when using symlinks
+    VAR    ${flows_dir}    /etc/tedge/mappers/local/flows
+    VAR    ${child_dir}    ${flows_dir}/childdir
+    Execute Command    cmd=mkdir ${child_dir}
+    VAR    ${symlink}    ${flows_dir}.link
+    Execute Command    cmd=ln -s ${flows_dir} ${symlink}
+
+    ${out1}    Execute Command    cmd=cd ${flows_dir} && tedge flows test --flows-dir . "" "" 2>&1    exp_exit_code=0
+    ${out2}    Execute Command    cmd=cd ${child_dir} && tedge flows test --flows-dir ../ "" "" 2>&1    exp_exit_code=0
+    ${out3}    Execute Command    cmd=tedge flows test --flows-dir ${symlink} "" "" 2>&1    exp_exit_code=0
+
+    # test shouldn't fail due to invalid path (path containing .)
+    # TODO: should we return an error exit code if any flow in test failed to compile? Currently we return 0.
+    VAR    ${fail_due_to_invalid_path}    Failed to compile flow on-startup.toml: Not a valid filename for a flow
+    Should Not Contain    ${out1}    ${fail_due_to_invalid_path}
+    Should Not Contain    ${out2}    ${fail_due_to_invalid_path}
+    Should Not Contain    ${out3}    ${fail_due_to_invalid_path}
+
+    Execute Command    rm -r ${child_dir} ${symlink}
+
 Add missing timestamps
     ${transformed_msg}    Execute Command
     ...    tedge flows test --processing-time "2025-06-27 11:31:02" te/device/main///m/ '{}'


### PR DESCRIPTION
## Proposed changes

This fixes an issue where `tedge flows list/test --flows-dir .` failed to print/test flows where using an absolute path did. It happened because we were stripping --flows-dir value from discovered flows, because only flows in flows-dir are flows. When flows-dir was `.`, it failed. The fix is to canonicalize the flows-dir path at the CLI boundary.

After the fix, `--flows-dir` correctly handles cases where:
- it's a relative directory
- it's behind a symlink


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#4080 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

