### PR TITLE
fix: generate tedgeUrl with https when TLS enabled in file-transfer service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,6 +872,7 @@ dependencies = [
  "serde_json",
  "tedge_api",
  "tedge_config",
+ "tedge_utils",
  "test-case",
  "thiserror 2.0.12",
  "time",

--- a/crates/common/tedge_utils/src/http.rs
+++ b/crates/common/tedge_utils/src/http.rs
@@ -1,0 +1,15 @@
+/// The scheme used to connect to an HTTP server.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Protocol {
+    Http,
+    Https,
+}
+
+impl Protocol {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Http => "http",
+            Self::Https => "https",
+        }
+    }
+}

--- a/crates/common/tedge_utils/src/lib.rs
+++ b/crates/common/tedge_utils/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod atomic;
 pub mod file;
 pub mod fs;
+pub mod http;
 pub mod paths;
 pub mod signals;
 pub mod timers;

--- a/crates/core/c8y_api/Cargo.toml
+++ b/crates/core/c8y_api/Cargo.toml
@@ -20,6 +20,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tedge_api = { workspace = true }
 tedge_config = { workspace = true }
+tedge_utils = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true, features = ["rt", "sync", "time"] }

--- a/crates/core/c8y_api/src/proxy_url.rs
+++ b/crates/core/c8y_api/src/proxy_url.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+pub use tedge_utils::http::Protocol;
+
 #[derive(Clone, Debug)]
 pub struct ProxyUrlGenerator {
     host: Arc<str>,
@@ -10,21 +12,6 @@ pub struct ProxyUrlGenerator {
 impl Default for ProxyUrlGenerator {
     fn default() -> Self {
         ProxyUrlGenerator::new("localhost".into(), 8001, Protocol::Http)
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Protocol {
-    Http,
-    Https,
-}
-
-impl Protocol {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Http => "http",
-            Self::Https => "https",
-        }
     }
 }
 

--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -61,6 +61,7 @@ use tedge_mqtt_ext::MqttConfig;
 use tedge_script_ext::ScriptActor;
 use tedge_signal_ext::SignalActor;
 use tedge_uploader_ext::UploaderActor;
+use tedge_utils::http::Protocol;
 use tedge_utils::paths::ManagedDir;
 use tedge_utils::paths::TedgePaths;
 use tracing::info;
@@ -88,6 +89,7 @@ pub(crate) struct AgentConfig {
     pub service_topic_id: ServiceTopicId,
     pub mqtt_topic_root: Arc<str>,
     pub tedge_http_host: Arc<str>,
+    pub tedge_http_protocol: Protocol,
     pub service: TEdgeConfigReaderService,
     pub identity: Option<Identity>,
     pub cloud_root_certs: CloudHttpConfig,
@@ -132,6 +134,13 @@ impl AgentConfig {
         let tedge_http_address = tedge_config.http.client.host.clone();
         let tedge_http_port = tedge_config.http.client.port;
         let tedge_http_host = format!("{}:{}", tedge_http_address, tedge_http_port).into();
+        let tedge_http_protocol = if tedge_config.http.cert_path.or_none().is_some()
+            && tedge_config.http.key_path.or_none().is_some()
+        {
+            Protocol::Https
+        } else {
+            Protocol::Http
+        };
 
         // HTTP config
         let data_dir = tedge_config.data_root();
@@ -224,6 +233,7 @@ impl AgentConfig {
             mqtt_device_topic_id,
             service_topic_id,
             tedge_http_host,
+            tedge_http_protocol,
             identity,
             cloud_root_certs,
             fts_url,
@@ -361,6 +371,7 @@ impl Agent {
                     mqtt_topic_root: mqtt_schema.clone(),
                     mqtt_device_topic_id: device_topic_id.clone(),
                     tedge_http_host: self.config.tedge_http_host,
+                    tedge_http_protocol: self.config.tedge_http_protocol,
                     tmp_path: self.config.tmp_dir.clone(),
                     ops_dir: self.config.operations_dir.clone(),
                     is_sudo_enabled: self.config.is_sudo_enabled,

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -50,6 +50,7 @@ pub struct C8yMapperConfig {
     pub c8y_host: String,
     pub c8y_mqtt: String,
     pub tedge_http_host: Arc<str>,
+    pub tedge_http_protocol: Protocol,
     pub topics: TopicFilter,
     pub capabilities: Capabilities,
     pub auth_proxy_addr: Arc<str>,
@@ -91,6 +92,7 @@ impl C8yMapperConfig {
         c8y_host: String,
         c8y_mqtt: String,
         tedge_http_host: Arc<str>,
+        tedge_http_protocol: Protocol,
         topics: TopicFilter,
         capabilities: Capabilities,
         auth_proxy_addr: Arc<str>,
@@ -132,6 +134,7 @@ impl C8yMapperConfig {
             c8y_host,
             c8y_mqtt,
             tedge_http_host,
+            tedge_http_protocol,
             topics,
             capabilities,
             auth_proxy_addr,
@@ -197,6 +200,13 @@ impl C8yMapperConfig {
             .map_or(Protocol::Http, |_| Protocol::Https);
 
         let tedge_http_host = format!("{}:{}", tedge_http_address, tedge_http_port).into();
+        let tedge_http_protocol = if tedge_config.http.cert_path.or_none().is_some()
+            && tedge_config.http.key_path.or_none().is_some()
+        {
+            Protocol::Https
+        } else {
+            Protocol::Http
+        };
 
         let capabilities = Capabilities {
             log_upload: c8y_config.cloud_specific.enable.log_upload,
@@ -266,6 +276,7 @@ impl C8yMapperConfig {
             c8y_host,
             c8y_mqtt,
             tedge_http_host,
+            tedge_http_protocol,
             topics,
             capabilities,
             auth_proxy_addr,

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -3139,6 +3139,7 @@ pub(crate) mod tests {
             c8y_host.clone(),
             c8y_host,
             tedge_http_host,
+            Protocol::Http,
             topics,
             Capabilities::default(),
             auth_proxy_addr,

--- a/crates/extensions/c8y_mapper_ext/src/operations/convert.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/convert.rs
@@ -88,7 +88,8 @@ impl CumulocityConverter {
 
         // Replace '/' with ':' to avoid creating unexpected directories in file transfer repo
         let tedge_url = format!(
-            "http://{}/te/v1/files/{}/config_snapshot/{}-{}",
+            "{}://{}/te/v1/files/{}/config_snapshot/{}-{}",
+            self.config.tedge_http_protocol.as_str(),
             &self.config.tedge_http_host,
             target.external_id.as_ref(),
             config_upload_request.config_type.replace('/', ":"),
@@ -127,7 +128,8 @@ impl CumulocityConverter {
         let topic = self.mqtt_schema.topic_for(target.topic_id(), &channel);
 
         let tedge_url = format!(
-            "http://{}/te/v1/files/{}/log_upload/{}-{}",
+            "{}://{}/te/v1/files/{}/log_upload/{}-{}",
+            self.config.tedge_http_protocol.as_str(),
             &self.config.tedge_http_host,
             target.external_id.as_ref(),
             log_request.log_file,

--- a/crates/extensions/c8y_mapper_ext/src/operations/handler.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handler.rs
@@ -62,6 +62,7 @@ impl OperationHandler {
                 capabilities: c8y_mapper_config.capabilities,
                 auto_log_upload: c8y_mapper_config.auto_log_upload,
                 tedge_http_host: c8y_mapper_config.tedge_http_host.clone(),
+                tedge_http_protocol: c8y_mapper_config.tedge_http_protocol,
                 tmp_dir: c8y_mapper_config.tmp_dir.root().into(),
                 mqtt_schema: c8y_mapper_config.mqtt_schema.clone(),
                 mqtt_publisher: mqtt_publisher.clone(),

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/config_snapshot.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/config_snapshot.rs
@@ -95,7 +95,8 @@ impl OperationContext {
             Some(ref tedge_file_url) => Cow::Borrowed(tedge_file_url),
             None => {
                 let tedge_file_url = format!(
-                    "http://{}/te/v1/files/{external_id}/config_snapshot/{config_filename}",
+                    "{}://{}/te/v1/files/{external_id}/config_snapshot/{config_filename}",
+                    self.tedge_http_protocol.as_str(),
                     &self.tedge_http_host,
                     external_id = target.external_id.as_ref()
                 );

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/mod.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/mod.rs
@@ -17,6 +17,7 @@ use crate::actor::IdDownloadResult;
 use crate::actor::IdUploadRequest;
 use crate::actor::IdUploadResult;
 use crate::Capabilities;
+use c8y_api::proxy_url::Protocol;
 use c8y_api::smartrest::payload::SmartrestPayload;
 use c8y_api::smartrest::smartrest_serializer::fail_operation_with_id;
 use c8y_api::smartrest::smartrest_serializer::fail_operation_with_name;
@@ -59,6 +60,7 @@ pub(super) struct OperationContext {
     pub(super) capabilities: Capabilities,
     pub(super) auto_log_upload: AutoLogUpload,
     pub(super) tedge_http_host: Arc<str>,
+    pub(super) tedge_http_protocol: Protocol,
     pub(super) tmp_dir: Arc<Utf8Path>,
     pub(super) mqtt_schema: MqttSchema,
     pub(super) software_management_api: SoftwareManagementApiFlag,

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -3324,6 +3324,7 @@ pub(crate) fn test_mapper_config(tmp_dir: &TempTedgeDir) -> C8yMapperConfig {
         c8y_host.clone(),
         c8y_host,
         tedge_http_host,
+        Protocol::Http,
         topics,
         capabilities,
         auth_proxy_addr,

--- a/crates/extensions/tedge_config_manager/src/actor.rs
+++ b/crates/extensions/tedge_config_manager/src/actor.rs
@@ -400,7 +400,8 @@ impl ConfigManagerWorker {
             };
 
         Ok(format!(
-            "http://{}/te/v1/files/{}/{}/{}-{}",
+            "{}://{}/te/v1/files/{}/{}/{}-{}",
+            self.config.tedge_http_protocol.as_str(),
             &self.config.tedge_http_host,
             device_name,
             operation_type,

--- a/crates/extensions/tedge_config_manager/src/config.rs
+++ b/crates/extensions/tedge_config_manager/src/config.rs
@@ -8,6 +8,7 @@ use tedge_api::mqtt_topics::OperationType;
 use tedge_config::tedge_toml::ReadError;
 use tedge_mqtt_ext::Topic;
 use tedge_mqtt_ext::TopicFilter;
+use tedge_utils::http::Protocol;
 use tedge_utils::paths::ManagedDir;
 use tedge_utils::paths::ManagedFile;
 use tedge_utils::paths::TedgePaths;
@@ -31,6 +32,7 @@ pub struct ConfigManagerConfig {
     pub config_update_topic: TopicFilter,
     pub config_snapshot_topic: TopicFilter,
     pub tedge_http_host: Arc<str>,
+    pub tedge_http_protocol: Protocol,
     pub config_snapshot_enabled: bool,
     pub config_update_enabled: bool,
     pub sudo_enabled: bool,
@@ -41,6 +43,7 @@ pub struct ConfigManagerOptions {
     pub mqtt_topic_root: MqttSchema,
     pub mqtt_device_topic_id: EntityTopicId,
     pub tedge_http_host: Arc<str>,
+    pub tedge_http_protocol: Protocol,
     pub tmp_path: Arc<TedgePaths>,
     pub ops_dir: ManagedDir,
     pub is_sudo_enabled: bool,
@@ -88,6 +91,7 @@ impl ConfigManagerConfig {
             config_update_topic,
             config_snapshot_topic,
             tedge_http_host: cliopts.tedge_http_host,
+            tedge_http_protocol: cliopts.tedge_http_protocol,
             config_snapshot_enabled: cliopts.config_snapshot_enabled,
             config_update_enabled: cliopts.config_update_enabled,
             sudo_enabled: cliopts.is_sudo_enabled,

--- a/crates/extensions/tedge_config_manager/src/tests.rs
+++ b/crates/extensions/tedge_config_manager/src/tests.rs
@@ -28,6 +28,7 @@ use tedge_mqtt_ext::Topic;
 use tedge_mqtt_ext::TopicFilter;
 use tedge_test_utils::fs::TempTedgeDir;
 use tedge_uploader_ext::UploadResponse;
+use tedge_utils::http::Protocol;
 use tedge_utils::paths::TedgePaths;
 use toml::from_str;
 use toml::Table;
@@ -131,6 +132,7 @@ async fn new_config_manager_builder(
         config_snapshot_topic: TopicFilter::new_unchecked("te/device/main///cmd/config_snapshot/+"),
         config_update_topic: TopicFilter::new_unchecked("te/device/main///cmd/config_update/+"),
         tedge_http_host: "127.0.0.1:3000".into(),
+        tedge_http_protocol: Protocol::Http,
         config_snapshot_enabled: true,
         config_update_enabled: true,
         sudo_enabled: false,
@@ -855,6 +857,7 @@ fn test_config(tempdir: &TempTedgeDir) -> ConfigManagerConfig {
         config_update_topic: TopicFilter::new_unchecked("te/device/main///cmd/config_update/+"),
         config_snapshot_topic: TopicFilter::new_unchecked("te/device/main///cmd/config_snapshot/+"),
         tedge_http_host: Arc::from("localhost"),
+        tedge_http_protocol: Protocol::Http,
         config_snapshot_enabled: false,
         config_update_enabled: false,
         sudo_enabled: false,

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -89,9 +89,17 @@ Configuration update succeeds despite mapper not supplying client certificate
 *** Keywords ***
 Get Configuration Should Succeed
     [Arguments]    ${device}    ${external_id}
+    ${start_time}=    Get Unix Timestamp
+
     Cumulocity.Set Device    ${external_id}
     ${operation}=    Cumulocity.Get Configuration    CONFIG1
-    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}    timeout=120
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=120
+
+    # Issue \#4187: deleting a log file from the file transfer service should not print warning
+    ${journal_log}=    Execute Command
+    ...    journalctl -u tedge-mapper-c8y --since "@${start_time}" --no-pager
+    ...    ignore_exit_code=${True}
+    Should Not Contain    ${journal_log}    Failed to delete log file from file transfer service
 
     ThinEdgeIO.Set Device Context    ${device}
     ${expected_checksum}=    Execute Command    md5sum '/etc/config1.json' | cut -d' ' -f1    strip=${True}

--- a/tests/RobotFramework/tests/cumulocity/log/generate_certificates.sh
+++ b/tests/RobotFramework/tests/cumulocity/log/generate_certificates.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+
+set -e
+
+DEVICE=$(tedge config get device.id)
+C8Y_PROXY_COMMON_NAME=$(tedge config get c8y.proxy.client.host)
+FTS_COMMON_NAME=$(tedge config get http.client.host)
+
+## Signing certificate
+openssl req \
+    -new \
+    -x509 \
+    -days 100 \
+    -extensions v3_ca \
+    -nodes \
+    -subj "/O=thin-edge/OU=$DEVICE/CN=tedge-ca" \
+    -keyout tedge-local-ca.key \
+    -out tedge-local-ca.crt
+
+## c8y mapper certificate
+
+openssl genrsa -out c8y-mapper.key 2048
+
+openssl req -out c8y-mapper.csr -key c8y-mapper.key \
+    -subj "/O=thin-edge/OU=$DEVICE/SN=c8y-mapper/CN=$C8Y_PROXY_COMMON_NAME" \
+    -new
+
+cat > v3.c8yproxy.ext << EOF
+authorityKeyIdentifier=keyid
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, keyAgreement
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName=DNS:localhost,IP:$C8Y_PROXY_COMMON_NAME,IP:127.0.0.1
+EOF
+
+openssl x509 -req \
+    -in c8y-mapper.csr \
+    -CA tedge-local-ca.crt \
+    -CAkey tedge-local-ca.key \
+    -extfile v3.c8yproxy.ext \
+    -CAcreateserial \
+    -out c8y-mapper.crt \
+    -days 100
+
+## main agent certificate
+
+cat > v3.agent.ext << EOF
+authorityKeyIdentifier=keyid
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, keyAgreement
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName=DNS:localhost,IP:$FTS_COMMON_NAME,IP:127.0.0.1
+EOF
+
+openssl genrsa -out main-agent.key 2048
+
+openssl req -out main-agent.csr \
+    -key main-agent.key \
+    -subj "/O=thin-edge/OU=$DEVICE/SN=main-agent/CN=$FTS_COMMON_NAME" \
+    -new
+
+openssl x509 -req \
+    -in main-agent.csr \
+    -CA tedge-local-ca.crt \
+    -CAkey tedge-local-ca.key \
+    -extfile v3.agent.ext \
+    -CAcreateserial \
+    -out main-agent.crt \
+    -days 100
+
+## client certificate
+
+openssl genrsa -out tedge-client.key 2048
+
+openssl req -out tedge-client.csr \
+    -key tedge-client.key \
+    -subj "/O=thin-edge/OU=$DEVICE/SN=child/CN=tedge-client" \
+    -new
+
+cat > client-v3.ext << EOF
+basicConstraints=CA:FALSE
+extendedKeyUsage = clientAuth
+EOF
+
+openssl x509 -req \
+    -in tedge-client.csr \
+    -CA tedge-local-ca.crt \
+    -CAkey tedge-local-ca.key \
+    -extfile client-v3.ext \
+    -CAcreateserial \
+    -out tedge-client.crt \
+    -days 100
+
+## Settings
+
+#cat tedge-local-ca.crt >> main-agent.crt
+
+mkdir -p /etc/tedge/device-local-certs/roots
+
+mv tedge-local-ca.* /etc/tedge/device-local-certs/roots
+mv c8y-mapper.* /etc/tedge/device-local-certs
+mv main-agent.* /etc/tedge/device-local-certs
+mv tedge-client.* /etc/tedge/device-local-certs
+
+sudo cp /etc/tedge/device-local-certs/roots/tedge-local-ca.crt /usr/local/share/ca-certificates
+sudo update-ca-certificates
+
+### c8y mapper (serving c8y-proxy, file-transfer client)
+#tedge config set c8y.proxy.ca_path /etc/tedge/device-local-certs/roots
+#tedge config set c8y.proxy.cert_path /etc/tedge/device-local-certs/c8y-mapper.crt
+#tedge config set c8y.proxy.key_path /etc/tedge/device-local-certs/c8y-mapper.key
+
+### main agent (serving file-transfer, c8y-proxy client)
+tedge config set http.client.auth.cert_file /etc/tedge/device-local-certs/main-agent.crt
+tedge config set http.client.auth.key_file /etc/tedge/device-local-certs/main-agent.key
+tedge config set http.cert_path /etc/tedge/device-local-certs/main-agent.crt
+tedge config set http.key_path /etc/tedge/device-local-certs/main-agent.key
+#tedge config set http.ca_path /etc/tedge/device-local-certs/roots
+
+chown -R tedge:tedge /etc/tedge/device-local-certs

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_with_file_transfer_https.robot
@@ -1,0 +1,74 @@
+*** Settings ***
+Resource            ../../../resources/common.resource
+Library             DateTime
+Library             OperatingSystem
+Library             String
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Suite Setup         Custom Setup
+Suite Teardown      Get Logs
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:log
+
+
+*** Variables ***
+${DEVICE_SN}    ${EMPTY}
+
+
+*** Test Cases ***
+Log upload operation succeeds when File Transfer Service has TLS enabled
+    [Documentation]    Issue \#4187
+    ${start_time}=    Get Unix Timestamp
+
+    ${start_timestamp}=    Get Current Date    UTC    -24 hours    result_format=%Y-%m-%dT%H:%M:%S+0000
+    ${end_timestamp}=    Get Current Date    UTC    +60 seconds    result_format=%Y-%m-%dT%H:%M:%S+0000
+    ${operation}=    Cumulocity.Create Operation
+    ...    description=Log file request
+    ...    fragments={"c8y_LogfileRequest":{"dateFrom":"${start_timestamp}","dateTo":"${end_timestamp}","logFile":"example","searchText":"first","maximumLines":10}}
+    ${operation}=    Operation Should Be SUCCESSFUL    ${operation}    timeout=120
+
+    # The init message published by the mapper must carry an https:// in tedgeUrl
+    Should Have MQTT Messages
+    ...    te/device/main///cmd/log_upload/+
+    ...    message_contains="tedgeUrl":"https://
+    ...    date_from=${start_timestamp}
+    ...    minimum=1
+
+    # Validate that all temporary files created for the log upload operation are cleaned up
+    Execute Command    ls /tmp/example*    exp_exit_code=2
+    Execute Command    ls /var/tedge/file-transfer/${DEVICE_SN}/log_upload/example*    exp_exit_code=2
+
+    # Issue \#4187: deleting a log file from the file transfer service should not print a warning
+    ${journal_log}=    Execute Command
+    ...    journalctl -u tedge-mapper-c8y --since "@${start_time}" --no-pager
+    ...    ignore_exit_code=${True}
+    Should Not Contain    ${journal_log}    Failed to delete log file from file transfer service
+
+
+*** Keywords ***
+Setup LogFiles
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/tedge-log-plugin.toml    /etc/tedge/plugins/tedge-log-plugin.toml
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/example.log    /var/log/example/
+    Execute Command
+    ...    chown root:root /etc/tedge/plugins/tedge-log-plugin.toml /var/log/example/example.log && touch /var/log/example/example.log
+
+Setup TLS For File Transfer Service
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/generate_certificates.sh    /etc/tedge/
+    Execute Command    chmod +x /etc/tedge/generate_certificates.sh
+    Execute Command    /etc/tedge/generate_certificates.sh    timeout=0
+
+    Execute Command    sudo systemctl restart tedge-agent
+    ThinEdgeIO.Service Health Status Should Be Up    tedge-agent
+
+    ThinEdgeIO.Disconnect Then Connect Mapper    c8y
+    ThinEdgeIO.Service Health Status Should Be Up    tedge-mapper-c8y
+
+Custom Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    $DEVICE_SN
+    Device Should Exist    ${DEVICE_SN}
+
+    Setup LogFiles
+    Setup TLS For File Transfer Service


### PR DESCRIPTION
## Proposed changes
#4141 added the http file deletion from the file transfer service after a`config_snapshot` or `log_upload` command completed.

https://github.com/thin-edge/thin-edge.io/blob/dda1013edc2724ef5b57e04b79fc6d2235d842c1/crates/extensions/c8y_mapper_ext/src/operations/handlers/log_upload.rs#L53

This HTTP request works when TLS is disabled in the file transfer service (that's why the existing test passes). However, when TLS is enabled, a warning message appeared.
```
Failed with HTTP error status 307 Temporary Redirect for DELETE request to endpoint
```

This warning (error) indicates that the http redirect to https occurs. The `hyper` backed client doesn't follow the redirect automatically.

Hence, this PR changes `tedgeUrl` generated by tedge-mapper to have a URL with `https://` when `http.cert_path` and `http.key_path` are configured.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#4187

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

