### PR TITLE
feat: Enable flows to take multiple input sources

### DIFF
--- a/crates/extensions/tedge_flows/src/actor.rs
+++ b/crates/extensions/tedge_flows/src/actor.rs
@@ -1,3 +1,4 @@
+use crate::connected_flow::watch_request_topic;
 use crate::connected_flow::ConnectedFlowRegistry;
 use crate::flow::FlowError;
 use crate::flow::FlowOutput;
@@ -46,7 +47,7 @@ pub struct FlowsMapper {
     mqtt_sender: DynSender<MqttMessage>,
     watch_request_sender: DynSender<WatchRequest>,
     subscriptions: TopicFilter,
-    watched_commands: HashSet<Utf8PathBuf>,
+    watched_commands: HashSet<String>,
     processor: MessageProcessor<ConnectedFlowRegistry>,
     next_dump: Instant,
     deferred_tick: bool,
@@ -153,25 +154,29 @@ impl FlowsMapper {
         let mut watch_requests = Vec::new();
         let mut new_watched_commands = HashSet::new();
         for flow in self.processor.registry.flows() {
-            let flow_path = flow.source_path();
-            let Some(request) = flow.watch_request() else {
-                continue;
-            };
-            if !self.watched_commands.contains(flow_path) {
-                info!(target: "flows", "Adding input: {}", flow.as_ref().input);
-                watch_requests.push(request);
+            for request in flow.watch_requests() {
+                let watch_topic = watch_request_topic(&request).to_string();
+                if !self.watched_commands.contains(&watch_topic) {
+                    info!(target: "flows", "Adding input: {}", flow.as_ref().input_description());
+                    watch_requests.push(request);
+                }
+                self.watched_commands.remove(&watch_topic);
+                new_watched_commands.insert(watch_topic);
             }
-            self.watched_commands.remove(flow_path);
-            new_watched_commands.insert(flow_path.to_owned());
         }
         for old_command in self.watched_commands.drain() {
             info!(target: "flows", "Removing input: {}", old_command);
-            watch_requests.push(WatchRequest::UnWatch {
-                topic: old_command.to_string(),
-            });
+            watch_requests.push(WatchRequest::UnWatch { topic: old_command });
         }
         self.watched_commands = new_watched_commands;
         watch_requests
+    }
+
+    fn flow_watch_request(&self, flow_path: &Utf8Path, watch_topic: &str) -> Option<WatchRequest> {
+        self.processor
+            .registry
+            .flow(flow_path)
+            .and_then(|flow| flow.watch_request(watch_topic))
     }
 
     async fn notify_flows_status(&mut self) -> Result<(), RuntimeError> {
@@ -311,19 +316,23 @@ impl FlowsMapper {
     async fn on_input_event(&mut self, event: WatchEvent) -> Result<(), RuntimeError> {
         match event {
             WatchEvent::StdoutLine { topic, line } => {
-                self.on_input_message(Utf8Path::new(&topic), line).await?;
+                let flow_path = flow_path_from_watch_topic(&topic);
+                self.on_input_message(&topic, Utf8Path::new(flow_path), line)
+                    .await?;
             }
             WatchEvent::StderrLine { topic, line } => {
                 warn!(target: "flows", "Input command {topic}: {line}");
             }
             WatchEvent::Error { topic, error } => {
                 error!(target: "flows", "Cannot monitor command: {error}");
-                self.on_input_error(Utf8Path::new(&topic), error.into())
+                let flow_path = flow_path_from_watch_topic(&topic);
+                self.on_input_error(&topic, Utf8Path::new(flow_path), error.into())
                     .await?;
             }
             WatchEvent::EndOfStream { topic } => {
                 error!(target: "flows", "End of input stream: {topic}");
-                self.on_input_eos(Utf8Path::new(&topic)).await?
+                let flow_path = flow_path_from_watch_topic(&topic);
+                self.on_input_eos(&topic, Utf8Path::new(flow_path)).await?
             }
         }
         Ok(())
@@ -331,11 +340,12 @@ impl FlowsMapper {
 
     async fn on_input_message(
         &mut self,
+        watch_topic: &str,
         flow_path: &Utf8Path,
         line: String,
     ) -> Result<(), RuntimeError> {
         if let Some(flow) = self.processor.registry.flow(flow_path) {
-            let topic = flow.input_topic().to_string();
+            let topic = flow.input_topic_for_watch(watch_topic).to_string();
             let timestamp = SystemTime::now();
             let message = Message::new(topic, line);
             if let Some(result) = self
@@ -352,12 +362,16 @@ impl FlowsMapper {
 
     async fn on_input_error(
         &mut self,
+        watch_topic: &str,
         flow_path: &Utf8Path,
         error: FlowError,
     ) -> Result<(), RuntimeError> {
         let Some((info, flow_error)) = self.processor.registry.flow(flow_path).map(|flow| {
             (
-                format!("Reconnecting input: {flow_path}: {}", flow.as_ref().input),
+                format!(
+                    "Reconnecting input: {flow_path}: {}",
+                    flow.as_ref().input_description()
+                ),
                 flow.on_error(error),
             )
         }) else {
@@ -365,12 +379,7 @@ impl FlowsMapper {
         };
         self.publish_result(flow_error).await?;
 
-        let Some(request) = self
-            .processor
-            .registry
-            .flow(flow_path)
-            .and_then(|flow| flow.watch_request())
-        else {
+        let Some(request) = self.flow_watch_request(flow_path, watch_topic) else {
             return Ok(());
         };
         let mut watch_request_sender = self.watch_request_sender.sender_clone();
@@ -383,13 +392,22 @@ impl FlowsMapper {
         Ok(())
     }
 
-    async fn on_input_eos(&mut self, flow_path: &Utf8Path) -> Result<(), RuntimeError> {
+    async fn on_input_eos(
+        &mut self,
+        watch_topic: &str,
+        flow_path: &Utf8Path,
+    ) -> Result<(), RuntimeError> {
+        let Some(request) = self.flow_watch_request(flow_path, watch_topic) else {
+            return Ok(());
+        };
         if let Some(flow) = self.processor.registry.flow(flow_path) {
-            if let Some(request) = flow.watch_request() {
-                info!(target: "flows", "Reconnecting input: {flow_path}: {}", flow.as_ref().input);
-                self.watch_request_sender.send(request).await?
-            };
+            info!(
+                target: "flows",
+                "Reconnecting input: {flow_path}: {}",
+                flow.as_ref().input_description()
+            );
         }
+        self.watch_request_sender.send(request).await?;
         Ok(())
     }
 
@@ -599,5 +617,34 @@ impl FlowsMapper {
             return Ok(());
         };
         self.on_directory_updated(directory).await
+    }
+}
+
+pub(crate) fn flow_path_from_watch_topic(topic: &str) -> &str {
+    topic.split_once("#input-").map_or(topic, |(flow, _)| flow)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_watch_topic_returned_unchanged() {
+        assert_eq!(
+            flow_path_from_watch_topic("/flows/test.toml"),
+            "/flows/test.toml"
+        );
+    }
+
+    #[test]
+    fn input_index_suffix_is_stripped_to_yield_flow_path() {
+        assert_eq!(
+            flow_path_from_watch_topic("/flows/test.toml#input-0"),
+            "/flows/test.toml"
+        );
+        assert_eq!(
+            flow_path_from_watch_topic("/flows/test.toml#input-2"),
+            "/flows/test.toml"
+        );
     }
 }

--- a/crates/extensions/tedge_flows/src/config.rs
+++ b/crates/extensions/tedge_flows/src/config.rs
@@ -37,6 +37,7 @@ pub struct FlowConfig {
     #[serde(default)]
     config: Map<String, Value>,
 
+    #[serde(default)]
     input: InputConfig,
     #[serde(default)]
     steps: Vec<StepConfig>,
@@ -74,35 +75,49 @@ pub enum StepSpec {
     JavaScript(Utf8PathBuf),
 }
 
+#[derive(Clone, Deserialize, Default)]
+#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
+pub struct InputConfig {
+    #[serde(default, deserialize_with = "deserialize_one_or_many")]
+    mqtt: Vec<MqttInputConfig>,
+
+    #[serde(default, deserialize_with = "deserialize_one_or_many")]
+    file: Vec<FileInputConfig>,
+
+    #[serde(default, deserialize_with = "deserialize_one_or_many")]
+    process: Vec<ProcessInputConfig>,
+}
+
 #[derive(Clone, Deserialize)]
 #[cfg_attr(test, derive(Debug, Eq, PartialEq))]
-pub enum InputConfig {
-    #[serde(rename = "mqtt")]
-    Mqtt { topics: Vec<String> },
+pub struct MqttInputConfig {
+    topics: Vec<String>,
+}
 
-    #[serde(rename = "file")]
-    File {
-        path: Utf8PathBuf,
+#[derive(Clone, Deserialize)]
+#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
+pub struct FileInputConfig {
+    path: Utf8PathBuf,
 
-        /// Default to path
-        topic: Option<String>,
+    /// Default to path
+    topic: Option<String>,
 
-        #[serde(default)]
-        #[serde(deserialize_with = "parse_human_interval")]
-        interval: Option<IntervalConfig>,
-    },
+    #[serde(default)]
+    #[serde(deserialize_with = "parse_human_interval")]
+    interval: Option<IntervalConfig>,
+}
 
-    #[serde(rename = "process")]
-    Process {
-        command: String,
+#[derive(Clone, Deserialize)]
+#[cfg_attr(test, derive(Debug, Eq, PartialEq))]
+pub struct ProcessInputConfig {
+    command: String,
 
-        /// Default to command
-        topic: Option<String>,
+    /// Default to command
+    topic: Option<String>,
 
-        #[serde(default)]
-        #[serde(deserialize_with = "parse_human_interval")]
-        interval: Option<IntervalConfig>,
-    },
+    #[serde(default)]
+    #[serde(deserialize_with = "parse_human_interval")]
+    interval: Option<IntervalConfig>,
 }
 
 #[derive(Deserialize)]
@@ -151,6 +166,9 @@ pub enum ConfigError {
 
     #[error("Flow '{name}' defines an infinite loop: the output file '{path}' is the same as the input file")]
     FileInfiniteLoop { name: String, path: String },
+
+    #[error("Flow '{name}' must define at least one input")]
+    NoInput { name: String },
 }
 
 /// ```
@@ -291,8 +309,11 @@ impl FlowConfig {
             config: Map::new(),
             // Expect a loop when wrapping a single script as a flow, as there is no way to statically identify input and output topics
             expect_loop: true,
-            input: InputConfig::Mqtt {
-                topics: vec![input_topic],
+            input: InputConfig {
+                mqtt: vec![MqttInputConfig {
+                    topics: vec![input_topic],
+                }],
+                ..Default::default()
             },
             steps: vec![step],
             output: default_output(),
@@ -308,7 +329,7 @@ impl FlowConfig {
         source: Utf8PathBuf,
     ) -> Result<Flow, ConfigError> {
         let source_dir = source.parent().unwrap_or(flows_dir);
-        let input = self.input.into_flow_input(source_dir)?;
+        let input = self.input.into_flow_inputs(source_dir)?;
         let output = self.output.try_into()?;
         let errors = self.errors.try_into()?;
         let mut steps = vec![];
@@ -327,6 +348,10 @@ impl FlowConfig {
                 path: source.to_owned(),
             });
         };
+
+        if input.is_empty() {
+            return Err(ConfigError::NoInput { name });
+        }
 
         detect_loop(&name, &input, &output, self.expect_loop)?;
 
@@ -447,32 +472,65 @@ impl StepConfig {
 
 impl InputConfig {
     fn substitute_params(self, params: &Params<&dyn MapperParams>) -> Result<Self, ConfigError> {
-        match self {
-            InputConfig::Mqtt { topics } => Ok(InputConfig::Mqtt {
-                topics: topics
-                    .into_iter()
-                    .map(|t| params.substitute_inner_paths(&t))
-                    .collect(),
-            }),
-            InputConfig::File {
-                path,
-                topic,
-                interval,
-            } => Ok(InputConfig::File {
-                path: params.substitute_inner_paths(path.as_str()).into(),
-                topic: topic.map(|t| params.substitute_inner_paths(&t)),
-                interval: interval.map(|i| i.substitute_params(params)).transpose()?,
-            }),
-            InputConfig::Process {
-                command,
-                topic,
-                interval,
-            } => Ok(InputConfig::Process {
-                command: params.substitute_inner_paths(&command),
-                topic: topic.map(|t| params.substitute_inner_paths(&t)),
-                interval: interval.map(|i| i.substitute_params(params)).transpose()?,
-            }),
-        }
+        Ok(InputConfig {
+            mqtt: self
+                .mqtt
+                .into_iter()
+                .map(|input| MqttInputConfig {
+                    topics: input
+                        .topics
+                        .into_iter()
+                        .map(|t| params.substitute_inner_paths(&t))
+                        .collect(),
+                })
+                .collect(),
+            file: self
+                .file
+                .into_iter()
+                .map(|input| {
+                    Ok(FileInputConfig {
+                        path: params.substitute_inner_paths(input.path.as_str()).into(),
+                        topic: input.topic.map(|t| params.substitute_inner_paths(&t)),
+                        interval: input
+                            .interval
+                            .map(|i| i.substitute_params(params))
+                            .transpose()?,
+                    })
+                })
+                .collect::<Result<_, ConfigError>>()?,
+            process: self
+                .process
+                .into_iter()
+                .map(|input| {
+                    Ok(ProcessInputConfig {
+                        command: params.substitute_inner_paths(&input.command),
+                        topic: input.topic.map(|t| params.substitute_inner_paths(&t)),
+                        interval: input
+                            .interval
+                            .map(|i| i.substitute_params(params))
+                            .transpose()?,
+                    })
+                })
+                .collect::<Result<_, ConfigError>>()?,
+        })
+    }
+}
+
+fn deserialize_one_or_many<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany<T> {
+        One(T),
+        Many(Vec<T>),
+    }
+
+    match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::One(value) => Ok(vec![value]),
+        OneOrMany::Many(values) => Ok(values),
     }
 }
 
@@ -495,51 +553,61 @@ fn resolve_process_command(command: String, flow_dir: &Utf8Path) -> String {
 }
 
 impl InputConfig {
-    fn into_flow_input(self, source_dir: &Utf8Path) -> Result<FlowInput, ConfigError> {
-        Ok(match self {
-            InputConfig::Mqtt { topics } => FlowInput::Mqtt {
+    fn into_flow_inputs(self, source_dir: &Utf8Path) -> Result<Vec<FlowInput>, ConfigError> {
+        let mut inputs = Vec::new();
+
+        for MqttInputConfig { topics } in self.mqtt {
+            inputs.push(FlowInput::Mqtt {
                 topics: topic_filters(topics)?,
-            },
-            InputConfig::File {
-                topic,
-                path,
-                interval,
-            } => {
-                let topic = topic.unwrap_or_else(|| path.clone().to_string());
-                match interval.map(|i| i.duration()) {
-                    Some(Ok(interval)) if !interval.is_zero() => FlowInput::PollFile {
-                        topic,
-                        path,
-                        interval,
-                    },
-                    Some(Err(e)) => return Err(e),
-                    _ => FlowInput::StreamFile { topic, path },
-                }
-            }
-            InputConfig::Process {
-                topic,
-                command,
-                interval,
-            } => {
-                let command = resolve_process_command(command, source_dir);
-                let topic = topic.unwrap_or_else(|| command.clone());
-                let cwd = source_dir.to_path_buf();
-                match interval.map(|i| i.duration()) {
-                    Some(Ok(interval)) if !interval.is_zero() => FlowInput::PollCommand {
-                        topic,
-                        command,
-                        interval,
-                        cwd,
-                    },
-                    Some(Err(e)) => return Err(e),
-                    _ => FlowInput::StreamCommand {
-                        topic,
-                        command,
-                        cwd,
-                    },
-                }
-            }
-        })
+            });
+        }
+
+        for FileInputConfig {
+            topic,
+            path,
+            interval,
+        } in self.file
+        {
+            let topic = topic.unwrap_or_else(|| path.clone().to_string());
+            let input = match interval.map(|i| i.duration()) {
+                Some(Ok(interval)) if !interval.is_zero() => FlowInput::PollFile {
+                    topic,
+                    path,
+                    interval,
+                },
+                Some(Err(e)) => return Err(e),
+                _ => FlowInput::StreamFile { topic, path },
+            };
+            inputs.push(input);
+        }
+
+        for ProcessInputConfig {
+            topic,
+            command,
+            interval,
+        } in self.process
+        {
+            let command = resolve_process_command(command, source_dir);
+            let topic = topic.unwrap_or_else(|| command.clone());
+            let cwd = source_dir.to_path_buf();
+            let input = match interval.map(|i| i.duration()) {
+                Some(Ok(interval)) if !interval.is_zero() => FlowInput::PollCommand {
+                    topic,
+                    command,
+                    interval,
+                    cwd,
+                },
+                Some(Err(e)) => return Err(e),
+                _ => FlowInput::StreamCommand {
+                    topic,
+                    command,
+                    cwd,
+                },
+            };
+            inputs.push(input);
+        }
+
+        Ok(inputs)
     }
 }
 
@@ -635,32 +703,38 @@ fn default_errors() -> OutputConfig {
 /// When `expect_loop` is true, the check is skipped.
 fn detect_loop(
     name: &str,
-    input: &FlowInput,
+    inputs: &[FlowInput],
     output: &FlowOutput,
     expect_loop: bool,
 ) -> Result<(), ConfigError> {
     if expect_loop {
         return Ok(());
     }
-    match (input, output) {
-        (FlowInput::Mqtt { topics }, FlowOutput::Mqtt { topic: Some(out) })
-            if topics.accept_topic_name(&out.name) =>
-        {
-            Err(ConfigError::MqttInfiniteLoop {
-                name: name.to_string(),
-                input_filter: format!("{topics:?}"),
-                output_topic: out.name.clone(),
-            })
+    for input in inputs {
+        match (input, output) {
+            (FlowInput::Mqtt { topics }, FlowOutput::Mqtt { topic: Some(out) })
+                if topics.accept_topic_name(&out.name) =>
+            {
+                return Err(ConfigError::MqttInfiniteLoop {
+                    name: name.to_string(),
+                    input_filter: format!("{topics:?}"),
+                    output_topic: out.name.clone(),
+                });
+            }
+            (
+                FlowInput::PollFile { path: in_path, .. }
+                | FlowInput::StreamFile { path: in_path, .. },
+                FlowOutput::File { path: out_path },
+            ) if in_path == out_path => {
+                return Err(ConfigError::FileInfiniteLoop {
+                    name: name.to_string(),
+                    path: in_path.to_string(),
+                });
+            }
+            _ => {}
         }
-        (
-            FlowInput::PollFile { path: in_path, .. } | FlowInput::StreamFile { path: in_path, .. },
-            FlowOutput::File { path: out_path },
-        ) if in_path == out_path => Err(ConfigError::FileInfiniteLoop {
-            name: name.to_string(),
-            path: in_path.to_string(),
-        }),
-        _ => Ok(()),
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -751,7 +825,7 @@ mod tests {
             topic: Some(Topic::new("te/loop/test").unwrap()),
         };
         assert!(matches!(
-            detect_loop("my-flow", &input, &output, false),
+            detect_loop("my-flow", &[input], &output, false),
             Err(ConfigError::MqttInfiniteLoop { .. })
         ));
     }
@@ -767,7 +841,7 @@ mod tests {
             path: Utf8PathBuf::from("/tmp/data.txt"),
         };
         assert!(matches!(
-            detect_loop("my-flow", &input, &output, false),
+            detect_loop("my-flow", &[input], &output, false),
             Err(ConfigError::FileInfiniteLoop { .. })
         ));
     }
@@ -782,7 +856,7 @@ mod tests {
             path: Utf8PathBuf::from("/tmp/data.txt"),
         };
         assert!(matches!(
-            detect_loop("my-flow", &input, &output, false),
+            detect_loop("my-flow", &[input], &output, false),
             Err(ConfigError::FileInfiniteLoop { .. })
         ));
     }
@@ -796,7 +870,7 @@ mod tests {
             topic: Some(Topic::new("te/loop/test").unwrap()),
         };
         // Would normally be an error, but expect_loop = true bypasses the check
-        assert!(detect_loop("my-flow", &input, &output, true).is_ok());
+        assert!(detect_loop("my-flow", &[input], &output, true).is_ok());
     }
 
     #[test_case(FlowOutput::Mqtt { topic: Some(Topic::new("te/another/test").unwrap()) }; "mqtt output different topic"
@@ -806,7 +880,7 @@ mod tests {
         let input = FlowInput::Mqtt {
             topics: TopicFilter::new_unchecked("te/loop/+"),
         };
-        assert!(detect_loop("my-flow", &input, &output, false).is_ok());
+        assert!(detect_loop("my-flow", &[input], &output, false).is_ok());
     }
 
     #[test]
@@ -957,12 +1031,12 @@ topic = "te/device/main///e/"
             .unwrap();
         assert_eq!(
             compiled.input,
-            FlowInput::PollCommand {
+            vec![FlowInput::PollCommand {
                 topic: "/flows/sub/monitor.sh".into(),
                 command: "/flows/sub/monitor.sh".into(),
                 interval: Duration::from_secs(1),
                 cwd: Utf8PathBuf::from("/flows/sub"),
-            }
+            }]
         );
     }
 
@@ -985,12 +1059,12 @@ topic = "te/device/main///e/"
             .unwrap();
         assert_eq!(
             compiled.input,
-            FlowInput::PollCommand {
+            vec![FlowInput::PollCommand {
                 topic: "/flows/test.sh".into(),
                 command: "/flows/test.sh".into(),
                 interval: Duration::from_secs(1),
                 cwd: Utf8PathBuf::from("/flows"),
-            }
+            }]
         )
     }
 
@@ -1002,14 +1076,17 @@ topic = "te/device/main///e/"
         "#;
 
         let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
-        let input = flow.input.into_flow_input(Utf8Path::new("/flows")).unwrap();
+        let input = flow
+            .input
+            .into_flow_inputs(Utf8Path::new("/flows"))
+            .unwrap();
         assert_eq!(
             input,
-            FlowInput::StreamCommand {
+            vec![FlowInput::StreamCommand {
                 topic: "/flows/monitor.sh".into(),
                 command: "/flows/monitor.sh".into(),
                 cwd: Utf8PathBuf::from("/flows"),
-            }
+            }]
         )
     }
 
@@ -1022,15 +1099,18 @@ topic = "te/device/main///e/"
         "#;
 
         let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
-        let input = flow.input.into_flow_input(Utf8Path::new("/flows")).unwrap();
+        let input = flow
+            .input
+            .into_flow_inputs(Utf8Path::new("/flows"))
+            .unwrap();
         assert_eq!(
             input,
-            FlowInput::PollCommand {
+            vec![FlowInput::PollCommand {
                 topic: "/flows/test.sh".into(),
                 command: "/flows/test.sh".into(),
                 interval: Duration::from_secs(1),
                 cwd: Utf8PathBuf::from("/flows"),
-            }
+            }]
         )
     }
 
@@ -1043,15 +1123,18 @@ topic = "te/device/main///e/"
         "#;
 
         let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
-        let input = flow.input.into_flow_input(Utf8Path::new("/flows")).unwrap();
+        let input = flow
+            .input
+            .into_flow_inputs(Utf8Path::new("/flows"))
+            .unwrap();
         assert_eq!(
             input,
-            FlowInput::PollCommand {
+            vec![FlowInput::PollCommand {
                 topic: "/flows/test.sh foo /../bar".into(),
                 command: "/flows/test.sh foo /../bar".into(),
                 interval: Duration::from_secs(1),
                 cwd: Utf8PathBuf::from("/flows"),
-            }
+            }]
         )
     }
 
@@ -1064,15 +1147,18 @@ topic = "te/device/main///e/"
         "#;
 
         let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
-        let input = flow.input.into_flow_input(Utf8Path::new("/flows")).unwrap();
+        let input = flow
+            .input
+            .into_flow_inputs(Utf8Path::new("/flows"))
+            .unwrap();
         assert_eq!(
             input,
-            FlowInput::PollCommand {
+            vec![FlowInput::PollCommand {
                 topic: "sudo journalctl -u tedge-agent".into(),
                 command: "sudo journalctl -u tedge-agent".into(),
                 interval: Duration::from_secs(1),
                 cwd: Utf8PathBuf::from("/flows"),
-            }
+            }]
         )
     }
 
@@ -1085,15 +1171,18 @@ topic = "te/device/main///e/"
         "#;
 
         let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
-        let input = flow.input.into_flow_input(Utf8Path::new("/flows")).unwrap();
+        let input = flow
+            .input
+            .into_flow_inputs(Utf8Path::new("/flows"))
+            .unwrap();
         assert_eq!(
             input,
-            FlowInput::PollCommand {
+            vec![FlowInput::PollCommand {
                 topic: "test.sh".into(),
                 command: "test.sh".into(),
                 interval: Duration::from_secs(1),
                 cwd: Utf8PathBuf::from("/flows"),
-            }
+            }]
         )
     }
 
@@ -1106,15 +1195,18 @@ topic = "te/device/main///e/"
         "#;
 
         let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
-        let input = flow.input.into_flow_input(Utf8Path::new("/flows")).unwrap();
+        let input = flow
+            .input
+            .into_flow_inputs(Utf8Path::new("/flows"))
+            .unwrap();
         assert_eq!(
             input,
-            FlowInput::PollCommand {
+            vec![FlowInput::PollCommand {
                 topic: "/test.sh".into(),
                 command: "/test.sh".into(),
                 interval: Duration::from_secs(1),
                 cwd: Utf8PathBuf::from("/flows"),
-            }
+            }]
         )
     }
 
@@ -1127,15 +1219,18 @@ topic = "te/device/main///e/"
         "#;
 
         let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
-        let input = flow.input.into_flow_input(Utf8Path::new("/flows")).unwrap();
+        let input = flow
+            .input
+            .into_flow_inputs(Utf8Path::new("/flows"))
+            .unwrap();
         assert_eq!(
             input,
-            FlowInput::PollCommand {
+            vec![FlowInput::PollCommand {
                 topic: "/usr/bin/script.sh foo bar".into(),
                 command: "/usr/bin/script.sh foo bar".into(),
                 interval: Duration::from_secs(1),
                 cwd: Utf8PathBuf::from("/flows"),
-            }
+            }]
         )
     }
 
@@ -1149,15 +1244,158 @@ topic = "te/device/main///e/"
         "#;
 
         let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
-        let input = flow.input.into_flow_input(Utf8Path::new("/flows")).unwrap();
+        let input = flow
+            .input
+            .into_flow_inputs(Utf8Path::new("/flows"))
+            .unwrap();
         assert_eq!(
             input,
-            FlowInput::PollCommand {
+            vec![FlowInput::PollCommand {
                 topic: "my/custom/topic".into(),
                 command: "/flows/test.sh".into(),
                 interval: Duration::from_secs(1),
                 cwd: Utf8PathBuf::from("/flows"),
-            }
+            }]
+        )
+    }
+
+    #[test]
+    fn multiple_process_inputs_can_be_deserialized_from_array_of_tables() {
+        let flow_toml = r#"
+        [[input.process]]
+        command = "./first.sh"
+        topic = "first"
+        interval = "1s"
+
+        [[input.process]]
+        command = "./second.sh"
+        topic = "second"
+        interval = "2s"
+        "#;
+
+        let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
+        let input = flow
+            .input
+            .into_flow_inputs(Utf8Path::new("/flows"))
+            .unwrap();
+        assert_eq!(
+            input,
+            vec![
+                FlowInput::PollCommand {
+                    topic: "first".into(),
+                    command: "/flows/first.sh".into(),
+                    interval: Duration::from_secs(1),
+                    cwd: Utf8PathBuf::from("/flows"),
+                },
+                FlowInput::PollCommand {
+                    topic: "second".into(),
+                    command: "/flows/second.sh".into(),
+                    interval: Duration::from_secs(2),
+                    cwd: Utf8PathBuf::from("/flows"),
+                },
+            ]
+        )
+    }
+
+    #[test]
+    fn multiple_input_types_can_be_deserialized_from_array_of_tables() {
+        let flow_toml = r#"
+        [[input.mqtt]]
+        topics = ["te/input/+"]
+
+        [[input.file]]
+        path = "/var/log/example.log"
+        topic = "log"
+
+        [[input.process]]
+        command = "./collect.sh"
+        topic = "collect"
+        interval = "1s"
+        "#;
+
+        let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
+        let input = flow
+            .input
+            .into_flow_inputs(Utf8Path::new("/flows"))
+            .unwrap();
+        assert_eq!(
+            input,
+            vec![
+                FlowInput::Mqtt {
+                    topics: TopicFilter::new_unchecked("te/input/+"),
+                },
+                FlowInput::StreamFile {
+                    topic: "log".into(),
+                    path: Utf8PathBuf::from("/var/log/example.log"),
+                },
+                FlowInput::PollCommand {
+                    topic: "collect".into(),
+                    command: "/flows/collect.sh".into(),
+                    interval: Duration::from_secs(1),
+                    cwd: Utf8PathBuf::from("/flows"),
+                },
+            ]
+        )
+    }
+
+    #[tokio::test]
+    async fn flow_missing_input_section_entirely_returns_no_input_error() {
+        let flow_toml = r#"
+        [output.mqtt]
+        "#;
+
+        let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
+        let rs_transformers = BuiltinTransformers::default();
+        let mut js_runtime = JsRuntime::with_default().await.unwrap();
+        let flows_dir = Utf8Path::new("/flows");
+        let source = Utf8PathBuf::from("/flows/empty.toml");
+        let result = flow
+            .compile(&rs_transformers, &mut js_runtime, flows_dir, source)
+            .await;
+        assert!(matches!(result, Err(ConfigError::NoInput { .. })));
+    }
+
+    #[tokio::test]
+    async fn flow_with_empty_input_section_returns_no_input_error() {
+        // [input] present but all sub-fields empty
+        let flow_toml = r#"
+        [input]
+        [output.mqtt]
+        "#;
+
+        let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
+        let rs_transformers = BuiltinTransformers::default();
+        let mut js_runtime = JsRuntime::with_default().await.unwrap();
+        let flows_dir = Utf8Path::new("/flows");
+        let source = Utf8PathBuf::from("/flows/empty.toml");
+        let result = flow
+            .compile(&rs_transformers, &mut js_runtime, flows_dir, source)
+            .await;
+        assert!(matches!(result, Err(ConfigError::NoInput { .. })));
+    }
+
+    #[test]
+    fn existing_single_table_input_syntax_is_still_supported() {
+        let flow_toml = r#"
+        [input.process]
+        command = "./collect.sh"
+        topic = "collect"
+        interval = "1s"
+        "#;
+
+        let flow: FlowConfig = toml::from_str(flow_toml).unwrap();
+        let input = flow
+            .input
+            .into_flow_inputs(Utf8Path::new("/flows"))
+            .unwrap();
+        assert_eq!(
+            input,
+            vec![FlowInput::PollCommand {
+                topic: "collect".into(),
+                command: "/flows/collect.sh".into(),
+                interval: Duration::from_secs(1),
+                cwd: Utf8PathBuf::from("/flows"),
+            }]
         )
     }
 }

--- a/crates/extensions/tedge_flows/src/connected_flow.rs
+++ b/crates/extensions/tedge_flows/src/connected_flow.rs
@@ -22,8 +22,8 @@ use tokio::time::Instant;
 /// A flow connected to a source of messages
 pub struct ConnectedFlow {
     pub(crate) flow: Flow,
-    streaming_source: Option<Box<dyn StreamingSource>>,
-    polling_source: Option<Box<dyn PollingSource>>,
+    streaming_sources: Vec<Box<dyn StreamingSource>>,
+    polling_sources: Vec<Box<dyn PollingSource>>,
 }
 
 impl AsRef<Flow> for ConnectedFlow {
@@ -40,12 +40,34 @@ impl AsMut<Flow> for ConnectedFlow {
 
 impl ConnectedFlow {
     pub fn new(flow: Flow) -> Self {
-        let streaming_source = streaming_source(flow.source.to_string(), flow.input.clone());
-        let polling_source = polling_source(flow.input.clone());
+        let streaming_inputs = flow
+            .input
+            .iter()
+            .filter(|input| input.is_streaming())
+            .count();
+        let streaming_sources = flow
+            .input
+            .iter()
+            .enumerate()
+            .filter_map(|(index, input)| {
+                let topic = if streaming_inputs == 1 {
+                    flow.source.to_string()
+                } else {
+                    format!("{}#input-{index}", flow.source)
+                };
+                streaming_source(topic, input.clone())
+            })
+            .collect();
+        let polling_sources = flow
+            .input
+            .iter()
+            .cloned()
+            .filter_map(polling_source)
+            .collect();
         ConnectedFlow {
             flow,
-            streaming_source,
-            polling_source,
+            streaming_sources,
+            polling_sources,
         }
     }
 
@@ -58,17 +80,40 @@ impl ConnectedFlow {
     }
 
     pub fn input_topic(&self) -> &str {
-        self.flow.input.enforced_topic().unwrap_or_default()
+        self.flow
+            .input
+            .iter()
+            .find_map(FlowInput::enforced_topic)
+            .unwrap_or_default()
     }
 
-    pub fn watch_request(&self) -> Option<WatchRequest> {
-        self.streaming_source
-            .as_ref()
-            .and_then(|source| source.watch_request())
+    pub fn input_topic_for_watch<'a>(&'a self, topic: &'a str) -> &'a str {
+        self.streaming_sources
+            .iter()
+            .find(|source| {
+                source
+                    .watch_request()
+                    .is_some_and(|request| watch_request_topic(&request) == topic)
+            })
+            .map_or(topic, |source| source.input_topic())
+    }
+
+    pub fn watch_requests(&self) -> Vec<WatchRequest> {
+        self.streaming_sources
+            .iter()
+            .filter_map(|source| source.watch_request())
+            .collect()
+    }
+
+    pub fn watch_request(&self, topic: &str) -> Option<WatchRequest> {
+        self.streaming_sources
+            .iter()
+            .filter_map(|s| s.watch_request())
+            .find(|r| watch_request_topic(r) == topic)
     }
 
     pub fn next_deadline(&self) -> Option<Instant> {
-        self.polling_source.as_ref().map(|p| p.next_deadline())
+        self.polling_sources.iter().map(|p| p.next_deadline()).min()
     }
 
     pub async fn on_source_poll(&mut self, timestamp: SystemTime, now: Instant) -> FlowResult {
@@ -81,60 +126,21 @@ impl ConnectedFlow {
         timestamp: SystemTime,
         now: Instant,
     ) -> Result<Vec<Message>, FlowError> {
-        let Some(source) = &mut self.polling_source.as_mut() else {
-            return Ok(vec![]);
-        };
-        if !source.is_ready(now) {
-            return Ok(vec![]);
-        };
+        let mut all_messages = Vec::new();
+        for source in &mut self.polling_sources {
+            if !source.is_ready(now) {
+                continue;
+            };
 
-        let messages = source.poll(timestamp).await;
-        source.update_after_poll(Instant::now());
-        let messages = messages?;
-        Ok(messages)
+            let messages = source.poll(timestamp).await;
+            source.update_after_poll(Instant::now());
+            all_messages.extend(messages?);
+        }
+        Ok(all_messages)
     }
 
     pub fn on_error(&self, error: FlowError) -> FlowResult {
         self.flow.publish(Err(error))
-    }
-}
-
-fn streaming_source(flow_name: String, input: FlowInput) -> Option<Box<dyn StreamingSource>> {
-    match input {
-        FlowInput::StreamFile { topic: _, path } => {
-            Some(Box::new(FileStreamingSource::new(flow_name, path)))
-        }
-
-        FlowInput::StreamCommand {
-            topic: _,
-            command,
-            cwd,
-        } => Some(Box::new(CommandStreamingSource::new(
-            flow_name, command, cwd,
-        ))),
-
-        _ => None,
-    }
-}
-
-fn polling_source(input: FlowInput) -> Option<Box<dyn PollingSource>> {
-    match input {
-        FlowInput::PollFile {
-            topic,
-            path,
-            interval,
-        } => Some(Box::new(FilePollingSource::new(topic, path, interval))),
-
-        FlowInput::PollCommand {
-            topic,
-            command,
-            interval,
-            cwd,
-        } => Some(Box::new(CommandPollingSource::new(
-            topic, command, cwd, interval,
-        ))),
-
-        _ => None,
     }
 }
 
@@ -195,5 +201,174 @@ impl FlowRegistry for ConnectedFlowRegistry {
         let source_deadlines = self.flows.flows().filter_map(|flow| flow.next_deadline());
 
         script_deadlines.chain(source_deadlines)
+    }
+}
+
+pub(crate) fn watch_request_topic(request: &WatchRequest) -> &str {
+    match request {
+        WatchRequest::WatchFile { topic, .. }
+        | WatchRequest::WatchCommand { topic, .. }
+        | WatchRequest::UnWatch { topic } => topic,
+    }
+}
+
+fn streaming_source(flow_name: String, input: FlowInput) -> Option<Box<dyn StreamingSource>> {
+    match input {
+        FlowInput::StreamFile { topic, path } => {
+            Some(Box::new(FileStreamingSource::new(flow_name, topic, path)))
+        }
+
+        FlowInput::StreamCommand {
+            topic,
+            command,
+            cwd,
+        } => Some(Box::new(CommandStreamingSource::new(
+            flow_name, topic, command, cwd,
+        ))),
+
+        _ => None,
+    }
+}
+
+fn polling_source(input: FlowInput) -> Option<Box<dyn PollingSource>> {
+    match input {
+        FlowInput::PollFile {
+            topic,
+            path,
+            interval,
+        } => Some(Box::new(FilePollingSource::new(topic, path, interval))),
+
+        FlowInput::PollCommand {
+            topic,
+            command,
+            interval,
+            cwd,
+        } => Some(Box::new(CommandPollingSource::new(
+            topic, command, cwd, interval,
+        ))),
+
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flow::FlowOutput;
+    use camino::Utf8PathBuf;
+
+    #[test]
+    fn multiple_streaming_sources_keep_distinct_message_topics() {
+        let flow = Flow {
+            name: "test".into(),
+            version: None,
+            description: None,
+            tags: None,
+            input: vec![
+                FlowInput::StreamCommand {
+                    topic: "first".into(),
+                    command: "first.sh".into(),
+                    cwd: Utf8PathBuf::from("/flows"),
+                },
+                FlowInput::StreamCommand {
+                    topic: "second".into(),
+                    command: "second.sh".into(),
+                    cwd: Utf8PathBuf::from("/flows"),
+                },
+            ],
+            steps: vec![],
+            output: FlowOutput::Mqtt { topic: None },
+            errors: FlowOutput::Mqtt { topic: None },
+            source: Utf8PathBuf::from("/flows/test.toml"),
+            expect_loop: false,
+        };
+
+        let connected = ConnectedFlow::new(flow);
+        let watch_topics = connected
+            .watch_requests()
+            .into_iter()
+            .map(|request| watch_request_topic(&request).to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            watch_topics,
+            vec!["/flows/test.toml#input-0", "/flows/test.toml#input-1"]
+        );
+        assert_eq!(
+            connected.input_topic_for_watch("/flows/test.toml#input-0"),
+            "first"
+        );
+        assert_eq!(
+            connected.input_topic_for_watch("/flows/test.toml#input-1"),
+            "second"
+        );
+    }
+
+    #[test]
+    fn single_streaming_source_among_mixed_inputs_uses_plain_flow_path_as_watch_topic() {
+        let flow = Flow {
+            name: "test".into(),
+            version: None,
+            description: None,
+            tags: None,
+            input: vec![
+                FlowInput::PollCommand {
+                    topic: "poll".into(),
+                    command: "poll.sh".into(),
+                    interval: std::time::Duration::from_secs(5),
+                    cwd: Utf8PathBuf::from("/flows"),
+                },
+                FlowInput::StreamCommand {
+                    topic: "stream".into(),
+                    command: "stream.sh".into(),
+                    cwd: Utf8PathBuf::from("/flows"),
+                },
+            ],
+            steps: vec![],
+            output: FlowOutput::Mqtt { topic: None },
+            errors: FlowOutput::Mqtt { topic: None },
+            source: Utf8PathBuf::from("/flows/test.toml"),
+            expect_loop: false,
+        };
+
+        let connected = ConnectedFlow::new(flow);
+        let watch_topics = connected
+            .watch_requests()
+            .into_iter()
+            .map(|request| watch_request_topic(&request).to_string())
+            .collect::<Vec<_>>();
+
+        // One streaming input → plain flow path, no #input-N suffix
+        assert_eq!(watch_topics, vec!["/flows/test.toml"]);
+        assert_eq!(
+            connected.input_topic_for_watch("/flows/test.toml"),
+            "stream"
+        );
+    }
+
+    #[test]
+    fn input_topic_for_watch_returns_watch_topic_itself_when_no_source_matches() {
+        let flow = Flow {
+            name: "test".into(),
+            version: None,
+            description: None,
+            tags: None,
+            input: vec![FlowInput::StreamCommand {
+                topic: "stream".into(),
+                command: "stream.sh".into(),
+                cwd: Utf8PathBuf::from("/flows"),
+            }],
+            steps: vec![],
+            output: FlowOutput::Mqtt { topic: None },
+            errors: FlowOutput::Mqtt { topic: None },
+            source: Utf8PathBuf::from("/flows/test.toml"),
+            expect_loop: false,
+        };
+
+        let connected = ConnectedFlow::new(flow);
+        assert_eq!(
+            connected.input_topic_for_watch("unknown/watch/topic"),
+            "unknown/watch/topic"
+        );
     }
 }

--- a/crates/extensions/tedge_flows/src/flow.rs
+++ b/crates/extensions/tedge_flows/src/flow.rs
@@ -37,8 +37,8 @@ pub struct Flow {
     /// User-defined tags
     pub tags: Option<Vec<String>>,
 
-    /// The message source
-    pub input: FlowInput,
+    /// The message sources
+    pub input: Vec<FlowInput>,
 
     /// Transformation steps to apply in order to the messages
     pub steps: Vec<FlowStep>,
@@ -187,11 +187,15 @@ impl Flow {
     }
 
     pub fn topics(&self) -> TopicFilter {
-        self.input.topics()
+        let mut topics = TopicFilter::empty();
+        for input in &self.input {
+            topics.add_all(input.topics());
+        }
+        topics
     }
 
     pub fn accept_message(&self, _source: &SourceTag, message: &Message) -> bool {
-        self.input.accept_message(message)
+        self.input.iter().any(|input| input.accept_message(message))
     }
 
     pub async fn on_message(
@@ -455,15 +459,11 @@ impl Flow {
         if self.expect_loop {
             return;
         }
-        if let (
-            FlowInput::Mqtt {
-                topics: input_topics,
-            },
-            FlowOutput::Mqtt { topic: None },
-        ) = (&self.input, &self.output)
-        {
+        if let FlowOutput::Mqtt { topic: None } = &self.output {
             messages.retain(|msg| {
-                if input_topics.accept_topic_name(&msg.topic) {
+                if self.input.iter().any(|input| {
+                    matches!(input, FlowInput::Mqtt { .. }) && input.accept_message(msg)
+                }) {
                     error!(
                         target: "flows",
                         "Flow '{}' is dropping output message to '{}' to prevent an infinite loop",
@@ -476,6 +476,14 @@ impl Flow {
                 }
             });
         }
+    }
+
+    pub fn input_description(&self) -> String {
+        self.input
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 }
 
@@ -517,6 +525,13 @@ impl FlowInput {
             | FlowInput::StreamFile { topic, .. }
             | FlowInput::StreamCommand { topic, .. } => Some(topic),
         }
+    }
+
+    pub fn is_streaming(&self) -> bool {
+        matches!(
+            self,
+            FlowInput::StreamFile { .. } | FlowInput::StreamCommand { .. }
+        )
     }
 
     pub fn accept_message(&self, message: &Message) -> bool {
@@ -698,7 +713,7 @@ mod tests {
             version: None,
             description: None,
             tags: None,
-            input,
+            input: vec![input],
             steps: vec![],
             output,
             errors: FlowOutput::Mqtt { topic: None },

--- a/crates/extensions/tedge_flows/src/input_source.rs
+++ b/crates/extensions/tedge_flows/src/input_source.rs
@@ -11,6 +11,9 @@ use tokio::time::Instant;
 pub trait StreamingSource: Send + Sync {
     /// Process watched by this source
     fn watch_request(&self) -> Option<WatchRequest>;
+
+    /// Topic assigned to messages emitted by this source
+    fn input_topic(&self) -> &str;
 }
 
 /// Trait for input sources that can be polled for messages
@@ -85,13 +88,19 @@ impl PollingSource for CommandPollingSource {
 
 pub struct CommandStreamingSource {
     flow: String,
+    topic: String,
     command: String,
     cwd: Utf8PathBuf,
 }
 
 impl CommandStreamingSource {
-    pub fn new(flow: String, command: String, cwd: Utf8PathBuf) -> Self {
-        CommandStreamingSource { flow, command, cwd }
+    pub fn new(flow: String, topic: String, command: String, cwd: Utf8PathBuf) -> Self {
+        CommandStreamingSource {
+            flow,
+            topic,
+            command,
+            cwd,
+        }
     }
 }
 
@@ -102,6 +111,10 @@ impl StreamingSource for CommandStreamingSource {
             command: self.command.clone(),
             cwd: self.cwd.clone(),
         })
+    }
+
+    fn input_topic(&self) -> &str {
+        &self.topic
     }
 }
 
@@ -152,12 +165,13 @@ impl PollingSource for FilePollingSource {
 
 pub struct FileStreamingSource {
     flow: String,
+    topic: String,
     path: Utf8PathBuf,
 }
 
 impl FileStreamingSource {
-    pub fn new(flow: String, path: Utf8PathBuf) -> Self {
-        FileStreamingSource { flow, path }
+    pub fn new(flow: String, topic: String, path: Utf8PathBuf) -> Self {
+        FileStreamingSource { flow, topic, path }
     }
 }
 
@@ -167,6 +181,10 @@ impl StreamingSource for FileStreamingSource {
             topic: self.flow.clone(),
             file: self.path.clone(),
         })
+    }
+
+    fn input_topic(&self) -> &str {
+        &self.topic
     }
 }
 

--- a/docs/src/extend/flows.md
+++ b/docs/src/extend/flows.md
@@ -586,6 +586,7 @@ A flow package is a gzip-compressed tar archive (`*.tar.gz`) containing the file
 A few practical points to keep in mind when building packages:
 
 - **Include version metadata.** Adding a version string and description to `flow.toml` makes it easy to identify which release is deployed on a device.
+- **Use multiple inputs when one processing pipeline should handle several sources.** A flow can define repeated `[[input.mqtt]]`, `[[input.file]]`, and `[[input.process]]` sections, and can mix those input types in a single `flow.toml`. All matching messages are passed through the same steps.
 - **Keep flows self-contained.** A flow can reference files from a sibling flow using relative paths such as `../other-flow/main.js`, but there is no dependency manager to enforce this — you are responsible for ensuring both flows are installed together. Self-contained packages are simpler to reason about and easier to update independently.
 - **Naming conventions** The name of a flow is derived from its file path. To keep names short, the path prefix corresponding to the mapper flows directory is removed as well as the `.toml` extension. For the typical case of `flow.toml`, the uninformative `flow` suffix is also removed.
   - For instance, the name derived for the flow `/etc/tedge/mappers/c8y/flows/high-temp-alert/flow.toml` is simply `high-temp-alert`.

--- a/docs/src/references/mappers/flows.md
+++ b/docs/src/references/mappers/flows.md
@@ -361,6 +361,7 @@ The transformation applied by a step is defined either by
 ### Input connectors
 
 Messages can be consumed from MQTT, files and background processes.
+A flow can define one or more input connectors, and the connectors can be of different types.
 
 An MQTT connector is simply defined by a list of MQTT topics
 
@@ -420,6 +421,37 @@ interval = "30s"
 
 If this flow definition is stored at `/etc/tedge/mappers/local/flows/my-sensor/flow.toml`,
 then `read-sensor.sh` is expected at `/etc/tedge/mappers/local/flows/my-sensor/read-sensor.sh`.
+
+#### Multiple input connectors
+
+Use TOML arrays of tables to define several connectors of the same type, or to mix MQTT, file and process inputs in the same flow.
+All matching input messages are passed through the same transformation steps.
+
+```toml
+[[input.mqtt]]
+topics = ["sensors/temperature/+"]
+
+[[input.mqtt]]
+topics = ["sensors/humidity/+"]
+
+[[input.file]]
+path = "/var/log/some-app.log"
+topic = "logs/some-app"
+
+[[input.process]]
+command = "./read-sensor.sh"
+topic = "sensor/readings"
+interval = "30s"
+```
+
+The single-connector forms remain valid:
+
+```toml
+input.mqtt.topics = ["sensors/#"]
+
+[input.file]
+path = "/var/log/some-app.log"
+```
 
 ### Output connectors
 

--- a/tests/RobotFramework/tests/tedge_flows/mixed-inputs/flow.toml
+++ b/tests/RobotFramework/tests/tedge_flows/mixed-inputs/flow.toml
@@ -1,0 +1,19 @@
+[[input.mqtt]]
+topics = ["test/mixed-inputs/mqtt"]
+
+[[input.file]]
+path = "/tmp/mixed-inputs-file"
+topic = "test/mixed-inputs/file"
+
+[[input.process]]
+command = "cat /tmp/mixed-inputs-process"
+topic = "test/mixed-inputs/process"
+
+[[steps]]
+script = "route-with-topic.js"
+
+[output.mqtt]
+topic = "test/mixed-inputs/out"
+
+[errors.mqtt]
+topic = "test/mixed-inputs/errors"

--- a/tests/RobotFramework/tests/tedge_flows/mixed-inputs/route-with-topic.js
+++ b/tests/RobotFramework/tests/tedge_flows/mixed-inputs/route-with-topic.js
@@ -1,0 +1,8 @@
+const utf8 = new TextDecoder();
+
+export function onMessage(message) {
+  return {
+    topic: message.topic,
+    payload: `${message.topic}:${utf8.decode(message.payload)}`,
+  };
+}

--- a/tests/RobotFramework/tests/tedge_flows/multiple-file-inputs/flow.toml
+++ b/tests/RobotFramework/tests/tedge_flows/multiple-file-inputs/flow.toml
@@ -1,0 +1,16 @@
+[[input.file]]
+path = "/tmp/multiple-file-inputs-a"
+topic = "test/multiple-file-inputs/a"
+
+[[input.file]]
+path = "/tmp/multiple-file-inputs-b"
+topic = "test/multiple-file-inputs/b"
+
+[[steps]]
+script = "route-with-topic.js"
+
+[output.mqtt]
+topic = "test/multiple-file-inputs/out"
+
+[errors.mqtt]
+topic = "test/multiple-file-inputs/errors"

--- a/tests/RobotFramework/tests/tedge_flows/multiple-file-inputs/route-with-topic.js
+++ b/tests/RobotFramework/tests/tedge_flows/multiple-file-inputs/route-with-topic.js
@@ -1,0 +1,8 @@
+const utf8 = new TextDecoder();
+
+export function onMessage(message) {
+  return {
+    topic: message.topic,
+    payload: `${message.topic}:${utf8.decode(message.payload)}`,
+  };
+}

--- a/tests/RobotFramework/tests/tedge_flows/multiple-mqtt-inputs/flow.toml
+++ b/tests/RobotFramework/tests/tedge_flows/multiple-mqtt-inputs/flow.toml
@@ -1,0 +1,14 @@
+[[input.mqtt]]
+topics = ["test/multiple-mqtt-inputs/a"]
+
+[[input.mqtt]]
+topics = ["test/multiple-mqtt-inputs/b"]
+
+[[steps]]
+script = "route-with-topic.js"
+
+[output.mqtt]
+topic = "test/multiple-mqtt-inputs/out"
+
+[errors.mqtt]
+topic = "test/multiple-mqtt-inputs/errors"

--- a/tests/RobotFramework/tests/tedge_flows/multiple-mqtt-inputs/route-with-topic.js
+++ b/tests/RobotFramework/tests/tedge_flows/multiple-mqtt-inputs/route-with-topic.js
@@ -1,0 +1,8 @@
+const utf8 = new TextDecoder();
+
+export function onMessage(message) {
+  return {
+    topic: message.topic,
+    payload: `${message.topic}:${utf8.decode(message.payload)}`,
+  };
+}

--- a/tests/RobotFramework/tests/tedge_flows/multiple-process-inputs/flow.toml
+++ b/tests/RobotFramework/tests/tedge_flows/multiple-process-inputs/flow.toml
@@ -1,0 +1,16 @@
+[[input.process]]
+command = "cat /tmp/multiple-process-inputs-a"
+topic = "test/multiple-process-inputs/a"
+
+[[input.process]]
+command = "cat /tmp/multiple-process-inputs-b"
+topic = "test/multiple-process-inputs/b"
+
+[[steps]]
+script = "route-with-topic.js"
+
+[output.mqtt]
+topic = "test/multiple-process-inputs/out"
+
+[errors.mqtt]
+topic = "test/multiple-process-inputs/errors"

--- a/tests/RobotFramework/tests/tedge_flows/multiple-process-inputs/route-with-topic.js
+++ b/tests/RobotFramework/tests/tedge_flows/multiple-process-inputs/route-with-topic.js
@@ -1,0 +1,8 @@
+const utf8 = new TextDecoder();
+
+export function onMessage(message) {
+  return {
+    topic: message.topic,
+    payload: `${message.topic}:${utf8.decode(message.payload)}`,
+  };
+}

--- a/tests/RobotFramework/tests/tedge_flows/tedge_flows.robot
+++ b/tests/RobotFramework/tests/tedge_flows/tedge_flows.robot
@@ -206,6 +206,64 @@ Consuming messages from the tail of file
     Should Have MQTT Messages    topic=log/events    message_contains=hello    minimum=1    date_from=${start}
     [Teardown]    Uninstall Flow    tail-named-pipe.toml
 
+Consuming messages from multiple MQTT inputs
+    Install Nested Flow    multiple-mqtt-inputs
+    MQTT Input Should Be Routed    test/multiple-mqtt-inputs/a    from-mqtt-a    test/multiple-mqtt-inputs/out
+    MQTT Input Should Be Routed    test/multiple-mqtt-inputs/b    from-mqtt-b    test/multiple-mqtt-inputs/out
+    [Teardown]    Uninstall Nested Flow    multiple-mqtt-inputs
+
+Consuming messages from multiple file inputs
+    Create Test Pipes    /tmp/multiple-file-inputs-a /tmp/multiple-file-inputs-b
+    Install Nested Flow    multiple-file-inputs
+    Write To Pipe And Assert MQTT Output
+    ...    path=/tmp/multiple-file-inputs-a
+    ...    input_topic=test/multiple-file-inputs/a
+    ...    payload=from-file-a
+    ...    output_topic=test/multiple-file-inputs/out
+    Write To Pipe And Assert MQTT Output
+    ...    path=/tmp/multiple-file-inputs-b
+    ...    input_topic=test/multiple-file-inputs/b
+    ...    payload=from-file-b
+    ...    output_topic=test/multiple-file-inputs/out
+    [Teardown]    Run Keywords
+    ...    Uninstall Nested Flow    multiple-file-inputs
+    ...    AND    Remove Test Pipes    /tmp/multiple-file-inputs-a /tmp/multiple-file-inputs-b
+
+Consuming messages from multiple process inputs
+    Create Test Pipes    /tmp/multiple-process-inputs-a /tmp/multiple-process-inputs-b
+    Install Nested Flow    multiple-process-inputs
+    Write To Pipe And Assert MQTT Output
+    ...    path=/tmp/multiple-process-inputs-a
+    ...    input_topic=test/multiple-process-inputs/a
+    ...    payload=from-process-a
+    ...    output_topic=test/multiple-process-inputs/out
+    Write To Pipe And Assert MQTT Output
+    ...    path=/tmp/multiple-process-inputs-b
+    ...    input_topic=test/multiple-process-inputs/b
+    ...    payload=from-process-b
+    ...    output_topic=test/multiple-process-inputs/out
+    [Teardown]    Run Keywords
+    ...    Uninstall Nested Flow    multiple-process-inputs
+    ...    AND    Remove Test Pipes    /tmp/multiple-process-inputs-a /tmp/multiple-process-inputs-b
+
+Consuming messages from mixed input types
+    Create Test Pipes    /tmp/mixed-inputs-file /tmp/mixed-inputs-process
+    Install Nested Flow    mixed-inputs
+    MQTT Input Should Be Routed    test/mixed-inputs/mqtt    from-mqtt    test/mixed-inputs/out
+    Write To Pipe And Assert MQTT Output
+    ...    path=/tmp/mixed-inputs-file
+    ...    input_topic=test/mixed-inputs/file
+    ...    payload=from-file
+    ...    output_topic=test/mixed-inputs/out
+    Write To Pipe And Assert MQTT Output
+    ...    path=/tmp/mixed-inputs-process
+    ...    input_topic=test/mixed-inputs/process
+    ...    payload=from-process
+    ...    output_topic=test/mixed-inputs/out
+    [Teardown]    Run Keywords
+    ...    Uninstall Nested Flow    mixed-inputs
+    ...    AND    Remove Test Pipes    /tmp/mixed-inputs-file /tmp/mixed-inputs-process
+
 Consuming messages from a file, periodically
     Install Flow    input-flows    read-file-periodically.toml
     Execute Command    echo hello >/tmp/file.input
@@ -655,11 +713,11 @@ Uninstall Flow
 
 Install Nested Flow
     [Arguments]    ${directory}
+    Remove Nested Flow Directories    ${directory}
     ${start}    Get Unix Timestamp
-    # transfer to parent dir + move to minimize reloads of flows and scripts
+    # Transfer to parent dir + move to minimize reloads of flows and scripts.
     ThinEdgeIO.Transfer To Device    ${CURDIR}/${directory}/*    /etc/tedge/mappers/local/${directory}/
     Execute Command    mv /etc/tedge/mappers/local/${directory} /etc/tedge/mappers/local/flows/${directory}
-    Execute Command    ls -lh /etc/tedge/mappers/local/flows/${directory}
     Should Have MQTT Messages
     ...    topic=te/device/main/service/tedge-mapper-local/status/flows
     ...    date_from=${start}
@@ -667,7 +725,42 @@ Install Nested Flow
 
 Uninstall Nested Flow
     [Arguments]    ${directory}
-    Execute Command    cmd=rm -fr /etc/tedge/mappers/local/flows/${directory}
+    Remove Nested Flow Directories    ${directory}
+
+Remove Nested Flow Directories
+    [Arguments]    ${directory}
+    Execute Command
+    ...    cmd=rm -fr /etc/tedge/mappers/local/${directory} /etc/tedge/mappers/local/flows/${directory}
+
+Create Test Pipes
+    [Arguments]    ${paths}
+    Remove Test Pipes    ${paths}
+    Execute Command    cmd=mkfifo ${paths}
+    Execute Command    cmd=chmod a+rw ${paths}
+
+Remove Test Pipes
+    [Arguments]    ${paths}
+    Execute Command    cmd=rm -f ${paths}
+
+MQTT Input Should Be Routed
+    [Arguments]    ${input_topic}    ${payload}    ${output_topic}
+    ${start}    Get Unix Timestamp
+    Execute Command    tedge mqtt pub ${input_topic} ${payload}
+    Should Have MQTT Messages
+    ...    topic=${output_topic}
+    ...    minimum=1
+    ...    message_contains=${input_topic}:${payload}
+    ...    date_from=${start}
+
+Write To Pipe And Assert MQTT Output
+    [Arguments]    ${path}    ${input_topic}    ${payload}    ${output_topic}
+    ${start}    Get Unix Timestamp
+    Execute Command    cmd=timeout 5 sh -c 'printf "%s\n" "${payload}" > ${path}'
+    Should Have MQTT Messages
+    ...    topic=${output_topic}
+    ...    minimum=1
+    ...    message_contains=${input_topic}:${payload}
+    ...    date_from=${start}
 
 Configure flows
     # Required by tail-named-pipe.toml


### PR DESCRIPTION
## Proposed changes
This update allows flows to mix different input types (e.g., running `mqtt` and `process` inputs simultaneously) as well as define multiple inputs of the same type. 

The latter is achieved by supporting TOML arrays of tables (`[[ ... ]]`) for inputs:

```toml
[[input.process]]
command = "./some-script.sh"
interval = "30s"

[[input.process]]
command = "./some-other-script.sh"
interval = "10s"
```

Existing configurations are not impacted. The syntax for defining a single input as a standard table (`[ ... ]`) is still fully supported:

```toml
[input.process]
command = "./some-script.sh"
interval = "30s"
```


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #4165

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

