### PR TITLE
feat: remove deprecated `--init` option from tedge-agent

### DIFF
--- a/crates/core/tedge_agent/src/lib.rs
+++ b/crates/core/tedge_agent/src/lib.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 use agent::AgentConfig;
 use tedge_config::cli::CommonArgs;
 use tedge_config::log_init;
-use tracing::log::warn;
 
 mod agent;
 mod device_profile_manager;
@@ -36,10 +35,6 @@ version = clap::crate_version!(),
 about = clap::crate_description!()
 )]
 pub struct AgentOpt {
-    /// Start the agent with clean session off, subscribe to the topics, so that no messages are lost
-    #[clap(short, long)]
-    pub init: bool,
-
     #[command(flatten)]
     pub common: CommonArgs,
 
@@ -62,19 +57,13 @@ pub async fn run(
         &agent_opt.common.config_dir,
     )?;
 
-    let init = agent_opt.init;
-
     let agent = agent::Agent::try_new(
         "tedge-agent",
         AgentConfig::from_config_and_cliopts(tedge_config, agent_opt).await?,
     )?;
 
-    if init {
-        warn!("This --init option has been deprecated and will be removed in a future release");
-        return Ok(());
-    } else {
-        agent.start().await?;
-    }
+    agent.start().await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
## Proposed changes

`tedge-agent --init` is deprecated since 2023, ticket [#1764](https://github.com/thin-edge/thin-edge.io/issues/1764). I think it's good time to remove the option. 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

