### PR TITLE
feat: take tedge.toml backup on tedge config upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5217,6 +5217,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tedge_api",
+ "tedge_config",
  "tedge_config_macros",
  "tedge_test_utils",
  "tedge_utils",

--- a/crates/common/tedge_config/Cargo.toml
+++ b/crates/common/tedge_config/Cargo.toml
@@ -48,6 +48,7 @@ yansi = { workspace = true }
 [dev-dependencies]
 assert_matches = { workspace = true }
 figment = { workspace = true, features = ["test"] }
+tedge_config = { path = ".", features = ["test"] }
 tedge_test_utils = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }

--- a/crates/common/tedge_config/src/lib.rs
+++ b/crates/common/tedge_config/src/lib.rs
@@ -65,17 +65,30 @@ impl TEdgeConfig {
         self.location().update_toml(update).await
     }
 
-    pub async fn migrate_mapper_configs(self) -> Result<(), TEdgeConfigError> {
+    pub async fn migrate_mapper_configs(self) -> Result<Option<PathBuf>, TEdgeConfigError> {
+        // Check if migration is actually required
+        if !self.location().is_migration_required().await {
+            tracing::info!("No migration required, skipping backup creation");
+            return Ok(None);
+        }
+
+        // Create a backup of tedge.toml before starting migration
+        let backup_path = self
+            .location()
+            .backup_tedge_config(self.config_root())
+            .await?;
+        tracing::info!("Created backup of tedge.toml at: {}", backup_path);
+
         for cloud_type in CloudType::iter() {
             self.location().migrate_mapper_config(cloud_type).await?;
         }
-        Ok(())
+        Ok(Some(backup_path))
     }
 
     pub fn mapper_config_dir<T: ExpectedCloudType>(
         &self,
         profile: Option<&ProfileName>,
-    ) -> camino::Utf8PathBuf {
+    ) -> PathBuf {
         self.location().config_dir::<T>(profile)
     }
 

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config_location.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config_location.rs
@@ -27,6 +27,7 @@ use tedge_config_macros::ProfileName;
 use tedge_utils::paths::TedgePaths;
 use tracing::debug;
 use tracing::subscriber::NoSubscriber;
+use tracing::warn;
 
 use super::tedge_config;
 use super::ParseKeyError;
@@ -97,6 +98,13 @@ impl TEdgeConfigLocation {
             .unwrap_or_default();
         let tedge_toml: toml::Table = toml::from_str(&toml).unwrap();
         CloudType::iter().any(|key| tedge_toml.contains_key(key.as_ref()))
+    }
+
+    // A generic abstration to check if a migration is required.
+    // Currently, the only migration we have is for mapper configs.
+    // This can be extended in the future if we need to add more migrations.
+    pub async fn is_migration_required(&self) -> bool {
+        self.tedge_toml_contains_cloud_config().await
     }
 
     pub async fn tedge_toml_contains_cloud_config_for(&self, cloud_type: CloudType) -> bool {
@@ -264,6 +272,35 @@ impl TEdgeConfigLocation {
 
     fn toml_path(&self) -> &Utf8Path {
         &self.tedge_config_file_path
+    }
+
+    /// Get the path where the tedge.toml backup file would be located
+    fn get_backup_path(&self) -> Utf8PathBuf {
+        let mut backup_path = self.tedge_config_file_path.clone();
+        backup_path.set_extension("toml.bak");
+        backup_path
+    }
+
+    /// Create a backup of tedge.toml before upgrade
+    ///
+    /// Returns the path to the created backup file, or an error if backup creation fails.
+    pub async fn backup_tedge_config(
+        &self,
+        root: TedgePaths,
+    ) -> Result<Utf8PathBuf, TEdgeConfigError> {
+        let backup_path = self.get_backup_path();
+        debug!("Creating backup of {} to {}", self.toml_path(), backup_path);
+
+        let content = tokio::fs::read(self.toml_path()).await?;
+        root.file(&backup_path)?.replace_atomic(content).await.map_err(|e| {
+                warn!("Failed to create backup of {}: {}", self.toml_path(), e);
+                TEdgeConfigError::Anyhow(anyhow::anyhow!(
+                    "Failed to create backup of {}: {}. Please ensure the file exists and you have write permissions.",
+                    self.toml_path(), e
+                ))
+            })?;
+
+        Ok(backup_path)
     }
 
     pub(crate) async fn load(self) -> Result<TEdgeConfig, TEdgeConfigError> {

--- a/crates/common/tedge_config/tests/tedge_config_upgrade.rs
+++ b/crates/common/tedge_config/tests/tedge_config_upgrade.rs
@@ -1,0 +1,211 @@
+use tedge_config::TEdgeConfig;
+use tedge_test_utils::fs::TempTedgeDir;
+
+/// Test that backup is created before config upgrade with cloud config present
+#[tokio::test]
+async fn backup_is_created_before_config_upgrade() {
+    let ttd = config_root();
+
+    // Set up multi-cloud configuration before upgrade
+    let original_config = toml::toml!(
+        [config]
+        version = "2"
+        [device]
+        id = "multi-cloud-device"
+        [c8y]
+        url = "c8y.example.com"
+        [az]
+        url = "az.example.com"
+        [aws]
+        url = "aws.example.com"
+    );
+    ttd.file("tedge.toml")
+        .with_toml_content(original_config.clone());
+
+    let tedge_config = TEdgeConfig::load(ttd.path()).await.unwrap();
+
+    let backup_path = ttd.path().join("tedge.toml.bak");
+    // Verify no backup exists initially
+    assert!(
+        !backup_path.exists(),
+        "Backup should not exist before upgrade"
+    );
+
+    // Get root dir before consuming tedge_config
+    let root_dir = tedge_config.root_dir().to_path_buf();
+
+    // Perform the upgrade (this creates the backup)
+    let backup_path = tedge_config
+        .migrate_mapper_configs()
+        .await
+        .expect("Upgrade should succeed")
+        .expect("Backup file is created");
+
+    // Verify backup was created
+    assert!(
+        backup_path.exists(),
+        "Backup file should exist after upgrade at {}",
+        backup_path
+    );
+
+    // Verify backup has correct filename
+    assert_eq!(
+        backup_path.file_name(),
+        Some("tedge.toml.bak"),
+        "Backup should have .bak extension"
+    );
+
+    // Verify backup is in the correct directory
+    assert_eq!(
+        backup_path.parent().unwrap(),
+        root_dir,
+        "Backup should be in config root directory"
+    );
+
+    // Verify backup content has the same TOML values as original (not necessarily the same formatting)
+    let backup_content = tokio::fs::read_to_string(&backup_path)
+        .await
+        .expect("Should read backup file");
+    let backup_config: toml::Table =
+        toml::from_str(&backup_content).expect("Should parse backup content as TOML");
+
+    assert_eq!(
+        original_config, backup_config,
+        "Backup TOML values should equal original configuration values"
+    );
+}
+
+/// Test that second upgrade with nothing to migrate returns None and preserves backup
+#[tokio::test]
+async fn second_upgrade_with_nothing_to_migrate_preserves_first_backup() {
+    let ttd = config_root();
+
+    // First upgrade with cloud config
+    let first_config = toml::toml!(
+        [config]
+        version = "2"
+        [device]
+        id = "test-device"
+        [c8y]
+        url = "c8y.example.com"
+    );
+    ttd.file("tedge.toml")
+        .with_toml_content(first_config.clone());
+
+    let tedge_config = TEdgeConfig::load(ttd.path()).await.unwrap();
+    let backup_path = tedge_config
+        .migrate_mapper_configs()
+        .await
+        .expect("First upgrade should succeed")
+        .expect("First migration should create backup");
+
+    // Read the backup content after first migration
+    let first_backup_content = tokio::fs::read_to_string(&backup_path)
+        .await
+        .expect("Should read backup file after first migration");
+
+    // Second upgrade with nothing to migrate (cloud config is now gone from tedge.toml)
+    let tedge_config = TEdgeConfig::load(ttd.path()).await.unwrap();
+    let second_result = tedge_config.migrate_mapper_configs().await.unwrap();
+
+    // Second migration should return None since nothing was migrated
+    assert!(
+        second_result.is_none(),
+        "Second migration should return None when nothing needs to migrate"
+    );
+
+    // Verify backup file still exists and content is unchanged
+    let second_backup_content = tokio::fs::read_to_string(&backup_path)
+        .await
+        .expect("Backup should still exist after second migration");
+
+    assert_eq!(
+        first_backup_content, second_backup_content,
+        "Backup content should be unchanged after second migration with nothing to migrate"
+    );
+}
+
+/// Test that sequential migrations overwrite backup with pre-migration state
+#[tokio::test]
+async fn second_upgrade_with_migration_overwrites_previous_backup() {
+    let ttd = config_root();
+
+    // First upgrade
+    let first_config = toml::toml!(
+        [config]
+        version = "2"
+        [device]
+        id = "test-device"
+        [c8y]
+        url = "c8y.example.com"
+    );
+    ttd.file("tedge.toml")
+        .with_toml_content(first_config.clone());
+
+    let tedge_config = TEdgeConfig::load(ttd.path()).await.unwrap();
+    let backup_path = tedge_config
+        .migrate_mapper_configs()
+        .await
+        .expect("First migration should succeed")
+        .expect("First migration should create backup");
+
+    // Verify first backup contains the original c8y config
+    let first_backup_content = tokio::fs::read_to_string(&backup_path)
+        .await
+        .expect("Should read backup file after first migration");
+    let first_backup_config: toml::Table =
+        toml::from_str(&first_backup_content).expect("Should parse first backup as TOML");
+    assert_eq!(
+        first_backup_config, first_config,
+        "First backup should contain original config with cloud section"
+    );
+
+    // Update the tedge.toml to simulate a new config version that requires migration
+    let second_config = toml::toml!(
+        [config]
+        version = "2"
+        [device]
+        id = "test-device"
+        [az]
+        url = "az.example.com"
+    );
+    ttd.file("tedge.toml")
+        .with_toml_content(second_config.clone());
+
+    // Second upgrade
+    let tedge_config = TEdgeConfig::load(ttd.path()).await.unwrap();
+    let backup_path = tedge_config
+        .migrate_mapper_configs()
+        .await
+        .expect("Second migration should succeed")
+        .expect("Second migration should create backup");
+
+    // Verify second backup contains the state before the second migration (with az config)
+    let second_backup_content = tokio::fs::read_to_string(&backup_path)
+        .await
+        .expect("Should read backup file after second migration");
+    let second_backup_config: toml::Table =
+        toml::from_str(&second_backup_content).expect("Should parse second backup as TOML");
+    assert_eq!(
+        second_backup_config, second_config,
+        "Second backup should contain the state before second migration (with az config)"
+    );
+
+    // Verify second backup doesn't contain first config
+    assert_ne!(
+        second_backup_config, first_config,
+        "Second backup should not contain first configuration"
+    );
+}
+
+fn config_root() -> TempTedgeDir {
+    let ttd = TempTedgeDir::new();
+
+    // Create system.toml with empty user and group to use current process ownership
+    ttd.file("system.toml").with_toml_content(toml::toml! {
+        user = ""
+        group = ""
+    });
+
+    ttd
+}

--- a/crates/core/tedge/src/cli/config/commands/upgrade.rs
+++ b/crates/core/tedge/src/cli/config/commands/upgrade.rs
@@ -11,14 +11,29 @@ impl Command for UpgradeConfigCommand {
     }
 
     async fn execute(&self, tedge_config: TEdgeConfig) -> Result<(), MaybeFancy<anyhow::Error>> {
-        tedge_config.migrate_mapper_configs().await.map_err(|e| {
+        let backup_path = tedge_config.migrate_mapper_configs().await.map_err(|e| {
             MaybeFancy::Unfancy(anyhow::Error::new(e).context(
                 "Failed to migrate mapper configurations. \
                      Fix the underlying issue and run 'tedge config upgrade' again to retry.",
             ))
         })?;
 
-        eprintln!("Configuration updates completed successfully.");
+        match backup_path {
+            Some(path) => {
+                eprintln!("Configuration updates completed successfully.");
+                eprintln!(
+                    "Your original configuration has been backed up to: {} in case the old configuration must be restored.",
+                    path
+                );
+                eprintln!(
+                    "You may delete it after validating that your upgraded configuration is working."
+                );
+            }
+            None => {
+                eprintln!("Configuration is already up to date, nothing was migrated.");
+            }
+        }
+
         Ok(())
     }
 }

--- a/tests/RobotFramework/tests/configuration/mapper_config_migration.robot
+++ b/tests/RobotFramework/tests/configuration/mapper_config_migration.robot
@@ -199,8 +199,8 @@ Migration Fails When Tedge Dir Not Writable And Mappers Dir Missing
     ...    stderr=${True}
     ...    stdout=${False}
     Should Contain    ${result}    Permission denied
-    # The error should talk about how `/etc/tedge/mappers` can't be created
-    Should Contain    ${result}    /etc/tedge/mappers
+    # The error should talk about how `/etc/tedge` can't be written to
+    Should Contain    ${result}    /etc/tedge
 
     # Cleanup: Restore permissions
     Execute Command    sudo chmod 755 /etc/tedge

--- a/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
+++ b/tests/RobotFramework/tests/cumulocity/self-update/tedge_self_update.robot
@@ -35,6 +35,9 @@ Update tedge version from previous using Cumulocity
     ...    {"name": "tedge-agent", "softwareType": "apt", "version": "${PREV_VERSION}"}
     ...    {"name": "tedge-watchdog", "softwareType": "apt", "version": "${PREV_VERSION}"}
     ...    {"name": "tedge-apt-plugin", "softwareType": "apt", "version": "${PREV_VERSION}"}
+
+    ${config_original}=    Execute Command    cmd=cat /etc/tedge/tedge.toml    strip=True
+
     # Install desired version
     Create Local Repository
     ${operation}=    Install Software
@@ -71,6 +74,10 @@ Update tedge version from previous using Cumulocity
     Should Be Equal    ${OUTPUT}    inactive    msg=Service should still be stopped
     ${OUTPUT}=    Execute Command    systemctl is-enabled tedge-mapper-az || exit 1    exp_exit_code=1    strip=True
     Should Be Equal    ${OUTPUT}    disabled    msg=Service should still be disabled
+
+    File Should Exist    /etc/tedge/tedge.toml.bak
+    ${config_backup}=    Execute Command    cmd=cat /etc/tedge/tedge.toml.bak    strip=True
+    Should Contain    ${config_backup}    [c8y]
 
     # Check that the mapper is reacting to operations after the upgrade
     # Notes:


### PR DESCRIPTION
## Proposed changes

Take `tedge.toml` backup during `tedge config upgrade` and notify the user about the existence of any stale backup in `tedge config get/set`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/4125

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

