### PR TITLE
feat: Respect `max_payload_size` in tedge-mqtt-bridge

### DIFF
--- a/crates/common/mqtt_channel/src/messages.rs
+++ b/crates/common/mqtt_channel/src/messages.rs
@@ -181,6 +181,32 @@ impl DebugPayload {
 /// A message payload
 pub type Payload = Vec<u8>;
 
+/// The number of bytes the MQTT "remaining length" field occupies for a packet
+/// whose remaining length is `len`
+fn remaining_length_size(len: usize) -> usize {
+    if len >= 2_097_152 {
+        4
+    } else if len >= 16_384 {
+        3
+    } else if len >= 128 {
+        2
+    } else {
+        1
+    }
+}
+
+/// Computes the wire size, in bytes, of an MQTT PUBLISH packet with the given
+/// topic, QoS and payload length
+///
+/// Matches `rumqttc::Publish::size()`
+pub fn publish_packet_size(topic: &str, qos: QoS, payload_len: usize) -> usize {
+    const TOPIC_LENGTH_SIZE: usize = 2; // 2 bytes for the topic length prefix
+    const FIXED_HEADER_SIZE: usize = 1; // 1 byte for the fixed header
+    let packet_id_size = if qos == QoS::AtMostOnce { 0 } else { 2 };
+    let remaining_length = TOPIC_LENGTH_SIZE + topic.len() + packet_id_size + payload_len;
+    FIXED_HEADER_SIZE + remaining_length_size(remaining_length) + remaining_length
+}
+
 impl MqttMessage {
     pub fn new<B>(topic: &Topic, payload: B) -> MqttMessage
     where
@@ -227,6 +253,11 @@ impl MqttMessage {
     /// Split the message into a (topic, payload) pair
     pub fn split(self) -> (String, Payload) {
         (self.topic.name, self.payload.0)
+    }
+
+    /// The size, in bytes, this message occupies as an MQTT PUBLISH packet on the wire
+    pub fn wire_size(&self) -> usize {
+        publish_packet_size(&self.topic.name, self.qos, self.payload().len())
     }
 }
 
@@ -319,6 +350,58 @@ mod tests {
         assert_eq!(
             message.payload_str().unwrap_err().to_string(),
             "Invalid UTF8 payload: invalid utf-8 sequence of 1 bytes from index 0: ..."
+        );
+    }
+
+    #[test]
+    fn wire_size_accounts_for_topic_and_framing() {
+        // topic "a/b" (3) + 2-byte length prefix + 2-byte packet id (QoS 1)
+        // + payload "xy" (2) => remaining length 9, encoded in 1 byte,
+        // plus the 1-byte control byte => 11 bytes on the wire.
+        let message = MqttMessage::new(&Topic::new_unchecked("a/b"), "xy");
+        assert_eq!(message.wire_size(), 11);
+    }
+
+    #[test]
+    fn wire_size_omits_packet_id_at_qos_0() {
+        let topic = Topic::new_unchecked("a/b");
+        let qos_1 = MqttMessage::new(&topic, "xy").with_qos(QoS::AtLeastOnce);
+        let qos_0 = MqttMessage::new(&topic, "xy").with_qos(QoS::AtMostOnce);
+
+        // The QoS-0 packet carries no packet identifier, so it is 2 bytes smaller.
+        assert_eq!(qos_1.wire_size(), 11);
+        assert_eq!(qos_0.wire_size(), 9);
+    }
+
+    #[test]
+    fn payload_within_limit_but_packet_over_limit() {
+        let limit = 20;
+        let payload = vec![b'x'; 18];
+        // Body of 18 is within the limit of 20...
+        assert!(payload.len() <= limit);
+        let message = MqttMessage::new(&Topic::new_unchecked("topic"), payload);
+        // ...but the full packet (topic + framing + payload) exceeds it.
+        assert!(message.wire_size() > limit);
+    }
+
+    #[test]
+    fn wire_size_matches_rumqttc_publish_size() {
+        let topic = "some/longer/topic/name";
+        let payload = vec![b'p'; 200];
+
+        // QoS 0: rumqttc never adds a packet id.
+        let qos_0 = Publish::new(topic, QoS::AtMostOnce, payload.clone());
+        assert_eq!(
+            publish_packet_size(topic, QoS::AtMostOnce, payload.len()),
+            qos_0.size()
+        );
+
+        // QoS 1: rumqttc only counts the packet id once one has been assigned.
+        let mut qos_1 = Publish::new(topic, QoS::AtLeastOnce, payload.clone());
+        qos_1.pkid = 1;
+        assert_eq!(
+            publish_packet_size(topic, QoS::AtLeastOnce, payload.len()),
+            qos_1.size()
         );
     }
 

--- a/crates/common/tedge_config/src/tedge_toml/models/mod.rs
+++ b/crates/common/tedge_config/src/tedge_toml/models/mod.rs
@@ -124,6 +124,12 @@ pub const MQTT_MAX_PAYLOAD_SIZE: u32 = 268435455;
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Document)]
 pub struct MqttPayloadLimit(pub u32);
 
+impl Default for MqttPayloadLimit {
+    fn default() -> Self {
+        MqttPayloadLimit(MQTT_MAX_PAYLOAD_SIZE)
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 #[error("Invalid MQTT payload size limit: {0}. Provide a value between 0 and 268435455 bytes")]
 pub struct InvalidMqttPayloadLimit(String);

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -77,7 +77,9 @@ pub use mqtt_config::TEdgeMqttClientAuthConfig;
 
 const DEFAULT_ROOT_CERT_PATH: &str = "/etc/ssl/certs";
 
-pub const C8Y_MQTT_PAYLOAD_LIMIT: u32 = 16184; // 16 KB
+// 200 bytes below Cumulocity's real 16384 limit, as headroom for payload growth
+// between the size check and the wire (e.g. CSV-doubled quotes in SmartREST).
+pub const C8Y_MQTT_PAYLOAD_LIMIT: u32 = 16184;
 pub const AZ_MQTT_PAYLOAD_LIMIT: u32 = 262144; // 256 KB
 pub const AWS_MQTT_PAYLOAD_LIMIT: u32 = 131072; // 128 KB
 

--- a/crates/core/tedge_mapper/src/aws/mapper.rs
+++ b/crates/core/tedge_mapper/src/aws/mapper.rs
@@ -81,6 +81,7 @@ impl TEdgeComponent for AwsMapper {
                 rules,
                 cloud_config,
                 None,
+                aws_config.mapper.mqtt.max_payload_size.0 as usize,
             )
             .await;
             runtime.spawn(bridge_actor).await?;

--- a/crates/core/tedge_mapper/src/az/mapper.rs
+++ b/crates/core/tedge_mapper/src/az/mapper.rs
@@ -89,6 +89,7 @@ impl TEdgeComponent for AzureMapper {
                 rules,
                 cloud_config,
                 None,
+                az_config.mapper.mqtt.max_payload_size.0 as usize,
             )
             .await;
             runtime.spawn(bridge_actor).await?;

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -111,6 +111,7 @@ impl TEdgeComponent for CumulocityMapper {
                         tc,
                         cloud_config,
                         Some(reconnect_message_mapper),
+                        c8y_config.mapper.mqtt.max_payload_size.0 as usize,
                     )
                     .await,
                 )

--- a/crates/core/tedge_mapper/src/custom/config.rs
+++ b/crates/core/tedge_mapper/src/custom/config.rs
@@ -11,7 +11,9 @@ use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use tedge_config::models::CloudType;
 use tedge_config::models::HostPort;
+use tedge_config::models::MqttPayloadLimit;
 use tedge_config::models::SecondsOrHumanTime;
+use tedge_config::models::MQTT_MAX_PAYLOAD_SIZE;
 use tedge_config::models::MQTT_TLS_PORT;
 
 /// Authentication method for the cloud broker connection.
@@ -107,7 +109,7 @@ pub enum BridgeTlsEnable {
 }
 
 /// MQTT bridge connection settings.
-#[derive(Debug, Default, Clone, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 pub struct BridgeConfig {
     /// Whether to use a clean MQTT session when connecting to the remote broker.
     /// Default: false (persistent session).
@@ -118,6 +120,26 @@ pub struct BridgeConfig {
     /// TLS transport control: on, off, or auto (default).
     #[serde(default)]
     pub tls: BridgeTls,
+    /// Maximum MQTT packet size the bridge forwards to the cloud for this mapper.
+    /// Defaults to the MQTT maximum, leaving the limit effectively disabled for
+    /// brokers whose limit is unknown.
+    #[serde(default)]
+    pub max_payload_size: MqttPayloadLimit,
+}
+
+impl Default for BridgeConfig {
+    fn default() -> Self {
+        BridgeConfig {
+            clean_session: false,
+            keepalive_interval: None,
+            tls: BridgeTls::default(),
+            max_payload_size: default_max_payload_size(),
+        }
+    }
+}
+
+fn default_max_payload_size() -> MqttPayloadLimit {
+    MqttPayloadLimit(MQTT_MAX_PAYLOAD_SIZE)
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -463,6 +485,44 @@ keepalive_interval = "60s"
         assert_eq!(device.id.as_deref(), Some("my-device-id"));
         assert!(config.bridge.clean_session);
         assert!(config.bridge.keepalive_interval.is_some());
+    }
+
+    #[tokio::test]
+    async fn parses_configured_max_payload_size() {
+        let ttd = TempTedgeDir::new();
+        let mapper_dir = ttd.utf8_path().join("mappers/limited");
+        tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
+
+        tokio::fs::write(
+            mapper_dir.join("mapper.toml"),
+            "url = \"mqtt.example.com\"\n\n[bridge]\nmax_payload_size = 16384\n",
+        )
+        .await
+        .unwrap();
+
+        let config = load_mapper_config(&mapper_dir).await.unwrap().unwrap();
+        assert_eq!(config.bridge.max_payload_size, MqttPayloadLimit(16384));
+    }
+
+    #[tokio::test]
+    async fn max_payload_size_defaults_to_mqtt_maximum() {
+        let ttd = TempTedgeDir::new();
+        let mapper_dir = ttd.utf8_path().join("mappers/unlimited");
+        tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
+
+        tokio::fs::write(
+            mapper_dir.join("mapper.toml"),
+            "url = \"mqtt.example.com\"\n",
+        )
+        .await
+        .unwrap();
+
+        let config = load_mapper_config(&mapper_dir).await.unwrap().unwrap();
+        // The default leaves the limit effectively disabled.
+        assert_eq!(
+            config.bridge.max_payload_size,
+            MqttPayloadLimit(MQTT_MAX_PAYLOAD_SIZE)
+        );
     }
 
     #[tokio::test]

--- a/crates/core/tedge_mapper/src/custom/mapper.rs
+++ b/crates/core/tedge_mapper/src/custom/mapper.rs
@@ -368,6 +368,7 @@ impl TEdgeComponent for CustomMapper {
                 bridge_rules,
                 cloud_config,
                 None,
+                effective.bridge.max_payload_size.0 as usize,
             )
             .await;
             runtime.spawn(bridge_actor).await?;

--- a/crates/core/tedge_mapper/src/custom/resolve.rs
+++ b/crates/core/tedge_mapper/src/custom/resolve.rs
@@ -12,6 +12,7 @@ use camino::Utf8PathBuf;
 use certificate::PemCertificate;
 use tedge_config::cli::format_config_set_cmd;
 use tedge_config::models::HostPort;
+use tedge_config::models::MqttPayloadLimit;
 use tedge_config::models::SecondsOrHumanTime;
 use tedge_config::models::MQTT_TLS_PORT;
 use tedge_config::tedge_toml::Cloud;
@@ -474,6 +475,7 @@ struct BridgeSchema<'a> {
     clean_session: bool,
     keepalive_interval: Option<&'a SecondsOrHumanTime>,
     tls: BridgeTls,
+    max_payload_size: MqttPayloadLimit,
 }
 
 /// Returns all known schema-level key paths for a custom mapper config (e.g. `"device.cert_path"`).
@@ -534,6 +536,7 @@ fn build_custom_mapper_schema(config: &CustomMapperConfig) -> serde_json::Value 
             clean_session: config.bridge.clean_session,
             keepalive_interval: config.bridge.keepalive_interval.as_ref(),
             tls: config.bridge.tls,
+            max_payload_size: config.bridge.max_payload_size,
         },
         auth_method: config.auth_method,
         credentials_path: config.credentials_path.as_ref(),
@@ -848,6 +851,7 @@ mod tests {
     use crate::custom::config::BridgeConfig;
     use crate::custom::config::DeviceConfig;
     use camino::Utf8PathBuf;
+    use tedge_config::models::MQTT_MAX_PAYLOAD_SIZE;
     use tedge_config::TEdgeConfig;
     use tedge_test_utils::fs::TempTedgeDir;
 
@@ -926,6 +930,44 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         let id = effective.device_id.unwrap();
         assert_eq!(id.value, "localhost");
         assert!(matches!(id.source, ConfigSource::CertificateCN { .. }));
+    }
+
+    #[tokio::test]
+    async fn max_payload_size_surfaces_through_effective_config() {
+        let ttd = TempTedgeDir::new();
+        let (cert, key) = write_cert(ttd.utf8_path()).await;
+        let tedge_config = TEdgeConfig::load_toml_str(&format!(
+            "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
+        ));
+        let mut config = make_config(Some("mqtt.example.com:1883"));
+        config.bridge.max_payload_size = MqttPayloadLimit(16384);
+
+        let effective = resolve_effective_config(&config, &tedge_config, None, None)
+            .await
+            .unwrap();
+
+        // The value the bridge builder is given for enforcement.
+        assert_eq!(effective.bridge.max_payload_size, MqttPayloadLimit(16384));
+    }
+
+    #[tokio::test]
+    async fn max_payload_size_defaults_to_mqtt_maximum() {
+        let ttd = TempTedgeDir::new();
+        let (cert, key) = write_cert(ttd.utf8_path()).await;
+        let tedge_config = TEdgeConfig::load_toml_str(&format!(
+            "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
+        ));
+        let config = make_config(Some("mqtt.example.com:1883"));
+
+        let effective = resolve_effective_config(&config, &tedge_config, None, None)
+            .await
+            .unwrap();
+
+        // The default leaves the limit effectively disabled.
+        assert_eq!(
+            effective.bridge.max_payload_size,
+            MqttPayloadLimit(MQTT_MAX_PAYLOAD_SIZE)
+        );
     }
 
     #[tokio::test]

--- a/crates/extensions/c8y_mapper_ext/src/mea/events.rs
+++ b/crates/extensions/c8y_mapper_ext/src/mea/events.rs
@@ -177,6 +177,53 @@ impl EventConverter {
         let Some(max_size) = self.max_mqtt_payload_size else {
             return true;
         };
-        message.payload.len() < max_size
+        // The topic here is the local one, slightly longer than the bridge-converted
+        // cloud topic, so this is a safe over-estimate of the real wire size.
+        message.wire_size() <= max_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_limit_always_sends_over_mqtt() {
+        let converter = EventConverter::default();
+        let message = Message::new("c8y/event/events/create", vec![b'x'; 100_000]);
+        assert!(converter.can_send_over_mqtt(&message));
+    }
+
+    #[test]
+    fn packet_at_limit_is_sent_over_mqtt() {
+        let message = Message::new("c8y/event/events/create", "payload");
+        let converter = converter_with_limit(message.wire_size());
+        assert!(converter.can_send_over_mqtt(&message));
+    }
+
+    #[test]
+    fn packet_over_limit_is_not_sent_over_mqtt() {
+        let message = Message::new("c8y/event/events/create", "payload");
+        let converter = converter_with_limit(message.wire_size() - 1);
+        assert!(!converter.can_send_over_mqtt(&message));
+    }
+
+    #[test]
+    fn body_within_limit_but_packet_over_limit_is_not_sent() {
+        let message = Message::new("c8y/event/events/create", "payload");
+        // The body alone fits the limit, but the full packet does not.
+        let max_size = message.payload.len() + 1;
+        assert!(message.payload.len() <= max_size);
+        assert!(message.wire_size() > max_size);
+
+        let converter = converter_with_limit(max_size);
+        assert!(!converter.can_send_over_mqtt(&message));
+    }
+
+    fn converter_with_limit(max_size: usize) -> EventConverter {
+        EventConverter {
+            max_mqtt_payload_size: Some(max_size),
+            ..EventConverter::default()
+        }
     }
 }

--- a/crates/extensions/tedge_flows/src/flow.rs
+++ b/crates/extensions/tedge_flows/src/flow.rs
@@ -612,6 +612,17 @@ impl std::fmt::Debug for Message {
     }
 }
 
+impl Message {
+    /// The size, in bytes, this message occupies as an MQTT PUBLISH packet on the wire
+    pub fn wire_size(&self) -> usize {
+        let qos = match &self.transport {
+            Some(Transport::Mqtt { qos, .. }) => *qos,
+            None => qos_default(),
+        };
+        tedge_mqtt_ext::publish_packet_size(&self.topic, qos, self.payload.len())
+    }
+}
+
 impl From<MqttMessage> for Message {
     fn from(message: MqttMessage) -> Self {
         let transport = Transport::Mqtt {

--- a/crates/extensions/tedge_flows/src/transformers/limit_payload_size.rs
+++ b/crates/extensions/tedge_flows/src/transformers/limit_payload_size.rs
@@ -33,7 +33,7 @@ impl Transformer for LimitPayloadSize {
         _context: &FlowContextHandle,
     ) -> Result<Vec<Message>, FlowError> {
         if let Some(max_size) = self.max_size {
-            if message.payload.len() > max_size {
+            if message.wire_size() > max_size {
                 if self.discard {
                     return Ok(vec![]);
                 } else {
@@ -44,5 +44,60 @@ impl Transformer for LimitPayloadSize {
             }
         }
         Ok(vec![message.clone()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn forwards_message_within_packet_limit() {
+        let message = Message::new("topic", "payload");
+        let mut transformer = transformer(message.wire_size(), false);
+
+        assert_eq!(forward(&mut transformer, &message).unwrap(), vec![message]);
+    }
+
+    #[test]
+    fn rejects_message_whose_packet_exceeds_limit_even_if_body_fits() {
+        // The body alone fits the limit, but the full packet does not.
+        let message = Message::new("some/topic", vec![b'x'; 10]);
+        let max_size = message.payload.len() + 2;
+        assert!(message.payload.len() <= max_size);
+        assert!(message.wire_size() > max_size);
+
+        let mut transformer = transformer(max_size, false);
+        assert!(matches!(
+            forward(&mut transformer, &message),
+            Err(FlowError::UnsupportedMessage(_))
+        ));
+    }
+
+    #[test]
+    fn discards_over_limit_message_when_configured() {
+        let message = Message::new("some/topic", vec![b'x'; 10]);
+        let max_size = message.payload.len() + 2;
+
+        let mut transformer = transformer(max_size, true);
+        assert_eq!(forward(&mut transformer, &message).unwrap(), vec![]);
+    }
+
+    fn transformer(max_size: usize, discard: bool) -> LimitPayloadSize {
+        LimitPayloadSize {
+            max_size: Some(max_size),
+            discard,
+        }
+    }
+
+    fn forward(
+        transformer: &mut LimitPayloadSize,
+        message: &Message,
+    ) -> Result<Vec<Message>, FlowError> {
+        transformer.on_message(
+            SystemTime::UNIX_EPOCH,
+            message,
+            &FlowContextHandle::default(),
+        )
     }
 }

--- a/crates/extensions/tedge_mqtt_bridge/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/lib.rs
@@ -101,6 +101,7 @@ impl MqttBridgeActorBuilder {
         rules: BridgeConfig,
         mut cloud_config: MqttOptions,
         on_cloud_reconnect: Option<Publish>,
+        max_payload_size: usize,
     ) -> Self {
         let mut local_config = MqttOptions::new(
             service_name,
@@ -191,6 +192,8 @@ impl MqttBridgeActorBuilder {
                     reconnect_policy.clone(),
                     None,
                     local_tx,
+                    // The local→cloud direction enforces the cloud broker's limit
+                    Some(max_payload_size),
                 )
                 .instrument(tracing::Span::current()),
             ),
@@ -207,6 +210,9 @@ impl MqttBridgeActorBuilder {
                     reconnect_policy,
                     on_cloud_reconnect,
                     cloud_tx,
+                    // The cloud→local direction is left unguarded: the local broker
+                    // accepts large messages and cloud messages already met the cloud's limit
+                    None,
                 )
                 .instrument(tracing::Span::current()),
             ),
@@ -515,6 +521,7 @@ async fn half_bridge(
     reconnect_policy: TEdgeConfigReaderMqttBridgeReconnectPolicy,
     reconnect_message: Option<Publish>,
     mut self_tx: BridgeMessageSender,
+    max_payload_size: Option<usize>,
 ) {
     let mut backoff = CustomBackoff::new(
         ::backoff::SystemClock {},
@@ -617,8 +624,24 @@ async fn half_bridge(
             Event::Incoming(Incoming::Publish(publish)) => {
                 if let Some(publish) = loop_breaker.ensure_not_looped(publish).await {
                     if let Some(topic) = transformer.convert_topic(&publish.topic) {
-                        received += 1;
-                        target.publish(topic.to_string(), publish);
+                        let wire_size = mqtt_channel::publish_packet_size(
+                            topic.as_ref(),
+                            publish.qos,
+                            publish.payload.len(),
+                        );
+                        if let Some(limit) = max_payload_size.filter(|&limit| wire_size > limit) {
+                            // The message is too large to ever be accepted by the cloud broker.
+                            // Acknowledge it locally so it is not redelivered, and drop it rather
+                            // than let it block the cloud connection.
+                            log_event!(
+                                warn: name,
+                                "Dropping cloud-bound message on topic {topic}: packet size {wire_size} B exceeds the configured limit of {limit} B"
+                            );
+                            recv_client.ack(&publish).await.unwrap()
+                        } else {
+                            received += 1;
+                            target.publish(topic.to_string(), publish);
+                        }
                     } else {
                         // Being not forwarded to this bridge target
                         // The message has to be acknowledged
@@ -1235,6 +1258,51 @@ mod tests {
         }
 
         #[tokio::test]
+        async fn over_limit_cloud_bound_message_is_acked_and_not_forwarded() {
+            let big_msg = Publish::new("c8y/s/us", QoS::AtLeastOnce, vec![b'x'; 100]);
+            let small_msg = Publish::new("c8y/s/us", QoS::AtLeastOnce, "payload");
+            let events = [inc!(publish(big_msg)), inc!(publish(small_msg))];
+
+            let bridge = Bridge::default()
+                .with_local_events(events)
+                .with_c8y_topics()
+                .with_max_payload_size(50)
+                .process_all_events()
+                .await;
+
+            // The over-limit message is acknowledged locally and never reaches the cloud.
+            assert_eq!(
+                bridge.local_client.next_action().unwrap(),
+                Action::Ack(big_msg)
+            );
+            // The following within-limit message is still forwarded to the cloud.
+            assert_eq!(
+                bridge.cloud_client.next_action().unwrap(),
+                Action::Publish(Publish::new("s/us", QoS::AtLeastOnce, "payload"))
+            );
+        }
+
+        #[tokio::test]
+        async fn over_limit_cloud_to_local_message_is_forwarded_unchanged() {
+            let big_msg = Publish::new("s/ds", QoS::AtLeastOnce, vec![b'x'; 100]);
+            let events = [inc!(publish(big_msg))];
+
+            let bridge = Bridge::default()
+                .with_cloud_events(events)
+                .with_c8y_topics()
+                // The limit applies to the local→cloud direction only; the cloud→local
+                // half is unguarded regardless of this value.
+                .with_max_payload_size(50)
+                .process_all_events()
+                .await;
+
+            assert_eq!(
+                bridge.local_client.next_action().unwrap(),
+                Action::Publish(Publish::new("c8y/s/ds", QoS::AtLeastOnce, vec![b'x'; 100]))
+            );
+        }
+
+        #[tokio::test]
         async fn forwards_message_acknowledgements() {
             let incoming_msg = Publish::new("c8y/s/us", QoS::AtLeastOnce, "payload");
             let local_events = [inc!(publish(incoming_msg))];
@@ -1575,6 +1643,7 @@ mod tests {
             local_topic_converter: TopicConverter,
             cloud_topic_converter: TopicConverter,
             cloud_reconnect_message: Option<Publish>,
+            max_payload_size: Option<usize>,
         }
 
         struct CompletedBridge<Local, Cloud> {
@@ -1602,6 +1671,7 @@ mod tests {
                     local_topic_converter: <_>::default(),
                     cloud_topic_converter: <_>::default(),
                     cloud_reconnect_message: None,
+                    max_payload_size: None,
                 }
             }
         }
@@ -1638,6 +1708,13 @@ mod tests {
                 }
             }
 
+            fn with_max_payload_size(self, max_payload_size: usize) -> Self {
+                Self {
+                    max_payload_size: Some(max_payload_size),
+                    ..self
+                }
+            }
+
             fn with_local_client<C>(self, client: C) -> Bridge<LoEv, ClEv, C, ClCl> {
                 Bridge {
                     local_client: client,
@@ -1648,6 +1725,7 @@ mod tests {
                     local_topic_converter: self.local_topic_converter,
                     cloud_topic_converter: self.cloud_topic_converter,
                     cloud_reconnect_message: self.cloud_reconnect_message,
+                    max_payload_size: self.max_payload_size,
                 }
             }
 
@@ -1661,6 +1739,7 @@ mod tests {
                     local_topic_converter: self.local_topic_converter,
                     cloud_topic_converter: self.cloud_topic_converter,
                     cloud_reconnect_message: self.cloud_reconnect_message,
+                    max_payload_size: self.max_payload_size,
                 }
             }
 
@@ -1677,6 +1756,7 @@ mod tests {
                     local_topic_converter: self.local_topic_converter,
                     cloud_topic_converter: self.cloud_topic_converter,
                     cloud_reconnect_message: self.cloud_reconnect_message,
+                    max_payload_size: self.max_payload_size,
                 }
             }
 
@@ -1703,6 +1783,7 @@ mod tests {
                     TEdgeConfigReaderMqttBridgeReconnectPolicy::test_value(),
                     None,
                     local_sender,
+                    self.max_payload_size,
                 ));
                 let cloud_task = tokio::spawn(half_bridge(
                     self.cloud_events.clone(),
@@ -1716,6 +1797,7 @@ mod tests {
                     TEdgeConfigReaderMqttBridgeReconnectPolicy::test_value(),
                     self.cloud_reconnect_message,
                     cloud_sender,
+                    None,
                 ));
 
                 tokio::time::timeout(Duration::from_secs(5), self.local_events.all_processed())

--- a/crates/extensions/tedge_mqtt_bridge/tests/bridge.rs
+++ b/crates/extensions/tedge_mqtt_bridge/tests/bridge.rs
@@ -62,6 +62,8 @@ async fn start_mqtt_bridge_with_reconnect_message(
         rules,
         cloud_config,
         reconnect_message,
+        // No effective limit: exercise the bridge's existing forwarding behaviour.
+        268_435_455,
     )
     .await;
 }

--- a/crates/extensions/tedge_mqtt_bridge/tests/no_warnings.rs
+++ b/crates/extensions/tedge_mqtt_bridge/tests/no_warnings.rs
@@ -112,6 +112,8 @@ async fn start_mqtt_bridge(local_port: u16, cloud_port: u16, rules: BridgeConfig
         rules,
         cloud_config,
         None,
+        // No effective limit: exercise the bridge's existing forwarding behaviour.
+        268_435_455,
     )
     .await;
 }

--- a/crates/extensions/tedge_mqtt_bridge/tests/republish.rs
+++ b/crates/extensions/tedge_mqtt_bridge/tests/republish.rs
@@ -40,6 +40,8 @@ async fn start_mqtt_bridge(
         rules,
         cloud_config,
         None,
+        // No effective limit: exercise the bridge's existing forwarding behaviour.
+        268_435_455,
     )
     .await;
 }

--- a/crates/extensions/tedge_mqtt_ext/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/lib.rs
@@ -6,6 +6,7 @@ pub mod trie;
 
 use async_trait::async_trait;
 pub use mqtt_channel::deserialize_qos;
+pub use mqtt_channel::publish_packet_size;
 pub use mqtt_channel::serialize_qos;
 pub use mqtt_channel::DebugPayload;
 pub use mqtt_channel::MqttError;

--- a/docs/src/references/mappers/user-defined-mappers.md
+++ b/docs/src/references/mappers/user-defined-mappers.md
@@ -90,6 +90,15 @@ clean_session = false
 # off: never use TLS (plain TCP, incompatible with certificate authentication)
 # tls.enable = "auto"
 
+# Maximum MQTT packet size (in bytes) the bridge forwards to the cloud.
+# This is measured as the full MQTT PUBLISH packet (topic + framing + payload),
+# not the payload body alone. A cloud-bound message whose packet size exceeds
+# this limit is dropped (and logged) rather than forwarded, preventing an
+# oversized message from blocking the cloud connection.
+# Defaults to the MQTT maximum (268435455), leaving the limit effectively
+# disabled for brokers whose limit is unknown.
+# max_payload_size = 16384
+
 # Any additional fields you add here are available as ${mapper.*} in bridge rules.
 # For example, this field is accessible as ${mapper.bridge.topic_prefix}.
 topic_prefix = "v1/devices/me"

--- a/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-16

--- a/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/design.md
+++ b/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The MQTT bridge (`crates/extensions/tedge_mqtt_bridge`) forwards messages between the local broker and a cloud broker. It does not enforce any payload-size limit. When a message exceeds the cloud broker's limit, the broker silently stops responding; the connection dies on keepalive timeout and, on reconnect with a fresh session, the bridge republishes the same message — an unbounded loop that blocks all cloud-bound traffic behind the offending message.
+
+`max_payload_size` already exists for the built-in clouds (`c8y`/`az`/`aws` under `<cloud>.mapper.mqtt.max_payload_size`) but is only consulted by the mappers to limit the messages they generate. Three independent checks exist, each comparing only the message body length:
+
+- `tedge_flows` `limit-payload-size` transformer (`crates/extensions/tedge_flows/src/transformers/limit_payload_size.rs`) — used by az/aws via a builtin flow.
+- `c8y_mapper_ext::can_send_over_mqtt` (`crates/extensions/c8y_mapper_ext/src/mea/events.rs`).
+- The bridge has none.
+
+Body-only checks undercount: the cloud broker limits the full MQTT packet (topic + framing + payload). The mappers also cannot protect messages published directly by other local clients, plugins, or passthrough topics — only the bridge sees all cloud-bound traffic.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One shared function computes the MQTT PUBLISH wire size; every payload-size check uses it.
+- The bridge enforces `max_payload_size` on cloud-bound messages and drops over-limit messages instead of letting them wedge the connection.
+- Custom (user-defined) mappers can configure `max_payload_size`, which the bridge then enforces.
+
+**Non-Goals:**
+- Detecting or quarantining other classes of poison message (malformed packets, broker-specific rejections). Only the size limit is in scope.
+- Splitting, compressing, or otherwise salvaging an over-limit message. An over-limit message is undeliverable and is dropped.
+- Reducing detection latency of a silently-dropped connection (a keepalive concern).
+
+## Decisions
+
+### Wire-size function lives in `mqtt_channel`
+
+`mqtt_channel` is the only crate that wraps `rumqttc`, it defines `MqttMessage`, and every consumer reaches it (`tedge_flows → tedge_mqtt_ext → mqtt_channel`; bridge → `mqtt_channel`; `c8y_mapper_ext → mqtt_channel`). The function computes `1 + len_len(remaining) + 2 + topic.len() + (qos>0 ? 2 : 0) + payload.len()`, matching `rumqttc::Publish::size()` — the exact byte count placed on the wire.
+
+Alternative considered: a helper in `tedge_api`. Rejected — `tedge_api` does not wrap the wire format, so it would have to duplicate the framing arithmetic that `mqtt_channel`/`rumqttc` already own.
+
+### The bridge enforces at forward time, on the local→cloud half only
+
+The limit is applied in the `half_bridge` that forwards local messages to the cloud, at the point a received publish is converted and about to be forwarded. Over-limit messages are acknowledged to the local broker (reusing the existing local-ack path already used for non-forwarded messages) and not forwarded.
+
+Catching the message before it is handed to the cloud client means it never enters the cloud event loop's pending/inflight queue, so there is nothing to clear there and the republish loop cannot begin. The cloud→local half is left unguarded: the local broker accepts large messages, and cloud-originated messages have already satisfied the cloud's own limit.
+
+Alternative considered: reactively inspecting the inflight set after a disconnect to blame the offending message. Rejected for this change — it is heuristic, risks dropping a legitimate message, and only acts after the connection has already failed.
+
+### One limit value, two enforcement points
+
+The bridge reuses the same `max_payload_size` value the mapper already uses, rather than introducing a separate setting. The mapper continues to limit the messages it generates; the bridge backstops everything else. Because mapper output already satisfies the limit, the bridge only ever drops messages that bypassed the mapper.
+
+### `max_payload_size` is threaded through `MqttBridgeActorBuilder::new`
+
+The value is passed as a parameter to the builder rather than embedded in the bridge rules, keeping it explicit at each call site (c8y, az, aws, custom). Custom mappers gain a `max_payload_size` field on their `[bridge]` config, surfaced through `EffectiveMapperConfig`, defaulting to the MQTT maximum (`268435455`).
+
+## Risks / Trade-offs
+
+- Switching from body size to packet size tightens the effective limit by the topic + framing overhead → for built-in clouds the conservative defaults sit well below broker hard limits, so the few extra bytes are immaterial; covered by a test asserting packet-size semantics.
+- Dropping an over-limit message loses that message → an over-limit message is undeliverable regardless; dropping it is strictly better than blocking all cloud-bound traffic. The drop is logged with topic and size for operator visibility.
+- Custom mappers default to the MQTT maximum → the limit is effectively off until the operator sets a value appropriate to their broker, preserving existing behaviour for those mappers.

--- a/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/proposal.md
+++ b/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+An oversized message forwarded to the cloud MQTT broker can wedge the bridge indefinitely: the broker silently stops responding, the connection dies on keepalive timeout, and on reconnect the same message is republished — head-of-line-blocking *all* cloud-bound traffic. The bridge does not enforce `max_payload_size` today, and the size checks that do exist measure only the message body, undercounting the true packet size the broker actually limits.
+
+## What Changes
+
+- Add a single shared function in `mqtt_channel` that computes the true MQTT PUBLISH wire size (control byte + remaining-length varint + topic + packet id + payload).
+- Replace the three independent, body-only size checks (`tedge_flows` `limit-payload-size` transformer, `c8y_mapper_ext` `can_send_over_mqtt`, and the bridge's absence of one) with calls to that shared function.
+- Enforce `max_payload_size` in the MQTT bridge on the local→cloud direction: a message whose wire size exceeds the limit is logged, acknowledged locally so it is not redelivered, and dropped rather than forwarded.
+- Add `max_payload_size` to the custom (user-defined) mapper configuration, defaulting to the MQTT maximum so the limit is effectively off for brokers whose limit is unknown.
+- **BREAKING**: the limit now measures the full MQTT packet (topic + framing + payload) rather than the payload body alone. A message whose body fits the limit but whose packet does not is now rejected.
+
+## Capabilities
+
+### New Capabilities
+- `mqtt-payload-limit`: defines how the MQTT payload-size limit is calculated (full packet wire size) and enforced — both at message generation in the mappers and as a backstop in the bridge for all cloud-bound traffic.
+
+### Modified Capabilities
+- `custom-mapper-config`: the custom mapper configuration gains a `max_payload_size` bridge setting.
+
+## Impact
+
+- `crates/common/mqtt_channel` — new wire-size function on `MqttMessage`.
+- `crates/extensions/tedge_mqtt_bridge` — `MqttBridgeActorBuilder::new` gains a `max_payload_size` parameter; the local→cloud half enforces it.
+- `crates/extensions/tedge_flows` (`limit-payload-size` transformer) and `crates/extensions/c8y_mapper_ext` (`can_send_over_mqtt`) — switch to the shared wire-size function.
+- `crates/core/tedge_mapper` — bridge call sites (c8y, az, aws, custom) pass the limit; custom mapper config/schema gains the new field.
+- Bridge construction signature change affects bridge integration tests.

--- a/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/specs/custom-mapper-config/spec.md
+++ b/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/specs/custom-mapper-config/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Custom mapper configuration file
+When present, a mapper's `mapper.toml` SHALL contain connection and device identity settings needed to establish the MQTT bridge to the cloud, plus an optional `cloud_type` field identifying the built-in cloud integration this mapper instance targets. The `mapper.toml` is OPTIONAL — it is only required when the mapper establishes a cloud connection via the built-in MQTT bridge.
+
+For user-defined mappers, `mapper.toml` is parsed directly and is not part of the global `tedge_config` schema. Certain fields (device cert and key paths) are inherited from the root `tedge.toml` when absent from `mapper.toml`.
+
+For built-in mappers (`c8y`, `az`, `aws`), `mapper.toml` is backed by `TEdgeConfig` and values are written via `tedge config set`. Built-in mappers are not required to have a `mapper.toml` on disk — the file is only created when the mapper configuration is upgraded via `tedge config upgrade`. Until upgraded, built-in mappers read their configuration directly from the root `tedge.toml`.
+
+The `[bridge]` section MAY contain a `max_payload_size` field setting the maximum MQTT packet size the bridge will forward to the cloud for this mapper. When absent, it SHALL default to the MQTT maximum packet size, leaving the limit effectively disabled for brokers whose limit is unknown.
+
+#### Scenario: Configuration with connection details
+- **WHEN** a user-defined mapper's `mapper.toml` contains a top-level `url` field and a `[device]` section with `cert_path` and `key_path` fields
+- **THEN** the mapper SHALL use these values to configure the MQTT bridge connection
+
+#### Scenario: Device cert fields inherited from root tedge.toml
+- **WHEN** a user-defined mapper's `mapper.toml` does not contain `[device] cert_path` or `key_path` and the root `tedge.toml` has these fields configured
+- **THEN** the mapper SHALL use the root `tedge.toml` values as fallback
+
+#### Scenario: Configuration with additional custom fields
+- **WHEN** a mapper's `mapper.toml` contains additional TOML keys beyond the required connection and device settings (e.g. `[bridge]` with `topic_prefix`)
+- **THEN** the mapper SHALL make all fields available via the `${mapper.*}` template namespace in bridge rule templates
+
+#### Scenario: Payload size limit configured for a user-defined mapper
+- **WHEN** a user-defined mapper's `mapper.toml` contains a `[bridge]` section with `max_payload_size`
+- **THEN** the bridge for that mapper SHALL enforce that limit on messages forwarded to the cloud
+
+#### Scenario: Payload size limit defaults when unset
+- **WHEN** a user-defined mapper's `mapper.toml` does not set `max_payload_size`
+- **THEN** the bridge SHALL use the MQTT maximum packet size as the limit
+
+#### Scenario: Invalid TOML in configuration file
+- **WHEN** a mapper's `mapper.toml` contains invalid TOML syntax
+- **THEN** `tedge-mapper` SHALL report a parse error with the file path and error location
+
+#### Scenario: cloud_type field present in user-defined mapper
+- **WHEN** a user-defined mapper's `mapper.toml` contains `cloud_type = "c8y"`
+- **THEN** `tedge mapper list` SHALL display `cloud_type=c8y` alongside that mapper's name
+
+#### Scenario: cloud_type field absent
+- **WHEN** a mapper's `mapper.toml` does not contain a `cloud_type` field
+- **THEN** `tedge mapper list` SHALL display the mapper without a cloud type annotation
+
+#### Scenario: Built-in mapper.toml pre-populated with cloud_type
+- **WHEN** the built-in `c8y` mapper directory is inspected after `tedge config upgrade`
+- **THEN** its `mapper.toml` SHALL contain `cloud_type = "c8y"`
+
+#### Scenario: Built-in mapper without mapper.toml
+- **WHEN** the built-in `c8y` mapper has not been upgraded via `tedge config upgrade`
+- **THEN** no `c8y/mapper.toml` file need exist — the mapper reads its configuration from the root `tedge.toml`

--- a/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/specs/mqtt-payload-limit/spec.md
+++ b/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/specs/mqtt-payload-limit/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Payload size limit is measured as the full MQTT packet size
+
+The MQTT payload size limit SHALL be evaluated against the full MQTT PUBLISH packet wire size, not the message body alone. The wire size SHALL be computed by a single shared function and comprises the fixed-header control byte, the remaining-length variable-byte integer, the topic name and its two-byte length prefix, the two-byte packet identifier when QoS is greater than zero, and the payload bytes.
+
+All payload size checks across the codebase SHALL use this shared function so that a value is interpreted identically everywhere.
+
+#### Scenario: Wire size accounts for topic and framing
+- **WHEN** the wire size of a PUBLISH is computed for a topic and payload
+- **THEN** the result SHALL include the topic length, the framing overhead, and the payload, and SHALL equal the number of bytes the message occupies on the wire
+
+#### Scenario: A message within the body limit but over the packet limit is rejected
+- **WHEN** a message whose payload alone is within the limit but whose full packet size exceeds the limit is evaluated
+- **THEN** it SHALL be treated as exceeding the limit
+
+### Requirement: The bridge enforces the payload size limit on cloud-bound messages
+
+The MQTT bridge SHALL enforce a configured `max_payload_size` on messages forwarded from the local broker to the cloud broker. A message whose wire size exceeds the limit SHALL NOT be forwarded to the cloud. The bridge SHALL acknowledge the over-limit message to the local broker so that it is not redelivered, and SHALL log the offending message's topic and size together with the configured limit.
+
+The limit SHALL apply only to the local→cloud direction. Messages forwarded from the cloud to the local broker SHALL NOT be subject to this limit.
+
+#### Scenario: Over-limit cloud-bound message is dropped, not forwarded
+- **WHEN** a message received from the local broker has a wire size exceeding the bridge's `max_payload_size`
+- **THEN** the bridge SHALL acknowledge it locally, SHALL NOT publish it to the cloud, and SHALL log its topic and size
+
+#### Scenario: Over-limit message does not block subsequent traffic
+- **WHEN** an over-limit message is followed by within-limit messages on bridged topics
+- **THEN** the within-limit messages SHALL be forwarded to the cloud without disruption
+
+#### Scenario: Cloud-to-local messages are not limited
+- **WHEN** a message received from the cloud broker exceeds `max_payload_size`
+- **THEN** the bridge SHALL forward it to the local broker
+
+### Requirement: Built-in cloud connections enforce their configured limit in the bridge
+
+For the built-in `c8y`, `az`, and `aws` cloud connections, the bridge SHALL enforce the cloud's configured `max_payload_size` value. This is the same value used by the mapper to limit the messages it generates, ensuring messages from any local source — not only the mapper — are checked before being sent to the cloud.
+
+#### Scenario: Non-mapper publisher is checked by the bridge
+- **WHEN** a local client publishes an over-limit message directly onto a topic bridged to a built-in cloud
+- **THEN** the bridge SHALL drop it according to the cloud's configured `max_payload_size`, even though the message never passed through the mapper

--- a/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/tasks.md
+++ b/openspec/changes/archive/2026-06-16-enforce-mqtt-payload-limit/tasks.md
@@ -1,0 +1,33 @@
+## 1. Shared wire-size function
+
+- [x] 1.1 Add a function to `mqtt_channel` computing the MQTT PUBLISH wire size for an `MqttMessage` (`1 + len_len(remaining) + 2 + topic.len() + (qos>0 ? 2 : 0) + payload.len()`), matching `rumqttc::Publish::size()`
+- [x] 1.2 Unit-test the function against known byte counts, including a case where the body is within a limit but the full packet exceeds it, and a QoS-0 vs QoS-1 case
+
+## 2. Adopt the shared function in existing checks
+
+- [x] 2.1 Replace the body-only comparison in the `tedge_flows` `limit-payload-size` transformer with the shared wire-size function
+- [x] 2.2 Replace the body-only comparison in `c8y_mapper_ext::can_send_over_mqtt` with the shared wire-size function
+- [x] 2.3 Reconcile the comparison so both treat the boundary identically (over-limit = wire size strictly greater than the limit)
+- [x] 2.4 Update or add unit tests covering the packet-size semantics for both call sites
+
+## 3. Bridge enforcement
+
+- [x] 3.1 Add a `max_payload_size` parameter to `MqttBridgeActorBuilder::new`
+- [x] 3.2 Thread the limit into the local→cloud `half_bridge` only; leave the cloud→local direction unguarded
+- [x] 3.3 In the local→cloud forward path, when a converted message's wire size exceeds the limit: acknowledge it to the local broker via the existing local-ack path, do not forward it, and log its topic and size with the configured limit
+- [x] 3.4 Add bridge tests: over-limit cloud-bound message is acked and not forwarded; a following within-limit message is still forwarded; an over-limit cloud→local message is forwarded unchanged
+
+## 4. Wire the limit through call sites
+
+- [x] 4.1 Pass each built-in cloud's configured `max_payload_size` (c8y/az/aws) into the bridge builder
+- [x] 4.2 Update bridge integration tests for the new `MqttBridgeActorBuilder::new` signature
+
+## 5. Custom mapper configuration
+
+- [x] 5.1 Add a `max_payload_size` field to the custom mapper `[bridge]` config (`crates/core/tedge_mapper/src/custom/config.rs`), defaulting to the MQTT maximum (`268435455`)
+- [x] 5.2 Surface the value through `EffectiveMapperConfig` and pass it into the bridge builder from the custom mapper
+- [x] 5.3 Test that a configured custom-mapper limit is enforced and that the default leaves it effectively disabled
+
+## 6. Documentation
+
+- [x] 6.1 Document the `max_payload_size` custom-mapper setting, noting that the limit measures the full MQTT packet rather than the body alone

--- a/openspec/specs/custom-mapper-config/spec.md
+++ b/openspec/specs/custom-mapper-config/spec.md
@@ -48,6 +48,8 @@ For user-defined mappers, `mapper.toml` is parsed directly and is not part of th
 
 For built-in mappers (`c8y`, `az`, `aws`), `mapper.toml` is backed by `TEdgeConfig` and values are written via `tedge config set`. Built-in mappers are not required to have a `mapper.toml` on disk — the file is only created when the mapper configuration is upgraded via `tedge config upgrade`. Until upgraded, built-in mappers read their configuration directly from the root `tedge.toml`.
 
+The `[bridge]` section MAY contain a `max_payload_size` field setting the maximum MQTT packet size the bridge will forward to the cloud for this mapper. When absent, it SHALL default to the MQTT maximum packet size, leaving the limit effectively disabled for brokers whose limit is unknown.
+
 #### Scenario: Configuration with connection details
 - **WHEN** a user-defined mapper's `mapper.toml` contains a top-level `url` field and a `[device]` section with `cert_path` and `key_path` fields
 - **THEN** the mapper SHALL use these values to configure the MQTT bridge connection
@@ -59,6 +61,14 @@ For built-in mappers (`c8y`, `az`, `aws`), `mapper.toml` is backed by `TEdgeConf
 #### Scenario: Configuration with additional custom fields
 - **WHEN** a mapper's `mapper.toml` contains additional TOML keys beyond the required connection and device settings (e.g. `[bridge]` with `topic_prefix`)
 - **THEN** the mapper SHALL make all fields available via the `${mapper.*}` template namespace in bridge rule templates
+
+#### Scenario: Payload size limit configured for a user-defined mapper
+- **WHEN** a user-defined mapper's `mapper.toml` contains a `[bridge]` section with `max_payload_size`
+- **THEN** the bridge for that mapper SHALL enforce that limit on messages forwarded to the cloud
+
+#### Scenario: Payload size limit defaults when unset
+- **WHEN** a user-defined mapper's `mapper.toml` does not set `max_payload_size`
+- **THEN** the bridge SHALL use the MQTT maximum packet size as the limit
 
 #### Scenario: Invalid TOML in configuration file
 - **WHEN** a mapper's `mapper.toml` contains invalid TOML syntax

--- a/openspec/specs/mqtt-payload-limit/spec.md
+++ b/openspec/specs/mqtt-payload-limit/spec.md
@@ -1,0 +1,47 @@
+# MQTT Payload Limit
+
+## Purpose
+
+Defines how thin-edge.io measures and enforces the maximum MQTT payload size on messages forwarded from the local broker to the cloud, ensuring the limit is computed consistently as the full MQTT packet wire size and applied in the bridge for both built-in and user-defined cloud connections.
+
+## Requirements
+
+### Requirement: Payload size limit is measured as the full MQTT packet size
+
+The MQTT payload size limit SHALL be evaluated against the full MQTT PUBLISH packet wire size, not the message body alone. The wire size SHALL be computed by a single shared function and comprises the fixed-header control byte, the remaining-length variable-byte integer, the topic name and its two-byte length prefix, the two-byte packet identifier when QoS is greater than zero, and the payload bytes.
+
+All payload size checks across the codebase SHALL use this shared function so that a value is interpreted identically everywhere.
+
+#### Scenario: Wire size accounts for topic and framing
+- **WHEN** the wire size of a PUBLISH is computed for a topic and payload
+- **THEN** the result SHALL include the topic length, the framing overhead, and the payload, and SHALL equal the number of bytes the message occupies on the wire
+
+#### Scenario: A message within the body limit but over the packet limit is rejected
+- **WHEN** a message whose payload alone is within the limit but whose full packet size exceeds the limit is evaluated
+- **THEN** it SHALL be treated as exceeding the limit
+
+### Requirement: The bridge enforces the payload size limit on cloud-bound messages
+
+The MQTT bridge SHALL enforce a configured `max_payload_size` on messages forwarded from the local broker to the cloud broker. A message whose wire size exceeds the limit SHALL NOT be forwarded to the cloud. The bridge SHALL acknowledge the over-limit message to the local broker so that it is not redelivered, and SHALL log the offending message's topic and size together with the configured limit.
+
+The limit SHALL apply only to the local→cloud direction. Messages forwarded from the cloud to the local broker SHALL NOT be subject to this limit.
+
+#### Scenario: Over-limit cloud-bound message is dropped, not forwarded
+- **WHEN** a message received from the local broker has a wire size exceeding the bridge's `max_payload_size`
+- **THEN** the bridge SHALL acknowledge it locally, SHALL NOT publish it to the cloud, and SHALL log its topic and size
+
+#### Scenario: Over-limit message does not block subsequent traffic
+- **WHEN** an over-limit message is followed by within-limit messages on bridged topics
+- **THEN** the within-limit messages SHALL be forwarded to the cloud without disruption
+
+#### Scenario: Cloud-to-local messages are not limited
+- **WHEN** a message received from the cloud broker exceeds `max_payload_size`
+- **THEN** the bridge SHALL forward it to the local broker
+
+### Requirement: Built-in cloud connections enforce their configured limit in the bridge
+
+For the built-in `c8y`, `az`, and `aws` cloud connections, the bridge SHALL enforce the cloud's configured `max_payload_size` value. This is the same value used by the mapper to limit the messages it generates, ensuring messages from any local source — not only the mapper — are checked before being sent to the cloud.
+
+#### Scenario: Non-mapper publisher is checked by the bridge
+- **WHEN** a local client publishes an over-limit message directly onto a topic bridged to a built-in cloud
+- **THEN** the bridge SHALL drop it according to the cloud's configured `max_payload_size`, even though the message never passed through the mapper

--- a/tests/RobotFramework/tests/cumulocity/bridge_config/builtin_bridge.robot
+++ b/tests/RobotFramework/tests/cumulocity/bridge_config/builtin_bridge.robot
@@ -68,6 +68,39 @@ Support publishing QoS 0 messages to c8y topic #2960
     END
     Cumulocity.Device Should Have Event/s    expected_text=Test event with qos 0.*    type=test_q0    minimum=10
 
+Bridge drops oversized cloud-bound message without blocking the connection
+    [Documentation]    A cloud-bound message whose MQTT packet exceeds the broker's payload limit
+    ...    would silently block the bridge connection if forwarded. The built-in bridge instead
+    ...    drops it, logs a warning, and keeps forwarding subsequent messages.
+    Cumulocity.Set Device    ${DEVICE_SN}
+
+    # A within-limit inventory update is forwarded and reaches the cloud
+    Execute Command
+    ...    tedge mqtt pub "c8y/inventory/managedObjects/update/${DEVICE_SN}" '{"bridgeFilterTest":"before"}'
+    Device Should Have Fragment Values    bridgeFilterTest\=before
+
+    # Send an inventory update whose packet is well over the limit (~18 kB vs the 16184 B default)
+    ${start_time}=    Get Unix Timestamp
+    Execute Command
+    ...    cmd=printf '{"oversized":"%s"}' "$(head -c 18000 /dev/zero | tr '\\0' 'x')" > /tmp/oversized.json
+    Execute Command
+    ...    cmd=tedge mqtt pub "c8y/inventory/managedObjects/update/${DEVICE_SN}" "$(cat /tmp/oversized.json)"
+
+    # The cloud connection is still healthy after the oversized message is dropped
+    Cloud Connection Should Be Healthy
+
+    # A following within-limit update with a different payload still reaches the cloud,
+    # proving the bridge kept working after dropping the oversized message
+    Execute Command    tedge mqtt pub "c8y/inventory/managedObjects/update/${DEVICE_SN}" '{"bridgeFilterTest":"after"}'
+    Device Should Have Fragment Values    bridgeFilterTest\=after
+
+    # The bridge logged that it dropped the oversized message rather than forwarding it.
+    # Checked last so the round-trips above guarantee the warning has reached the journal.
+    Logs Should Contain
+    ...    text=Dropping cloud-bound message on topic inventory/managedObjects/update/${DEVICE_SN}
+    ...    date_from=${start_time}
+    [Teardown]    Clear Oversized Message
+
 
 *** Keywords ***
 Custom Setup
@@ -76,3 +109,23 @@ Custom Setup
     Execute Command    tedge config set mqtt.bridge.built_in true
     Execute Command    tedge reconnect c8y
     Set Managed Object    ${DEVICE_SN}
+
+Clear Oversized Message
+    # Even if the test fails part way, ensure nothing is left persisted in the local broker
+    # that could be redelivered and affect later tests (the bridge uses a durable session).
+    Execute Command    tedge mqtt pub --retain "c8y/inventory/managedObjects/update/${DEVICE_SN}" ''
+    Execute Command    cmd=rm -f /tmp/oversized.json
+
+Cloud Connection Should Be Healthy
+    [Documentation]    Assert the Cumulocity bridge connection is up, with a failure message that
+    ...    explains the likely cause (an oversized message forwarded to the cloud) so the cause is
+    ...    clear from the test logs alone.
+    ${output}=    Execute Command
+    ...    cmd=tedge connect c8y --test 2>&1; echo "exit_code=$?"
+    ...    timeout=10
+    ...    ignore_exit_code=${True}
+    Should Contain
+    ...    ${output}
+    ...    exit_code=0
+    ...    msg=Cumulocity dropped the bridge connection: the bridge forwarded a cloud-bound MQTT message larger than Cumulocity's maximum packet size instead of filtering it, so the broker silently closed the connection and 'tedge connect c8y --test' exited non-zero. Output: ${output}
+    ...    values=${False}


### PR DESCRIPTION
## Proposed changes
- Enforce a strict limit of the max payload size for the builtin bridge, dropping messages (with a warning) if they exceed the limit
- Refine calculation for the size of a message when deciding in `tedge-mapper-c8y` whether to use MQTT or HTTP, taking into account the full packet size, instead of just the payload itself

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #4216

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

