### PR TITLE
fix: deduplicate agent sync messages so only most recent one is processed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1949,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
@@ -1983,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"

--- a/crates/core/tedge_actors/src/message_boxes.rs
+++ b/crates/core/tedge_actors/src/message_boxes.rs
@@ -92,6 +92,7 @@ use crate::Message;
 use crate::RuntimeRequest;
 use async_trait::async_trait;
 use futures::channel::mpsc;
+use futures::channel::mpsc::TryRecvError;
 use futures::StreamExt;
 use log::debug;
 use std::fmt::Debug;
@@ -396,5 +397,75 @@ impl<Input: Send> MessageReceiver<Input> for CombinedReceiver<Input> {
 
     async fn recv_signal(&mut self) -> Option<RuntimeRequest> {
         self.signal_receiver.next().await
+    }
+}
+
+pub trait MessageReceiverNoblock<T>: MessageReceiver<T> {
+    /// Tries to receive a message from the channel without blocking.
+    /// If the channel is empty, or empty and closed, this method returns an error.
+    fn recv_noblock(&mut self) -> Result<T, RecvNoblockError>;
+
+    /// Returns all the currently received messages in the message box.
+    ///
+    /// Returns `None` if input channel is closed or RuntimeRequest is recieved. Returns
+    /// `Some(messages)` if there is at least 1 message. If there are currently no messages, we
+    /// await until one is received.
+    ///
+    /// If there are many messages currently ready, it can be useful to collect them all for
+    /// inspection/filtering/deduplication/reordering instead of strictly processing them in order 1
+    /// at a time.
+    ///
+    /// https://matklad.github.io/2025/05/14/scalar-select-aniti-pattern
+    #[expect(async_fn_in_trait)]
+    async fn recv_many(&mut self) -> Option<Vec<T>> {
+        // don't return until we have at least 1 message
+        let message = self.recv().await?;
+        // instead of always allocating and returning a vec from this function we could consider
+        // taking one as an &mut argument
+        let mut messages = vec![message];
+        while let Ok(message) = self.recv_noblock() {
+            messages.push(message);
+        }
+        Some(messages)
+    }
+}
+
+pub enum RecvNoblockError {
+    Empty,
+    Closed,
+}
+
+impl From<TryRecvError> for RecvNoblockError {
+    fn from(value: TryRecvError) -> Self {
+        match value {
+            TryRecvError::Closed => Self::Closed,
+            TryRecvError::Empty => Self::Empty,
+        }
+    }
+}
+
+impl<T: Send> MessageReceiverNoblock<T> for CombinedReceiver<T> {
+    /// Tries to receive a message from the channel without blocking.
+    /// If the channel is empty, or empty and closed, this method returns an error.
+    fn recv_noblock(&mut self) -> Result<T, RecvNoblockError> {
+        self.input_receiver
+            .try_recv()
+            .map_err(RecvNoblockError::from)
+    }
+}
+
+impl<T: Send + Debug> MessageReceiverNoblock<T> for LoggingReceiver<T> {
+    fn recv_noblock(&mut self) -> Result<T, RecvNoblockError> {
+        self.receiver.recv_noblock()
+    }
+}
+
+impl<I, O> MessageReceiverNoblock<I> for SimpleMessageBox<I, O>
+where
+    I: Send + Debug + 'static,
+    O: Send + Debug + 'static,
+{
+    fn recv_noblock(&mut self) -> Result<I, RecvNoblockError> {
+        self.input_receiver.recv_noblock()
     }
 }

--- a/crates/core/tedge_agent/src/http_server/actor.rs
+++ b/crates/core/tedge_agent/src/http_server/actor.rs
@@ -281,7 +281,7 @@ mod tests {
 
     impl<C> Drop for TestFileTransferService<C> {
         fn drop(&mut self) {
-            if let Ok(Some(value)) = self.server_err.try_next() {
+            if let Ok(value) = self.server_err.try_recv() {
                 if std::thread::panicking() {
                     println!("Error running server: {value}")
                 } else {

--- a/crates/extensions/tedge_config_manager/src/actor.rs
+++ b/crates/extensions/tedge_config_manager/src/actor.rs
@@ -14,7 +14,7 @@ use tedge_actors::ChannelError;
 use tedge_actors::ClientMessageBox;
 use tedge_actors::LoggingReceiver;
 use tedge_actors::LoggingSender;
-use tedge_actors::MessageReceiver;
+use tedge_actors::MessageReceiverNoblock;
 use tedge_actors::RequestEnvelope;
 use tedge_actors::RuntimeError;
 use tedge_actors::Sender;
@@ -147,35 +147,44 @@ impl Actor for ConfigManagerActor {
 
     async fn run(mut self) -> Result<(), RuntimeError> {
         let mut worker = ConfigManagerWorker {
-            config: Arc::from(self.config),
-            output_sender: self.output_sender,
-            downloader: self.downloader,
-            uploader: self.uploader,
-            external_plugins: self.external_plugins,
+            config: Arc::from(self.config.clone()),
+            output_sender: self.output_sender.clone(),
+            downloader: self.downloader.clone(),
+            uploader: self.uploader.clone(),
+            external_plugins: self.external_plugins.clone(),
         };
 
         worker.reload_supported_config_types().await?;
 
-        while let Some(event) = self.input_receiver.recv().await {
-            let result = match event {
-                ConfigInput::ConfigOperation(request) => {
-                    let mut worker = worker.clone();
-                    tokio::spawn(async move { worker.process_operation_request(request).await });
-                    Ok(())
-                }
-                ConfigInput::FsWatchEvent(event) => worker.process_file_watch_events(event).await,
-                ConfigInput::CmdMetaSyncSignal(_) => worker.reload_supported_config_types().await,
-                ConfigInput::OperationStepRequestEnvelope(request) => {
-                    let mut worker = worker.clone();
-                    tokio::spawn(async move {
-                        worker.process_operation_step_request(request).await;
-                    });
-                    Ok(())
-                }
-            };
+        while let Some(mut events) = self.input_receiver.recv_many().await {
+            deduplicate_messages(&mut events);
+            for event in events {
+                let result = match event {
+                    ConfigInput::ConfigOperation(request) => {
+                        let mut worker = worker.clone();
+                        tokio::spawn(
+                            async move { worker.process_operation_request(request).await },
+                        );
+                        Ok(())
+                    }
+                    ConfigInput::FsWatchEvent(event) => {
+                        worker.process_file_watch_events(event).await
+                    }
+                    ConfigInput::CmdMetaSyncSignal(_) => {
+                        worker.reload_supported_config_types().await
+                    }
+                    ConfigInput::OperationStepRequestEnvelope(request) => {
+                        let mut worker = worker.clone();
+                        tokio::spawn(async move {
+                            worker.process_operation_step_request(request).await;
+                        });
+                        Ok(())
+                    }
+                };
 
-            if let Err(err) = result {
-                error!("Error processing event: {err:?}");
+                if let Err(err) = result {
+                    error!("Error processing event: {err:?}");
+                }
             }
         }
 
@@ -913,6 +922,16 @@ fn build_cloud_config_type(config_type: &str, plugin_name: &str) -> String {
     format!("{}::{}", config_type, plugin_name)
 }
 
+fn deduplicate_messages(messages: &mut Vec<ConfigInput>) {
+    // remove duplicate sync messages because processing them takes a long time and we really only
+    // want to process the most recent one(#4169); but preserve their order so state updated after sync
+    // message is not synced, as expected by the sender
+    messages.dedup_by(|a, b| {
+        matches!(a, ConfigInput::CmdMetaSyncSignal(_))
+            && matches!(b, ConfigInput::CmdMetaSyncSignal(_))
+    });
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ConfigOperation {
     Snapshot(Topic, ConfigSnapshotCmdPayload),
@@ -970,5 +989,37 @@ impl From<ConfigOperationData> for MqttMessage {
                     .with_qos(QoS::AtLeastOnce)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    #[test]
+    fn sync_messages_are_deduplicated() {
+        let mut messages = vec![
+            ConfigInput::CmdMetaSyncSignal(()),
+            ConfigInput::CmdMetaSyncSignal(()),
+            ConfigInput::CmdMetaSyncSignal(()),
+            ConfigInput::CmdMetaSyncSignal(()),
+            ConfigInput::CmdMetaSyncSignal(()),
+            ConfigInput::FsWatchEvent(FsWatchEvent::Modified(PathBuf::new())),
+            ConfigInput::CmdMetaSyncSignal(()),
+            ConfigInput::CmdMetaSyncSignal(()),
+            ConfigInput::CmdMetaSyncSignal(()),
+            ConfigInput::CmdMetaSyncSignal(()),
+        ];
+        deduplicate_messages(&mut messages);
+        assert!(matches!(
+            messages[..],
+            [
+                ConfigInput::CmdMetaSyncSignal(()),
+                ConfigInput::FsWatchEvent(FsWatchEvent::Modified(_)),
+                ConfigInput::CmdMetaSyncSignal(()),
+            ]
+        ))
     }
 }

--- a/crates/extensions/tedge_log_manager/src/actor.rs
+++ b/crates/extensions/tedge_log_manager/src/actor.rs
@@ -9,7 +9,7 @@ use tedge_actors::fan_in_message_type;
 use tedge_actors::Actor;
 use tedge_actors::ChannelError;
 use tedge_actors::DynSender;
-use tedge_actors::MessageReceiver;
+use tedge_actors::MessageReceiverNoblock;
 use tedge_actors::RuntimeError;
 use tedge_actors::Sender;
 use tedge_actors::SimpleMessageBox;
@@ -71,20 +71,22 @@ impl Actor for LogManagerActor {
 
     async fn run(mut self) -> Result<(), RuntimeError> {
         self.reload_supported_log_types().await?;
-
-        while let Some(event) = self.messages.recv().await {
-            match event {
-                LogInput::LogUploadCmd(request) => {
-                    self.process_logfile_request(request).await?;
-                }
-                LogInput::FsWatchEvent(event) => {
-                    self.process_file_watch_events(event).await?;
-                }
-                LogInput::LogUploadResult((topic, result)) => {
-                    self.process_uploaded_log(&topic, result).await?;
-                }
-                LogInput::CmdMetaSyncSignal(_) => {
-                    self.reload_supported_log_types().await?;
+        while let Some(mut messages) = self.messages.recv_many().await {
+            deduplicate_messages(&mut messages);
+            for event in messages {
+                match event {
+                    LogInput::LogUploadCmd(request) => {
+                        self.process_logfile_request(request).await?;
+                    }
+                    LogInput::FsWatchEvent(event) => {
+                        self.process_file_watch_events(event).await?;
+                    }
+                    LogInput::LogUploadResult((topic, result)) => {
+                        self.process_uploaded_log(&topic, result).await?;
+                    }
+                    LogInput::CmdMetaSyncSignal(_) => {
+                        self.reload_supported_log_types().await?;
+                    }
                 }
             }
         }
@@ -357,5 +359,46 @@ impl LogManagerActor {
 
     async fn publish_command_status(&mut self, request: LogUploadCmd) -> Result<(), ChannelError> {
         self.messages.send(LogOutput::LogUploadCmd(request)).await
+    }
+}
+
+fn deduplicate_messages(messages: &mut Vec<LogInput>) {
+    // remove duplicate sync messages because processing them takes a long time and we really only
+    // want to process the most recent one(#4169); but preserve their order so state updated after sync
+    // message is not synced, as expected by the sender
+    messages.dedup_by(|a, b| {
+        matches!(a, LogInput::CmdMetaSyncSignal(_)) && matches!(b, LogInput::CmdMetaSyncSignal(_))
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::PathBuf;
+
+    #[test]
+    fn sync_messages_are_deduplicated() {
+        let mut messages = vec![
+            LogInput::CmdMetaSyncSignal(()),
+            LogInput::CmdMetaSyncSignal(()),
+            LogInput::CmdMetaSyncSignal(()),
+            LogInput::CmdMetaSyncSignal(()),
+            LogInput::CmdMetaSyncSignal(()),
+            LogInput::FsWatchEvent(FsWatchEvent::Modified(PathBuf::new())),
+            LogInput::CmdMetaSyncSignal(()),
+            LogInput::CmdMetaSyncSignal(()),
+            LogInput::CmdMetaSyncSignal(()),
+            LogInput::CmdMetaSyncSignal(()),
+        ];
+        deduplicate_messages(&mut messages);
+        assert!(matches!(
+            messages[..],
+            [
+                LogInput::CmdMetaSyncSignal(()),
+                LogInput::FsWatchEvent(FsWatchEvent::Modified(_)),
+                LogInput::CmdMetaSyncSignal(()),
+            ]
+        ))
     }
 }

--- a/crates/extensions/tedge_mqtt_ext/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/lib.rs
@@ -752,6 +752,7 @@ mod unit_tests {
 
     use super::*;
     use async_trait::async_trait;
+    use futures::channel::mpsc::TryRecvError;
 
     macro_rules! subscription_request {
         (sub: $($sub:literal),*; unsub: $($unsub:literal),*; id: $id:literal $(;)?) => {
@@ -855,12 +856,15 @@ mod unit_tests {
             actor.next_message_for(1).await,
             MqttMessage::new(&Topic::new("b/c").unwrap(), "test message")
         );
-        assert!(actor
-            .sent_to_clients
-            .get_mut(&0)
-            .unwrap()
-            .try_next()
-            .is_err());
+        assert_eq!(
+            actor
+                .sent_to_clients
+                .get_mut(&0)
+                .unwrap()
+                .try_recv()
+                .unwrap_err(),
+            TryRecvError::Empty
+        );
 
         actor.close().await;
     }
@@ -944,12 +948,15 @@ mod unit_tests {
             actor.next_message_for(client_id_2).await,
             MqttMessage::new(&Topic::new("b/c").unwrap(), "test message")
         );
-        assert!(actor
-            .sent_to_clients
-            .get_mut(&client_id)
-            .unwrap()
-            .try_next()
-            .is_err());
+        assert_eq!(
+            actor
+                .sent_to_clients
+                .get_mut(&client_id)
+                .unwrap()
+                .try_recv()
+                .unwrap_err(),
+            TryRecvError::Empty
+        );
 
         actor.close().await;
     }

--- a/crates/extensions/tedge_mqtt_ext/src/tests.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/tests.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use futures::channel::mpsc::TryRecvError;
 use mqtt_channel::Topic;
 use std::future::Future;
 use std::time::Duration;
@@ -523,8 +524,9 @@ async fn retrieve_retain_does_not_forward_last_will() {
         tokio::time::timeout(Duration::from_secs(5), rx.next()).await,
         Ok(None)
     );
-    assert!(
-        last_will_topic.try_next().is_err(),
+    assert_eq!(
+        last_will_topic.try_recv().unwrap_err(),
+        TryRecvError::Empty,
         "Last will should not be published by retrieve retain"
     );
 }


### PR DESCRIPTION
## Proposed changes

As part of #4169, where part of the problem is that sync messages are getting queued up because they're processed much slower than they are arriving, ~~rate limit sync messages to only process 1 sync message of each type every 10s.~~ deduplicate sync messages so we don't waste time processing stale messages.

I haven't made a test for that since it would be annoying to do as it relies somewhat on the environment and its performance characteristics and is very bandwidth heavy if CPU is not limited, so I've been testing it manually.
The scenario before the fix is applied looks as follows:

1. Run a single thin-edge instance in a docker container (can be the project's default devcontainer)
2. Limit CPU time for the container using `docker update --cpus=".05" CONTAINER_ID` (tweak as necessary to make it as slow as you want, you could also perhaps use systemd's CPU quotas to only slow down `tedge-agent` and `tedge-mapper-c8y` and not the entire container, but I haven't tried that)
3. Run a publish loop: `while true; do tedge mqtt pub te/device/main/service/tedge-agent/signal/sync_log_upload {}; sleep 0.5; done`
4. Then invoke a shell command from c8y (`tedge-command-plugin` must be installed)
5. The command stays in `PENDING` for a long time, potentially indefinitely, if it progresses to `EXECUTING` then it stays there indefinitely
6. When running `tedge mqtt sub "#"` one can see that sync messages are sent much faster than `tedge-agent` can respond to them
7. After stopping the publish loop, `tedge-agent` continues to respond to queued messages

With the fix, because we're immediately discarding additional sync messages ~~if one has already been sent in the last 10s~~, sent commands complete promptly and once publish loop is stopped, `tedge-agent` does not continue replying (because sync messages we didn't have bandwidth to process were dropped). We can do it because `sync...` messages do not have any payload and are used only to trigger the agent to possibly run some other commands, save their output, and sync this with the cloud.
In other words, `sync...` is a type of request that only the most recent one has to be handled and previous ones can be safely dropped, but so far we're processing them like regular messages that contain payloads and have to be processed individually.

~~This fix is thus a simple mechanism to reduce the number of sync messages that are processed. It's main disadvantage is that if there is some update that changes the state we're syncing but the sync message falls within the rate limit it will not be processed, i.e. the most recent sync message will not be processed. Potential alternatives that address this are discussed in _Further comments_.~~ See https://github.com/thin-edge/thin-edge.io/pull/4180#issuecomment-4510407130.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

The current mechanism only slightly changes `process_signal_message` to implement rate limiting, however, it has the disadvantage that the most recent sync message is not processed if it falls within the rate limit window, but we'd like to always process the most recent one and just reduce the amount of duplicate syncs we have to process.
Addressing that though would have to involve some changes to the actor's main processing loop. From the least to most complete:

### Instead of discarding, delay the message until after rate limit interval and deduplicate

Actor's even loop could be changed as follows:

```rust
        while let Some(input) = self.input_receiver.recv().await {
            match input {
                AgentInput::MqttMessage(message) => {
                    self.process_mqtt_message(message).await?;
                }
                AgentInput::InternalCommandState(InternalCommandState(command_state)) => {
                    self.process_command_update(command_state).await?;
                }
                AgentInput::GenericCommandData(GenericCommandData::State(new_state)) => {
                    self.process_builtin_command_update(new_state).await?;
                }
                AgentInput::GenericCommandData(GenericCommandData::Metadata(
                    GenericCommandMetadata { operation, payload },
                )) => {
                    self.publish_builtin_capability(operation, payload).await?;
                }
                AgentInput::FsWatchEvent(file_update) => {
                    if let Some(updated_capability) = self
                        .workflow_repository
                        .update_operation_workflows(
                            &self.mqtt_schema,
                            &self.device_topic_id,
                            file_update,
                        )
                        .await
                    {
                        self.mqtt_publisher.send(updated_capability).await?
                    }
                }
            }
           self.process_pending_sync_messages().await?; // NEW
        }
```

The in the main sync processing function we could deduplicate and schedule sync message to be run some interval after last processed message and `process_pending_messages` process only after that interval. However there would still have to be some message that triggers it and without any new messages the most recent sync will not be published.

### Instead of rate limiting peek the next message in the receiver and deduplicate if it's the same type of sync message

Instead of rate limiting try to consume and deduplicate as much sync messages of the same type to process most recent one. In main event loop we would peek one additional message and if we could deduplicate it with the current one, we would consume it and potentially repeat until we can't deduplicate. We could still fall behind if sync messages are interleaved with some other messages or are shuffled sync messages of different types. Also our current receiver doesn't provide a `peek()` method that doesn't immediately take the message off the receiver.

### Instead of processing one message at a time, fetch all current messages into a list and then decide what to do with them.

Inspired by https://matklad.github.io/2025/05/14/scalar-select-aniti-pattern.html

If instead of processing 1 message at a time we could consume all messages that are ready we could more effectively deduplicate them. For sync messages especially, interleaved messages of different types could be reordered and deduplicated. However the receiver would have to provide a method to get many messages that are currently ready without awaiting the next one once the current channel is ready, or provide a way to query for the current number of messages in the channel so we can receive set number of messages. 