### PR TITLE
fix: complete deprecation of c8y.entity_store.* keys

### DIFF
--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -783,16 +783,6 @@ define_tedge_config! {
 
         },
 
-        entity_store: {
-            /// Enable auto registration feature
-            #[tedge_config(example = "true", default(value = true))]
-            auto_register: bool,
-
-            /// On a clean start, the whole state of the device, services and child-devices is resent to the cloud
-            #[tedge_config(example = "true", default(value = true))]
-            clean_start: bool,
-        },
-
         software_management: {
             /// Switch legacy or advanced software management API to use. Value: legacy or advanced
             #[tedge_config(example = "advanced", default(variable = "SoftwareManagementApiFlag::Legacy"))]
@@ -1875,6 +1865,12 @@ mod tests {
     #[test_case::test_case("apt.name")]
     #[test_case::test_case("apt.maintainer")]
     fn all_0_10_keys_can_be_deserialised(key: &str) {
+        key.parse::<ReadableKey>().unwrap();
+    }
+
+    #[test_case::test_case("c8y.entity_store.auto_register")]
+    #[test_case::test_case("c8y.entity_store.clean_start")]
+    fn deprecated_keys_can_be_parsed(key: &str) {
         key.parse::<ReadableKey>().unwrap();
     }
 

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config/mapper_config/compat.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config/mapper_config/compat.rs
@@ -107,10 +107,6 @@ impl FromCloudConfig for C8yMapperSpecificConfig {
                 key_path: c8y.proxy.key_path.clone(),
                 ca_path: c8y.proxy.ca_path.clone(),
             },
-            entity_store: EntityStoreConfig {
-                auto_register: c8y.entity_store.auto_register,
-                clean_start: c8y.entity_store.clean_start,
-            },
             software_management: SoftwareManagementConfig {
                 api: c8y.software_management.api,
                 with_types: c8y.software_management.with_types,
@@ -488,8 +484,6 @@ mod tests {
         let config: C8yMapperConfig = load_cloud_mapper_config(None, &tedge_config).unwrap();
 
         assert_eq!(config.cloud_specific.auth_method, AuthMethod::Certificate);
-        assert!(config.cloud_specific.entity_store.auto_register);
-        assert!(config.cloud_specific.entity_store.clean_start);
 
         assert_eq!(
             config.http().or_none().unwrap().to_string(),
@@ -633,7 +627,6 @@ mod tests {
 
         assert_eq!(config.cloud_specific.auth_method, AuthMethod::Basic);
         assert!(!config.cloud_specific.smartrest.use_operation_id);
-        assert!(!config.cloud_specific.entity_store.auto_register);
         assert!(!config.cloud_specific.enable.log_upload);
     }
 

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config/mapper_config/mod.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config/mapper_config/mod.rs
@@ -464,9 +464,6 @@ pub struct C8yMapperSpecificConfig {
     /// HTTP proxy configuration
     pub proxy: ProxyConfig,
 
-    /// Entity store configuration
-    pub entity_store: EntityStoreConfig,
-
     /// Software management configuration
     pub software_management: SoftwareManagementConfig,
 

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config/version.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config/version.rs
@@ -196,10 +196,18 @@ impl TEdgeTomlVersion {
                     value: Self::Two.into(),
                 },
             ],
-            Self::Two => vec![TomlMigrationStep::MoveKey {
-                original: "apt.dpk",
-                target: "apt.dpkg".into(),
-            }],
+            Self::Two => vec![
+                TomlMigrationStep::MoveKey {
+                    original: "apt.dpk",
+                    target: "apt.dpkg".into(),
+                },
+                mv(
+                    "c8y.entity_store.auto_register",
+                    AgentEntityStoreAutoRegister,
+                ),
+                mv("c8y.entity_store.clean_start", AgentEntityStoreCleanStart),
+                rm("c8y.entity_store"),
+            ],
         }
     }
 
@@ -368,5 +376,42 @@ mod tests {
             Some("keepold")
         );
         assert!(migrated["apt"].as_table().unwrap().get("dpk").is_none());
+    }
+
+    #[test]
+    fn v2_migration_moves_c8y_entity_store_to_agent_entity_store() {
+        let input = toml::toml!(
+            [config]
+            version = "2"
+
+            [c8y.entity_store]
+            auto_register = false
+            clean_start = false
+        );
+        let (migrated, any_keys_migrated) = TEdgeTomlVersion::Two
+            .migrations()
+            .try_fold(
+                (toml::Value::Table(input), false),
+                |(toml, any_migrated), step| {
+                    let (toml, step_migrated) = step.apply_to(toml)?;
+                    Ok::<_, String>((toml, any_migrated || step_migrated))
+                },
+            )
+            .unwrap();
+
+        assert!(any_keys_migrated);
+        assert_eq!(
+            migrated["agent"]["entity_store"]["auto_register"].as_bool(),
+            Some(false)
+        );
+        assert_eq!(
+            migrated["agent"]["entity_store"]["clean_start"].as_bool(),
+            Some(false)
+        );
+        assert!(migrated["c8y"]
+            .as_table()
+            .unwrap()
+            .get("entity_store")
+            .is_none());
     }
 }

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -57,8 +57,6 @@ pub struct C8yMapperConfig {
     pub auth_proxy_port: u16,
     pub auth_proxy_protocol: Protocol,
     pub mqtt_schema: MqttSchema,
-    pub enable_auto_register: bool,
-    pub clean_start: bool,
     pub bridge_config: BridgeConfig,
     pub bridge_in_mapper: bool,
     pub software_management_api: SoftwareManagementApiFlag,
@@ -99,8 +97,6 @@ impl C8yMapperConfig {
         auth_proxy_port: u16,
         auth_proxy_protocol: Protocol,
         mqtt_schema: MqttSchema,
-        enable_auto_register: bool,
-        clean_start: bool,
         bridge_config: BridgeConfig,
         bridge_in_mapper: bool,
         software_management_api: SoftwareManagementApiFlag,
@@ -141,8 +137,6 @@ impl C8yMapperConfig {
             auth_proxy_port,
             auth_proxy_protocol,
             mqtt_schema,
-            enable_auto_register,
-            clean_start,
             bridge_config,
             bridge_in_mapper,
             software_management_api,
@@ -223,9 +217,6 @@ impl C8yMapperConfig {
 
         let mut topics = Self::default_internal_topic_filter(&bridge_config.c8y_prefix)?;
 
-        let enable_auto_register = c8y_config.cloud_specific.entity_store.auto_register;
-        let clean_start = c8y_config.cloud_specific.entity_store.clean_start;
-
         let software_management_api = c8y_config.cloud_specific.software_management.api;
         let software_management_with_types =
             c8y_config.cloud_specific.software_management.with_types;
@@ -283,8 +274,6 @@ impl C8yMapperConfig {
             auth_proxy_port,
             auth_proxy_protocol,
             mqtt_schema,
-            enable_auto_register,
-            clean_start,
             bridge_config,
             bridge_in_mapper,
             software_management_api,

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -2810,7 +2810,6 @@ pub(crate) mod tests {
     async fn early_messages_cached_and_processed_only_after_registration() {
         let tmp_dir = TempTedgeDir::new();
         let mut config = c8y_converter_config(&tmp_dir);
-        config.enable_auto_register = false;
         config.bridge_config.c8y_prefix = "custom-c8y-prefix".try_into().unwrap();
 
         let (mut converter, _http_proxy) = create_c8y_converter_from_config(config);
@@ -2888,8 +2887,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn early_child_device_registrations_processed_only_after_parent_registration() {
         let tmp_dir = TempTedgeDir::new();
-        let mut config = c8y_converter_config(&tmp_dir);
-        config.enable_auto_register = false;
+        let config = c8y_converter_config(&tmp_dir);
 
         let (mut converter, _http_proxy) = create_c8y_converter_from_config(config);
 
@@ -3002,8 +3000,7 @@ pub(crate) mod tests {
             "#,
             );
 
-        let mut config = c8y_converter_config(&tmp_dir);
-        config.enable_auto_register = false;
+        let config = c8y_converter_config(&tmp_dir);
 
         let (mut converter, _http_proxy) = create_c8y_converter_from_config(config);
 
@@ -3146,8 +3143,6 @@ pub(crate) mod tests {
             auth_proxy_port,
             auth_proxy_protocol,
             MqttSchema::default(),
-            true,
-            true,
             bridge_config,
             false,
             SoftwareManagementApiFlag::Advanced,

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -3331,8 +3331,6 @@ pub(crate) fn test_mapper_config(tmp_dir: &TempTedgeDir) -> C8yMapperConfig {
         auth_proxy_port,
         Protocol::Http,
         MqttSchema::default(),
-        true,
-        true,
         bridge_config,
         false,
         SoftwareManagementApiFlag::Advanced,

--- a/tests/RobotFramework/tests/tedge/tedge_config_deprecated_keys.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_config_deprecated_keys.robot
@@ -2,8 +2,8 @@
 Resource            ../../resources/common.resource
 Library             ThinEdgeIO
 
-Test Setup         Custom Setup
-Test Teardown      Get Logs
+Test Setup          Custom Setup
+Test Teardown       Get Logs
 
 Test Tags           theme:cli    theme:configuration
 
@@ -41,7 +41,7 @@ Migrate c8y.entity_store.* keys to agent.entity_store.* keys 1.4->1.5->2.0.0->la
     # The values from agent.entity_store.* keys should be effective, not the values from c8y.entity_store.* keys
     ${auto_register}=    Execute Command    tedge config get agent.entity_store.auto_register    strip=True
     Should Be Equal    ${auto_register}    true
-    ${clean_start}=    Execute Command    tedge config get agent.entity_store.clean_start   strip=True
+    ${clean_start}=    Execute Command    tedge config get agent.entity_store.clean_start    strip=True
     Should Be Equal    ${clean_start}    true
 
     # Update to the test version

--- a/tests/RobotFramework/tests/tedge/tedge_config_deprecated_keys.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_config_deprecated_keys.robot
@@ -1,0 +1,94 @@
+*** Settings ***
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+
+Test Setup         Custom Setup
+Test Teardown      Get Logs
+
+Test Tags           theme:cli    theme:configuration
+
+
+*** Test Cases ***
+Migrate c8y.entity_store.* keys to agent.entity_store.* keys 1.4->1.5->2.0.0->latest
+    [Documentation]    \#4191
+    ...    In normal deprecation scenario, we don't need this kind of test.
+    ...    However, since c8y.entity_store.* keys deprecation was partially done in 1.5.0,
+    ...    this can cause the mix state that both c8y.entity_store.* and agent.entity_store.* keys exist at the same time,
+    ...    and the values of these two keys can be different.
+    ...    Hence, we need to verify the migration of these keys in this test case.
+    # c8y.entity_store.* keys are used in 1.4.0
+    Execute Command    wget -O - https://thin-edge.io/install.sh | sh -s -- 1.4.0
+    Execute Command    sudo tedge config add c8y.entity_store.auto_register false
+    Execute Command    sudo tedge config add c8y.entity_store.clean_start false
+
+    # Update tedge to 1.5.0 which deprecates c8y.entity_store.* keys
+    Execute Command    wget -O - https://thin-edge.io/install.sh | sh -s -- 1.5.0
+    Execute Command    sudo tedge config add agent.entity_store.auto_register true
+    Execute Command    sudo tedge config add agent.entity_store.clean_start true
+
+    # Update tedge to 2.0.0 which migrates cloud specific keys to mapper config
+    Execute Command    wget -O - https://thin-edge.io/install.sh | sh -s -- 2.0.0
+
+    ${output_tedge_toml}=    Execute Command    cat /etc/tedge/tedge.toml
+    Should Contain    ${output_tedge_toml}    auto_register = true
+    Should Contain    ${output_tedge_toml}    clean_start = true
+
+    # This entity_store.auto_register & clean_start are zombie configuration, cannot be modified by CLI
+    ${output_c8y_mapper_toml}=    Execute Command    cat /etc/tedge/mappers/c8y/mapper.toml
+    Should Contain    ${output_c8y_mapper_toml}    auto_register = false
+    Should Contain    ${output_c8y_mapper_toml}    clean_start = false
+
+    # The values from agent.entity_store.* keys should be effective, not the values from c8y.entity_store.* keys
+    ${auto_register}=    Execute Command    tedge config get agent.entity_store.auto_register    strip=True
+    Should Be Equal    ${auto_register}    true
+    ${clean_start}=    Execute Command    tedge config get agent.entity_store.clean_start   strip=True
+    Should Be Equal    ${clean_start}    true
+
+    # Update to the test version
+    Execute Command    apt-get install -y /setup/packages/tedge_*.deb
+    Set Cumulocity URLs
+    Register Device With Cumulocity CA    ${DEVICE_SN}
+    Execute Command    tedge connect c8y
+
+    # If tedge config migration error happens, these services will fail to start
+    Service Health Status Should Be Up    tedge-agent
+    Service Health Status Should Be Up    tedge-mapper-c8y
+
+    # The zombie config is gone
+    ${output_c8y_mapper_toml}=    Execute Command    cat /etc/tedge/mappers/c8y/mapper.toml
+    Should Not Contain    ${output_c8y_mapper_toml}    auto_register = false
+    Should Not Contain    ${output_c8y_mapper_toml}    clean_start = false
+
+Migrate c8y.entity_store.* keys to agent.entity_store.* keys 1.4->1.5->latest
+    [Documentation]    \#4191
+    ...    The half deprecation is not solved in 2.0.0, but 2.0.0 migrates the cloud specific keys to mapper config.
+    # c8y.entity_store.* keys are used in 1.4.0
+    Execute Command    wget -O - https://thin-edge.io/install.sh | sh -s -- 1.4.0
+    Execute Command    sudo tedge config add c8y.entity_store.auto_register false
+    Execute Command    sudo tedge config add c8y.entity_store.clean_start false
+
+    # Update tedge to 1.5.0 which deprecates c8y.entity_store.* keys
+    Execute Command    wget -O - https://thin-edge.io/install.sh | sh -s -- 1.5.0
+    Execute Command    sudo tedge config add agent.entity_store.auto_register true
+    Execute Command    sudo tedge config add agent.entity_store.clean_start true
+
+    # Update to the test version without stepping stone 2.0.0
+    Execute Command    apt-get install -y /setup/packages/tedge_*.deb
+    Set Cumulocity URLs
+    Register Device With Cumulocity CA    ${DEVICE_SN}
+    Execute Command    tedge connect c8y
+
+    # If tedge config migration error happens, these services will fail to start
+    Service Health Status Should Be Up    tedge-agent
+    Service Health Status Should Be Up    tedge-mapper-c8y
+
+    # There is no zombie config
+    ${output_c8y_mapper_toml}=    Execute Command    cat /etc/tedge/mappers/c8y/mapper.toml
+    Should Not Contain    ${output_c8y_mapper_toml}    auto_register = false
+    Should Not Contain    ${output_c8y_mapper_toml}    clean_start = false
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}=    Setup    skip_bootstrap=True
+    Set Suite Variable    ${DEVICE_SN}


### PR DESCRIPTION
## Proposed changes

The deprecation of
* `c8y.entity_store.auto_register`
* `c8y.entity_store.clean_start`
was partially done. That's why it didn't mask those deprecated keys in `tedge config list`.

This PR finalizes the deprecation of the keys. Below are examples of CLI output:

```sh
# No `c8y.entity_store.*` listed
root@60dca65925f8:/setup# tedge config list entity --all
agent.entity_store.auto_register=true
agent.entity_store.clean_start=false
```

```sh
# Deprecation announcement in the output
root@60dca65925f8:/setup# tedge config get c8y.entity_store.auto_register
2026-05-26T15:06:27.739503035Z  WARN tedge_config::tedge_toml::tedge_config: The key 'c8y.entity_store.auto_register' is deprecated. Use 'agent.entity_store.auto_register' instead.
true
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
Found during the review of https://github.com/thin-edge/thin-edge.io/pull/4190#discussion_r3303717385

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

