### PR TITLE
fix: use approximate matches for Alpine Linux virtual packages

### DIFF
--- a/ci/build_scripts/version.sh
+++ b/ci/build_scripts/version.sh
@@ -146,6 +146,11 @@ set_version_variables() {
         APK_VERSION="${GIT_SEMVER//\~/_rc}"
     fi
 
+    # strip everything after and including the '+'
+    # as Alpine Linux virtual package dependencies don't seem
+    # to resolve properly if the '+' is contained in the name
+    APK_VERSION_APPROXIMATE="${APK_VERSION%%+*}"
+
     if [[ "$GIT_SEMVER" = *-rc* ]]; then
         # Debian expects a tilde as a separator
         DEB_VERSION="${GIT_SEMVER//-/\~}"
@@ -171,6 +176,7 @@ set_version_variables() {
 
     export GIT_SEMVER
     export APK_VERSION
+    export APK_VERSION_APPROXIMATE
     export DEB_VERSION
     export RPM_VERSION
     export CONTAINER_VERSION

--- a/configuration/package_manifests/virtual/nfpm.tedge-full.yaml
+++ b/configuration/package_manifests/virtual/nfpm.tedge-full.yaml
@@ -26,15 +26,16 @@ overrides:
   # slightly different formats
   apk:
     depends:
+        # Note: use the approximate apk version due to issues with the '+' sign
         - mosquitto
-        - tedge=${APK_VERSION}
-        - tedge-mapper=${APK_VERSION}
-        - tedge-agent=${APK_VERSION}
+        - tedge~=${APK_VERSION_APPROXIMATE}
+        - tedge-mapper~=${APK_VERSION_APPROXIMATE}
+        - tedge-agent~=${APK_VERSION_APPROXIMATE}
         # Watchdog does not make sense on apk as it does not use systemd
-        # - tedge-watchdog = ${APK_VERSION}
-        - tedge-apt-plugin=${APK_VERSION}
-        - c8y-remote-access-plugin=${APK_VERSION}
-        - c8y-firmware-plugin=${APK_VERSION}
+        # - tedge-watchdog~=${APK_VERSION_APPROXIMATE}
+        - tedge-apt-plugin~=${APK_VERSION_APPROXIMATE}
+        - c8y-remote-access-plugin~=${APK_VERSION_APPROXIMATE}
+        - c8y-firmware-plugin~=${APK_VERSION_APPROXIMATE}
   rpm:
     depends:
         # FIXME: Work out a better way to reference the full package specific version which includes the release number (-1) suffix

--- a/configuration/package_manifests/virtual/nfpm.tedge-minimal.yaml
+++ b/configuration/package_manifests/virtual/nfpm.tedge-minimal.yaml
@@ -26,9 +26,10 @@ overrides:
   # slightly different formats
   apk:
     depends:
+        # Note: use the approximate apk version due to issues with the '+' sign
         - mosquitto
-        - tedge=${APK_VERSION}
-        - tedge-mapper=${APK_VERSION}
+        - tedge~=${APK_VERSION_APPROXIMATE}
+        - tedge-mapper~=${APK_VERSION_APPROXIMATE}
   rpm:
     depends:
         # FIXME: Work out a better way to reference the full package specific version which includes the release number (-1) suffix


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Fix the Alpine Linux virtual package dependencies by using an "approximate" match which doesn't care about the -r0 suffix, or git commit information (for tedge-main channel releases).

For some reason the dependency resolution within the virtual packages on Alpine Linux don't function correctly if the version contains a '+' sign. Instead just use approximate version matching which should be accurate enough considering we auto-increment using the git distance anyway.

The problem was partially introduced in https://github.com/thin-edge/thin-edge.io/pull/4109, however the PR made the problem more visible, as previously, the version information was being silently ignored due to the extra spaces between the package name and version.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/pull/4109

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

