### PR TITLE
fix: Use unique client id for `tedge mqtt` commands

### DIFF
--- a/crates/core/tedge/src/cli/mqtt/publish.rs
+++ b/crates/core/tedge/src/cli/mqtt/publish.rs
@@ -49,16 +49,20 @@ impl Command for MqttPublishCommand {
     }
 }
 
-async fn publish(cmd: &MqttPublishCommand) -> Result<(), anyhow::Error> {
+fn build_config(cmd: &MqttPublishCommand) -> Result<mqtt_channel::Config, anyhow::Error> {
     let mut config = mqtt_channel::Config::default()
         .with_host(cmd.host.clone())
         .with_port(cmd.port)
-        .with_session_name(cmd.client_id.clone())
+        .with_session_prefix(cmd.client_id.clone())
         .with_clean_session(true)
         .with_max_packet_size(MAX_PACKET_SIZE)
         .with_queue_capacity(DEFAULT_QUEUE_CAPACITY);
-
     config.with_client_auth(cmd.auth_config.clone().try_into()?)?;
+    Ok(config)
+}
+
+async fn publish(cmd: &MqttPublishCommand) -> Result<(), anyhow::Error> {
+    let config = build_config(cmd)?;
 
     let mut mqtt = mqtt_channel::Connection::new(&config).await?;
     let mut signals = tedge_utils::signals::TermSignals::new(None);
@@ -84,4 +88,44 @@ async fn publish(cmd: &MqttPublishCommand) -> Result<(), anyhow::Error> {
     mqtt.close().await;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mqtt_channel::Topic;
+    use tedge_config::TEdgeMqttClientAuthConfig;
+
+    #[test]
+    fn two_publishers_with_same_client_id_use_different_session_names() {
+        // In containerised environments, multiple hosts can share the same PID,
+        // meaning cli.rs may provide the same client_id to concurrent publishers.
+        let client_id = "tedge-pub-1";
+        let cmd1 = pub_command_with_client_id(client_id);
+        let cmd2 = pub_command_with_client_id(client_id);
+
+        let session1 = build_config(&cmd1).unwrap().session_name;
+        let session2 = build_config(&cmd2).unwrap().session_name;
+
+        assert_ne!(
+            session1, session2,
+            "Concurrent publishers with the same client_id must get unique MQTT session names"
+        );
+    }
+
+    fn pub_command_with_client_id(client_id: &str) -> MqttPublishCommand {
+        MqttPublishCommand {
+            host: "localhost".into(),
+            port: 1883,
+            topic: Topic::new("test/topic").unwrap(),
+            message: "hello".into(),
+            qos: mqtt_channel::QoS::AtMostOnce,
+            client_id: client_id.to_string(),
+            retain: false,
+            base64: false,
+            auth_config: TEdgeMqttClientAuthConfig::default(),
+            count: 1,
+            sleep: std::time::Duration::ZERO,
+        }
+    }
 }

--- a/crates/core/tedge/src/cli/mqtt/subscribe.rs
+++ b/crates/core/tedge/src/cli/mqtt/subscribe.rs
@@ -45,19 +45,22 @@ impl Command for MqttSubscribeCommand {
     }
 }
 
-async fn subscribe(cmd: &MqttSubscribeCommand) -> Result<(), anyhow::Error> {
+fn build_config(cmd: &MqttSubscribeCommand) -> Result<mqtt_channel::Config, anyhow::Error> {
     let topic = TopicFilter::new(cmd.topic.pattern())?.with_qos(cmd.qos);
-
     let mut config = mqtt_channel::Config::default()
         .with_host(cmd.host.clone())
         .with_port(cmd.port)
-        .with_session_name(cmd.client_id.clone())
+        .with_session_prefix(cmd.client_id.clone())
         .with_clean_session(true)
         .with_subscriptions(topic)
         .with_max_packet_size(MAX_PACKET_SIZE)
         .with_queue_capacity(DEFAULT_QUEUE_CAPACITY);
-
     config.with_client_auth(cmd.auth_config.clone().try_into()?)?;
+    Ok(config)
+}
+
+async fn subscribe(cmd: &MqttSubscribeCommand) -> Result<(), anyhow::Error> {
+    let config = build_config(cmd)?;
 
     let mut mqtt = mqtt_channel::Connection::new(&config).await?;
     let mut signals = tedge_utils::signals::TermSignals::new(cmd.duration);
@@ -120,5 +123,44 @@ impl SimpleTopicFilter {
 
     pub fn pattern(&self) -> &str {
         self.0.as_str()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tedge_config::TEdgeMqttClientAuthConfig;
+
+    #[test]
+    fn two_subscribers_with_same_client_id_use_different_session_names() {
+        // In containerised environments, multiple hosts can share the same PID,
+        // meaning cli.rs may provide the same client_id to concurrent subscribers.
+        let client_id = "tedge-sub-1";
+        let cmd1 = sub_command_with_client_id(client_id);
+        let cmd2 = sub_command_with_client_id(client_id);
+
+        let session1 = build_config(&cmd1).unwrap().session_name;
+        let session2 = build_config(&cmd2).unwrap().session_name;
+
+        assert_ne!(
+            session1, session2,
+            "Concurrent subscribers with the same client_id must get unique MQTT session names"
+        );
+    }
+
+    fn sub_command_with_client_id(client_id: &str) -> MqttSubscribeCommand {
+        MqttSubscribeCommand {
+            host: "localhost".into(),
+            port: 1883,
+            topic: SimpleTopicFilter::new("test/#").unwrap(),
+            qos: QoS::AtMostOnce,
+            hide_topic: false,
+            base64: false,
+            client_id: client_id.to_string(),
+            auth_config: TEdgeMqttClientAuthConfig::default(),
+            duration: None,
+            count: None,
+            retained_only: false,
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

Switch `tedge mqtt` commands to use session_prefix rather than session_name in `mqtt_channel`, so the MQTT client IDs are truly random, ensuring multiple processes don't conflict. This was previously an issue since `tedge mqtt` only used process IDs to make the client IDs unique, and across a network (especially in a containerised context), PIDs are not unique.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #4163 

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

