### PR TITLE
fix: hot reloading of flows over symlinks

### DIFF
--- a/crates/core/tedge/src/cli/flows/cli.rs
+++ b/crates/core/tedge/src/cli/flows/cli.rs
@@ -212,10 +212,7 @@ impl TEdgeFlowsCli {
         flows_dir: &Utf8PathBuf,
         js_config: JsRuntimeConfig,
     ) -> Result<MessageProcessor<BaseFlowRegistry>, Error> {
-        let flows_dir = flows_dir
-            .canonicalize_utf8()
-            .context("Invalid flows-dir path")?;
-        let mut processor = Self::init_processor(config, mapper_dir, &flows_dir, js_config)
+        let mut processor = Self::init_processor(config, mapper_dir, flows_dir, js_config)
             .await
             .with_context(|| format!("loading flows and steps from {flows_dir}"))?;
         processor.load_all_flows().await;
@@ -233,16 +230,14 @@ impl TEdgeFlowsCli {
             .await
             .with_context(|| format!("loading flow {path}"))?;
 
-        let resolved_path = if path.is_absolute() {
-            path.clone()
-        } else if tokio::fs::try_exists(path).await.unwrap_or(false) {
-            // Exists relative to current working directory
-            path.canonicalize_utf8().unwrap_or(path.clone())
-        } else {
-            // Try to find the file under flows_dir using glob
-            Self::find_in_flows_dir(flows_dir, path).await?
+        let path = match tokio::fs::try_exists(path).await {
+            Ok(true) => path.clone(),
+            _ => {
+                // Try to find the file under flows_dir using glob
+                Self::find_in_flows_dir(flows_dir, path).await?
+            }
         };
-
+        let resolved_path = path.canonicalize_utf8().unwrap_or(path.clone());
         match resolved_path.extension() {
             Some("toml") => processor.load_single_flow(&resolved_path).await,
             _ => processor.load_single_script(&resolved_path).await,

--- a/crates/core/tedge_mapper/src/lib.rs
+++ b/crates/core/tedge_mapper/src/lib.rs
@@ -304,7 +304,7 @@ pub async fn test_cli_flow_registry(
     let mut flows = match mapper_config {
         None => BaseFlowRegistry::new(HashMap::new(), flows_dir),
         Some(effective_mapper_config) => BaseFlowRegistry::new(effective_mapper_config, flows_dir),
-    };
+    }?;
     load_builtin_transformers(&mut flows);
     Ok(flows)
 }
@@ -326,7 +326,7 @@ async fn flow_registry(
         Some(effective_mapper_config) => {
             ConnectedFlowRegistry::new(effective_mapper_config, flows_dir)
         }
-    };
+    }?;
 
     load_builtin_transformers(&mut flows);
     Ok(flows)

--- a/crates/extensions/aws_mapper_ext/src/lib.rs
+++ b/crates/extensions/aws_mapper_ext/src/lib.rs
@@ -759,7 +759,7 @@ mod tests {
         let flows_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
         let flows_path = Utf8Path::from_path(flows_dir.path()).unwrap();
         let mapper_config = HashMap::new();
-        let mut flows = ConnectedFlowRegistry::new(mapper_config, flows_path);
+        let mut flows = ConnectedFlowRegistry::new(mapper_config, flows_path).unwrap();
         load_builtin_transformers(&mut flows);
         converter.persist_builtin_flow(&mut flows).await.unwrap();
 

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -1972,7 +1972,7 @@ async fn mapper_converts_custom_operation_for_main_device() {
             r#"[exec]
             topic = "c8y/devicecontrol/notifications"
             on_fragment = "c8y_Command"
-            
+
             [exec.workflow]
             operation = "command"
             input = "${.payload.c8y_Command}"
@@ -2128,7 +2128,7 @@ async fn mapper_converts_custom_operation_for_main_device_without_workflow_input
             r#"[exec]
             topic = "c8y/devicecontrol/notifications"
             on_fragment = "c8y_Command"
-            
+
             [exec.workflow]
             operation = "command"
             "#,
@@ -2196,7 +2196,7 @@ async fn mapper_converts_custom_operation_for_main_device_with_invalid_workflow_
             r#"[exec]
             topic = "c8y/devicecontrol/notifications"
             on_fragment = "c8y_Command"
-            
+
             [exec.workflow]
             operation = "command"
             input = "invalid input"
@@ -3216,7 +3216,7 @@ pub(crate) async fn c8y_mapper_builder(
         .await
         .unwrap();
     let mapper_config = HashMap::new();
-    let mut flows = ConnectedFlowRegistry::new(mapper_config, flows_dir);
+    let mut flows = ConnectedFlowRegistry::new(mapper_config, flows_dir).unwrap();
     crate::load_builtin_transformers(&mut flows);
     c8y_mapper_builder
         .persist_builtin_flows(&mut flows)

--- a/crates/extensions/tedge_flows/src/config.rs
+++ b/crates/extensions/tedge_flows/src/config.rs
@@ -154,7 +154,6 @@ pub enum ConfigError {
 
 /// ```
 /// use tedge_flows::derive_flow_name;
-/// assert_eq!(derive_flow_name("/flows".into(), "/flows/flow.toml".into()), Some("flow".into()));
 /// assert_eq!(derive_flow_name("/flows".into(), "/flows/hello.toml".into()), Some("hello".into()));
 /// assert_eq!(derive_flow_name("/flows".into(), "/flows/hello/flow.toml".into()), Some("hello".into()));
 /// assert_eq!(derive_flow_name("/flows".into(), "/flows/hello/world.toml".into()), Some("hello/world".into()));
@@ -163,6 +162,10 @@ pub enum ConfigError {
 /// assert_eq!(derive_flow_name("/flows".into(), "/flows/hello/params.toml".into()), None);
 /// assert_eq!(derive_flow_name("/flows".into(), "/flows/hello/world.js".into()), None);
 /// assert_eq!(derive_flow_name("/flows".into(), "/unrelated/flows/hello.toml".into()), None);
+/// // Not recommended but working:
+/// assert_eq!(derive_flow_name("/flows".into(), "/flows/flow.toml".into()), Some("flow".into()));
+/// assert_eq!(derive_flow_name("/flows".into(), "/flows/params/flow.toml".into()), Some("params".into()));
+/// assert_eq!(derive_flow_name("/flows".into(), "/flows/flow/flow.toml".into()), Some("flow".into()));
 /// ```
 pub fn derive_flow_name(flows_dir: &Utf8Path, flow_path: &Utf8Path) -> Option<String> {
     let path = flow_path.strip_prefix(flows_dir).ok()?;

--- a/crates/extensions/tedge_flows/src/config.rs
+++ b/crates/extensions/tedge_flows/src/config.rs
@@ -123,8 +123,8 @@ pub enum IntervalConfig {
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConfigError {
-    #[error("Not a valid filename for a flow")]
-    IncorrectFlowFilename,
+    #[error("The flow name cannot be derived from its relative path to {dir}")]
+    FlowNameCannotBeDerived { dir: Utf8PathBuf, path: Utf8PathBuf },
 
     #[error("Not a valid MQTT topic: {0}")]
     IncorrectTopic(String),
@@ -317,7 +317,10 @@ impl FlowConfig {
         }
 
         let Some(name) = derive_flow_name(flows_dir, &source) else {
-            return Err(ConfigError::IncorrectFlowFilename);
+            return Err(ConfigError::FlowNameCannotBeDerived {
+                dir: flows_dir.to_owned(),
+                path: source.to_owned(),
+            });
         };
 
         detect_loop(&name, &input, &output, self.expect_loop)?;

--- a/crates/extensions/tedge_flows/src/connected_flow.rs
+++ b/crates/extensions/tedge_flows/src/connected_flow.rs
@@ -140,12 +140,15 @@ pub struct ConnectedFlowRegistry {
 }
 
 impl ConnectedFlowRegistry {
-    pub fn new(mapper_params: impl MapperParams, flows_dir: impl AsRef<Utf8Path>) -> Self {
-        ConnectedFlowRegistry {
-            flows: FlowStore::new(flows_dir),
+    pub fn new(
+        mapper_params: impl MapperParams,
+        flows_dir: impl AsRef<Utf8Path>,
+    ) -> Result<Self, std::io::Error> {
+        Ok(ConnectedFlowRegistry {
+            flows: FlowStore::new(flows_dir)?,
             builtins: BuiltinTransformers::default(),
             mapper_params: Box::new(mapper_params),
-        }
+        })
     }
 }
 

--- a/crates/extensions/tedge_flows/src/registry.rs
+++ b/crates/extensions/tedge_flows/src/registry.rs
@@ -41,12 +41,15 @@ pub struct BaseFlowRegistry {
 }
 
 impl BaseFlowRegistry {
-    pub fn new(mapper_params: impl MapperParams, flows_dir: impl AsRef<Utf8Path>) -> Self {
-        BaseFlowRegistry {
-            flows: FlowStore::new(flows_dir),
+    pub fn new(
+        mapper_params: impl MapperParams,
+        flows_dir: impl AsRef<Utf8Path>,
+    ) -> Result<Self, std::io::Error> {
+        Ok(BaseFlowRegistry {
+            flows: FlowStore::new(flows_dir)?,
             builtins: BuiltinTransformers::default(),
             mapper_params: Box::new(mapper_params),
-        }
+        })
     }
 }
 
@@ -334,6 +337,9 @@ impl<T: FlowRegistry + Send> FlowRegistryExt for T {
 #[derive(thiserror::Error, Debug)]
 pub enum UpdateFlowRegistryError {
     #[error(transparent)]
+    IoError(#[from] std::io::Error),
+
+    #[error(transparent)]
     FileError(#[from] file::FileError),
 
     #[error(transparent)]
@@ -350,12 +356,13 @@ pub struct FlowStore<F> {
 }
 
 impl<F> FlowStore<F> {
-    pub fn new(config_dir: impl AsRef<Utf8Path>) -> Self {
-        FlowStore {
-            config_dir: config_dir.as_ref().to_owned(),
+    pub fn new(config_dir: impl AsRef<Utf8Path>) -> Result<Self, std::io::Error> {
+        let config_dir = config_dir.as_ref().to_owned().canonicalize_utf8()?;
+        Ok(FlowStore {
+            config_dir,
             flows: HashMap::new(),
             unloaded_flows: HashSet::new(),
-        }
+        })
     }
 
     pub fn config_dir(&self) -> &Utf8Path {

--- a/crates/extensions/tedge_flows/tests/interval.rs
+++ b/crates/extensions/tedge_flows/tests/interval.rs
@@ -649,7 +649,8 @@ type ActorHandle = tokio::task::JoinHandle<Result<(), tedge_actors::RuntimeError
 
 async fn spawn_flows_actor(config_dir: &TempDir, mqtt: &mut MockMqtt) -> ActorHandle {
     let mapper_config = HashMap::new();
-    let flows = ConnectedFlowRegistry::new(mapper_config, config_dir.path().to_str().unwrap());
+    let flows =
+        ConnectedFlowRegistry::new(mapper_config, config_dir.path().to_str().unwrap()).unwrap();
     let mut flows_builder = FlowsMapperBuilder::try_new(flows, FlowsMapperConfig::default())
         .await
         .expect("Failed to create FlowsMapper");

--- a/crates/extensions/tedge_flows/tests/stats_dump.rs
+++ b/crates/extensions/tedge_flows/tests/stats_dump.rs
@@ -230,7 +230,8 @@ async fn stats_not_dumped_before_300_seconds() {
 
 async fn flows_builder(config_dir: &Path) -> FlowsMapperBuilder {
     let mapper_config = HashMap::new();
-    let flows = ConnectedFlowRegistry::new(mapper_config, Utf8Path::from_path(config_dir).unwrap());
+    let flows = ConnectedFlowRegistry::new(mapper_config, Utf8Path::from_path(config_dir).unwrap())
+        .unwrap();
     let config = FlowsMapperConfig::default();
     FlowsMapperBuilder::try_new(flows, config)
         .await

--- a/docs/src/extend/flows.md
+++ b/docs/src/extend/flows.md
@@ -587,6 +587,9 @@ A few practical points to keep in mind when building packages:
 
 - **Include version metadata.** Adding a version string and description to `flow.toml` makes it easy to identify which release is deployed on a device.
 - **Keep flows self-contained.** A flow can reference files from a sibling flow using relative paths such as `../other-flow/main.js`, but there is no dependency manager to enforce this — you are responsible for ensuring both flows are installed together. Self-contained packages are simpler to reason about and easier to update independently.
+- **Naming conventions** The name of a flow is derived from its file path. To keep names short, the path prefix corresponding to the mapper flows directory is removed as well as the `.toml` extension. For the typical case of `flow.toml`, the uninformative `flow` suffix is also removed.
+  - For instance, the name derived for the flow `/etc/tedge/mappers/c8y/flows/high-temp-alert/flow.toml` is simply `high-temp-alert`.
+  - This implies some restrictions. A flow must be defined by a `.toml` file under the mapper flow directory and cannot be named `params.toml`.
 
 ### Uploading to the Cumulocity software repository
 

--- a/tests/RobotFramework/tests/configuration/mapper_config_connect.robot
+++ b/tests/RobotFramework/tests/configuration/mapper_config_connect.robot
@@ -31,7 +31,11 @@ Connect Output Shows Legacy Config Path Before Migration
     Setup Test Config    c8y    test.c8y.io
 
     # Run connect in test mode
-    ${output}=    Execute Command    tedge connect c8y --test    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
+    ${output}=    Execute Command
+    ...    tedge connect c8y --test
+    ...    stderr=${True}
+    ...    stdout=${False}
+    ...    ignore_exit_code=${True}
 
     # Verify: Shows tedge.toml as config source
     Should Contain    ${output}    mapper configuration file
@@ -44,7 +48,11 @@ Connect Output Shows Migrated Config Path After Migration
     Migrate Cloud Configs
 
     # Run connect in test mode
-    ${output}=    Execute Command    tedge connect c8y --test    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
+    ${output}=    Execute Command
+    ...    tedge connect c8y --test
+    ...    stderr=${True}
+    ...    stdout=${False}
+    ...    ignore_exit_code=${True}
 
     # Verify: Shows mapper config file as source
     Should Contain    ${output}    mapper configuration file
@@ -75,7 +83,11 @@ Connect Test Mode Works With Migrated Config
     Migrate Cloud Configs
 
     # Run connect in test mode - should succeed even with fake URL
-    ${output}=    Execute Command    tedge connect c8y --test    stderr=${True}    stdout=${False}    ignore_exit_code=${True}
+    ${output}=    Execute Command
+    ...    tedge connect c8y --test
+    ...    stderr=${True}
+    ...    stdout=${False}
+    ...    ignore_exit_code=${True}
 
     # Verify: Test mode completes and shows config
     Should Contain    ${output}    mapper configuration file

--- a/tests/RobotFramework/tests/tedge_flows/flows_hot_reloading.robot
+++ b/tests/RobotFramework/tests/tedge_flows/flows_hot_reloading.robot
@@ -31,6 +31,42 @@ Flow is reloaded after being touched many times
     ...    message_contains=42
     ...    date_from=${start}
 
+Flows are reloaded when the flow directory is a symlink
+    Stop Service    tedge-mapper-local
+    Execute Command    mkdir -p /data/tedge
+    Execute Command    mv /etc/tedge/mappers /data/tedge/mappers
+    Execute Command    ln -s /data/tedge/mappers /etc/tedge/mappers
+    ThinEdgeIO.Transfer To Device
+    ...    ${CURDIR}/greeting-flows/hello.js
+    ...    /data/tedge/mappers/local/flows/greeting-flows/hello.js
+    ThinEdgeIO.Transfer To Device
+    ...    ${CURDIR}/greeting-flows/hello.toml
+    ...    /data/tedge/mappers/local/flows/greeting-flows/hello.toml
+
+    ${start}    Get Unix Timestamp
+    Start Service    tedge-mapper-local
+    ${status}    Should Have MQTT Messages
+    ...    topic=te/device/main/service/tedge-mapper-local/status/flows
+    ...    date_from=${start}
+    ...    message_contains=greeting-flows/hello.toml
+    Should Contain    ${status}[0]    "enabled"
+
+    ${start}    Get Unix Timestamp
+    Execute Command    touch /data/tedge/mappers/local/flows/greeting-flows/hello.toml
+    ${status}    Should Have MQTT Messages
+    ...    topic=te/device/main/service/tedge-mapper-local/status/flows
+    ...    date_from=${start}
+    ...    message_contains=greeting-flows/hello.toml
+    Should Contain    ${status}[0]    "updated"
+
+    ${start}    Get Unix Timestamp
+    Execute Command    tedge mqtt pub hello/in hi
+    Should Have MQTT Messages
+    ...    topic=hello/out
+    ...    minimum=1
+    ...    date_from=${start}
+    ...    message_contains=Hello World!
+
 
 *** Keywords ***
 Custom Setup

--- a/tests/RobotFramework/tests/tedge_flows/tedge_flows.robot
+++ b/tests/RobotFramework/tests/tedge_flows/tedge_flows.robot
@@ -21,13 +21,17 @@ Normalizes flows-dir path
     ${out1}    Execute Command    cmd=cd ${flows_dir} && tedge flows test --flows-dir . "" "" 2>&1    exp_exit_code=0
     ${out2}    Execute Command    cmd=cd ${child_dir} && tedge flows test --flows-dir ../ "" "" 2>&1    exp_exit_code=0
     ${out3}    Execute Command    cmd=tedge flows test --flows-dir ${symlink} "" "" 2>&1    exp_exit_code=0
+    ${out4}    Execute Command
+    ...    cmd=tedge flows test --flows-dir ${symlink} "" "" --flow ${flows_dir}/events.js 2>&1
+    ...    exp_exit_code=0
 
     # test shouldn't fail due to invalid path (path containing .)
     # TODO: should we return an error exit code if any flow in test failed to compile? Currently we return 0.
-    VAR    ${fail_due_to_invalid_path}    Failed to compile flow on-startup.toml: Not a valid filename for a flow
+    VAR    ${fail_due_to_invalid_path}    The flow name cannot be derived
     Should Not Contain    ${out1}    ${fail_due_to_invalid_path}
     Should Not Contain    ${out2}    ${fail_due_to_invalid_path}
     Should Not Contain    ${out3}    ${fail_due_to_invalid_path}
+    Should Not Contain    ${out4}    ${fail_due_to_invalid_path}
 
     Execute Command    rm -r ${child_dir} ${symlink}
 


### PR DESCRIPTION
## Proposed changes

When the flow directory passed to a mapper is a symlink (e.g. `/etc/tedge/mapper` -> `/data/tedge/mapper`), then flows can no more be added or updated while the mapper is running. Errors are reported telling the flow filename is "not a valid filename for a flow", which is more puzzling than helpful.

The root cause of the issue is that the name of a flow is derived from its file path, checking first that this file sits in the mapper flows directory. However this check was done without properly canonicalizing first the flow and directory paths.

- [x] Improve the error message when a flow name cannot be derived from its file path.
- [x] Reproduce the error - combining symlinks and dynamic flow reloading
- [x] Reproduce a similar error - combining symlinks and invoking `tedge flows test` on a specific `--flow`
- [x] Ensure that a flow registry root path is canonicalized. 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- https://community.cumulocity.com/t/error-not-a-valid-filename-for-a-flow-deploying-tedge-flow/14538

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

