### PR TITLE
fix: Automatically compact `entity_store.jsonl` after a large number of repeat topics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5172,6 +5172,7 @@ dependencies = [
  "clock",
  "csv",
  "download",
+ "indexmap",
  "json-writer",
  "log",
  "maplit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ hyper-rustls = { version = "0.27.5", default-features = false, features = [
     "http2",
 ] }
 hyper-util = { version = "0.1" }
+indexmap = "2.11"
 itertools = "0.14"
 log = "0.4"
 maplit = "1.0"

--- a/crates/core/tedge_api/Cargo.toml
+++ b/crates/core/tedge_api/Cargo.toml
@@ -13,6 +13,7 @@ camino = { workspace = true, features = ["serde1"] }
 clock = { workspace = true }
 csv = { workspace = true }
 download = { workspace = true }
+indexmap = { workspace = true }
 json-writer = { workspace = true }
 log = { workspace = true }
 mqtt_channel = { workspace = true }

--- a/crates/core/tedge_api/src/entity_store.rs
+++ b/crates/core/tedge_api/src/entity_store.rs
@@ -16,8 +16,7 @@ use crate::mqtt_topics::default_topic_schema;
 use crate::mqtt_topics::Channel;
 use crate::mqtt_topics::EntityTopicId;
 use crate::mqtt_topics::MqttSchema;
-use crate::store::message_log::MessageLogReader;
-use crate::store::message_log::MessageLogWriter;
+use crate::store::message_log::MessageLog;
 use crate::store::pending_entity_store::PendingEntityStore;
 use crate::store::pending_entity_store::RegisteredEntityData;
 use log::debug;
@@ -78,7 +77,7 @@ pub struct EntityStore {
     entities: EntityTree,
     pending_entity_store: PendingEntityStore,
     // The persistent message log to persist entity registrations and twin data messages
-    message_log: MessageLogWriter,
+    message_log: MessageLog,
 }
 
 impl EntityStore {
@@ -109,13 +108,13 @@ impl EntityStore {
         };
 
         let message_log = if clean_start {
-            MessageLogWriter::new_truncated(log_dir.as_ref()).map_err(|err| {
+            MessageLog::new_truncated(log_dir.as_ref()).map_err(|err| {
                 InitError::Custom(format!(
                     "Loading the entity store log for writes failed with {err}",
                 ))
             })?
         } else {
-            MessageLogWriter::new(log_dir.as_ref()).map_err(|err| {
+            MessageLog::new(log_dir.as_ref()).map_err(|err| {
                 InitError::Custom(format!(
                     "Loading the entity store log for writes failed with {err}",
                 ))
@@ -130,100 +129,63 @@ impl EntityStore {
             message_log,
         };
 
-        entity_store.load_from_message_log(log_dir.as_ref());
+        entity_store.load_from_message_log();
 
         Ok(entity_store)
     }
 
-    pub fn load_from_message_log<P>(&mut self, log_dir: P)
-    where
-        P: AsRef<Path>,
-    {
+    pub fn load_from_message_log(&mut self) {
         info!("Loading the entity store from the log");
-        match MessageLogReader::new(log_dir) {
-            Err(err) => {
-                error!(
-                    "Failed to read the entity store log due to {err}. Ignoring and proceeding..."
-                )
-            }
-            Ok(mut message_log_reader) => {
-                loop {
-                    match message_log_reader.next_message() {
-                        Err(err) => {
-                            error!("Parsing log entry failed with {err}");
-                            continue;
-                        }
-                        Ok(None) => {
-                            info!("Finished loading the entity store from the log");
-                            return;
-                        }
-                        Ok(Some(message)) => {
-                            if let Ok((source, channel)) =
-                                self.mqtt_schema.entity_channel_of(&message.topic)
-                            {
-                                match channel {
-                                    Channel::EntityMetadata => {
-                                        if let Ok(register_message) =
-                                            EntityRegistrationMessage::try_from(
-                                                source.clone(),
-                                                message.payload_bytes(),
-                                            )
-                                        {
-                                            if let Err(err) = self.register_entity(register_message)
-                                            {
-                                                error!("Failed to re-register {source} from the persistent entity store due to {err}");
-                                                continue;
-                                            }
-                                        }
-                                    }
-                                    Channel::EntityTwinData { fragment_key } => {
-                                        let fragment_value = if message.payload_bytes().is_empty() {
-                                            JsonValue::Null
-                                        } else {
-                                            match serde_json::from_slice::<JsonValue>(
-                                                message.payload_bytes(),
-                                            ) {
-                                                Ok(json_value) => json_value,
-                                                Err(err) => {
-                                                    error!("Failed to parse twin fragment value of {fragment_key} of {source} from the persistent entity store due to {err}");
-                                                    continue;
-                                                }
-                                            }
-                                        };
-
-                                        let twin_data = EntityTwinMessage::new(
-                                            source.clone(),
-                                            fragment_key,
-                                            fragment_value,
-                                        );
-                                        if let Err(err) =
-                                            self.register_twin_fragment(twin_data.clone())
-                                        {
-                                            error!("Failed to restore twin fragment: {twin_data:?} from the persistent entity store due to {err}");
-                                            continue;
-                                        }
-                                    }
-                                    Channel::CommandMetadata { .. } => {
-                                        // Do nothing for now as supported operations are not part of the entity store
-                                    }
-                                    channel => {
-                                        warn!(
-                                            "Restoring messages on channel: {:?} not supported",
-                                            channel
-                                        )
-                                    }
-                                }
-                            } else {
-                                warn!(
-                                    "Ignoring unsupported message retrieved from entity store: {:?}",
-                                    message
-                                );
+        let messages: Vec<_> = self.message_log.messages().collect();
+        for message in messages {
+            if let Ok((source, channel)) = self.mqtt_schema.entity_channel_of(&message.topic) {
+                match channel {
+                    Channel::EntityMetadata => {
+                        if let Ok(register_message) = EntityRegistrationMessage::try_from(
+                            source.clone(),
+                            message.payload_bytes(),
+                        ) {
+                            if let Err(err) = self.register_entity(register_message) {
+                                error!("Failed to re-register {source} from the persistent entity store due to {err}");
+                                continue;
                             }
                         }
                     }
+                    Channel::EntityTwinData { fragment_key } => {
+                        let fragment_value = if message.payload_bytes().is_empty() {
+                            JsonValue::Null
+                        } else {
+                            match serde_json::from_slice::<JsonValue>(message.payload_bytes()) {
+                                Ok(json_value) => json_value,
+                                Err(err) => {
+                                    error!("Failed to parse twin fragment value of {fragment_key} of {source} from the persistent entity store due to {err}");
+                                    continue;
+                                }
+                            }
+                        };
+
+                        let twin_data =
+                            EntityTwinMessage::new(source.clone(), fragment_key, fragment_value);
+                        if let Err(err) = self.register_twin_fragment(twin_data.clone()) {
+                            error!("Failed to restore twin fragment: {twin_data:?} from the persistent entity store due to {err}");
+                            continue;
+                        }
+                    }
+                    Channel::CommandMetadata { .. } => {
+                        // Do nothing for now as supported operations are not part of the entity store
+                    }
+                    channel => {
+                        warn!("Restoring messages on channel: {:?} not supported", channel)
+                    }
                 }
+            } else {
+                warn!(
+                    "Ignoring unsupported message retrieved from entity store: {:?}",
+                    message
+                );
             }
         }
+        info!("Finished loading the entity store from the log");
     }
 
     /// Iterates over the entity topic ids

--- a/crates/core/tedge_api/src/store/message_log.rs
+++ b/crates/core/tedge_api/src/store/message_log.rs
@@ -1,8 +1,10 @@
 //! The message log is a persistent append-only log of MQTT messages.
 //! Each line is the JSON representation of that MQTT message.
 //! The underlying file is a JSON lines file.
+use indexmap::IndexMap;
 use mqtt_channel::MqttMessage;
 use serde_json::json;
+use std::collections::HashSet;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::BufRead;
@@ -10,9 +12,12 @@ use std::io::BufReader;
 use std::io::BufWriter;
 use std::io::Write;
 use std::path::Path;
+use std::path::PathBuf;
 
 const LOG_FILE_NAME: &str = "entity_store.jsonl";
+const LOG_FILE_TEMP_NAME: &str = "entity_store.jsonl.tmp";
 const LOG_FORMAT_VERSION: &str = "1.0";
+const DEFAULT_REDUNDANCY_THRESHOLD: usize = 100;
 
 #[derive(thiserror::Error, Debug)]
 pub enum LogEntryError {
@@ -65,6 +70,10 @@ impl MessageLogReader {
 /// A writer to append new MQTT messages to the end of the log
 pub(crate) struct MessageLogWriter {
     writer: BufWriter<File>,
+    log_dir: PathBuf,
+    redundancy_threshold: usize,
+    unique_topics: HashSet<String>,
+    total_entries: usize,
 }
 
 impl MessageLogWriter {
@@ -72,36 +81,76 @@ impl MessageLogWriter {
     where
         P: AsRef<Path>,
     {
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(log_dir.as_ref().join(LOG_FILE_NAME))?;
-
-        // If the file is empty append the version information as a header
-        let metadata = file.metadata()?;
-        let file_is_empty = metadata.len() == 0;
-
-        let mut writer = BufWriter::new(file);
-
-        if file_is_empty {
-            let version_info = json!({ "version": LOG_FORMAT_VERSION }).to_string();
-            writeln!(writer, "{}", version_info)?;
-        }
-
-        Ok(MessageLogWriter { writer })
+        Self::open(log_dir, DEFAULT_REDUNDANCY_THRESHOLD, false)
     }
 
     pub fn new_truncated<P>(log_dir: P) -> Result<MessageLogWriter, std::io::Error>
     where
         P: AsRef<Path>,
     {
-        let _ = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(log_dir.as_ref().join(LOG_FILE_NAME))?;
+        Self::open(log_dir, DEFAULT_REDUNDANCY_THRESHOLD, true)
+    }
 
-        MessageLogWriter::new(log_dir)
+    #[cfg(test)]
+    pub fn new_with_redundancy_threshold<P>(
+        log_dir: P,
+        redundancy_threshold: usize,
+    ) -> Result<MessageLogWriter, std::io::Error>
+    where
+        P: AsRef<Path>,
+    {
+        Self::open(log_dir, redundancy_threshold, false)
+    }
+
+    fn open<P>(
+        log_dir: P,
+        redundancy_threshold: usize,
+        truncate: bool,
+    ) -> Result<MessageLogWriter, std::io::Error>
+    where
+        P: AsRef<Path>,
+    {
+        let log_dir = log_dir.as_ref();
+        let log_path = log_dir.join(LOG_FILE_NAME);
+
+        // Read the existing file to build the topic index for accurate redundancy tracking.
+        let mut unique_topics = HashSet::new();
+        let mut total_entries = 0;
+
+        let file = if !truncate {
+            if let Ok(mut reader) = MessageLogReader::new(log_dir) {
+                while let Some(msg) = reader.next_message().map_err(std::io::Error::other)? {
+                    unique_topics.insert(msg.topic.name.clone());
+                    total_entries += 1;
+                }
+            }
+
+            OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&log_path)?
+        } else {
+            OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&log_path)?
+        };
+
+        let metadata = file.metadata()?;
+        let mut writer = BufWriter::new(file);
+
+        if metadata.len() == 0 {
+            writeln!(writer, "{}", json!({ "version": LOG_FORMAT_VERSION }))?;
+        }
+
+        Ok(MessageLogWriter {
+            writer,
+            log_dir: log_dir.to_path_buf(),
+            redundancy_threshold,
+            unique_topics,
+            total_entries,
+        })
     }
 
     /// Append the JSON representation of the given message to the log.
@@ -111,6 +160,61 @@ impl MessageLogWriter {
         writeln!(self.writer, "{}", json_line)?;
         self.writer.flush()?;
         self.writer.get_ref().sync_all()?;
+
+        let is_new_topic = self.unique_topics.insert(message.topic.name.clone());
+        self.total_entries += 1;
+
+        if !is_new_topic {
+            let redundant_count = self.total_entries - self.unique_topics.len();
+            if redundant_count >= self.redundancy_threshold {
+                self.compact()?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn compact(&mut self) -> Result<(), std::io::Error> {
+        let mut compacted_messages = IndexMap::new();
+        let mut reader = MessageLogReader::new(&self.log_dir)?;
+        while let Some(msg) = reader.next_message().map_err(std::io::Error::other)? {
+            let topic = msg.topic.name.clone();
+            if msg.payload_bytes().is_empty() {
+                compacted_messages.shift_remove(&topic);
+            } else {
+                compacted_messages.insert(topic, msg);
+            }
+        }
+        drop(reader);
+
+        // Write to a temp file so that any failure leaves the original log intact.
+        let temp_path = self.log_dir.join(LOG_FILE_TEMP_NAME);
+        {
+            let temp_file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&temp_path)?;
+            let mut temp_writer = BufWriter::new(temp_file);
+
+            writeln!(temp_writer, "{}", json!({ "version": LOG_FORMAT_VERSION }))?;
+            for msg in compacted_messages.values() {
+                writeln!(temp_writer, "{}", serde_json::to_string(msg)?)?;
+            }
+            temp_writer.flush()?;
+            temp_writer.get_ref().sync_all()?;
+        } // temp_file closed before rename
+
+        // Atomically replace the log with the compacted version.
+        std::fs::rename(&temp_path, self.log_dir.join(LOG_FILE_NAME))?;
+
+        let file = OpenOptions::new()
+            .append(true)
+            .open(self.log_dir.join(LOG_FILE_NAME))?;
+        self.writer = BufWriter::new(file);
+        self.unique_topics = compacted_messages.keys().cloned().collect();
+        self.total_entries = compacted_messages.len();
+
         Ok(())
     }
 }
@@ -156,7 +260,9 @@ mod tests {
         let temp_dir = tempdir().unwrap();
 
         let mut writer = MessageLogWriter::new(&temp_dir).unwrap();
-        writer.append_message(&make_message("topic", "payload")).unwrap();
+        writer
+            .append_message(&make_message("topic", "payload"))
+            .unwrap();
 
         let mut reader = MessageLogReader::new(&temp_dir).unwrap();
         reader.next_message().unwrap();
@@ -177,6 +283,258 @@ mod tests {
         MessageLogWriter::new_truncated(&temp_dir).unwrap();
 
         let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        assert_eq!(reader.next_message().unwrap(), None);
+    }
+
+    #[test]
+    fn truncated_log_starts_with_empty_topic_index() {
+        let temp_dir = tempdir().unwrap();
+
+        let mut writer = MessageLogWriter::new(&temp_dir).unwrap();
+        writer
+            .append_message(&make_message("topic", "payload"))
+            .unwrap();
+
+        let writer = MessageLogWriter::new_truncated(&temp_dir).unwrap();
+
+        assert_eq!(writer.unique_topics.len(), 0);
+        assert_eq!(writer.total_entries, 0);
+    }
+
+    #[test]
+    fn compaction_keeps_parent_before_child_in_first_surviving_topic_order() {
+        let temp_dir = tempdir().unwrap();
+
+        // threshold=1: compact as soon as there is 1 redundant entry
+        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        writer
+            .append_message(&make_message(
+                "te/device/child0//",
+                r#"{"@type":"child-device"}"#,
+            ))
+            .unwrap(); // redundant=0
+        writer
+            .append_message(&make_message(
+                "te/device/child01//",
+                r#"{"@type":"child-device","@parent":"device/child0"}"#,
+            ))
+            .unwrap(); // redundant=0
+        writer
+            .append_message(&make_message(
+                "te/device/child0//",
+                r#"{"@type":"child-device","name":"Child 0"}"#,
+            ))
+            .unwrap(); // redundant=1 → compact
+
+        // After compaction: latest value per topic, keeping parent before child for replay.
+        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message(
+                "te/device/child0//",
+                r#"{"@type":"child-device","name":"Child 0"}"#
+            ))
+        );
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message(
+                "te/device/child01//",
+                r#"{"@type":"child-device","@parent":"device/child0"}"#
+            ))
+        );
+        assert_eq!(reader.next_message().unwrap(), None);
+    }
+
+    #[test]
+    fn compaction_removes_topics_where_latest_message_is_empty() {
+        let temp_dir = tempdir().unwrap();
+
+        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        writer
+            .append_message(&make_message("topic1", "v1"))
+            .unwrap();
+        writer
+            .append_message(&make_message("topic2", "v2"))
+            .unwrap();
+        writer.append_message(&make_message("topic1", "")).unwrap();
+
+        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message("topic2", "v2"))
+        );
+        assert_eq!(reader.next_message().unwrap(), None);
+    }
+
+    #[test]
+    fn compaction_does_not_preserve_position_after_empty_payload() {
+        let temp_dir = tempdir().unwrap();
+
+        // threshold=1: compact as soon as there is 1 redundant entry
+        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        writer
+            .append_message(&make_message(
+                "te/device/child_a//",
+                r#"{"@type":"child-device"}"#,
+            ))
+            .unwrap(); // redundant=0
+        writer
+            .append_message(&make_message(
+                "te/device/child_b//",
+                r#"{"@type":"child-device"}"#,
+            ))
+            .unwrap(); // redundant=0
+        writer
+            .append_message(&make_message("te/device/child_a//", ""))
+            .unwrap(); // redundant=1 → compact; child_a removed from log
+
+        // child_a is no longer in unique_topics after compaction, so this is treated as a new topic
+        writer
+            .append_message(&make_message(
+                "te/device/child_a//",
+                r#"{"@type":"child-device","name":"Child A"}"#,
+            ))
+            .unwrap();
+
+        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        // child_b retains its original position; child_a lost its position when it received an
+        // empty payload and was removed during compaction
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message(
+                "te/device/child_b//",
+                r#"{"@type":"child-device"}"#
+            ))
+        );
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message(
+                "te/device/child_a//",
+                r#"{"@type":"child-device","name":"Child A"}"#
+            ))
+        );
+        assert_eq!(reader.next_message().unwrap(), None);
+    }
+
+    #[test]
+    fn writing_to_new_topics_does_not_trigger_compaction() {
+        let temp_dir = tempdir().unwrap();
+
+        // threshold=1, but all topics are unique — redundant count stays 0, no compaction
+        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        let messages: Vec<_> = (0..5)
+            .map(|i| make_message(&format!("topic{i}"), "v1"))
+            .collect();
+        for msg in &messages {
+            writer.append_message(msg).unwrap();
+        }
+
+        // All 5 messages should be present — no compaction triggered
+        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        for expected in &messages {
+            assert_eq!(reader.next_message().unwrap().as_ref(), Some(expected));
+        }
+        assert_eq!(reader.next_message().unwrap(), None);
+    }
+
+    #[test]
+    fn duplicates_below_the_threshold_are_not_compacted() {
+        let temp_dir = tempdir().unwrap();
+
+        // threshold=3: tolerates up to 2 redundant entries; compacts only at 3
+        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 3).unwrap();
+        writer
+            .append_message(&make_message("topic1", "v1"))
+            .unwrap(); // redundant=0
+        writer
+            .append_message(&make_message("topic1", "v2"))
+            .unwrap(); // redundant=1
+        writer
+            .append_message(&make_message("topic1", "v3"))
+            .unwrap(); // redundant=2, still below 3
+
+        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message("topic1", "v1"))
+        );
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message("topic1", "v2"))
+        );
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message("topic1", "v3"))
+        );
+        assert_eq!(reader.next_message().unwrap(), None);
+    }
+
+    #[test]
+    fn writer_can_continue_writing_after_compaction() {
+        let temp_dir = tempdir().unwrap();
+
+        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        writer
+            .append_message(&make_message("topic1", "v1"))
+            .unwrap();
+        writer
+            .append_message(&make_message("topic1", "v2"))
+            .unwrap(); // redundant=1 → compact
+
+        // Write more messages after compaction
+        writer
+            .append_message(&make_message("topic2", "v1"))
+            .unwrap();
+        writer
+            .append_message(&make_message("topic2", "v2"))
+            .unwrap(); // redundant=1 → compact again
+
+        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message("topic1", "v2"))
+        );
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message("topic2", "v2"))
+        );
+        assert_eq!(reader.next_message().unwrap(), None);
+    }
+
+    #[test]
+    fn new_writer_correctly_loads_compacted_state() {
+        let temp_dir = tempdir().unwrap();
+
+        // First writer: trigger compaction, then drop
+        {
+            let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+            writer
+                .append_message(&make_message("topic1", "v1"))
+                .unwrap();
+            writer
+                .append_message(&make_message("topic2", "v2"))
+                .unwrap();
+            writer
+                .append_message(&make_message("topic1", "v3"))
+                .unwrap(); // redundant=1 → compact
+        }
+
+        // Second writer: reads compacted state (2 unique topics, 0 redundant)
+        // One more duplicate should immediately trigger another compaction.
+        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        writer
+            .append_message(&make_message("topic2", "v4"))
+            .unwrap(); // redundant=1 → compact
+
+        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message("topic1", "v3"))
+        );
+        assert_eq!(
+            reader.next_message().unwrap(),
+            Some(make_message("topic2", "v4"))
+        );
         assert_eq!(reader.next_message().unwrap(), None);
     }
 

--- a/crates/core/tedge_api/src/store/message_log.rs
+++ b/crates/core/tedge_api/src/store/message_log.rs
@@ -2,9 +2,10 @@
 //! Each line is the JSON representation of that MQTT message.
 //! The underlying file is a JSON lines file.
 use indexmap::IndexMap;
+use log::warn;
 use mqtt_channel::MqttMessage;
+use mqtt_channel::Topic;
 use serde_json::json;
-use std::collections::HashSet;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::BufRead;
@@ -19,72 +20,29 @@ const LOG_FILE_TEMP_NAME: &str = "entity_store.jsonl.tmp";
 const LOG_FORMAT_VERSION: &str = "1.0";
 const DEFAULT_REDUNDANCY_THRESHOLD: usize = 100;
 
-#[derive(thiserror::Error, Debug)]
-pub enum LogEntryError {
-    #[error(transparent)]
-    FromStdIo(std::io::Error),
-
-    #[error("Deserialization failed with {0} while parsing {1}")]
-    FromSerdeJson(#[source] serde_json::Error, String),
-}
-
-/// A reader to read the log file entries line by line
-pub(crate) struct MessageLogReader {
-    reader: BufReader<File>,
-}
-
-impl MessageLogReader {
-    pub fn new<P>(log_dir: P) -> Result<MessageLogReader, std::io::Error>
-    where
-        P: AsRef<Path>,
-    {
-        let file = OpenOptions::new()
-            .read(true)
-            .open(log_dir.as_ref().join(LOG_FILE_NAME))?;
-        let mut reader = BufReader::new(file);
-
-        let mut version_info = String::new();
-        reader.read_line(&mut version_info)?;
-        // TODO: Validate if the read version is supported
-
-        Ok(MessageLogReader { reader })
-    }
-
-    /// Return the next MQTT message from the log
-    /// The reads start from the beginning of the file
-    /// and each read advances the file pointer to the next line
-    pub fn next_message(&mut self) -> Result<Option<MqttMessage>, LogEntryError> {
-        let mut buffer = String::new();
-        match self.reader.read_line(&mut buffer) {
-            Ok(bytes_read) if bytes_read > 0 => {
-                let message: MqttMessage = serde_json::from_str(&buffer)
-                    .map_err(|err| LogEntryError::FromSerdeJson(err, buffer))?;
-                Ok(Some(message))
-            }
-            Ok(_) => Ok(None), // EOF
-            Err(err) => Err(LogEntryError::FromStdIo(err)),
-        }
-    }
-}
-
-/// A writer to append new MQTT messages to the end of the log
-pub(crate) struct MessageLogWriter {
+/// A persistent append-only log of MQTT messages.
+///
+/// Tracks the latest payload per topic and compacts the on-disk file when
+/// redundant entries exceed a configured threshold.
+pub(crate) struct MessageLog {
     writer: BufWriter<File>,
     log_dir: PathBuf,
     redundancy_threshold: usize,
-    unique_topics: HashSet<String>,
+    // Latest payload per topic; topics removed by empty-payload writes are absent
+    messages: IndexMap<String, String>,
+    // Number of entries on disk; subtracting messages.len() gives the redundant entry count
     total_entries: usize,
 }
 
-impl MessageLogWriter {
-    pub fn new<P>(log_dir: P) -> Result<MessageLogWriter, std::io::Error>
+impl MessageLog {
+    pub fn new<P>(log_dir: P) -> Result<MessageLog, std::io::Error>
     where
         P: AsRef<Path>,
     {
         Self::open(log_dir, DEFAULT_REDUNDANCY_THRESHOLD, false)
     }
 
-    pub fn new_truncated<P>(log_dir: P) -> Result<MessageLogWriter, std::io::Error>
+    pub fn new_truncated<P>(log_dir: P) -> Result<MessageLog, std::io::Error>
     where
         P: AsRef<Path>,
     {
@@ -95,7 +53,7 @@ impl MessageLogWriter {
     pub fn new_with_redundancy_threshold<P>(
         log_dir: P,
         redundancy_threshold: usize,
-    ) -> Result<MessageLogWriter, std::io::Error>
+    ) -> Result<MessageLog, std::io::Error>
     where
         P: AsRef<Path>,
     {
@@ -106,22 +64,25 @@ impl MessageLogWriter {
         log_dir: P,
         redundancy_threshold: usize,
         truncate: bool,
-    ) -> Result<MessageLogWriter, std::io::Error>
+    ) -> Result<MessageLog, std::io::Error>
     where
         P: AsRef<Path>,
     {
         let log_dir = log_dir.as_ref();
         let log_path = log_dir.join(LOG_FILE_NAME);
 
-        // Read the existing file to build the topic index for accurate redundancy tracking.
-        let mut unique_topics = HashSet::new();
+        let mut messages = IndexMap::new();
         let mut total_entries = 0;
 
         let file = if !truncate {
-            if let Ok(mut reader) = MessageLogReader::new(log_dir) {
-                while let Some(msg) = reader.next_message().map_err(std::io::Error::other)? {
-                    unique_topics.insert(msg.topic.name.clone());
+            if let Ok(entries) = Self::read_file(log_dir) {
+                for (topic, payload) in entries {
                     total_entries += 1;
+                    if payload.is_empty() {
+                        messages.shift_remove(&topic);
+                    } else {
+                        messages.insert(topic, payload);
+                    }
                 }
             }
 
@@ -144,28 +105,73 @@ impl MessageLogWriter {
             writeln!(writer, "{}", json!({ "version": LOG_FORMAT_VERSION }))?;
         }
 
-        Ok(MessageLogWriter {
+        Ok(MessageLog {
             writer,
             log_dir: log_dir.to_path_buf(),
             redundancy_threshold,
-            unique_topics,
+            messages,
             total_entries,
         })
     }
 
-    /// Append the JSON representation of the given message to the log.
-    /// Each message is appended on a new line.
+    /// Reads raw (topic, payload) pairs from the log file on disk
+    fn read_file(log_dir: &Path) -> Result<Vec<(String, String)>, std::io::Error> {
+        let file = OpenOptions::new()
+            .read(true)
+            .open(log_dir.join(LOG_FILE_NAME))?;
+        let mut reader = BufReader::new(file);
+
+        // Skip the version line
+        let mut version_info = String::new();
+        reader.read_line(&mut version_info)?;
+
+        let mut entries = Vec::new();
+        let mut buffer = String::new();
+        loop {
+            buffer.clear();
+            match reader.read_line(&mut buffer) {
+                Ok(0) => break,
+                Ok(_) => match serde_json::from_str::<MqttMessage>(&buffer) {
+                    Ok(message) => {
+                        let topic = message.topic.name.clone();
+                        let payload = String::from_utf8_lossy(message.payload_bytes()).into_owned();
+                        entries.push((topic, payload));
+                    }
+                    Err(e) => warn!("Skipping corrupt entity store log entry: {e}"),
+                },
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(entries)
+    }
+
+    /// Iterates over the latest message per topic, in the order topics were first seen
+    pub fn messages(&self) -> impl Iterator<Item = MqttMessage> + '_ {
+        self.messages.iter().map(|(topic, payload)| {
+            MqttMessage::new(&Topic::new_unchecked(topic), payload.as_str())
+        })
+    }
+
+    /// Persists the message to the log
     pub fn append_message(&mut self, message: &MqttMessage) -> Result<(), std::io::Error> {
         let json_line = serde_json::to_string(message)?;
         writeln!(self.writer, "{}", json_line)?;
         self.writer.flush()?;
         self.writer.get_ref().sync_all()?;
 
-        let is_new_topic = self.unique_topics.insert(message.topic.name.clone());
+        let topic = message.topic.name.clone();
+        let payload = String::from_utf8_lossy(message.payload_bytes()).into_owned();
+
+        let is_new_topic = !self.messages.contains_key(&topic);
+        if payload.is_empty() {
+            self.messages.shift_remove(&topic);
+        } else {
+            self.messages.insert(topic, payload);
+        }
         self.total_entries += 1;
 
         if !is_new_topic {
-            let redundant_count = self.total_entries - self.unique_topics.len();
+            let redundant_count = self.total_entries - self.messages.len();
             if redundant_count >= self.redundancy_threshold {
                 self.compact()?;
             }
@@ -175,19 +181,7 @@ impl MessageLogWriter {
     }
 
     fn compact(&mut self) -> Result<(), std::io::Error> {
-        let mut compacted_messages = IndexMap::new();
-        let mut reader = MessageLogReader::new(&self.log_dir)?;
-        while let Some(msg) = reader.next_message().map_err(std::io::Error::other)? {
-            let topic = msg.topic.name.clone();
-            if msg.payload_bytes().is_empty() {
-                compacted_messages.shift_remove(&topic);
-            } else {
-                compacted_messages.insert(topic, msg);
-            }
-        }
-        drop(reader);
-
-        // Write to a temp file so that any failure leaves the original log intact.
+        // Write the in-memory compacted state to a temp file.
         let temp_path = self.log_dir.join(LOG_FILE_TEMP_NAME);
         {
             let temp_file = OpenOptions::new()
@@ -198,12 +192,13 @@ impl MessageLogWriter {
             let mut temp_writer = BufWriter::new(temp_file);
 
             writeln!(temp_writer, "{}", json!({ "version": LOG_FORMAT_VERSION }))?;
-            for msg in compacted_messages.values() {
-                writeln!(temp_writer, "{}", serde_json::to_string(msg)?)?;
+            for (topic, payload) in &self.messages {
+                let msg = MqttMessage::new(&Topic::new_unchecked(topic), payload.as_str());
+                writeln!(temp_writer, "{}", serde_json::to_string(&msg)?)?;
             }
             temp_writer.flush()?;
             temp_writer.get_ref().sync_all()?;
-        } // temp_file closed before rename
+        }
 
         // Atomically replace the log with the compacted version.
         std::fs::rename(&temp_path, self.log_dir.join(LOG_FILE_NAME))?;
@@ -212,8 +207,7 @@ impl MessageLogWriter {
             .append(true)
             .open(self.log_dir.join(LOG_FILE_NAME))?;
         self.writer = BufWriter::new(file);
-        self.unique_topics = compacted_messages.keys().cloned().collect();
-        self.total_entries = compacted_messages.len();
+        self.total_entries = self.messages.len();
 
         Ok(())
     }
@@ -221,18 +215,16 @@ impl MessageLogWriter {
 
 #[cfg(test)]
 mod tests {
-    use super::MessageLogReader;
-    use super::MessageLogWriter;
+    use super::MessageLog;
     use mqtt_channel::MqttMessage;
     use mqtt_channel::Topic;
+    use std::io::Write;
     use tempfile::tempdir;
 
     #[test]
     fn reading_from_empty_log_returns_none() {
-        let temp_dir = tempdir().unwrap();
-        MessageLogWriter::new(&temp_dir).unwrap();
-        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
-        assert_eq!(reader.next_message().unwrap(), None);
+        let log = MessageLog::new(tempdir().unwrap()).unwrap();
+        assert_eq!(log.messages().next(), None);
     }
 
     #[test]
@@ -244,61 +236,68 @@ mod tests {
             make_message("topic3", "payload3"),
         ];
 
-        let mut writer = MessageLogWriter::new(&temp_dir).unwrap();
+        let mut log = MessageLog::new(&temp_dir).unwrap();
         for message in &messages {
-            writer.append_message(message).unwrap();
+            log.append_message(message).unwrap();
         }
 
-        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
-        for expected in &messages {
-            assert_eq!(reader.next_message().unwrap().as_ref(), Some(expected));
-        }
-    }
-
-    #[test]
-    fn reading_past_the_last_message_returns_none() {
-        let temp_dir = tempdir().unwrap();
-
-        let mut writer = MessageLogWriter::new(&temp_dir).unwrap();
-        writer
-            .append_message(&make_message("topic", "payload"))
-            .unwrap();
-
-        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
-        reader.next_message().unwrap();
-        assert_eq!(reader.next_message().unwrap(), None);
+        let read_messages: Vec<_> = log.messages().collect();
+        assert_eq!(read_messages, messages);
     }
 
     #[test]
     fn truncated_log_discards_previously_written_messages() {
         let temp_dir = tempdir().unwrap();
 
-        let mut writer = MessageLogWriter::new(&temp_dir).unwrap();
+        let mut log = MessageLog::new(&temp_dir).unwrap();
         for i in 1..=3 {
-            writer
-                .append_message(&make_message(&format!("topic{i}"), &format!("payload{i}")))
+            log.append_message(&make_message(&format!("topic{i}"), &format!("payload{i}")))
                 .unwrap();
         }
 
-        MessageLogWriter::new_truncated(&temp_dir).unwrap();
-
-        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
-        assert_eq!(reader.next_message().unwrap(), None);
+        let log = MessageLog::new_truncated(&temp_dir).unwrap();
+        assert_eq!(log.messages().next(), None);
     }
 
     #[test]
-    fn truncated_log_starts_with_empty_topic_index() {
+    fn truncated_log_resets_redundancy_tracking() {
         let temp_dir = tempdir().unwrap();
 
-        let mut writer = MessageLogWriter::new(&temp_dir).unwrap();
-        writer
-            .append_message(&make_message("topic", "payload"))
+        let mut log = MessageLog::new(&temp_dir).unwrap();
+        log.append_message(&make_message("topic", "payload"))
             .unwrap();
 
-        let writer = MessageLogWriter::new_truncated(&temp_dir).unwrap();
+        // After truncation, redundancy tracking must start from zero: a single
+        // duplicate write at threshold=1 should immediately trigger compaction.
+        let mut log = MessageLog::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        log.append_message(&make_message("topic", "v1")).unwrap();
+        log.append_message(&make_message("topic", "v2")).unwrap(); // redundant=1 → compact
+        assert_eq!(
+            log.messages().collect::<Vec<_>>(),
+            vec![make_message("topic", "v2")]
+        );
+    }
 
-        assert_eq!(writer.unique_topics.len(), 0);
-        assert_eq!(writer.total_entries, 0);
+    #[test]
+    fn messages_are_persisted_across_log_instances() {
+        let temp_dir = tempdir().unwrap();
+
+        {
+            let mut log = MessageLog::new(&temp_dir).unwrap();
+            log.append_message(&make_message("topic1", "v1")).unwrap();
+            log.append_message(&make_message("topic2", "v2")).unwrap();
+            log.append_message(&make_message("topic3", "v3")).unwrap();
+        }
+
+        let log = MessageLog::new(&temp_dir).unwrap();
+        assert_eq!(
+            log.messages().collect::<Vec<_>>(),
+            vec![
+                make_message("topic1", "v1"),
+                make_message("topic2", "v2"),
+                make_message("topic3", "v3"),
+            ]
+        );
     }
 
     #[test]
@@ -306,64 +305,51 @@ mod tests {
         let temp_dir = tempdir().unwrap();
 
         // threshold=1: compact as soon as there is 1 redundant entry
-        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
-        writer
-            .append_message(&make_message(
-                "te/device/child0//",
-                r#"{"@type":"child-device"}"#,
-            ))
-            .unwrap(); // redundant=0
-        writer
-            .append_message(&make_message(
-                "te/device/child01//",
-                r#"{"@type":"child-device","@parent":"device/child0"}"#,
-            ))
-            .unwrap(); // redundant=0
-        writer
-            .append_message(&make_message(
-                "te/device/child0//",
-                r#"{"@type":"child-device","name":"Child 0"}"#,
-            ))
-            .unwrap(); // redundant=1 → compact
+        let mut log = MessageLog::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        log.append_message(&make_message(
+            "te/device/child0//",
+            r#"{"@type":"child-device"}"#,
+        ))
+        .unwrap();
+        log.append_message(&make_message(
+            "te/device/child01//",
+            r#"{"@type":"child-device","@parent":"device/child0"}"#,
+        ))
+        .unwrap();
+        log.append_message(&make_message(
+            "te/device/child0//",
+            r#"{"@type":"child-device","name":"Child 0"}"#,
+        ))
+        .unwrap(); // redundant=1 → compact
 
         // After compaction: latest value per topic, keeping parent before child for replay.
-        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        let read_messages: Vec<_> = log.messages().collect();
         assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message(
-                "te/device/child0//",
-                r#"{"@type":"child-device","name":"Child 0"}"#
-            ))
+            read_messages,
+            vec![
+                make_message(
+                    "te/device/child0//",
+                    r#"{"@type":"child-device","name":"Child 0"}"#
+                ),
+                make_message(
+                    "te/device/child01//",
+                    r#"{"@type":"child-device","@parent":"device/child0"}"#
+                ),
+            ]
         );
-        assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message(
-                "te/device/child01//",
-                r#"{"@type":"child-device","@parent":"device/child0"}"#
-            ))
-        );
-        assert_eq!(reader.next_message().unwrap(), None);
     }
 
     #[test]
     fn compaction_removes_topics_where_latest_message_is_empty() {
         let temp_dir = tempdir().unwrap();
 
-        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
-        writer
-            .append_message(&make_message("topic1", "v1"))
-            .unwrap();
-        writer
-            .append_message(&make_message("topic2", "v2"))
-            .unwrap();
-        writer.append_message(&make_message("topic1", "")).unwrap();
+        let mut log = MessageLog::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        log.append_message(&make_message("topic1", "v1")).unwrap();
+        log.append_message(&make_message("topic2", "v2")).unwrap();
+        log.append_message(&make_message("topic1", "")).unwrap();
 
-        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
-        assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message("topic2", "v2"))
-        );
-        assert_eq!(reader.next_message().unwrap(), None);
+        let read_messages: Vec<_> = log.messages().collect();
+        assert_eq!(read_messages, vec![make_message("topic2", "v2")]);
     }
 
     #[test]
@@ -371,49 +357,39 @@ mod tests {
         let temp_dir = tempdir().unwrap();
 
         // threshold=1: compact as soon as there is 1 redundant entry
-        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
-        writer
-            .append_message(&make_message(
-                "te/device/child_a//",
-                r#"{"@type":"child-device"}"#,
-            ))
-            .unwrap(); // redundant=0
-        writer
-            .append_message(&make_message(
-                "te/device/child_b//",
-                r#"{"@type":"child-device"}"#,
-            ))
-            .unwrap(); // redundant=0
-        writer
-            .append_message(&make_message("te/device/child_a//", ""))
-            .unwrap(); // redundant=1 → compact; child_a removed from log
+        let mut log = MessageLog::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        log.append_message(&make_message(
+            "te/device/child_a//",
+            r#"{"@type":"child-device"}"#,
+        ))
+        .unwrap();
+        log.append_message(&make_message(
+            "te/device/child_b//",
+            r#"{"@type":"child-device"}"#,
+        ))
+        .unwrap();
+        log.append_message(&make_message("te/device/child_a//", ""))
+            .unwrap(); // redundant=1 → compact; child_a removed
 
-        // child_a is no longer in unique_topics after compaction, so this is treated as a new topic
-        writer
-            .append_message(&make_message(
-                "te/device/child_a//",
-                r#"{"@type":"child-device","name":"Child A"}"#,
-            ))
-            .unwrap();
+        // child_a is no longer in messages after compaction, so this is treated as a new topic
+        log.append_message(&make_message(
+            "te/device/child_a//",
+            r#"{"@type":"child-device","name":"Child A"}"#,
+        ))
+        .unwrap();
 
-        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
-        // child_b retains its original position; child_a lost its position when it received an
-        // empty payload and was removed during compaction
+        // child_b retains its original position; child_a lost its position
+        let read_messages: Vec<_> = log.messages().collect();
         assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message(
-                "te/device/child_b//",
-                r#"{"@type":"child-device"}"#
-            ))
+            read_messages,
+            vec![
+                make_message("te/device/child_b//", r#"{"@type":"child-device"}"#),
+                make_message(
+                    "te/device/child_a//",
+                    r#"{"@type":"child-device","name":"Child A"}"#
+                ),
+            ]
         );
-        assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message(
-                "te/device/child_a//",
-                r#"{"@type":"child-device","name":"Child A"}"#
-            ))
-        );
-        assert_eq!(reader.next_message().unwrap(), None);
     }
 
     #[test]
@@ -421,20 +397,17 @@ mod tests {
         let temp_dir = tempdir().unwrap();
 
         // threshold=1, but all topics are unique — redundant count stays 0, no compaction
-        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        let mut log = MessageLog::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
         let messages: Vec<_> = (0..5)
             .map(|i| make_message(&format!("topic{i}"), "v1"))
             .collect();
         for msg in &messages {
-            writer.append_message(msg).unwrap();
+            log.append_message(msg).unwrap();
         }
 
         // All 5 messages should be present — no compaction triggered
-        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
-        for expected in &messages {
-            assert_eq!(reader.next_message().unwrap().as_ref(), Some(expected));
-        }
-        assert_eq!(reader.next_message().unwrap(), None);
+        let read_messages: Vec<_> = log.messages().collect();
+        assert_eq!(read_messages, messages);
     }
 
     #[test]
@@ -442,100 +415,90 @@ mod tests {
         let temp_dir = tempdir().unwrap();
 
         // threshold=3: tolerates up to 2 redundant entries; compacts only at 3
-        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 3).unwrap();
-        writer
-            .append_message(&make_message("topic1", "v1"))
-            .unwrap(); // redundant=0
-        writer
-            .append_message(&make_message("topic1", "v2"))
-            .unwrap(); // redundant=1
-        writer
-            .append_message(&make_message("topic1", "v3"))
-            .unwrap(); // redundant=2, still below 3
+        let mut log = MessageLog::new_with_redundancy_threshold(&temp_dir, 3).unwrap();
+        log.append_message(&make_message("topic1", "v1")).unwrap();
+        log.append_message(&make_message("topic1", "v2")).unwrap();
+        log.append_message(&make_message("topic1", "v3")).unwrap(); // redundant=2, still below 3
 
-        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
-        assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message("topic1", "v1"))
-        );
-        assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message("topic1", "v2"))
-        );
-        assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message("topic1", "v3"))
-        );
-        assert_eq!(reader.next_message().unwrap(), None);
+        // The in-memory state only keeps the latest, but total_entries tracks disk state
+        let read_messages: Vec<_> = log.messages().collect();
+        assert_eq!(read_messages, vec![make_message("topic1", "v3")]);
     }
 
     #[test]
     fn writer_can_continue_writing_after_compaction() {
         let temp_dir = tempdir().unwrap();
 
-        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
-        writer
-            .append_message(&make_message("topic1", "v1"))
-            .unwrap();
-        writer
-            .append_message(&make_message("topic1", "v2"))
-            .unwrap(); // redundant=1 → compact
+        let mut log = MessageLog::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        log.append_message(&make_message("topic1", "v1")).unwrap();
+        log.append_message(&make_message("topic1", "v2")).unwrap(); // redundant=1 → compact
 
         // Write more messages after compaction
-        writer
-            .append_message(&make_message("topic2", "v1"))
-            .unwrap();
-        writer
-            .append_message(&make_message("topic2", "v2"))
-            .unwrap(); // redundant=1 → compact again
+        log.append_message(&make_message("topic2", "v1")).unwrap();
+        log.append_message(&make_message("topic2", "v2")).unwrap(); // redundant=1 → compact again
 
-        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        let read_messages: Vec<_> = log.messages().collect();
         assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message("topic1", "v2"))
+            read_messages,
+            vec![make_message("topic1", "v2"), make_message("topic2", "v2"),]
         );
-        assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message("topic2", "v2"))
-        );
-        assert_eq!(reader.next_message().unwrap(), None);
     }
 
     #[test]
-    fn new_writer_correctly_loads_compacted_state() {
+    fn new_log_correctly_loads_compacted_state() {
         let temp_dir = tempdir().unwrap();
 
-        // First writer: trigger compaction, then drop
+        // First log: trigger compaction, then drop
         {
-            let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
-            writer
-                .append_message(&make_message("topic1", "v1"))
-                .unwrap();
-            writer
-                .append_message(&make_message("topic2", "v2"))
-                .unwrap();
-            writer
-                .append_message(&make_message("topic1", "v3"))
-                .unwrap(); // redundant=1 → compact
+            let mut log = MessageLog::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+            log.append_message(&make_message("topic1", "v1")).unwrap();
+            log.append_message(&make_message("topic2", "v2")).unwrap();
+            log.append_message(&make_message("topic1", "v3")).unwrap(); // redundant=1 → compact
         }
 
-        // Second writer: reads compacted state (2 unique topics, 0 redundant)
+        // Second log: reads compacted state (2 unique topics, 0 redundant)
         // One more duplicate should immediately trigger another compaction.
-        let mut writer = MessageLogWriter::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
-        writer
-            .append_message(&make_message("topic2", "v4"))
-            .unwrap(); // redundant=1 → compact
+        let mut log = MessageLog::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        log.append_message(&make_message("topic2", "v4")).unwrap(); // redundant=1 → compact
 
-        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        let read_messages: Vec<_> = log.messages().collect();
         assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message("topic1", "v3"))
+            read_messages,
+            vec![make_message("topic1", "v3"), make_message("topic2", "v4"),]
         );
+    }
+
+    #[test]
+    fn corrupt_log_line_is_skipped_and_valid_messages_are_preserved() {
+        let temp_dir = tempdir().unwrap();
+
+        {
+            let mut log = MessageLog::new(&temp_dir).unwrap();
+            log.append_message(&make_message("topic1", "v1")).unwrap();
+            log.append_message(&make_message("topic2", "v2")).unwrap();
+        }
+
+        // All non-corrupt lines should be read successfully.
+        {
+            let mut file = std::fs::OpenOptions::new()
+                .append(true)
+                .open(temp_dir.path().join("entity_store.jsonl"))
+                .unwrap();
+            writeln!(file, "this is not valid json").unwrap();
+            let msg3 = make_message("topic3", "v3");
+            writeln!(file, "{}", serde_json::to_string(&msg3).unwrap()).unwrap();
+        }
+
+        let log = MessageLog::new(&temp_dir).unwrap();
+        let messages: Vec<_> = log.messages().collect();
         assert_eq!(
-            reader.next_message().unwrap(),
-            Some(make_message("topic2", "v4"))
+            messages,
+            vec![
+                make_message("topic1", "v1"),
+                make_message("topic2", "v2"),
+                make_message("topic3", "v3"),
+            ]
         );
-        assert_eq!(reader.next_message().unwrap(), None);
     }
 
     fn make_message(topic: &str, payload: &str) -> MqttMessage {

--- a/crates/core/tedge_api/src/store/message_log.rs
+++ b/crates/core/tedge_api/src/store/message_log.rs
@@ -124,41 +124,63 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn test_append_and_retrieve() {
+    fn reading_from_empty_log_returns_none() {
+        let temp_dir = tempdir().unwrap();
+        MessageLogWriter::new(&temp_dir).unwrap();
+        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        assert_eq!(reader.next_message().unwrap(), None);
+    }
+
+    #[test]
+    fn messages_are_read_back_in_the_order_they_were_written() {
+        let temp_dir = tempdir().unwrap();
+        let messages = [
+            make_message("topic1", "payload1"),
+            make_message("topic2", "payload2"),
+            make_message("topic3", "payload3"),
+        ];
+
+        let mut writer = MessageLogWriter::new(&temp_dir).unwrap();
+        for message in &messages {
+            writer.append_message(message).unwrap();
+        }
+
+        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        for expected in &messages {
+            assert_eq!(reader.next_message().unwrap().as_ref(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn reading_past_the_last_message_returns_none() {
         let temp_dir = tempdir().unwrap();
 
-        // Prepare some dummy messages
-        let mut messages = vec![];
-        for i in 1..5 {
-            let message = MqttMessage::new(
-                &Topic::new(&format!("topic{i}")).unwrap(),
-                format!("payload{i}"),
-            );
-            messages.push(message);
+        let mut writer = MessageLogWriter::new(&temp_dir).unwrap();
+        writer.append_message(&make_message("topic", "payload")).unwrap();
+
+        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        reader.next_message().unwrap();
+        assert_eq!(reader.next_message().unwrap(), None);
+    }
+
+    #[test]
+    fn truncated_log_discards_previously_written_messages() {
+        let temp_dir = tempdir().unwrap();
+
+        let mut writer = MessageLogWriter::new(&temp_dir).unwrap();
+        for i in 1..=3 {
+            writer
+                .append_message(&make_message(&format!("topic{i}"), &format!("payload{i}")))
+                .unwrap();
         }
 
-        // Populate the log
-        {
-            let mut message_log = MessageLogWriter::new(&temp_dir).unwrap();
-            let mut message_log_reader = MessageLogReader::new(&temp_dir).unwrap();
+        MessageLogWriter::new_truncated(&temp_dir).unwrap();
 
-            assert_eq!(message_log_reader.next_message().unwrap(), None);
+        let mut reader = MessageLogReader::new(&temp_dir).unwrap();
+        assert_eq!(reader.next_message().unwrap(), None);
+    }
 
-            for message in messages.clone() {
-                message_log.append_message(&message).unwrap();
-            }
-        }
-
-        // Read from the log
-        {
-            // Reload the message log
-            let mut message_log_reader = MessageLogReader::new(&temp_dir).unwrap();
-
-            for message in messages {
-                assert_eq!(message_log_reader.next_message().unwrap(), Some(message));
-            }
-            // EOF -> None
-            assert_eq!(message_log_reader.next_message().unwrap(), None);
-        }
+    fn make_message(topic: &str, payload: &str) -> MqttMessage {
+        MqttMessage::new(&Topic::new(topic).unwrap(), payload)
     }
 }

--- a/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_compaction.robot
+++ b/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_compaction.robot
@@ -1,0 +1,74 @@
+*** Settings ***
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Suite Setup         Custom Setup
+Test Teardown       Get Logs    ${DEVICE_SN}
+
+Test Tags           theme:tedge_agent
+
+
+*** Variables ***
+${DEVICE_SN}        ${EMPTY}
+${ENTITY_STORE}     /etc/tedge/.agent/entity_store.jsonl
+
+
+*** Test Cases ***
+Entity store log is compacted when redundancy threshold is exceeded
+    [Documentation]    Writing to the same twin fragment 101 times produces 100 redundant log
+    ...    entries, which meets the compaction threshold. After compaction only one entry for
+    ...    that topic is present in the file rather than 101.
+    Write Twin Fragment Many Times    compaction_count    101
+    ${count}=    Execute Command    grep -c "compaction_count" ${ENTITY_STORE}    strip=${True}
+    # The compaction might trigger earlier than expected as services may have reregistered on startup,
+    # but the count should be well below the threshold of 100 redundant entries
+    Should Be True    ${count} < 10
+
+Latest twin value is preserved after compaction
+    [Documentation]    After compaction the twin fragment retains the most recently written
+    ...    value, not an older one.
+    Write Twin Fragment Many Times    compaction_value    101
+    ${value}=    Execute Command
+    ...    curl -s http://localhost:8000/te/v1/entities/device/main///twin/compaction_value    strip=${True}
+    Should Be Equal    ${value}    101
+
+Compacted entity store survives agent restart without data loss
+    [Documentation]    After compaction the agent can be restarted and reload the compacted log
+    ...    correctly. Twin data written before the restart remains accessible afterwards.
+    Execute Command    sudo tedge config set agent.entity_store.clean_start false
+    Write Twin Fragment Many Times    compaction_restart    101
+    Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
+    ${value}=    Execute Command
+    ...    curl -s http://localhost:8000/te/v1/entities/device/main///twin/compaction_restart    strip=${True}
+    Should Be Equal    ${value}    101
+    [Teardown]    Restart Test Teardown
+
+Writing to unique topics accumulates entries without triggering compaction
+    [Documentation]    Registering child devices — each a unique topic — should not trigger
+    ...    compaction. The log grows by exactly one entry per registration with no entries
+    ...    silently removed.
+    ${before}=    Execute Command    wc -l < ${ENTITY_STORE}    strip=${True}
+    FOR    ${i}    IN RANGE    1    11
+        Execute Command
+        ...    curl -sf -X POST http://localhost:8000/te/v1/entities -H 'Content-Type: application/json' -d '{"@topic-id": "device/unique_child_${i}//", "@type": "child-device"}'
+    END
+    ${after}=    Execute Command    wc -l < ${ENTITY_STORE}    strip=${True}
+    # Each registration adds one unique line; no redundancy means no compaction
+    Should Be Equal    ${${after} + 0}    ${${before} + 10}
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+
+Write Twin Fragment Many Times
+    [Arguments]    ${fragment}    ${count}
+    Execute Command
+    ...    for i in $(seq 1 ${count}); do tedge http put /te/v1/entities/device/main///twin/${fragment} "$i"; done
+
+Restart Test Teardown
+    Execute Command    sudo tedge config set agent.entity_store.clean_start true
+    Get Logs    ${DEVICE_SN}


### PR DESCRIPTION
## Proposed changes
Adds a compaction mechanism to the entity store file. This will trigger after we have written a significant number (currently 100) messages to topics that already exist in the file, preventing unbounded growth.

It also refactors the existing test for the readers/writers into well-defined unit tests.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #4172

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

