### PR TITLE
test: fix flaky symlink flow-reload test

### DIFF
--- a/tests/RobotFramework/tests/tedge_flows/flows_hot_reloading.robot
+++ b/tests/RobotFramework/tests/tedge_flows/flows_hot_reloading.robot
@@ -45,19 +45,19 @@ Flows are reloaded when the flow directory is a symlink
 
     ${start}    Get Unix Timestamp
     Start Service    tedge-mapper-local
-    ${status}    Should Have MQTT Messages
+    # The flow is enabled on startup. A spurious watcher event may also emit an
+    # "updated" status, so match on content rather than message order.
+    Should Have MQTT Messages
     ...    topic=te/device/main/service/tedge-mapper-local/status/flows
     ...    date_from=${start}
-    ...    message_contains=greeting-flows/hello.toml
-    Should Contain    ${status}[0]    "enabled"
+    ...    message_pattern=.*greeting-flows/hello[.]toml.*"status":"enabled".*
 
     ${start}    Get Unix Timestamp
     Execute Command    touch /data/tedge/mappers/local/flows/greeting-flows/hello.toml
-    ${status}    Should Have MQTT Messages
+    Should Have MQTT Messages
     ...    topic=te/device/main/service/tedge-mapper-local/status/flows
     ...    date_from=${start}
-    ...    message_contains=greeting-flows/hello.toml
-    Should Contain    ${status}[0]    "updated"
+    ...    message_pattern=.*greeting-flows/hello[.]toml.*"status":"updated".*
 
     ${start}    Get Unix Timestamp
     Execute Command    tedge mqtt pub hello/in hi
@@ -66,6 +66,7 @@ Flows are reloaded when the flow directory is a symlink
     ...    minimum=1
     ...    date_from=${start}
     ...    message_contains=Hello World!
+    [Teardown]    Restore Flows Directory
 
 
 *** Keywords ***
@@ -83,3 +84,13 @@ Install Hot Reload Flow
     ...    date_from=${start}
     ...    message_contains=hot-reload
     ...    timeout=15
+
+Restore Flows Directory
+    [Documentation]    Restore /etc/tedge/mappers from the symlink back to a real
+    ...    directory so retries (which re-run Test Teardown but not Suite Setup)
+    ...    start from a clean state.
+    Stop Service    tedge-mapper-local
+    # Only restore when the symlink is actually in place, so a failure before the
+    # symlink is created never removes the real directory.
+    Execute Command    if [ -L /etc/tedge/mappers ]; then rm -f /etc/tedge/mappers && mv /data/tedge/mappers /etc/tedge/mappers; fi
+    Start Service    tedge-mapper-local


### PR DESCRIPTION
## Proposed changes
The "Flows are reloaded when the flow directory is a symlink" test asserted that the first flows-status message after startup was "enabled". On startup the flow engine emits "enabled" while the directory watcher may emit a spurious "updated" for the just-transferred file; their ordering is not guaranteed, so `${status}[0]` was sometimes "updated" and the test failed.

This PR changes the test to check for any message with the correct content so the test is no longer flaky. It also adds a teardown step that restores the state of the test after it has failed, so the test reruns with a clean slate, as the original failure I observed saw the retries fail due to a lack of cleanup.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

