### PR TITLE
feat: Live log-level reloading for single process supervisor

### DIFF
--- a/crates/common/tedge_config/src/system_toml/log_level.rs
+++ b/crates/common/tedge_config/src/system_toml/log_level.rs
@@ -2,6 +2,7 @@ use super::SystemConfig;
 use super::SystemTomlError;
 use crate::cli::LogConfigArgs;
 use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use std::collections::HashMap;
 use std::fmt;
 use std::io::IsTerminal;
@@ -14,8 +15,10 @@ use tracing_subscriber::fmt::time::FormatTime;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::reload;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::Layer;
+use tracing_subscriber::Registry;
 
 const DEFAULT_LEVEL: tracing::Level = tracing::Level::INFO;
 
@@ -58,6 +61,86 @@ pub fn log_init_for_services(
     Ok(())
 }
 
+/// Initialises logging for several co-hosted services, returning a handle to
+/// refresh their log levels from `system.toml` at runtime.
+///
+/// Returns `None` when an explicit override (`--debug`/`--log-level`/`RUST_LOG`,
+/// see [`log_init`]) takes priority, as those are fixed for the process lifetime.
+pub fn log_init_reloadable_for_services(
+    service_names: &[&str],
+    flags: &LogConfigArgs,
+    config_dir: &Utf8Path,
+) -> Result<Option<LogLevelReloadHandle>, SystemTomlError> {
+    let default_level = DEFAULT_LEVEL;
+    let is_running_as_systemd_unit = std::env::var("INVOCATION_ID").is_ok();
+
+    // Explicit flags / RUST_LOG take priority and opt out of runtime reload.
+    if let Some(subscriber) = override_subscriber(flags, is_running_as_systemd_unit) {
+        subscriber.init();
+        return Ok(None);
+    }
+
+    // File-configured levels in a reload layer, so SIGHUP can swap them in later.
+    // As with the standalone agent/mapper, a malformed `system.toml` falls back to
+    // defaults rather than blocking startup; we warn once logging is up.
+    let (filter, parse_error) =
+        match build_component_log_filter(service_names, config_dir, default_level) {
+            Ok(filter) => (filter, None),
+            Err(err) => (
+                ComponentLogFilter {
+                    default_level,
+                    component_levels: HashMap::new(),
+                },
+                Some(err),
+            ),
+        };
+    let (filter, handle) = reload::Layer::new(filter);
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(stderr_fmt_layer(is_running_as_systemd_unit))
+        .init();
+
+    if let Some(err) = parse_error {
+        tracing::warn!("could not read log levels from system.toml; using defaults: {err}");
+    }
+
+    Ok(Some(LogLevelReloadHandle {
+        handle,
+        service_names: service_names.iter().map(|s| s.to_string()).collect(),
+        config_dir: config_dir.to_path_buf(),
+        default_level,
+    }))
+}
+
+/// Refreshes the live log levels of co-hosted services from `system.toml`.
+///
+/// Returned by [`log_init_reloadable_for_services`]; [`reload`] swaps the active
+/// filter in place without restarting the process.
+///
+/// [`reload`]: LogLevelReloadHandle::reload
+pub struct LogLevelReloadHandle {
+    handle: reload::Handle<ComponentLogFilter, Registry>,
+    service_names: Vec<String>,
+    config_dir: Utf8PathBuf,
+    default_level: tracing::Level,
+}
+
+impl LogLevelReloadHandle {
+    /// Re-reads `system.toml` and applies the configured log levels live.
+    ///
+    /// On a syntax error the previous levels are kept and the error is returned.
+    /// Levels removed from the file revert to the default.
+    pub fn reload(&self) -> Result<(), SystemTomlError> {
+        let service_names: Vec<&str> = self.service_names.iter().map(String::as_str).collect();
+        let filter =
+            build_component_log_filter(&service_names, &self.config_dir, self.default_level)?;
+        // `reload` only fails if the subscriber has been dropped, which cannot
+        // happen while the process is running.
+        let _ = self.handle.reload(filter);
+        Ok(())
+    }
+}
+
 pub fn log_init_with_default_level(
     sname: &str,
     flags: &LogConfigArgs,
@@ -88,31 +171,65 @@ fn logger_for_services(
     config_dir: Option<&Utf8Path>,
     default_level: tracing::Level,
 ) -> Result<Arc<dyn tracing::Subscriber + Send + Sync>, SystemTomlError> {
-    let subscriber = subscriber_builder!();
-
-    // Added by systemd if the process is running as systemd unit
-    // https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#%24INVOCATION_ID
     let is_running_as_systemd_unit = std::env::var("INVOCATION_ID").is_ok();
 
-    // disable time formatting if journald because journald already records the time
-    let subscriber = if is_running_as_systemd_unit {
-        subscriber.with_timer(TimeFormat::Disabled)
-    } else {
-        subscriber.with_timer(TimeFormat::Enabled)
-    };
+    // Flags / RUST_LOG take priority over file config.
+    if let Some(subscriber) = override_subscriber(flags, is_running_as_systemd_unit) {
+        return Ok(subscriber);
+    }
 
-    // first use log level from flags
+    if let Some(config_dir) = config_dir {
+        if service_names.len() == 1 {
+            if let Some(log_level) = log_level_for_service(service_names[0], config_dir) {
+                return Ok(max_level_subscriber(is_running_as_systemd_unit, log_level));
+            }
+        }
+
+        if let Some(filter) = log_filter_for_services(service_names, config_dir, default_level) {
+            return Ok(Arc::new(
+                tracing_subscriber::registry()
+                    .with(filter)
+                    .with(stderr_fmt_layer(is_running_as_systemd_unit)),
+            ));
+        }
+    }
+
+    Ok(max_level_subscriber(
+        is_running_as_systemd_unit,
+        default_level,
+    ))
+}
+
+/// `TimeFormat::Disabled` under systemd (journald already timestamps records),
+/// `Enabled` otherwise.
+fn time_format(is_running_as_systemd_unit: bool) -> TimeFormat {
+    // INVOCATION_ID is set by systemd: see
+    // https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#%24INVOCATION_ID
+    if is_running_as_systemd_unit {
+        TimeFormat::Disabled
+    } else {
+        TimeFormat::Enabled
+    }
+}
+
+/// The subscriber that takes priority over file config: `--log-level`/`--debug`,
+/// then `RUST_LOG`. Returns `None` when neither applies, leaving the caller to
+/// fall back to file or default levels.
+fn override_subscriber(
+    flags: &LogConfigArgs,
+    is_running_as_systemd_unit: bool,
+) -> Option<Arc<dyn tracing::Subscriber + Send + Sync>> {
+    let subscriber = subscriber_builder!().with_timer(time_format(is_running_as_systemd_unit));
+
     let log_level = flags
         .log_level
         .or(flags.debug.then_some(tracing::Level::DEBUG));
-
     if let Some(log_level) = log_level {
-        return Ok(Arc::new(subscriber.with_max_level(log_level).finish()));
+        return Some(Arc::new(subscriber.with_max_level(log_level).finish()));
     }
 
-    // if no flags used, use EnvFilter
     if std::env::var("RUST_LOG").is_ok() {
-        return Ok(Arc::new(
+        return Some(Arc::new(
             subscriber
                 .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
                 .with_file(true)
@@ -121,31 +238,31 @@ fn logger_for_services(
         ));
     }
 
-    // if no EnvFilter, get log level from config file
-    if let Some(config_dir) = config_dir {
-        if service_names.len() == 1 {
-            if let Some(log_level) = log_level_for_service(service_names[0], config_dir) {
-                return Ok(Arc::new(subscriber.with_max_level(log_level).finish()));
-            }
-        }
+    None
+}
 
-        if let Some(filter) = log_filter_for_services(service_names, config_dir, default_level) {
-            let fmt_layer = tracing_subscriber::fmt::layer()
-                .with_writer(std::io::stderr)
-                .with_ansi(std::io::stderr().is_terminal() && yansi::Condition::no_color())
-                .with_timer(if is_running_as_systemd_unit {
-                    TimeFormat::Disabled
-                } else {
-                    TimeFormat::Enabled
-                });
-            return Ok(Arc::new(
-                tracing_subscriber::registry().with(filter).with(fmt_layer),
-            ));
-        }
-    }
+/// A subscriber applying a single max level to every component.
+fn max_level_subscriber(
+    is_running_as_systemd_unit: bool,
+    level: tracing::Level,
+) -> Arc<dyn tracing::Subscriber + Send + Sync> {
+    Arc::new(
+        subscriber_builder!()
+            .with_timer(time_format(is_running_as_systemd_unit))
+            .with_max_level(level)
+            .finish(),
+    )
+}
 
-    // otherwise, use the default log level
-    Ok(Arc::new(subscriber.with_max_level(default_level).finish()))
+/// The shared stderr `fmt` layer used alongside a [`ComponentLogFilter`].
+fn stderr_fmt_layer<S>(is_running_as_systemd_unit: bool) -> impl Layer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    tracing_subscriber::fmt::layer()
+        .with_writer(std::io::stderr)
+        .with_ansi(std::io::stderr().is_terminal() && yansi::Condition::no_color())
+        .with_timer(time_format(is_running_as_systemd_unit))
 }
 
 /// Return the log level for a given service, if it's defined in the config file. Otherwise return `None`.
@@ -179,54 +296,69 @@ fn log_level_for_service(sname: &str, config_dir: &Utf8Path) -> Option<tracing::
     log_level_from_config(&config, sname).ok().flatten()
 }
 
+/// A component filter built only when `system.toml` actually configures levels,
+/// so callers can otherwise fall back to a plain default-level subscriber. A
+/// malformed file is treated as "nothing configured".
 fn log_filter_for_services(
     service_names: &[&str],
     config_dir: &Utf8Path,
     default_level: tracing::Level,
 ) -> Option<ComponentLogFilter> {
     let config = SystemConfig::try_new(config_dir).ok()?;
-    let fallback_level = log_level_from_config(&config, "tedge")
+    let filter = component_log_filter(&config, service_names, default_level).ok()?;
+    let tedge_default_configured = log_level_from_config(&config, "tedge")
         .ok()
         .flatten()
-        .unwrap_or(default_level);
-    let mut levels = HashMap::new();
+        .is_some();
+    (!filter.component_levels.is_empty() || tedge_default_configured).then_some(filter)
+}
+
+/// Builds a [`ComponentLogFilter`] from `system.toml`, propagating parse errors.
+///
+/// Unlike [`log_filter_for_services`], always yields a filter (falling back to
+/// `default_level` when nothing is configured), so it can drive a reload layer.
+fn build_component_log_filter(
+    service_names: &[&str],
+    config_dir: &Utf8Path,
+    default_level: tracing::Level,
+) -> Result<ComponentLogFilter, SystemTomlError> {
+    let config = SystemConfig::try_new(config_dir)?;
+    component_log_filter(&config, service_names, default_level)
+}
+
+/// Maps an already-parsed [`SystemConfig`] to per-component levels. The `tedge`
+/// key sets the fallback level; a `tedge-mapper-*` service inherits `tedge-mapper`
+/// when it has no level of its own.
+fn component_log_filter(
+    config: &SystemConfig,
+    service_names: &[&str],
+    default_level: tracing::Level,
+) -> Result<ComponentLogFilter, SystemTomlError> {
+    let fallback_level = log_level_from_config(config, "tedge")?.unwrap_or(default_level);
+    let mut component_levels = HashMap::new();
 
     for service_name in service_names {
         if *service_name == "tedge" {
             continue;
         }
 
-        if let Some(service_level) = log_level_from_config(&config, service_name)
-            .ok()
-            .flatten()
-            .or_else(|| {
-                service_name
-                    .starts_with("tedge-mapper-")
-                    .then(|| {
-                        log_level_from_config(&config, "tedge-mapper")
-                            .ok()
-                            .flatten()
-                    })
-                    .flatten()
-            })
-        {
-            levels.insert((*service_name).to_string(), service_level);
+        let level = match log_level_from_config(config, service_name)? {
+            Some(level) => Some(level),
+            None if service_name.starts_with("tedge-mapper-") => {
+                log_level_from_config(config, "tedge-mapper")?
+            }
+            None => None,
+        };
+
+        if let Some(level) = level {
+            component_levels.insert((*service_name).to_string(), level);
         }
     }
 
-    if !levels.is_empty()
-        || log_level_from_config(&config, "tedge")
-            .ok()
-            .flatten()
-            .is_some()
-    {
-        Some(ComponentLogFilter {
-            default_level: fallback_level,
-            component_levels: levels,
-        })
-    } else {
-        None
-    }
+    Ok(ComponentLogFilter {
+        default_level: fallback_level,
+        component_levels,
+    })
 }
 
 #[derive(Debug)]
@@ -516,20 +648,6 @@ mod tests {
 
     #[test]
     fn component_filter_uses_current_component_span() {
-        #[derive(Clone)]
-        struct Buffer(Arc<Mutex<Vec<u8>>>);
-
-        impl io::Write for Buffer {
-            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-                self.0.lock().unwrap().extend_from_slice(buf);
-                Ok(buf.len())
-            }
-
-            fn flush(&mut self) -> io::Result<()> {
-                Ok(())
-            }
-        }
-
         let output = Arc::new(Mutex::new(Vec::new()));
         let writer = Buffer(output.clone());
         let filter = ComponentLogFilter {
@@ -556,27 +674,80 @@ mod tests {
             tracing::trace!("mapper_trace");
         });
 
-        let output = String::from_utf8(output.lock().unwrap().clone()).unwrap();
-        assert!(output.contains("agent_trace"));
-        assert!(!output.contains("mapper_trace"));
+        assert!(buffer_contains(&output, "agent_trace"));
+        assert!(!buffer_contains(&output, "mapper_trace"));
+    }
+
+    #[test]
+    fn build_filter_falls_back_to_default_when_nothing_configured() -> anyhow::Result<()> {
+        let (_dir, config_dir) = create_temp_system_config("")?;
+        let filter =
+            build_component_log_filter(&["tedge", "tedge-agent"], &config_dir, Level::WARN)?;
+        assert_eq!(Level::WARN, filter.default_level);
+        assert!(filter.component_levels.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn build_filter_propagates_syntax_errors() -> anyhow::Result<()> {
+        let (_dir, config_dir) = create_temp_system_config("[log\nnot = valid")?;
+        let err = build_component_log_filter(&["tedge"], &config_dir, Level::INFO).unwrap_err();
+        assert!(matches!(err, SystemTomlError::InvalidSyntax { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn reload_applies_updated_levels_without_reinit() -> anyhow::Result<()> {
+        // Start with the default (INFO) for the agent component.
+        let (dir, config_dir) = create_temp_system_config("")?;
+        let initial =
+            build_component_log_filter(&["tedge", "tedge-agent"], &config_dir, Level::INFO)?;
+        let (filter, handle) = reload::Layer::new(initial);
+
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let writer = Buffer(output.clone());
+        let fmt_layer = tracing_subscriber::fmt::layer()
+            .without_time()
+            .with_ansi(false)
+            .with_writer(move || writer.clone());
+        let subscriber = tracing_subscriber::registry().with(filter).with(fmt_layer);
+
+        let reloader = LogLevelReloadHandle {
+            handle,
+            service_names: vec!["tedge".to_string(), "tedge-agent".to_string()],
+            config_dir: config_dir.clone(),
+            default_level: Level::INFO,
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            let emit_debug = || {
+                let agent = tracing::info_span!("component", name = "tedge-agent");
+                let _guard = agent.enter();
+                tracing::debug!("agent_debug");
+            };
+
+            // Before reload: agent debug is below the INFO default and is dropped.
+            emit_debug();
+            assert!(!buffer_contains(&output, "agent_debug"));
+
+            // Operator raises the agent to debug and signals a reload.
+            std::fs::write(
+                dir.path().join("system.toml"),
+                "[log]\ntedge-agent = \"debug\"\n",
+            )
+            .unwrap();
+            reloader.reload().unwrap();
+
+            // After reload: the same debug event is now recorded, no restart needed.
+            emit_debug();
+            assert!(buffer_contains(&output, "agent_debug"));
+        });
+
+        Ok(())
     }
 
     #[test]
     fn component_filter_applies_to_nested_dependency_spans() {
-        #[derive(Clone)]
-        struct Buffer(Arc<Mutex<Vec<u8>>>);
-
-        impl io::Write for Buffer {
-            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-                self.0.lock().unwrap().extend_from_slice(buf);
-                Ok(buf.len())
-            }
-
-            fn flush(&mut self) -> io::Result<()> {
-                Ok(())
-            }
-        }
-
         let output = Arc::new(Mutex::new(Vec::new()));
         let writer = Buffer(output.clone());
         let filter = ComponentLogFilter {
@@ -600,8 +771,27 @@ mod tests {
             tracing::trace!("dependency_trace");
         });
 
-        let output = String::from_utf8(output.lock().unwrap().clone()).unwrap();
-        assert!(output.contains("dependency_trace"));
+        assert!(buffer_contains(&output, "dependency_trace"));
+    }
+
+    #[derive(Clone)]
+    struct Buffer(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for Buffer {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn buffer_contains(output: &Arc<Mutex<Vec<u8>>>, needle: &str) -> bool {
+        String::from_utf8(output.lock().unwrap().clone())
+            .unwrap()
+            .contains(needle)
     }
 
     // Need to return TempDir, otherwise the dir will be deleted when this function ends.

--- a/crates/core/tedge/src/supervisor.rs
+++ b/crates/core/tedge/src/supervisor.rs
@@ -33,7 +33,8 @@ use tedge_actors::Runtime;
 use tedge_actors::RuntimeHandle;
 use tedge_agent::AgentOpt;
 use tedge_config::cli::CommonArgs;
-use tedge_config::log_init_for_services;
+use tedge_config::log_init_reloadable_for_services;
+use tedge_config::LogLevelReloadHandle;
 use tedge_config::TEdgeConfig;
 use tedge_mapper::MapperName;
 use tokio::signal::unix;
@@ -127,6 +128,9 @@ enum Command {
     ShutdownAll,
     /// Restart all mapper units, leaving the agent running (SIGUSR1).
     RestartMappers,
+    /// Re-read `system.toml` and apply the log levels live, without restarting
+    /// any component (SIGHUP).
+    ReloadLogLevels,
 }
 
 struct Supervisor {
@@ -143,6 +147,9 @@ struct Supervisor {
     /// Deadline by which a drain must complete before the supervisor force-exits.
     drain_deadline: Option<tokio::time::Instant>,
     drain_timeout: Duration,
+    /// Refreshes log levels on SIGHUP; `None` when an override fixes them (see
+    /// [`Command::ReloadLogLevels`]).
+    log_reload: Option<LogLevelReloadHandle>,
 }
 
 impl Supervisor {
@@ -162,7 +169,14 @@ impl Supervisor {
             // Generous bound on the collective drain; each unit's own runtime has a
             // shorter internal cleanup timeout.
             drain_timeout: Duration::from_secs(75),
+            log_reload: None,
         }
+    }
+
+    /// Attaches the handle used to refresh log levels live on SIGHUP.
+    fn with_log_reload(mut self, log_reload: Option<LogLevelReloadHandle>) -> Self {
+        self.log_reload = log_reload;
+        self
     }
 
     /// A handle for injecting [`Command`]s (used by the signal listener, and tests).
@@ -315,6 +329,20 @@ impl Supervisor {
         }
     }
 
+    /// Applies the file-configured log levels to the running components without
+    /// restarting them (the SIGHUP action).
+    fn reload_log_levels(&mut self) {
+        let Some(handle) = self.log_reload.as_ref() else {
+            warn!("SIGHUP: log levels are fixed by --log-level/--debug/RUST_LOG; ignoring");
+            return;
+        };
+        info!("SIGHUP: reloading log levels from system.toml");
+        match handle.reload() {
+            Ok(()) => info!("log levels reloaded"),
+            Err(err) => warn!("failed to reload log levels; keeping current levels: {err}"),
+        }
+    }
+
     /// Restarts all mapper units, leaving the agent running (the SIGUSR1 action).
     async fn restart_mappers(&mut self) {
         info!("SIGUSR1: restarting all mapper components");
@@ -390,6 +418,7 @@ impl Supervisor {
                         }
                         Command::ShutdownAll => self.begin_shutdown().await,
                         Command::RestartMappers => self.restart_mappers().await,
+                        Command::ReloadLogLevels => self.reload_log_levels(),
                     }
                 }
                 _ = async {
@@ -412,6 +441,7 @@ impl Supervisor {
 ///
 /// - SIGINT / SIGTERM / SIGQUIT — graceful shutdown of every component
 /// - SIGUSR1 — restart the mappers, leaving the agent running
+/// - SIGHUP — reload log levels from `system.toml` live (no restart)
 ///
 /// The supervisor owns all signal handling, so the per-component `SignalActor` is
 /// unused on this path.
@@ -424,6 +454,8 @@ fn spawn_signal_listener(commands: mpsc::Sender<Command>) -> anyhow::Result<()> 
         unix::signal(unix::SignalKind::quit()).context("registering SIGQUIT handler")?;
     let mut sigusr1 =
         unix::signal(unix::SignalKind::user_defined1()).context("registering SIGUSR1 handler")?;
+    let mut sighup =
+        unix::signal(unix::SignalKind::hangup()).context("registering SIGHUP handler")?;
 
     tokio::spawn(async move {
         loop {
@@ -432,6 +464,7 @@ fn spawn_signal_listener(commands: mpsc::Sender<Command>) -> anyhow::Result<()> 
                 _ = sigterm.recv() => Command::ShutdownAll,
                 _ = sigquit.recv() => Command::ShutdownAll,
                 _ = sigusr1.recv() => Command::RestartMappers,
+                _ = sighup.recv() => Command::ReloadLogLevels,
             };
             // The supervisor has exited (loop dropped the receiver): stop listening.
             if commands.send(command).await.is_err() {
@@ -449,7 +482,13 @@ pub async fn run(opt: RunAllOpt) -> anyhow::Result<()> {
     // attributed to its component via the `component` span field.
     let log_services = log_service_names(opt.mapper.as_ref());
     let log_services: Vec<_> = log_services.iter().map(String::as_str).collect();
-    log_init_for_services(&log_services, &opt.common.log_args, &opt.common.config_dir)?;
+    // The handle lets SIGHUP refresh these levels from system.toml at runtime;
+    // it is `None` when an explicit override (flags / RUST_LOG) is in effect.
+    let log_reload = log_init_reloadable_for_services(
+        &log_services,
+        &opt.common.log_args,
+        &opt.common.config_dir,
+    )?;
 
     let config_dir = opt.common.config_dir.clone();
     let tedge_config = TEdgeConfig::load(&config_dir).await?;
@@ -513,7 +552,10 @@ pub async fn run(opt: RunAllOpt) -> anyhow::Result<()> {
         });
     }
 
-    Supervisor::new(units).run().await
+    Supervisor::new(units)
+        .with_log_reload(log_reload)
+        .run()
+        .await
 }
 
 fn log_service_names(mapper: Option<&MapperName>) -> Vec<String> {

--- a/tests/RobotFramework/tests/tedge_run_all/run_all_logging.robot
+++ b/tests/RobotFramework/tests/tedge_run_all/run_all_logging.robot
@@ -1,0 +1,151 @@
+*** Settings ***
+Documentation       Live log-level reload for the single-process supervisor (`tedge run all`).
+...                 On SIGHUP the supervisor re-reads the per-component `[log]` levels from
+...                 `system.toml` and applies them without restarting any component, unless
+...                 an explicit override (`--log-level`/`--debug`/`RUST_LOG`) is in effect.
+...                 The change is proven from the supervisor's journal: the MQTT actor logs
+...                 received messages at DEBUG, so a published measurement leaves a
+...                 `MQTT recv` line only once the component has been raised to `debug`.
+
+Resource            ../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Suite Setup         Register Device
+Test Teardown       Stop Supervisor
+
+Test Tags           theme:supervisor    theme:c8y
+
+
+*** Test Cases ***
+SIGHUP applies updated log levels live
+    [Documentation]    Raising a component's level in system.toml and sending SIGHUP makes
+    ...    the new level take effect immediately, with no component restart.
+    Start Supervisor
+    ${before}=    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-mapper-c8y
+
+    # Baseline: at the default INFO level the mapper does not log the messages it
+    # receives, so a published measurement leaves no `MQTT recv` line behind.
+    ${start}=    Get Unix Timestamp
+    Trigger Mapper Mqtt Activity
+    Sleep    2s    reason=Give the mapper time to (not) log the received message
+    Supervisor Log Should Not Contain    MQTT recv    date_from=${start}
+
+    # Operator raises the mapper to debug and signals a reload.
+    Set Component Log Level    tedge-mapper-c8y    debug
+    Execute Command    cmd=systemctl kill --signal=SIGHUP tedge-run-all.service
+    Wait Until Keyword Succeeds
+    ...    30s    2s    Supervisor Log Should Contain    log levels reloaded
+
+    # After the reload the same publish is now recorded at DEBUG, proving the new
+    # level applies to subsequent records without a restart.
+    ${after}=    Get Unix Timestamp
+    Trigger Mapper Mqtt Activity
+    Wait Until Keyword Succeeds
+    ...    30s    2s    Supervisor Log Should Contain    MQTT recv    date_from=${after}
+
+    # No component was restarted: the mapper's health `up` message is unchanged.
+    # A restart would have refreshed its `time` (that is the SIGUSR1 behaviour),
+    # while its `pid` is the supervisor process id either way.
+    Mapper Not Restarted Since    ${before}
+
+Explicit override is not affected by SIGHUP
+    [Documentation]    With RUST_LOG in effect the reload handle is disabled, so SIGHUP is
+    ...    ignored and the pinned levels stay put.
+    Start Supervisor With Env    RUST_LOG=info
+    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-mapper-c8y
+
+    # Raising the mapper in system.toml and signalling a reload must be a no-op: the
+    # supervisor logs that the levels are fixed and leaves them alone.
+    Set Component Log Level    tedge-mapper-c8y    debug
+    ${start}=    Get Unix Timestamp
+    Execute Command    cmd=systemctl kill --signal=SIGHUP tedge-run-all.service
+    Wait Until Keyword Succeeds
+    ...    30s    2s    Supervisor Log Should Contain    log levels are fixed    date_from=${start}
+
+    # The level really did not change: a published measurement is still dropped
+    # because the mapper stays at the RUST_LOG-pinned INFO level.
+    ${after}=    Get Unix Timestamp
+    Trigger Mapper Mqtt Activity
+    Sleep    2s    reason=Give the mapper time to (not) log the received message
+    Supervisor Log Should Not Contain    MQTT recv    date_from=${after}
+
+
+*** Keywords ***
+Register Device
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    ${DEVICE_SN}
+
+    # Hand the components over to the supervisor: stop the systemd-managed services so
+    # their single-instance locks stay free for `tedge run all`.
+    Execute Command    systemctl stop tedge-mapper-c8y tedge-agent
+
+    # Keep a pristine copy of system.toml so each test starts from the same levels and
+    # `Set Component Log Level` never stacks duplicate `[log]` tables across tests.
+    Execute Command    cmd=cp /etc/tedge/system.toml /etc/tedge/system.toml.orig    ignore_exit_code=${True}
+
+Start Supervisor
+    # `tedge run all` is a long-running foreground process, so launch it as a transient
+    # systemd unit (running as the tedge user, like the real services). `--collect` reaps
+    # the unit when it stops, freeing the name for the next test.
+    Execute Command
+    ...    cmd=systemd-run --unit=tedge-run-all --collect -p User=tedge -p Group=tedge /usr/bin/tedge run all c8y
+
+Start Supervisor With Env
+    [Arguments]    ${env}
+    # Same as `Start Supervisor` but with an extra environment variable in the unit, used
+    # to put an explicit log override (e.g. RUST_LOG) in effect for the override test.
+    Execute Command
+    ...    cmd=systemd-run --unit=tedge-run-all --collect -p User=tedge -p Group=tedge -E ${env} /usr/bin/tedge run all c8y
+
+Set Component Log Level
+    [Arguments]    ${component}    ${level}
+    # Rewrite system.toml from the pristine copy plus a fresh `[log]` table, so repeated
+    # calls never accumulate stale entries or duplicate sections.
+    Execute Command    cmd=cp -f /etc/tedge/system.toml.orig /etc/tedge/system.toml    ignore_exit_code=${True}
+    Execute Command    cmd=printf '\\n[log]\\n%s = "%s"\\n' '${component}' '${level}' >> /etc/tedge/system.toml
+
+Trigger Mapper Mqtt Activity
+    # The c8y mapper subscribes to the `te/#` topic tree, so a published measurement is
+    # received by it and, at DEBUG, logged with the `MQTT recv` target.
+    Execute Command    cmd=tedge mqtt pub te/device/main///m/test '{"temperature":25}'
+
+Supervisor Log Should Contain
+    [Arguments]    ${pattern}    ${date_from}=${EMPTY}
+    ${logs}=    Get Supervisor Logs    ${date_from}
+    Should Contain    ${logs}    ${pattern}
+
+Supervisor Log Should Not Contain
+    [Arguments]    ${pattern}    ${date_from}=${EMPTY}
+    ${logs}=    Get Supervisor Logs    ${date_from}
+    Should Not Contain    ${logs}    ${pattern}
+
+Get Supervisor Logs
+    [Arguments]    ${date_from}=${EMPTY}
+    # Read the supervisor unit's journal, optionally only since the given unix timestamp
+    # so a check is scoped to events after a particular point in the test.
+    IF    "${date_from}" == "${EMPTY}"
+        ${logs}=    Execute Command    cmd=journalctl -u tedge-run-all.service --no-pager --output=cat
+    ELSE
+        ${logs}=    Execute Command
+        ...    cmd=journalctl -u tedge-run-all.service --no-pager --output=cat --since @${date_from}
+    END
+    RETURN    ${logs}
+
+Mapper Not Restarted Since
+    [Arguments]    ${before}
+    # SIGHUP must not restart the mapper: its health `up` message keeps the same `time`
+    # (a restart would refresh it — that is the SIGUSR1 behaviour) and the same `pid`
+    # (the supervisor process id, unchanged across the whole test).
+    ${now}=    Service Health Status Should Be Up    tedge-mapper-c8y
+    Should Be Equal As Numbers    ${now["time"]}    ${before["time"]}
+    Should Be Equal As Integers    ${now["pid"]}    ${before["pid"]}
+
+Stop Supervisor
+    # Tear the supervisor down and restore the pristine system.toml so the next test starts
+    # from the same levels. The device registration from the suite setup is left untouched.
+    Execute Command    systemctl stop tedge-run-all.service    ignore_exit_code=${True}
+    Execute Command    cmd=cp -f /etc/tedge/system.toml.orig /etc/tedge/system.toml    ignore_exit_code=${True}
+    Get Logs


### PR DESCRIPTION
## Proposed changes
Add the ability for the supervisor to update the log-level (without restarting any components) from `system.toml` by sending `SIGHUP` to the process. Unlike `SIGUSR1` (which restarts only mappers), this reloads for all components running under the supervisor.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

