### PR TITLE
fix: tedge init ensures all configured paths exist

### DIFF
--- a/crates/common/tedge_utils/src/file.rs
+++ b/crates/common/tedge_utils/src/file.rs
@@ -242,6 +242,9 @@ impl PermissionEntry {
         dir: &Path,
         root: Option<&Path>,
     ) -> Result<(), FileError> {
+        if let Some(root_dir) = root {
+            ensure_parents_exist(root_dir).await?;
+        }
         match dir.parent() {
             None => return Ok(()),
             Some(_parent) if Some(dir) == root => {}
@@ -278,6 +281,24 @@ impl PermissionEntry {
             }),
         }
     }
+}
+
+async fn ensure_parents_exist(dir: &Path) -> Result<(), FileError> {
+    if let Some(parent) = dir.parent() {
+        if !path_exists(parent).await {
+            Box::pin(ensure_parents_exist(parent)).await?;
+
+            if let Err(e) = fs::create_dir(&parent).await {
+                if e.kind() != io::ErrorKind::AlreadyExists {
+                    return Err(FileError::DirectoryCreateFailed {
+                        dir: parent.display().to_string(),
+                        from: e,
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Overwrite the content of existing file. The file permissions will be kept.

--- a/crates/common/tedge_utils/src/paths.rs
+++ b/crates/common/tedge_utils/src/paths.rs
@@ -601,7 +601,6 @@ pub fn ok_if_not_found(err: std::io::Error) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::file::FileError;
     use nix::unistd::Uid;
     use std::os::unix::fs::PermissionsExt;
     use tedge_test_utils::fs::TempTedgeDir;
@@ -920,25 +919,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ensure_does_not_create_directories_above_the_root() {
+    async fn ensure_creates_directories_above_the_root_but_does_not_take_ownership() {
         let ttd = TempTedgeDir::new();
         let root = ttd.utf8_path().join("missing-parent").join("managed-root");
-        let config_root = TedgePaths::from_root_with_defaults(&root, "", "");
+        let config_root = TedgePaths::from_root_with_defaults(&root, "root", "root");
 
         let err = config_root
-            .dir("operations/c8y")
+            .dir("log")
             .unwrap()
             .ensure()
             .await
-            .unwrap_err();
+            .unwrap_err()
+            .to_string();
 
-        assert!(matches!(
-            err,
-            PathsError::FileError(FileError::DirectoryCreateFailed { .. })
-        ));
-        assert!(err.to_string().contains(&root.to_string()));
-        assert!(!root.exists());
-        assert!(!ttd.path().join("missing-parent").exists());
+        assert!(err.contains("Failed to change owner"));
+        assert!(err.contains("missing-parent/managed-root"));
+        assert!(ttd.utf8_path().join("missing-parent").is_dir());
     }
 
     #[tokio::test]

--- a/tests/RobotFramework/tests/tedge/tedge_init.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_init.robot
@@ -1,0 +1,18 @@
+*** Settings ***
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+
+Suite Setup         Setup
+Suite Teardown      Get Suite Logs
+
+Test Tags           theme:cli
+
+
+*** Test Cases ***
+call tedge init
+    Execute Command    tedge config set logs.path /var/local-logs/tedge
+    Execute Command    sudo tedge init --user tedge --group tedge
+    ${output}=    Execute Command    ls -ld /var/local-logs
+    Should Contain    ${output}    root root
+    ${output}=    Execute Command    ls -ld /var/local-logs/tedge
+    Should Contain    ${output}    tedge tedge


### PR DESCRIPTION
## Proposed changes

`tedge init` creates all missing path components - *even* those above tedge root.

-  E.g. ensure `/var/log`  exists, before creating `/var/log/tedge`
-  While folders below tedge root (e.g. `/etc/tedge/mappers`) are `chown` to be owned by the configured tedge user
-  folders above tedge root (e.g. `/var/log`) are owned by the user running `tedge init` (root in practice)

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

