### PR TITLE
refactor: Fix flakiness in custom_operation.robot

### DIFF
--- a/crates/core/tedge_agent/src/operation_workflows/actor.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/actor.rs
@@ -253,6 +253,11 @@ impl WorkflowActor {
             Err(WorkflowExecutionError::UnknownOperation { operation }) => {
                 info!("Ignoring {operation} operation which is not registered");
             }
+            Err(WorkflowExecutionError::DuplicatedRequest { topic }) => {
+                error!(
+                    "{operation} operation request cannot be processed: Two concurrent requests are under execution on the same topic: {topic}"
+                );
+            }
             Err(err) => {
                 error!("{operation} operation request cannot be processed: {err}");
                 log_file.log_step(&step, &format!("Error: {err}\n")).await;

--- a/tests/RobotFramework/tests/tedge_agent/workflows/custom_operation.robot
+++ b/tests/RobotFramework/tests/tedge_agent/workflows/custom_operation.robot
@@ -167,11 +167,15 @@ Invoke sub-operation from a sub-operation
     Should Be Equal    ${actual_log}    ${expected_log}
 
 Command steps should not be executed twice
-    Execute Command    tedge mqtt pub --retain te/device/main///cmd/issue-2896/test-1 '{"status":"init"}'
-    ${cmd_messages}    Should Have MQTT Messages
-    ...    te/device/main///cmd/issue-2896/test-1
-    ...    message_pattern=.*successful.*
-    Execute Command    tedge mqtt pub --retain te/device/main///cmd/issue-2896/test-1 ''
+    TRY
+        Execute Command    tedge mqtt pub --retain te/device/main///cmd/issue-2896/test-1 '{"status":"init"}'
+        ${cmd_messages}    Should Have MQTT Messages
+        ...    te/device/main///cmd/issue-2896/test-1
+        ...    message_pattern=.*successful.*
+        ...    timeout=300
+    FINALLY
+        Execute Command    tedge mqtt pub --retain te/device/main///cmd/issue-2896/test-1 ''
+    END
     ${workflow_log}    Execute Command
     ...    grep '\\[ issue-2896' /var/log/tedge/agent/workflow-issue-2896-test-1.log | cut -d '|' -f 1 | sed 's/ $//'
     TRY

--- a/tests/images/debian-systemd/files/mqtt-logger
+++ b/tests/images/debian-systemd/files/mqtt-logger
@@ -8,6 +8,7 @@ MQTT_CERT_FILE=${MQTT_CERT_FILE:-}
 MQTT_KEY_FILE=${MQTT_KEY_FILE:-}
 OUTPUT_LOG=${OUTPUT_LOG:-}
 WAIT=${WAIT:-1}
+STOPPING=false
 
 usage() {
     echo "
@@ -104,6 +105,12 @@ log() {
     echo "$*" >&2
 }
 
+stop() {
+    STOPPING=true
+}
+
+trap stop INT TERM
+
 subscribe() {
     if [ -n "$MQTT_CA_FILE" ] && [ -n "$MQTT_KEY_FILE" ] && [ -n "$MQTT_CERT_FILE" ]; then
         log "Connecting to broker using certificate"
@@ -139,12 +146,15 @@ if command -v pgrep >/dev/null 2>&1; then
 fi
 
 # Keep trying forever
-while true; do
+while [ "$STOPPING" = false ]; do
     log "Starting mqtt-logger to ${MQTT_HOST}:${MQTT_PORT}"
     if [ -n "$OUTPUT_LOG" ]; then
         subscribe | tee -a "$OUTPUT_LOG" || true
     else
         subscribe || true
+    fi
+    if [ "$STOPPING" = true ]; then
+        break
     fi
     log "mqtt-logger stopped, waiting ${WAIT} second/s and trying again"
     sleep "$WAIT"

--- a/tests/images/debian-systemd/files/mqtt-logger.service
+++ b/tests/images/debian-systemd/files/mqtt-logger.service
@@ -7,6 +7,8 @@ EnvironmentFile=-/etc/mosquitto-logger/env
 ExecStart=/usr/bin/mqtt-logger
 Restart=always
 RestartSec=3
+KillMode=control-group
+TimeoutStopSec=10s
 
 [Install]
 WantedBy = multi-user.target


### PR DESCRIPTION
Fixes a flaky test that waits for a device reboot.

Failure observed in this run: https://github.com/thin-edge/thin-edge.io/actions/runs/26159165183/job/76948246437

The test was failing because mqtt-logger.service, which runs `mosquitto_sub` to record MQTT messages during Robot tests, could hang during shutdown and delay the reboot. Retries could also leave old retained command messages behind. This change makes mqtt-logger.service stop quickly, gives the reboot test enough time to finish, and makes sure the test always clears its command message, allowing retries to recover from the failure.

It also stops rejected duplicate command messages from appearing in the workflow log as if they were real workflow steps.

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

