### PR TITLE
refactor: don't set TEDGE_CLOUD_PROFILE in tedge-mapper

### DIFF
--- a/crates/core/tedge_api/src/workflow/log/logged_command.rs
+++ b/crates/core/tedge_api/src/workflow/log/logged_command.rs
@@ -199,6 +199,11 @@ impl LoggedCommand {
         self
     }
 
+    pub fn env(&mut self, key: impl AsRef<OsStr>, value: impl AsRef<OsStr>) -> &mut LoggedCommand {
+        self.command.env(key, value);
+        self
+    }
+
     /// Execute the command and log its exit status, stdout and stderr
     ///
     /// If the command has been executed the outcome is returned (successful or not).

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -89,6 +89,7 @@ impl TEdgeComponent for CumulocityMapper {
             &tedge_config,
             &c8y_config,
             service_topic_id.clone(),
+            self.profile.clone(),
         )?;
         let auth_method = auth_method(&c8y_config);
         if tedge_config.mqtt.bridge.built_in {

--- a/crates/core/tedge_mapper/src/lib.rs
+++ b/crates/core/tedge_mapper/src/lib.rs
@@ -81,22 +81,21 @@ pub use custom::config as custom_mapper_config;
 /// Re-export custom mapper config resolution for use by CLI commands.
 pub use custom::resolve as custom_mapper_resolve;
 
-/// Set the cloud profile either from the CLI argument or env variable,
-/// then set the environment variable so child processes automatically
-/// have the correct profile set.
-macro_rules! read_and_set_var {
+/// Read the cloud profile from the CLI argument or env variable.
+macro_rules! read_profile {
     ($profile:ident, $var:literal) => {
-        $profile
-            .or_else(|| {
-                Some(
-                    std::env::var($var)
-                        .ok()?
-                        .parse()
-                        .context(concat!("Reading environment variable ", $var))
-                        .unwrap(),
-                )
-            })
-            .inspect(|profile| std::env::set_var($var, profile))
+        $profile.or_else(|| {
+            let profile = std::env::var($var).ok()?;
+            if profile.is_empty() {
+                return None;
+            }
+            Some(
+                profile
+                    .parse()
+                    .context(concat!("Reading environment variable ", $var))
+                    .unwrap(),
+            )
+        })
     };
 }
 
@@ -104,16 +103,16 @@ fn lookup_component(component_name: MapperName) -> anyhow::Result<Box<dyn TEdgeC
     Ok(match component_name {
         #[cfg(feature = "azure")]
         MapperName::Az { profile } => Box::new(AzureMapper {
-            profile: read_and_set_var!(profile, "TEDGE_CLOUD_PROFILE"),
+            profile: read_profile!(profile, "TEDGE_CLOUD_PROFILE"),
         }),
         #[cfg(feature = "aws")]
         MapperName::Aws { profile } => Box::new(AwsMapper {
-            profile: read_and_set_var!(profile, "TEDGE_CLOUD_PROFILE"),
+            profile: read_profile!(profile, "TEDGE_CLOUD_PROFILE"),
         }),
         MapperName::Collectd => Box::new(CollectdMapper),
         #[cfg(feature = "c8y")]
         MapperName::C8y { profile } => Box::new(CumulocityMapper {
-            profile: read_and_set_var!(profile, "TEDGE_CLOUD_PROFILE"),
+            profile: read_profile!(profile, "TEDGE_CLOUD_PROFILE"),
         }),
         MapperName::UserDefined(mut args) => {
             let name = args.remove(0);

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -30,6 +30,7 @@ use tedge_config::tedge_toml::mapper_config;
 use tedge_config::tedge_toml::mapper_config::MapperConfigError;
 use tedge_config::tedge_toml::ConfigNotSet;
 use tedge_config::tedge_toml::MultiError;
+use tedge_config::tedge_toml::ProfileName;
 use tedge_config::tedge_toml::ReadError;
 use tedge_config::tedge_toml::TEdgeConfigReaderService;
 use tedge_config::TEdgeConfig;
@@ -43,6 +44,7 @@ const C8Y_CLOUD: &str = "c8y";
 const SUPPORTED_OPERATIONS_DIRECTORY: &str = "operations";
 
 pub struct C8yMapperConfig {
+    pub cloud_profile: Option<ProfileName>,
     pub device_id: String,
     pub device_topic_id: EntityTopicId,
     pub service_topic_id: EntityTopicId,
@@ -82,6 +84,7 @@ impl C8yMapperConfig {
         config_dir: Arc<TedgePaths>,
         logs_path: Arc<TedgePaths>,
         tmp_dir: Arc<TedgePaths>,
+        cloud_profile: Option<ProfileName>,
 
         device_id: String,
         device_topic_id: EntityTopicId,
@@ -123,6 +126,7 @@ impl C8yMapperConfig {
             service_health_topic(&mqtt_schema, &device_topic_id, &bridge_service_name);
 
         Self {
+            cloud_profile,
             device_id,
             device_topic_id,
             service_topic_id,
@@ -162,6 +166,7 @@ impl C8yMapperConfig {
         tedge_config: &TEdgeConfig,
         c8y_config: &mapper_config::C8yMapperConfig,
         service_topic_id: EntityTopicId,
+        cloud_profile: Option<ProfileName>,
     ) -> Result<C8yMapperConfig, C8yMapperConfigBuildError> {
         let config_dir: Arc<TedgePaths> = config_dir.clone().into();
 
@@ -260,6 +265,7 @@ impl C8yMapperConfig {
             config_dir,
             logs_path,
             tmp_dir,
+            cloud_profile,
             device_id,
             device_topic_id,
             service_topic_id,

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -910,6 +910,9 @@ impl CumulocityConverter {
             }
         })?;
 
+        if let Some(profile) = &self.config.cloud_profile {
+            logged.env("TEDGE_CLOUD_PROFILE", profile);
+        }
         logged.args(script.args);
 
         let maybe_child_process =
@@ -3136,6 +3139,7 @@ pub(crate) mod tests {
             root_dir.clone().into(),
             root_dir.clone().into(),
             root_dir.clone().into(),
+            None,
             device_id,
             device_topic_id,
             service_topic_id,

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -47,6 +47,7 @@ use tedge_api::mqtt_topics::MqttSchema;
 use tedge_config::models::AutoLogUpload;
 use tedge_config::models::SoftwareManagementApiFlag;
 use tedge_config::models::TopicPrefix;
+use tedge_config::tedge_toml::ProfileName;
 use tedge_config::tedge_toml::C8Y_MQTT_PAYLOAD_LIMIT;
 use tedge_config::TEdgeConfig;
 use tedge_downloader_ext::DownloadResponse;
@@ -1696,6 +1697,92 @@ async fn json_custom_operation_status_update_with_operation_id() {
 }
 
 #[tokio::test]
+async fn json_custom_operation_receives_cloud_profile_env() {
+    let ttd = TempTedgeDir::new();
+    ttd.dir("operations")
+        .dir("c8y")
+        .file("c8y_Command")
+        .with_raw_content(
+            r#"[exec]
+            command = "sh -c 'printf %s \"$TEDGE_CLOUD_PROFILE\"'"
+            on_fragment = "c8y_Command"
+            "#,
+        );
+
+    let config = C8yMapperConfig {
+        cloud_profile: Some(ProfileName::try_from("profile-a".to_string()).unwrap()),
+        smartrest_use_operation_id: true,
+        ..test_mapper_config(&ttd)
+    };
+    let test_handle = spawn_c8y_mapper_actor_with_config(&ttd, config, true).await;
+    let TestHandle { mqtt, http, .. } = test_handle;
+    spawn_dummy_c8y_http_proxy(http);
+
+    let mut mqtt = mqtt.with_timeout(TEST_TIMEOUT_MS);
+    let input_message = MqttMessage::new(
+        &Topic::new_unchecked("c8y/devicecontrol/notifications"),
+        json!({
+            "status":"PENDING",
+            "id": "1234",
+            "c8y_Command": {},
+            "externalSource":{
+                "externalId":"test-device",
+                "type":"c8y_Serial"
+            }
+        })
+        .to_string(),
+    );
+    mqtt.send(input_message).await.expect("Send failed");
+
+    assert_received_contains_str(&mut mqtt, [("c8y/s/us", "504,1234")]).await;
+    assert_received_contains_str(&mut mqtt, [("c8y/s/us", "506,1234,profile-a")]).await;
+}
+
+#[tokio::test]
+async fn json_custom_operation_without_cloud_profile_receives_no_env() {
+    let ttd = TempTedgeDir::new();
+    // The script wraps the profile in BEGIN/END markers so an empty value is
+    // distinguishable from a leaked one under the substring-based assertion.
+    ttd.dir("operations")
+        .dir("c8y")
+        .file("c8y_Command")
+        .with_raw_content(
+            r#"[exec]
+            command = "sh -c 'printf BEGIN%sEND \"$TEDGE_CLOUD_PROFILE\"'"
+            on_fragment = "c8y_Command"
+            "#,
+        );
+
+    let config = C8yMapperConfig {
+        cloud_profile: None,
+        smartrest_use_operation_id: true,
+        ..test_mapper_config(&ttd)
+    };
+    let test_handle = spawn_c8y_mapper_actor_with_config(&ttd, config, true).await;
+    let TestHandle { mqtt, http, .. } = test_handle;
+    spawn_dummy_c8y_http_proxy(http);
+
+    let mut mqtt = mqtt.with_timeout(TEST_TIMEOUT_MS);
+    let input_message = MqttMessage::new(
+        &Topic::new_unchecked("c8y/devicecontrol/notifications"),
+        json!({
+            "status":"PENDING",
+            "id": "1234",
+            "c8y_Command": {},
+            "externalSource":{
+                "externalId":"test-device",
+                "type":"c8y_Serial"
+            }
+        })
+        .to_string(),
+    );
+    mqtt.send(input_message).await.expect("Send failed");
+
+    assert_received_contains_str(&mut mqtt, [("c8y/s/us", "504,1234")]).await;
+    assert_received_contains_str(&mut mqtt, [("c8y/s/us", "506,1234,BEGINEND")]).await;
+}
+
+#[tokio::test]
 async fn json_custom_operation_status_multiple_operations_in_one_mqtt_message() {
     let ttd = TempTedgeDir::new();
     ttd.dir("operations")
@@ -3231,6 +3318,7 @@ pub(crate) fn test_mapper_config(tmp_dir: &TempTedgeDir) -> C8yMapperConfig {
         root_dir.clone().into(),
         root_dir.clone().into(),
         root_dir.clone().into(),
+        None,
         device_name,
         device_topic_id,
         service_topic_id,

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_cloud_profile/c8y_Command
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_cloud_profile/c8y_Command
@@ -1,0 +1,4 @@
+[exec]
+topic = "${.bridge.topic_prefix}/devicecontrol/notifications"
+on_fragment = "c8y_Command"
+command = "/etc/tedge/operations/print_profile"

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_cloud_profile/custom_operation_cloud_profile.robot
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_cloud_profile/custom_operation_cloud_profile.robot
@@ -1,0 +1,79 @@
+*** Settings ***
+Documentation       Custom operations receive the mapper's cloud profile via the
+...                 TEDGE_CLOUD_PROFILE environment variable. A mapper running for a
+...                 named profile must expose that profile to the operation script,
+...                 while the default (unnamed) profile must leave it unset.
+
+Resource            ../../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Suite Setup         Custom Setup
+Suite Teardown      Get Suite Logs    name=${DEVICE_SN}
+
+Test Tags           theme:c8y    theme:troubleshooting    theme:plugins
+
+
+*** Variables ***
+${DEVICE_SN}            ${EMPTY}
+${SECOND_DEVICE_SN}     ${EMPTY}
+
+
+*** Test Cases ***
+Custom operation on the default profile has no cloud profile
+    Cumulocity.Set Device    ${DEVICE_SN}
+    ${operation}=    Cumulocity.Create Operation
+    ...    description=print cloud profile
+    ...    fragments={"c8y_Command":{"text":"print profile"}}
+    Operation Should Be SUCCESSFUL    ${operation}
+    Should Be Equal    ${operation.to_json()["c8y_Command"]["result"]}    profile=
+
+Custom operation on a named profile receives the cloud profile
+    Cumulocity.Set Device    ${SECOND_DEVICE_SN}
+    ${operation}=    Cumulocity.Create Operation
+    ...    description=print cloud profile
+    ...    fragments={"c8y_Command":{"text":"print profile"}}
+    Operation Should Be SUCCESSFUL    ${operation}
+    Should Be Equal    ${operation.to_json()["c8y_Command"]["result"]}    profile=second
+
+
+*** Keywords ***
+Custom Setup
+    # Original device (default profile)
+    ${device_sn}=    Setup
+    Set Suite Variable    $DEVICE_SN    ${device_sn}
+    Device Should Exist    ${DEVICE_SN}
+    Install Custom Operation
+
+    # "Profiled" device
+    Setup Second Device
+
+Install Custom Operation
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/c8y_Command    /etc/tedge/operations/c8y/c8y_Command
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/print_profile.sh    /etc/tedge/operations/print_profile
+    Execute Command    chmod a+x /etc/tedge/operations/print_profile
+
+Setup Second Device
+    ${second_device_sn}=    Catenate    SEPARATOR=_    ${DEVICE_SN}    second
+    Set Suite Variable    $SECOND_DEVICE_SN    ${second_device_sn}
+
+    Execute Command
+    ...    tedge config set c8y.device.cert_path --profile second /etc/tedge/device-certs/tedge@second-certificate.pem
+    Execute Command
+    ...    tedge config set c8y.device.key_path --profile second /etc/tedge/device-certs/tedge@second-key.pem
+    Execute Command    tedge config set c8y.proxy.bind.port --profile second 8002
+    Execute Command    tedge config set c8y.bridge.topic_prefix --profile second c8y-second
+
+    Set Cumulocity URLs    profile=second
+
+    Execute Command    tedge cert create --device-id ${second_device_sn} c8y --profile second
+    Register Certificate For Cleanup    cloud_profile=second    common_name=${second_device_sn}
+    Execute Command
+    ...    cmd=sudo env C8Y_USER='${C8Y_CONFIG.username}' C8Y_PASSWORD='${C8Y_CONFIG.password}' tedge cert upload c8y --profile second
+
+    Execute Command    tedge connect c8y --profile second
+    # Verify the mapper has actually started successfully
+    Execute Command    systemctl is-active tedge-mapper-c8y@second
+
+    Device Should Exist    ${second_device_sn}
+    RETURN    ${second_device_sn}

--- a/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_cloud_profile/print_profile.sh
+++ b/tests/RobotFramework/tests/cumulocity/custom_operation/custom_operation_cloud_profile/print_profile.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Print the cloud profile passed to the operation by the mapper.
+# A mapper running for a named cloud profile sets TEDGE_CLOUD_PROFILE on the
+# operation's child process; the default (unnamed) profile leaves it unset.
+printf 'profile=%s' "${TEDGE_CLOUD_PROFILE}"


### PR DESCRIPTION
## Proposed changes
Following #4207, this modifies tedge-mapper to not globally set `TEDGE_CLOUD_PROFILE` in the mapper process. This should enable `tedge run all` to run multiple mappers (but this PR doesn't enable that behaviour).

Background: `TEDGE_CLOUD_PROFILE` was set so it is automatically passed to child processes (e.g. custom operations). This was purely for simplicity, we can (and now do) easily set this for the child process spawn.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

