### PR TITLE
fix: disable entity store clean_start of tedge-agent

### DIFF
--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -1242,8 +1242,9 @@ define_tedge_config! {
             #[tedge_config(example = "true", default(value = true), deprecated_key = "c8y.entity_store.auto_register")]
             auto_register: bool,
 
-            /// On a clean start, the whole state of the device, services and child-devices is resent to the cloud
-            #[tedge_config(example = "true", default(value = true), deprecated_key = "c8y.entity_store.clean_start")]
+            /// When set to `false`, the entity store is persisted and restored over agent restarts.
+            /// When set to `true`, the entity store is re-created from the retained entity registration MQTT messages.
+            #[tedge_config(example = "true", default(value = false), deprecated_key = "c8y.entity_store.clean_start")]
             clean_start: bool,
         },
 

--- a/justfile
+++ b/justfile
@@ -188,6 +188,35 @@ build-integration-test: build
 integration-test *ARGS: build-integration-test
     invoke tests {{ARGS}}
 
+# All arguments are forwarded as-is to the `invoke flake-finder` task.
+# See `invoke --help flake-finder` (from tests/RobotFramework) for the full list of options.
+#
+# Common options:
+#   --iterations N                 Number of test iterations to run (default: 2)
+#   --suite TEXT                   Only run suites matching the given text
+#   --test-name TEXT               Only run tests matching the given text
+#   --adapter {docker,ssh,local}   Device adapter to use (default: docker)
+#   --retries N                    Max global retries on failed tests (default: 0)
+#   --outputdir PATH               Output directory for reports (default: output_flake_finder)
+#   --processes N                  Number of processes to use when running tests
+#   --include TAG                  Only run tests matching the given tag
+#   --exclude TAG                  Don't run tests matching the given tag
+#   --clean                        Remove the output folder if it already exists
+#
+# Examples:
+#   just flake-finder --iterations 100 --outputdir output_flake_finder_100 --clean
+#   just flake-finder --suite service_monitoring
+#   just flake-finder --test-name "MyTest" --iterations 10 --clean
+#
+# Run integration tests multiple times to find flaky tests
+[positional-arguments]
+flake-finder *ARGS:
+    #!/usr/bin/env bash
+    set -e
+    cd tests/RobotFramework
+    source .venv/bin/activate
+    invoke flake-finder "$@"
+
 # Generate linux package scripts from templates
 generate-linux-package-scripts:
     ./configuration/package_scripts/generate.py

--- a/tests/RobotFramework/tests/tedge_agent/entity_store_persistence.robot
+++ b/tests/RobotFramework/tests/tedge_agent/entity_store_persistence.robot
@@ -1,0 +1,180 @@
+*** Settings ***
+Resource            ../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Test Setup          Custom Setup
+Test Teardown       Get Logs    ${DEVICE_SN}
+
+Test Tags           theme:c8y    theme:registration    theme:deregistration
+
+
+*** Variables ***
+${DEVICE_SN}    ${EMPTY}
+${CHILD_SN}     ${EMPTY}
+${CHILD_XID}    ${EMPTY}
+
+
+*** Test Cases ***
+Twin fragment in registration message survives agent restart
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","name":"${CHILD_SN}-custom"}'
+    Device Should Exist    ${CHILD_XID}
+    Device Should Have Fragment Values    name\=${CHILD_SN}-custom
+
+    # Re-publish registration with a different name — must NOT clobber the user's value
+    Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
+
+    Should Have Retained MQTT Messages
+    ...    te/device/${CHILD_SN}///twin/name
+    ...    message_contains=${CHILD_SN}-custom
+    Device Should Have Fragment Values    name\=${CHILD_SN}-custom
+
+Twin fragment set via twin topic survives agent restart
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_XID}"}'
+    Device Should Exist    ${CHILD_XID}
+    Device Should Have Fragment Values    name\=${DEVICE_SN}:device:${CHILD_SN}
+
+    Execute Command
+    ...    tedge mqtt pub --retain "te/device/${CHILD_SN}///twin/name" '"${CHILD_SN}-custom"'
+    Device Should Have Fragment Values    name\=${CHILD_SN}-custom
+
+    Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
+
+    Should Have Retained MQTT Messages
+    ...    te/device/${CHILD_SN}///twin/name
+    ...    message_contains=${CHILD_SN}-custom
+    Device Should Have Fragment Values    name\=${CHILD_SN}-custom
+
+Twin fragment in registration message updated via twin topic survives agent restart
+    Skip
+    ...    msg=When the registration message is re-delivered to the agent on startup, the twin value in it is accepted as the latest twin value, which causes the updated twin value to be lost.
+
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_XID}","name":"${CHILD_SN}-initial"}'
+    Device Should Exist    ${CHILD_XID}
+    Device Should Have Fragment Values    name\=${CHILD_SN}-initial
+
+    Execute Command
+    ...    tedge mqtt pub --retain "te/device/${CHILD_SN}///twin/name" '"${CHILD_SN}-updated"'
+    Device Should Have Fragment Values    name\=${CHILD_SN}-updated
+
+    Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
+
+    Should Have Retained MQTT Messages
+    ...    te/device/${CHILD_SN}///twin/name
+    ...    message_contains=${CHILD_SN}-updated
+    Device Should Have Fragment Values    name\=${CHILD_SN}-updated
+
+Twin fragment in registration message updated via re-registration survives agent restart
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_XID}","name":"${CHILD_SN}-initial"}'
+    Device Should Exist    ${CHILD_XID}
+    Device Should Have Fragment Values    name\=${CHILD_SN}-initial
+
+    # Re-publish registration with a different name
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_XID}","name":"${CHILD_SN}-updated"}'
+    Device Should Have Fragment Values    name\=${CHILD_SN}-updated
+
+    Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
+
+    Should Have Retained MQTT Messages
+    ...    te/device/${CHILD_SN}///twin/name
+    ...    message_contains=${CHILD_SN}-updated
+    Device Should Have Fragment Values    name\=${CHILD_SN}-updated
+
+Twin fragment update via re-registration message takes precedence over twin topic update on agent restart
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_XID}","name":"${CHILD_SN}-initial"}'
+    Device Should Exist    ${CHILD_XID}
+    Device Should Have Fragment Values    name\=${CHILD_SN}-initial
+
+    Stop Service    tedge-agent
+
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_XID}","name":"${CHILD_SN}-updated"}'
+    Execute Command
+    ...    tedge mqtt pub --retain "te/device/${CHILD_SN}///twin/name" '"${CHILD_SN}-custom"'
+
+    Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
+
+    Should Have Retained MQTT Messages
+    ...    te/device/${CHILD_SN}///twin/name
+    ...    message_contains=${CHILD_SN}-updated
+    Device Should Have Fragment Values    name\=${CHILD_SN}-updated
+
+Twin fragment updated via twin topic while agent is offline survives agent restart
+    Skip
+    ...    msg=When the registration message is re-delivered to the agent on startup, the twin value in it is accepted as the latest twin value, which causes the updated twin value to be lost.
+
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_XID}","name":"${CHILD_SN}-initial"}'
+    Device Should Exist    ${CHILD_XID}
+    Device Should Have Fragment Values    name\=${CHILD_SN}-initial
+
+    Stop Service    tedge-agent
+
+    Execute Command
+    ...    tedge mqtt pub --retain "te/device/${CHILD_SN}///twin/name" '"${CHILD_SN}-updated"'
+
+    Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
+
+    Should Have Retained MQTT Messages
+    ...    te/device/${CHILD_SN}///twin/name
+    ...    message_contains=${CHILD_SN}-updated
+    Device Should Have Fragment Values    name\=${CHILD_SN}-updated
+
+Twin fragment updated via re-registration while agent is offline survives agent restart
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_XID}","name":"${CHILD_SN}-initial"}'
+    Device Should Exist    ${CHILD_XID}
+    Device Should Have Fragment Values    name\=${CHILD_SN}-initial
+
+    Stop Service    tedge-agent
+
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_XID}","name":"${CHILD_SN}-updated"}'
+
+    Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
+
+    Should Have Retained MQTT Messages
+    ...    te/device/${CHILD_SN}///twin/name
+    ...    message_contains=${CHILD_SN}-updated
+    Device Should Have Fragment Values    name\=${CHILD_SN}-updated
+
+Twin fragment in registration message survives agent restart even after deletion
+    Skip
+    ...    Since clearing the twin message does not clear the twin value in the registration message, when it is re-delivered to the agent on startup, the twin value in it is accepted as the latest twin value.
+
+    Execute Command
+    ...    tedge mqtt pub --retain 'te/device/${CHILD_SN}//' '{"@type":"child-device","@id":"${CHILD_XID}","name":"${CHILD_SN}-initial"}'
+    Device Should Exist    ${CHILD_XID}
+    Device Should Have Fragment Values    name\=${CHILD_SN}-initial
+
+    # Delete the twin/name fragment via empty retained payload
+    Execute Command    tedge mqtt pub --retain "te/device/${CHILD_SN}///twin/name" ''
+
+    Restart Service    tedge-agent
+    Service Health Status Should Be Up    tedge-agent
+
+    Should Not Have Retained MQTT Messages    te/device/${CHILD_SN}///twin/name
+
+
+*** Keywords ***
+Custom Setup
+    ${device_sn}=    Setup
+    ${child_sn}=    Get Random Name
+    VAR    ${DEVICE_SN}=    ${device_sn}    scope=TEST
+    VAR    ${CHILD_SN}=    ${child_sn}    scope=TEST
+    VAR    ${CHILD_XID}=    ${device_sn}:device:${child_sn}    scope=TEST
+
+    ThinEdgeIO.Set Device Context    ${DEVICE_SN}


### PR DESCRIPTION
## Proposed changes

Disable entity store clean_start of tedge-agent by default. This reduces the amount of message races that the agent has to deal with on startup, when all entity registrations and their data messages are delivered to the agent.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/4186

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

