### PR TITLE
refactor: tedge flows registry using configured user

### DIFF
--- a/crates/core/tedge_mapper/src/lib.rs
+++ b/crates/core/tedge_mapper/src/lib.rs
@@ -290,7 +290,7 @@ pub(crate) async fn mapper_flow_registry(
 ) -> anyhow::Result<ConnectedFlowRegistry> {
     let flows_dir = tedge_flows::managed_flows_dir(mapper_dir);
     let mapper_config = effective_mapper_config(tedge_config, mapper_dir).await?;
-    let flows = flow_registry(mapper_config, &flows_dir).await?;
+    let flows = flow_registry(mapper_config, flows_dir).await?;
     Ok(flows)
 }
 
@@ -310,7 +310,7 @@ pub async fn test_cli_flow_registry(
 
 async fn flow_registry(
     mapper_config: Option<EffectiveMapperConfig>,
-    flows_dir: &ManagedDir,
+    flows_dir: ManagedDir,
 ) -> Result<ConnectedFlowRegistry, UpdateFlowRegistryError> {
     if let Err(err) = flows_dir.ensure().await {
         error!(

--- a/crates/extensions/aws_mapper_ext/src/lib.rs
+++ b/crates/extensions/aws_mapper_ext/src/lib.rs
@@ -152,7 +152,7 @@ mod tests {
     use super::*;
     use assert_json_diff::*;
     use assert_matches::*;
-    use camino::Utf8Path;
+    use camino::Utf8PathBuf;
     use serde_json::json;
     use std::collections::HashMap;
     use tedge_config::tedge_toml::AWS_MQTT_PAYLOAD_LIMIT;
@@ -161,6 +161,7 @@ mod tests {
     use tedge_flows::MessageProcessor;
     use tedge_flows::SourceTag;
     use tedge_mqtt_ext::MqttMessage;
+    use tedge_utils::paths::TedgePaths;
     use time::macros::datetime;
     static TE_MEA_TOPICS: &str =
         r#"["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]"#;
@@ -756,10 +757,11 @@ mod tests {
             size_threshold.unwrap_or(AWS_MQTT_PAYLOAD_LIMIT),
             TE_MEA_TOPICS.to_string(),
         );
-        let flows_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
-        let flows_path = Utf8Path::from_path(flows_dir.path()).unwrap();
+        let temp_dir = tempfile::TempDir::new().expect("Failed to create temp dir");
+        let flows_dir = Utf8PathBuf::from_path_buf(temp_dir.path().to_path_buf()).unwrap();
+        let managed_dir = TedgePaths::from_root_with_defaults(&flows_dir, "", "").root_dir();
         let mapper_config = HashMap::new();
-        let mut flows = ConnectedFlowRegistry::new(mapper_config, flows_path).unwrap();
+        let mut flows = ConnectedFlowRegistry::new(mapper_config, managed_dir).unwrap();
         load_builtin_transformers(&mut flows);
         converter.persist_builtin_flow(&mut flows).await.unwrap();
 
@@ -768,7 +770,7 @@ mod tests {
 
         AwsFlows {
             runtime,
-            _flows_dir: flows_dir,
+            _flows_dir: temp_dir,
         }
     }
 

--- a/crates/extensions/c8y_mapper_ext/src/flows.rs
+++ b/crates/extensions/c8y_mapper_ext/src/flows.rs
@@ -1,6 +1,5 @@
 use crate::actor::C8yMapperBuilder;
 use tedge_flows::ConnectedFlowRegistry;
-use tedge_flows::FlowRegistryExt;
 use tedge_flows::UpdateFlowRegistryError;
 use tedge_mqtt_ext::TopicFilter;
 

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -3231,12 +3231,9 @@ pub(crate) async fn c8y_mapper_builder(
     c8y_mapper_builder.connect_source(NoConfig, &mut availability_box_builder);
 
     let mapper_dir = tmp_dir.utf8_path().join("mappers").join("c8y");
-    let flows_dir = tedge_flows::flows_dir(&mapper_dir);
-    TedgePaths::from_root_with_defaults(&flows_dir, "", "")
-        .root_dir()
-        .ensure()
-        .await
-        .unwrap();
+    let managed_dir = TedgePaths::from_root_with_defaults(&mapper_dir, "", "").root_dir();
+    let flows_dir = tedge_flows::managed_flows_dir(&managed_dir);
+    flows_dir.ensure().await.unwrap();
     let mapper_config = HashMap::new();
     let mut flows = ConnectedFlowRegistry::new(mapper_config, flows_dir).unwrap();
     crate::load_builtin_transformers(&mut flows);

--- a/crates/extensions/tedge_flows/src/connected_flow.rs
+++ b/crates/extensions/tedge_flows/src/connected_flow.rs
@@ -17,7 +17,7 @@ use crate::transformers::BuiltinTransformers;
 use crate::UpdateFlowRegistryError;
 use camino::Utf8Path;
 use std::time::SystemTime;
-use tedge_utils::paths::TedgePaths;
+use tedge_utils::paths::ManagedDir;
 use tedge_watch_ext::WatchRequest;
 use tokio::time::Instant;
 
@@ -147,6 +147,7 @@ impl ConnectedFlow {
 }
 
 pub struct ConnectedFlowRegistry {
+    flows_dir: ManagedDir,
     flows: FlowStore<ConnectedFlow>,
     builtins: BuiltinTransformers,
     mapper_params: Box<dyn MapperParams>,
@@ -155,10 +156,12 @@ pub struct ConnectedFlowRegistry {
 impl ConnectedFlowRegistry {
     pub fn new(
         mapper_params: impl MapperParams,
-        flows_dir: impl AsRef<Utf8Path>,
+        flows_dir: ManagedDir,
     ) -> Result<Self, std::io::Error> {
+        let flows = FlowStore::new(&flows_dir)?;
         Ok(ConnectedFlowRegistry {
-            flows: FlowStore::new(flows_dir)?,
+            flows_dir,
+            flows,
             builtins: BuiltinTransformers::default(),
             mapper_params: Box::new(mapper_params),
         })
@@ -181,8 +184,7 @@ impl ConnectedFlowRegistry {
         name: &str,
         content: &str,
     ) -> Result<(), UpdateFlowRegistryError> {
-        let dir = self.store().config_dir();
-        TedgePaths::from_root_with_defaults(dir, "", "")
+        self.flows_dir
             .template_file(format!("{}.toml", name))?
             .persist(content)
             .await?;

--- a/crates/extensions/tedge_flows/src/connected_flow.rs
+++ b/crates/extensions/tedge_flows/src/connected_flow.rs
@@ -14,8 +14,10 @@ use crate::params::MapperParams;
 use crate::registry::FlowRegistry;
 use crate::registry::FlowStore;
 use crate::transformers::BuiltinTransformers;
+use crate::UpdateFlowRegistryError;
 use camino::Utf8Path;
 use std::time::SystemTime;
+use tedge_utils::paths::TedgePaths;
 use tedge_watch_ext::WatchRequest;
 use tokio::time::Instant;
 
@@ -160,6 +162,31 @@ impl ConnectedFlowRegistry {
             builtins: BuiltinTransformers::default(),
             mapper_params: Box::new(mapper_params),
         })
+    }
+
+    /// Create a builtin flow definition in the flow configuration directory.
+    ///
+    /// This flow definition is persisted as a file
+    /// with the given name, a `.toml` extension and the given content.
+    ///
+    /// A copy of the flow is also persisted with the name and a `.toml.template` extension.
+    /// This template can be used by used to derive and tune custom flows.
+    /// This template is also used by `tedge flows` as a witness for user updates:
+    /// if a flow definition differs with its template, then the flow as updated by the user is kept unchanged.
+    ///
+    /// Also, if a file exists with the same name and a `.toml.disabled` extension,
+    /// then the file for the builtin flow is not created: this is how a user can disable a builtin flow.
+    pub async fn persist_builtin_flow(
+        &mut self,
+        name: &str,
+        content: &str,
+    ) -> Result<(), UpdateFlowRegistryError> {
+        let dir = self.store().config_dir();
+        TedgePaths::from_root_with_defaults(dir, "", "")
+            .template_file(format!("{}.toml", name))?
+            .persist(content)
+            .await?;
+        Ok(())
     }
 }
 

--- a/crates/extensions/tedge_flows/src/registry.rs
+++ b/crates/extensions/tedge_flows/src/registry.rs
@@ -13,7 +13,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use tedge_utils::file;
 use tedge_utils::paths::PathsError;
-use tedge_utils::paths::TedgePaths;
 use tracing::error;
 use tracing::info;
 
@@ -124,24 +123,6 @@ pub trait FlowRegistryExt: FlowRegistry {
         path: &Utf8Path,
         config: FlowConfig,
     );
-
-    /// Create a builtin flow definition in the flow configuration directory.
-    ///
-    /// This flow definition is persisted as a file
-    /// with the given name, a `.toml` extension and the given content.
-    ///
-    /// A copy of the flow is also persisted with the name and a `.toml.template` extension.
-    /// This template can be used by used to derive and tune custom flows.
-    /// This template is also used by `tedge flows` as a witness for user updates:
-    /// if a flow definition differs with its template, then the flow as updated by the user is kept unchanged.
-    ///
-    /// Also, if a file exists with the same name and a `.toml.disabled` extension,
-    /// then the file for the builtin flow is not created: this is how a user can disable a builtin flow.
-    async fn persist_builtin_flow(
-        &mut self,
-        name: &str,
-        content: &str,
-    ) -> Result<(), UpdateFlowRegistryError>;
 
     /// Register a transformer that can be used as a builtin in flow steps
     fn register_builtin(&mut self, transformer: impl TransformerBuilder + Transformer);
@@ -310,19 +291,6 @@ impl<T: FlowRegistry + Send> FlowRegistryExt for T {
                 self.store_mut().add_unloaded(path.to_owned());
             }
         }
-    }
-
-    async fn persist_builtin_flow(
-        &mut self,
-        name: &str,
-        content: &str,
-    ) -> Result<(), UpdateFlowRegistryError> {
-        let dir = self.store().config_dir();
-        TedgePaths::from_root_with_defaults(dir, "", "")
-            .template_file(format!("{}.toml", name))?
-            .persist(content)
-            .await?;
-        Ok(())
     }
 
     fn register_builtin(&mut self, transformer: impl TransformerBuilder + Transformer) {

--- a/crates/extensions/tedge_flows/tests/interval.rs
+++ b/crates/extensions/tedge_flows/tests/interval.rs
@@ -20,6 +20,7 @@ use tedge_mqtt_ext::DynSubscriptions;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::MqttRequest;
 use tedge_mqtt_ext::TopicFilter;
+use tedge_utils::paths::TedgePaths;
 use tempfile::TempDir;
 
 #[tokio::test(start_paused = true)]
@@ -758,8 +759,9 @@ type ActorHandle = tokio::task::JoinHandle<Result<(), tedge_actors::RuntimeError
 
 async fn spawn_flows_actor(config_dir: &TempDir, mqtt: &mut MockMqtt) -> ActorHandle {
     let mapper_config = HashMap::new();
-    let flows =
-        ConnectedFlowRegistry::new(mapper_config, config_dir.path().to_str().unwrap()).unwrap();
+    let flows_path = config_dir.path().to_str().unwrap();
+    let flows_dir = TedgePaths::from_root_with_defaults(flows_path, "", "").root_dir();
+    let flows = ConnectedFlowRegistry::new(mapper_config, flows_dir).unwrap();
     let mut flows_builder = FlowsMapperBuilder::try_new(flows, FlowsMapperConfig::default())
         .await
         .expect("Failed to create FlowsMapper");

--- a/crates/extensions/tedge_flows/tests/stats_dump.rs
+++ b/crates/extensions/tedge_flows/tests/stats_dump.rs
@@ -21,6 +21,7 @@ use tedge_flows::FlowsMapperConfig;
 use tedge_mqtt_ext::DynSubscriptions;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::MqttRequest;
+use tedge_utils::paths::TedgePaths;
 use tempfile::TempDir;
 use tracing::Subscriber;
 use tracing_subscriber::layer::SubscriberExt;
@@ -230,8 +231,9 @@ async fn stats_not_dumped_before_300_seconds() {
 
 async fn flows_builder(config_dir: &Path) -> FlowsMapperBuilder {
     let mapper_config = HashMap::new();
-    let flows = ConnectedFlowRegistry::new(mapper_config, Utf8Path::from_path(config_dir).unwrap())
-        .unwrap();
+    let flows_path = Utf8Path::from_path(config_dir).unwrap();
+    let flows_dir = TedgePaths::from_root_with_defaults(flows_path, "", "").root_dir();
+    let flows = ConnectedFlowRegistry::new(mapper_config, flows_dir).unwrap();
     let config = FlowsMapperConfig::default();
     FlowsMapperBuilder::try_new(flows, config)
         .await


### PR DESCRIPTION
## Proposed changes

Stop using `TedgePaths::from_root_with_defaults(dir, "", "")` when creating flow templates. Doing so was creating template files owner by the user running the command and not the user configured in `/etc/tedge/system.toml`.

Now, templates are created using a `ManagerDir` properly configured from `/etc/tedge/system.toml`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- https://github.com/thin-edge/thin-edge.io/issues/4199

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

