### PR TITLE
feat: add configurable option for tedge-mosquitto.conf file creation

### DIFF
--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -1050,6 +1050,10 @@ define_tedge_config! {
         device_topic_id: EntityTopicId,
 
         bind: {
+            #[tedge_config(example = "true", default(value = true))]
+            /// Creates a mosquitto bridge configuration file with recommended listener settings
+            enabled: bool,
+
             /// The address mosquitto binds to for internal use
             #[tedge_config(example = "127.0.0.1", default(variable = "Ipv4Addr::LOCALHOST"))]
             address: IpAddr,

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -911,12 +911,14 @@ impl ConnectCommand {
             Cloud::Azure(_) => (),
         }
 
-        if let Err(err) =
-            write_generic_mosquitto_config_to_file(tedge_config, common_mosquitto_config).await
-        {
-            // We want to preserve previous errors and therefore discard result of this function.
-            let _ = clean_up(tedge_config, bridge_config);
-            return Err(err.into());
+        if tedge_config.mqtt.bind.enabled {
+            if let Err(err) =
+                write_generic_mosquitto_config_to_file(tedge_config, common_mosquitto_config).await
+            {
+                // We want to preserve previous errors and therefore discard result of this function.
+                let _ = clean_up(tedge_config, bridge_config);
+                return Err(err.into());
+            }
         }
 
         if bridge_config.bridge_location == BridgeLocation::Mosquitto {

--- a/docs/src/operate/configuration/mosquitto-configuration.md
+++ b/docs/src/operate/configuration/mosquitto-configuration.md
@@ -4,6 +4,23 @@ tags: [Operate, Configuration, MQTT]
 description: Mosquitto specific configuration guide
 ---
 
+## Disabling the default mosquitto listener configuration {#mosquitto-bind-enabled}
+
+By default, `tedge connect` creates the file `/etc/tedge/mosquitto-conf/tedge-mosquitto.conf`,
+which configures mosquitto listener settings (bind address and port) recommended for %%te%%.
+
+If you manage your own mosquitto configuration — for example because you are running an external
+mosquitto broker or have custom listener settings — you can tell %%te%% **not** to create that file:
+
+```sh
+sudo tedge config set mqtt.bind.enabled false
+```
+
+With this setting, `tedge connect` will skip writing `tedge-mosquitto.conf` entirely,
+leaving your existing mosquitto configuration untouched.
+You are then responsible for ensuring that mosquitto is configured to match the
+`mqtt.bind.address` and `mqtt.bind.port` values used by %%te%%.
+
 ## Configuring mosquitto bind address and port {#mosquitto-bind-address}
 
 Configuring a mosquitto port and bind address in %%te%% is a three-step process.

--- a/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
+++ b/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
@@ -6,8 +6,8 @@ Documentation       Run connection test while being connected and check the posi
 Resource            ../../resources/common.resource
 Library             ThinEdgeIO
 
-Suite Setup         Suite Setup
 Suite Teardown      Get Suite Logs
+Test Setup          Setup
 
 Test Tags           theme:cli    theme:mqtt    theme:c8y
 
@@ -42,7 +42,7 @@ tedge_connect_test_negative
     ...    stderr=${True}
 
 tedge_connect_test_sm_services
-    ${output}=    Execute Command    sudo tedge connect c8y    stdout=${False}    stderr=${True}
+    ${output}=    Execute Command    sudo tedge reconnect c8y    stdout=${False}    stderr=${True}
     Should Contain    ${output}    Enabling tedge-agent... ✓
     Should Contain    ${output}    Enabling tedge-mapper-c8y... ✓
     Should Not Contain
@@ -70,10 +70,10 @@ tedge reconnect restarts mapper
 Check absence of OpenSSL Error messages #3024
     Skip
     ...    msg=This test is flaky. There is client (yet to be identified) that fails to connect on port 8883 leading to OpenSSL Error
-    ${SuiteStart}=    Get Suite Start Time
+    ${TestStartSeconds}=    Get Test Start Time
     # Only checkout output if mosquitto is being used
     ${output}=    Execute Command
-    ...    systemctl is-active mosquitto && journalctl -u mosquitto -n 5000 --since "@${SuiteStartSeconds}" || true
+    ...    systemctl is-active mosquitto && journalctl -u mosquitto -n 5000 --since "@${TestStartSeconds}" || true
     Should Not Contain    ${output}    OpenSSL Error
 
 tedge reconnect validates and uses the new certificate if any
@@ -117,13 +117,14 @@ tedge reconnect rejects any new invalid certificate
     ${new-cert}=    Execute Command    cat "$(tedge config get c8y.device.cert_path).new"
     Should Contain    ${new-cert}    garbage
 
+tedge connect does not create tedge-mosquitto.conf when mqtt.bind.enabled is false
+    Execute Command    mv /etc/tedge/mosquitto-conf/tedge-mosquitto.conf /etc/tedge/mosquitto-conf/custom.conf
+    Execute Command    sudo tedge config set mqtt.bind.enabled false
+    Execute Command    sudo tedge reconnect c8y
+    File Should Not Exist    /etc/tedge/mosquitto-conf/tedge-mosquitto.conf
+
 
 *** Keywords ***
-Suite Setup
-    Setup
-    ${SuiteStartSeconds}=    Get Unix Timestamp
-    Set Suite Variable    $SuiteStartSeconds
-
 Should Have File Permissions
     [Arguments]    ${file}    ${expected_permissions}
     ${FILE_MODE_OWNERSHIP}=    Execute Command    stat -c '%a %U:%G' ${file}    strip=${True}


### PR DESCRIPTION
## Proposed changes

This PR allows users to diable the automatic creation of `/etc/tedge/mosquitto-conf/tedge-mosquitto.conf` with `tedge connect <cloud>`. The configuration file contains listener settings, which might not be wanted by all users.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#3837

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

