### PR TITLE
fix: Don't write time if logging to journald

### DIFF
--- a/crates/common/tedge_config/src/system_toml/log_level.rs
+++ b/crates/common/tedge_config/src/system_toml/log_level.rs
@@ -5,6 +5,7 @@ use camino::Utf8Path;
 use std::io::IsTerminal;
 use std::str::FromStr;
 use std::sync::Arc;
+use tracing_subscriber::fmt::time::FormatTime;
 use tracing_subscriber::util::SubscriberInitExt;
 
 const DEFAULT_LEVEL: tracing::Level = tracing::Level::INFO;
@@ -69,6 +70,17 @@ fn logger(
     default_level: tracing::Level,
 ) -> Result<Arc<dyn tracing::Subscriber + Send + Sync>, SystemTomlError> {
     let subscriber = subscriber_builder!();
+
+    // Added by systemd if the process is running as systemd unit
+    // https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#%24INVOCATION_ID
+    let is_running_as_systemd_unit = std::env::var("INVOCATION_ID").is_ok();
+
+    // disable time formatting if journald because journald already records the time
+    let subscriber = if is_running_as_systemd_unit {
+        subscriber.with_timer(TimeFormat::Disabled)
+    } else {
+        subscriber.with_timer(TimeFormat::Enabled)
+    };
 
     // first use log level from flags
     let log_level = flags
@@ -139,6 +151,20 @@ pub fn set_log_level(log_level: tracing::Level) {
             .init();
     } else {
         subscriber.with_max_level(log_level).init();
+    }
+}
+
+enum TimeFormat {
+    Enabled,
+    Disabled,
+}
+
+impl FormatTime for TimeFormat {
+    fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> std::fmt::Result {
+        match self {
+            Self::Enabled => tracing_subscriber::fmt::time::UtcTime::rfc_3339().format_time(w),
+            Self::Disabled => ().format_time(w),
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed changes

Journald already records the timestamp of each log and allows the user to easily customise the format using journalctl's `--output` flag, and to filter the logs using `--since/--until`. So only format time if not logging to journald.

Before:

<img width="1544" height="290" alt="Screenshot From 2026-04-30 10-00-58" src="https://github.com/user-attachments/assets/49a05943-71d9-48c1-87d8-62383b5e6069" />

After:

<img width="1347" height="443" alt="Screenshot From 2026-04-30 10-11-30" src="https://github.com/user-attachments/assets/16eac53c-ccf4-4aa2-836c-c4eab7d8de51" />

In this PR, while we use `tracing-journald` to detect if we're logging to journald and change our formatting based on that, we aren't yet fully using its functionality to send structured logs containing log levels and fields, because the default formatting of the journald's `MESSAGE` field (i.e. the log message shown by `journalctl` after the timestamp and identifier) does not format attached fields and the target to be present in the message.

Given an event like this:

```rust
info!(field = 42, "event happened");
```

our current logging to `stderr` gives us this:

```
Apr 30 08:27:10 32df1eef46c8 tedge-mapper[399038]:   INFO tedge_config::system_toml::log_level: event happened field=42
```

Logging with journald gives us this:
```
Apr 30 08:30:26 32df1eef46c8 tedge-mapper[406816]: **event happened**
```

Though field are accessible when selecting a more verbose output level:

```
{
        "_HOSTNAME" : "32df1eef46c8",
        "_SYSTEMD_INVOCATION_ID" : "192c32fe9c8f4fdf9dd20a9667569419",
        "_CMDLINE" : "/workspace/target/debug/tedge-mapper c8y",
        ...
        "CODE_FILE" : "crates/common/tedge_config/src/system_toml/log.rs",
        "__MONOTONIC_TIMESTAMP" : "196768238204",
        "MESSAGE" : "event happened",
        "CODE_LINE" : "66",
        "F_FIELD" : "42",
        "_PID" : "406816",
        "SYSLOG_IDENTIFIER" : "tedge-mapper",
        "_GID" : "995",
}
```

Given that this is a change from the current behaviour where in some cases we assume that the field should appear next to the message where it's relevant, which could be surprising to the users, we will still log to stderr and only switch once we can put embed relevant fields into the message.

There are some proposed solutions (https://github.com/tokio-rs/tracing/pull/3474), but they haven't been merged yet. 

Still, one nice thing about logging to journald is that information relevant to debugging, like `CODE_FILE` and `CODE_LINE` are attached to the logs by default and can be shown with `--output json-pretty/verbose` and at the same time they don't have to shown to users by default. With these and other fields it can make our debugging easier while not making logs too noisy for the users. 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

