### PR TITLE
tests: use specific version instead of the latest available version

### DIFF
--- a/tests/RobotFramework/tests/cumulocity/self-update/software_update.toml
+++ b/tests/RobotFramework/tests/cumulocity/self-update/software_update.toml
@@ -10,12 +10,19 @@ on_success = "prepare"
 
 [prepare]
 script = "sudo /etc/tedge/sm-plugins/apt prepare"
+on_success = "get-version"
+
+# Extract the exact version to upgrade to
+# otherwise the server will just get the latest available version which maybe newer than the
+# version under test
+[get-version]
+script = """bash -c "printf ':::begin-tedge:::\\n{\\"version\\":\\"%s\\"}\\n:::end-tedge:::\\n' \\"$(jq -r '.updateList[].modules[].version' <<< '${.payload}')\\"""""
 on_success = "self-update"
 
 [self-update]
 # Note: update tedge as it is used by the tedge-agent (as tedge is a multi-call binary)
 # Note: installing the new tedge package will not restart the tedge-agent service
-script = "sudo /etc/tedge/sm-plugins/apt install tedge"
+script = "sudo /etc/tedge/sm-plugins/apt install tedge --module-version '${.payload.version}'"
 on_success = "restart-agent"
 
 [restart-agent]


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

After the release of 2.0.0, this broke a system test which didn't specify an exact tedge version to upgrade to, leading to the 2.0.0 version being installed instead of the version under test.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

