### PR TITLE
fix: Rename `--debug` to `--show-all` in `tedge bridge test`

### DIFF
--- a/crates/core/tedge/src/cli/bridge/test_command.rs
+++ b/crates/core/tedge/src/cli/bridge/test_command.rs
@@ -37,7 +37,7 @@ pub struct BridgeTestCmd {
 
     /// Show skipped rules (e.g. due to unmet conditions or empty template loops)
     #[clap(long)]
-    debug: bool,
+    show_all: bool,
 }
 
 #[async_trait::async_trait]
@@ -52,7 +52,7 @@ impl Command for BridgeTestCmd {
     #[mutants::skip]
     async fn execute(&self, config: TEdgeConfig) -> Result<(), MaybeFancy<anyhow::Error>> {
         tedge_mapper::warn_misconfigured_mapper_dirs(&config.root_dir().join("mappers")).await;
-        let detail = if self.debug {
+        let detail = if self.show_all {
             DetailLevel::Debug
         } else {
             DetailLevel::Normal
@@ -371,7 +371,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
             cloud: cloud.to_string(),
             topic: topic.to_string(),
             profile,
-            debug: detail == DetailLevel::Debug,
+            show_all: detail == DetailLevel::Debug,
         };
         let rt = tokio::runtime::Runtime::new().unwrap();
         let mut buf = Vec::new();
@@ -668,7 +668,7 @@ topic = "measurements"
             cloud: cloud.to_string(),
             topic: topic.to_string(),
             profile,
-            debug: detail == DetailLevel::Debug,
+            show_all: detail == DetailLevel::Debug,
         };
         let rt = tokio::runtime::Runtime::new().unwrap();
         let mut buf = Vec::new();
@@ -706,7 +706,7 @@ topic = "measurements"
             cloud: "c8y".to_string(),
             topic: "te/measurements".to_string(),
             profile: None,
-            debug: false,
+            show_all: false,
         };
         assert_eq!(
             cmd.description(),


### PR DESCRIPTION
## Proposed changes
Rename `--debug` arg to `--show-all` in `tedge bridge test` command to not collide with the existing `--debug` argument/match the behaviour of  `tedge bridge inspect`

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #4121 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

