### PR TITLE
refactor: remove unused `c8y.entity_store` configs from c8y-mapper

### DIFF
--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -57,8 +57,6 @@ pub struct C8yMapperConfig {
     pub auth_proxy_port: u16,
     pub auth_proxy_protocol: Protocol,
     pub mqtt_schema: MqttSchema,
-    pub enable_auto_register: bool,
-    pub clean_start: bool,
     pub bridge_config: BridgeConfig,
     pub bridge_in_mapper: bool,
     pub software_management_api: SoftwareManagementApiFlag,
@@ -99,8 +97,6 @@ impl C8yMapperConfig {
         auth_proxy_port: u16,
         auth_proxy_protocol: Protocol,
         mqtt_schema: MqttSchema,
-        enable_auto_register: bool,
-        clean_start: bool,
         bridge_config: BridgeConfig,
         bridge_in_mapper: bool,
         software_management_api: SoftwareManagementApiFlag,
@@ -141,8 +137,6 @@ impl C8yMapperConfig {
             auth_proxy_port,
             auth_proxy_protocol,
             mqtt_schema,
-            enable_auto_register,
-            clean_start,
             bridge_config,
             bridge_in_mapper,
             software_management_api,
@@ -223,9 +217,6 @@ impl C8yMapperConfig {
 
         let mut topics = Self::default_internal_topic_filter(&bridge_config.c8y_prefix)?;
 
-        let enable_auto_register = c8y_config.cloud_specific.entity_store.auto_register;
-        let clean_start = c8y_config.cloud_specific.entity_store.clean_start;
-
         let software_management_api = c8y_config.cloud_specific.software_management.api;
         let software_management_with_types =
             c8y_config.cloud_specific.software_management.with_types;
@@ -283,8 +274,6 @@ impl C8yMapperConfig {
             auth_proxy_port,
             auth_proxy_protocol,
             mqtt_schema,
-            enable_auto_register,
-            clean_start,
             bridge_config,
             bridge_in_mapper,
             software_management_api,

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -2810,7 +2810,6 @@ pub(crate) mod tests {
     async fn early_messages_cached_and_processed_only_after_registration() {
         let tmp_dir = TempTedgeDir::new();
         let mut config = c8y_converter_config(&tmp_dir);
-        config.enable_auto_register = false;
         config.bridge_config.c8y_prefix = "custom-c8y-prefix".try_into().unwrap();
 
         let (mut converter, _http_proxy) = create_c8y_converter_from_config(config);
@@ -2888,8 +2887,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn early_child_device_registrations_processed_only_after_parent_registration() {
         let tmp_dir = TempTedgeDir::new();
-        let mut config = c8y_converter_config(&tmp_dir);
-        config.enable_auto_register = false;
+        let config = c8y_converter_config(&tmp_dir);
 
         let (mut converter, _http_proxy) = create_c8y_converter_from_config(config);
 
@@ -3002,8 +3000,7 @@ pub(crate) mod tests {
             "#,
             );
 
-        let mut config = c8y_converter_config(&tmp_dir);
-        config.enable_auto_register = false;
+        let config = c8y_converter_config(&tmp_dir);
 
         let (mut converter, _http_proxy) = create_c8y_converter_from_config(config);
 
@@ -3146,8 +3143,6 @@ pub(crate) mod tests {
             auth_proxy_port,
             auth_proxy_protocol,
             MqttSchema::default(),
-            true,
-            true,
             bridge_config,
             false,
             SoftwareManagementApiFlag::Advanced,

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -3331,8 +3331,6 @@ pub(crate) fn test_mapper_config(tmp_dir: &TempTedgeDir) -> C8yMapperConfig {
         auth_proxy_port,
         Protocol::Http,
         MqttSchema::default(),
-        true,
-        true,
         bridge_config,
         false,
         SoftwareManagementApiFlag::Advanced,


### PR DESCRIPTION
## Proposed changes
Remove unused `c8y.entity_store.auto_register` and `c8y.entity_store.clean_start` variables from cumucity mapper.
This change is extracted from #4191.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#4191

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

