### PR TITLE
feat: improved placeholder replacement in system.toml

### DIFF
--- a/crates/common/tedge_system_services/src/managers/general_manager.rs
+++ b/crates/common/tedge_system_services/src/managers/general_manager.rs
@@ -158,7 +158,7 @@ fn replace_with_service_name<'a>(
     config_path: impl Into<Utf8PathBuf>,
     service: SystemService<'a>,
 ) -> Result<Vec<String>, SystemServiceError> {
-    if !input_args.iter().any(|s| s == "{}") {
+    if !input_args.iter().any(|s| s.contains("{}")) {
         return Err(SystemServiceError::SystemConfigInvalidSyntax {
             reason: "A placeholder '{}' is missing.".to_string(),
             cmd: service_cmd.to_string(),
@@ -168,9 +168,7 @@ fn replace_with_service_name<'a>(
 
     let mut args = input_args.to_owned();
     for item in args.iter_mut() {
-        if item == "{}" {
-            *item = service.to_string();
-        }
+        *item = item.replace("{}", &service.to_string());
     }
 
     Ok(args)

--- a/docs/src/references/init-system-configuration.md
+++ b/docs/src/references/init-system-configuration.md
@@ -5,8 +5,7 @@ sidebar_position: 6
 description: Configuring %%te%% to work with Linux init systems
 ---
 
-To support multiple init systems and service managers, `tedge` requires the `/etc/tedge/system.toml` file.
-The file contains configurations about the init system and the supported actions.
+To run %%te%% on a non-Systemd device, the file `/etc/tedge/system.toml` must be configured for the device init system.
 
 The format of the file is:
 

--- a/tests/RobotFramework/tests/customizing/resources/custom_system.toml
+++ b/tests/RobotFramework/tests/customizing/resources/custom_system.toml
@@ -1,0 +1,15 @@
+user = "tedge"
+group = "tedge"
+
+[init]
+name = "sh-c-systemd"
+is_available = ["/bin/sh", "-c", "systemctl", "--version"]
+restart = ["/bin/sh", "-c", "systemctl restart {}"]
+stop =  ["/bin/sh", "-c", "systemctl stop {}"]
+start =  ["/bin/sh", "-c", "systemctl start {}"]
+enable =  ["/bin/sh", "-c", "systemctl enable {}"]
+disable =  ["/bin/sh", "-c", "systemctl disable {}"]
+is_active = ["/bin/sh", "-c", "systemctl is-active {}"]
+
+[system]
+reboot = ["/usr/bin/echo", "no-op"]

--- a/tests/RobotFramework/tests/customizing/system_toml.robot
+++ b/tests/RobotFramework/tests/customizing/system_toml.robot
@@ -1,0 +1,31 @@
+*** Settings ***
+Resource            ../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Suite Teardown      Custom Teardown
+Test Setup          Custom Setup
+
+Test Tags           theme:configuration
+
+
+*** Test Cases ***
+Use placeholders in tedge.toml
+    [Documentation]    Check that `{}` placeholders in `/etc/tedge/system.toml`
+    ...    are properly replaced by service names
+    ...    when starting or restarting services using tedge cli
+    ...    even when the placeholders are not defined as standalone arguments
+    Transfer To Device    ${CURDIR}/resources/custom_system.toml    /etc/tedge/system.toml
+
+    Execute Command    tedge reconnect c8y
+    Service Should Be Running    tedge-mapper-c8y
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    ${DEVICE_SN}
+    Service Should Be Running    tedge-mapper-c8y
+
+Custom Teardown
+    Get Suite Logs


### PR DESCRIPTION
## Proposed changes

Now `restart = ["/bin/sh", "-c", "systemctl restart {}"]` is properly interpreted, the service name being substitute for the placeholder `{}`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- https://github.com/thin-edge/thin-edge.io/issues/4198

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

