### PR TITLE
fix: Don't store twin messages in entity_store.jsonl

### DIFF
--- a/crates/core/tedge_api/src/entity_store.rs
+++ b/crates/core/tedge_api/src/entity_store.rs
@@ -151,25 +151,8 @@ impl EntityStore {
                             }
                         }
                     }
-                    Channel::EntityTwinData { fragment_key } => {
-                        let fragment_value = if message.payload_bytes().is_empty() {
-                            JsonValue::Null
-                        } else {
-                            match serde_json::from_slice::<JsonValue>(message.payload_bytes()) {
-                                Ok(json_value) => json_value,
-                                Err(err) => {
-                                    error!("Failed to parse twin fragment value of {fragment_key} of {source} from the persistent entity store due to {err}");
-                                    continue;
-                                }
-                            }
-                        };
-
-                        let twin_data =
-                            EntityTwinMessage::new(source.clone(), fragment_key, fragment_value);
-                        if let Err(err) = self.register_twin_fragment(twin_data.clone()) {
-                            error!("Failed to restore twin fragment: {twin_data:?} from the persistent entity store due to {err}");
-                            continue;
-                        }
+                    Channel::EntityTwinData { .. } => {
+                        // Twin fragments are intentionally not restored from the entity store log.
                     }
                     Channel::CommandMetadata { .. } => {
                         // Do nothing for now as supported operations are not part of the entity store
@@ -444,7 +427,7 @@ impl EntityStore {
         &mut self,
         twin_message: EntityTwinMessage,
     ) -> Result<bool, entity_store::Error> {
-        self.register_and_persist_twin_fragment(twin_message.clone())
+        self.register_twin_fragment(twin_message)
     }
 
     pub fn register_twin_fragment(
@@ -474,19 +457,6 @@ impl EntityStore {
         }
 
         Ok(true)
-    }
-
-    pub fn register_and_persist_twin_fragment(
-        &mut self,
-        twin_message: EntityTwinMessage,
-    ) -> Result<bool, entity_store::Error> {
-        let updated = self.register_twin_fragment(twin_message.clone())?;
-        if updated {
-            self.message_log
-                .append_message(&twin_message.to_mqtt_message(&self.mqtt_schema))?;
-        }
-
-        Ok(updated)
     }
 
     pub fn get_twin_fragments(
@@ -1093,6 +1063,7 @@ mod tests {
     use assert_matches::assert_matches;
     use serde_json::json;
     use std::collections::BTreeSet;
+    use std::io::Write;
     use std::str::FromStr;
     use tempfile::TempDir;
     use test_case::test_case;
@@ -1911,6 +1882,50 @@ mod tests {
     }
 
     #[test]
+    fn twin_fragment_updates_are_not_persisted() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut store = new_entity_store(&temp_dir, false);
+        let topic_id = EntityTopicId::default_main_device();
+
+        store
+            .update_twin_fragment(EntityTwinMessage::new(
+                topic_id.clone(),
+                "foo".into(),
+                json!("bar"),
+            ))
+            .unwrap();
+
+        assert_eq!(
+            store.get_twin_fragment(&topic_id, "foo"),
+            Some(&json!("bar"))
+        );
+
+        let log = std::fs::read_to_string(temp_dir.path().join("entity_store.jsonl")).unwrap();
+        assert!(!log.contains("twin/foo"));
+        assert!(!log.contains("bar"));
+    }
+
+    #[test]
+    fn twin_fragment_updates_from_old_logs_are_ignored() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let topic_id = EntityTopicId::default_main_device();
+        let topic = MqttSchema::default().topic_for(
+            &topic_id,
+            &Channel::EntityTwinData {
+                fragment_key: "foo".into(),
+            },
+        );
+        let message = MqttMessage::new(&topic, r#""bar""#);
+        let mut file = std::fs::File::create(temp_dir.path().join("entity_store.jsonl")).unwrap();
+        writeln!(file, "{}", json!({ "version": "1.0" })).unwrap();
+        writeln!(file, "{}", serde_json::to_string(&message).unwrap()).unwrap();
+
+        let store = new_entity_store(&temp_dir, false);
+
+        assert_eq!(store.get_twin_fragment(&topic_id, "foo"), None);
+    }
+
+    #[test]
     fn early_child_device_registrations_processed_only_after_parent_registration() {
         let temp_dir = tempfile::tempdir().unwrap();
         let mut store = new_entity_store(&temp_dir, true);
@@ -1964,7 +1979,6 @@ mod tests {
         let child2_topic_id = EntityTopicId::default_child_device("child2").unwrap();
 
         let twin_fragment_key = "foo".to_string();
-        let twin_fragment_value = json!("bar");
 
         {
             let mut store = new_entity_store(&temp_dir, false);
@@ -1981,7 +1995,7 @@ mod tests {
                 .update_twin_fragment(EntityTwinMessage::new(
                     child1_topic_id.clone(),
                     twin_fragment_key.clone(),
-                    twin_fragment_value.clone(),
+                    json!("bar"),
                 ))
                 .unwrap();
 
@@ -1999,18 +2013,13 @@ mod tests {
         {
             // Reload the entity store using the same persistent file
             let store = new_entity_store(&temp_dir, false);
-            let mut expected_entity_metadata =
-                EntityMetadata::child_device("child1".into()).unwrap();
-            expected_entity_metadata
-                .twin_data
-                .insert(twin_fragment_key.clone(), twin_fragment_value.clone());
 
             let entity_metadata = store.get(&child1_topic_id).unwrap();
-            assert_eq!(entity_metadata, &expected_entity_metadata);
             assert_eq!(
-                entity_metadata.twin_data.get(&twin_fragment_key).unwrap(),
-                &twin_fragment_value
+                entity_metadata,
+                &EntityMetadata::child_device("child1".into()).unwrap()
             );
+            assert_eq!(entity_metadata.twin_data.get(&twin_fragment_key), None);
 
             assert_eq!(
                 store.get(&child2_topic_id).unwrap(),

--- a/crates/core/tedge_api/src/mqtt_topics.rs
+++ b/crates/core/tedge_api/src/mqtt_topics.rs
@@ -721,6 +721,17 @@ impl Channel {
     pub fn is_health(&self) -> bool {
         matches!(self, Channel::Health)
     }
+
+    pub fn is_entity_twin_data(&self) -> bool {
+        matches!(self, Channel::EntityTwinData { .. })
+    }
+}
+
+/// Returns true if the given topic carries entity twin data
+pub fn is_entity_twin_topic(topic: &str) -> bool {
+    MqttSchema::default()
+        .entity_channel_of(topic)
+        .is_ok_and(|(_, channel)| channel.is_entity_twin_data())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/core/tedge_api/src/store/message_log.rs
+++ b/crates/core/tedge_api/src/store/message_log.rs
@@ -1,6 +1,7 @@
 //! The message log is a persistent append-only log of MQTT messages.
 //! Each line is the JSON representation of that MQTT message.
 //! The underlying file is a JSON lines file.
+use crate::mqtt_topics::is_entity_twin_topic;
 use indexmap::IndexMap;
 use log::warn;
 use mqtt_channel::MqttMessage;
@@ -134,6 +135,9 @@ impl MessageLog {
                 Ok(_) => match serde_json::from_str::<MqttMessage>(&buffer) {
                     Ok(message) => {
                         let topic = message.topic.name.clone();
+                        if is_entity_twin_topic(&topic) {
+                            continue;
+                        }
                         let payload = String::from_utf8_lossy(message.payload_bytes()).into_owned();
                         entries.push((topic, payload));
                     }
@@ -154,6 +158,10 @@ impl MessageLog {
 
     /// Persists the message to the log
     pub fn append_message(&mut self, message: &MqttMessage) -> Result<(), std::io::Error> {
+        if is_entity_twin_topic(&message.topic.name) {
+            return Ok(());
+        }
+
         let json_line = serde_json::to_string(message)?;
         writeln!(self.writer, "{}", json_line)?;
         self.writer.flush()?;
@@ -218,6 +226,7 @@ mod tests {
     use super::MessageLog;
     use mqtt_channel::MqttMessage;
     use mqtt_channel::Topic;
+    use serde_json::json;
     use std::io::Write;
     use tempfile::tempdir;
 
@@ -350,6 +359,34 @@ mod tests {
 
         let read_messages: Vec<_> = log.messages().collect();
         assert_eq!(read_messages, vec![make_message("topic2", "v2")]);
+    }
+
+    #[test]
+    fn compaction_removes_twin_messages_from_existing_log_files() {
+        let temp_dir = tempdir().unwrap();
+        let log_path = temp_dir.path().join("entity_store.jsonl");
+        let mut file = std::fs::File::create(&log_path).unwrap();
+        let entity_v1 = make_message(
+            "te/device/child//",
+            r#"{"@type":"child-device","name":"v1"}"#,
+        );
+        let twin = make_message("te/device/child///twin/name", r#""legacy-twin""#);
+        writeln!(file, "{}", json!({ "version": "1.0" })).unwrap();
+        writeln!(file, "{}", serde_json::to_string(&entity_v1).unwrap()).unwrap();
+        writeln!(file, "{}", serde_json::to_string(&twin).unwrap()).unwrap();
+
+        let mut log = MessageLog::new_with_redundancy_threshold(&temp_dir, 1).unwrap();
+        log.append_message(&make_message(
+            "te/device/child//",
+            r#"{"@type":"child-device","name":"v2"}"#,
+        ))
+        .unwrap();
+
+        let compacted_log = std::fs::read_to_string(log_path).unwrap();
+        assert!(compacted_log.contains("te/device/child//"));
+        assert!(compacted_log.contains(r#""name\":\"v2"#));
+        assert!(!compacted_log.contains("te/device/child///twin/name"));
+        assert!(!compacted_log.contains("legacy-twin"));
     }
 
     #[test]

--- a/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_compaction.robot
+++ b/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_compaction.robot
@@ -16,33 +16,68 @@ ${ENTITY_STORE}     /etc/tedge/.agent/entity_store.jsonl
 
 *** Test Cases ***
 Entity store log is compacted when redundancy threshold is exceeded
-    [Documentation]    Writing to the same twin fragment 101 times produces 100 redundant log
+    [Documentation]    Updating the same entity registration 101 times produces 100 redundant log
     ...    entries, which meets the compaction threshold. After compaction only one entry for
     ...    that topic is present in the file rather than 101.
-    Write Twin Fragment Many Times    compaction_count    101
+    Write Entity Registration Many Times    compaction_count    101
     ${count}=    Execute Command    grep -c "compaction_count" ${ENTITY_STORE}    strip=${True}
     # The compaction might trigger earlier than expected as services may have reregistered on startup,
     # but the count should be well below the threshold of 100 redundant entries
     Should Be True    ${count} < 10
 
-Latest twin value is preserved after compaction
-    [Documentation]    After compaction the twin fragment retains the most recently written
-    ...    value, not an older one.
-    Write Twin Fragment Many Times    compaction_value    101
-    ${value}=    Execute Command
-    ...    curl -s http://localhost:8000/te/v1/entities/device/main///twin/compaction_value    strip=${True}
-    Should Be Equal    ${value}    101
+Latest entity metadata is preserved after compaction
+    [Documentation]    After compaction, entity metadata retains the most recently written
+    ...    registration value, not an older one.
+    Write Entity Registration Many Times    compaction_value    101
+    Wait Until Keyword Succeeds
+    ...    10s
+    ...    500ms
+    ...    Entity Twin Fragment Should Be
+    ...    device/compaction_value//
+    ...    name
+    ...    101
 
 Compacted entity store survives agent restart without data loss
     [Documentation]    After compaction the agent can be restarted and reload the compacted log
-    ...    correctly. Twin data written before the restart remains accessible afterwards.
+    ...    correctly. Entity metadata written before the restart remains accessible afterwards.
     Execute Command    sudo tedge config set agent.entity_store.clean_start false
-    Write Twin Fragment Many Times    compaction_restart    101
+    Write Entity Registration Many Times    compaction_restart    101
     Restart Service    tedge-agent
     Service Health Status Should Be Up    tedge-agent
-    ${value}=    Execute Command
-    ...    curl -s http://localhost:8000/te/v1/entities/device/main///twin/compaction_restart    strip=${True}
-    Should Be Equal    ${value}    101
+    Wait Until Keyword Succeeds
+    ...    10s
+    ...    500ms
+    ...    Entity Twin Fragment Should Be
+    ...    device/compaction_restart//
+    ...    name
+    ...    101
+    [Teardown]    Restart Test Teardown
+
+Twin fragments are not logged to the entity store
+    [Documentation]    Direct twin fragment updates are retained MQTT state, but they are not
+    ...    persisted in entity_store.jsonl.
+    Write Twin Fragment Many Times    twin_not_logged    101
+    ${count}=    Execute Command    grep -c "twin_not_logged" ${ENTITY_STORE} || true    strip=${True}
+    Should Be Equal    ${count}    0
+
+Twin fragments are restored from retained MQTT messages after restart
+    [Documentation]    Direct twin fragment updates are restored from retained MQTT messages,
+    ...    not from entity_store.jsonl.
+    Execute Command    sudo tedge config set agent.entity_store.clean_start false
+    Write Twin Fragment Many Times    retained_twin_not_logged    101
+    ${count}=    Execute Command    grep -c "retained_twin_not_logged" ${ENTITY_STORE} || true    strip=${True}
+    Should Be Equal    ${count}    0
+    Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
+    Wait Until Keyword Succeeds
+    ...    10s
+    ...    500ms
+    ...    Entity Twin Fragment Should Be
+    ...    device/main//
+    ...    retained_twin_not_logged
+    ...    101
+    ${count}=    Execute Command    grep -c "retained_twin_not_logged" ${ENTITY_STORE} || true    strip=${True}
+    Should Be Equal    ${count}    0
     [Teardown]    Restart Test Teardown
 
 Writing to unique topics accumulates entries without triggering compaction
@@ -68,6 +103,17 @@ Write Twin Fragment Many Times
     [Arguments]    ${fragment}    ${count}
     Execute Command
     ...    for i in $(seq 1 ${count}); do tedge http put /te/v1/entities/device/main///twin/${fragment} "$i"; done
+
+Write Entity Registration Many Times
+    [Arguments]    ${child}    ${count}
+    Execute Command
+    ...    for i in $(seq 1 ${count}); do tedge mqtt pub --retain 'te/device/${child}//' '{"@type":"child-device","name":'"$i"'}'; done
+
+Entity Twin Fragment Should Be
+    [Arguments]    ${topic_id}    ${fragment}    ${expected}
+    ${value}=    Execute Command
+    ...    curl -s http://localhost:8000/te/v1/entities/${topic_id}/twin/${fragment}    strip=${True}
+    Should Be Equal    ${value}    ${expected}
 
 Restart Test Teardown
     Execute Command    sudo tedge config set agent.entity_store.clean_start true


### PR DESCRIPTION
## Proposed changes
As discussed the other day, part of the issue faced in #4172 was that `entity_store.jsonl` is storing twin data, and this is not necessary/useful. This PR removes the logging of twin fragments to `entity_store.jsonl`, which should remove the most likely culprit of regular compaction of the entity store.

For existing twin fragments in the log, they are ignored when reading the log and will be removed if/when the log is compacted.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #4172

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

