### PR TITLE
fix: avoid reading external log plugin's stdout to memory

### DIFF
--- a/crates/core/tedge_api/src/workflow/log/logged_command.rs
+++ b/crates/core/tedge_api/src/workflow/log/logged_command.rs
@@ -2,6 +2,7 @@ use crate::CommandLog;
 use std::ffi::OsStr;
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
+use std::process::ExitStatus;
 use std::process::Output;
 use std::process::Stdio;
 use std::time::Duration;
@@ -222,6 +223,22 @@ impl LoggedCommand {
                 .await;
         }
         outcome
+    }
+
+    pub fn stdout(&mut self, stdout: impl Into<Stdio>) {
+        self.command.stdout(stdout);
+    }
+
+    pub fn stderr(&mut self, stderr: impl Into<Stdio>) {
+        self.command.stderr(stderr);
+    }
+
+    /// Execute the command returning its status code and without logging its output.
+    ///
+    /// If the command has been executed the outcome is returned (successful or not). If the command
+    /// fails to execute (say not found or not executable) an `std::io::Error` is returned.
+    pub async fn status(mut self) -> Result<ExitStatus, std::io::Error> {
+        self.command.status().await
     }
 
     pub fn spawn(&mut self) -> Result<LoggingChild, std::io::Error> {

--- a/crates/extensions/tedge_log_manager/Cargo.toml
+++ b/crates/extensions/tedge_log_manager/Cargo.toml
@@ -23,6 +23,7 @@ tedge_file_system_ext = { workspace = true }
 tedge_mqtt_ext = { workspace = true }
 tedge_uploader_ext = { workspace = true }
 tedge_utils = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true, features = ["formatting"] }
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/extensions/tedge_log_manager/src/plugin.rs
+++ b/crates/extensions/tedge_log_manager/src/plugin.rs
@@ -3,8 +3,12 @@ use camino::Utf8Path;
 use std::collections::BTreeSet;
 use std::collections::VecDeque;
 use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::BufRead;
+use std::io::BufReader;
 use std::io::Write;
 use std::path::PathBuf;
+use std::process::ExitStatus;
 use std::process::Output;
 use std::sync::Arc;
 use tedge_api::CommandLog;
@@ -58,6 +62,14 @@ impl ExternalPluginCommand {
             .await
             .map_err(|err| self.plugin_error(err))?;
         Ok(output)
+    }
+
+    pub async fn status(&self, command: LoggedCommand) -> Result<ExitStatus, LogManagementError> {
+        let status = command
+            .status()
+            .await
+            .map_err(|err| self.plugin_error(err))?;
+        Ok(status)
     }
 
     pub fn plugin_error(&self, err: impl std::fmt::Display) -> LogManagementError {
@@ -118,18 +130,67 @@ impl ExternalPluginCommand {
             command.arg(until_time.unix_timestamp().to_string());
         }
 
+        let stdout_file =
+            tempfile::NamedTempFile::new_in(self.tmp_dir.as_std_path()).map_err(|err| {
+                self.plugin_error(format!(
+                    "Failed to create temporary file in {}: {err}",
+                    tempfile::env::temp_dir().to_string_lossy()
+                ))
+            })?;
+        let stderr_file =
+            tempfile::NamedTempFile::new_in(self.tmp_dir.as_std_path()).map_err(|err| {
+                self.plugin_error(format!(
+                    "Failed to create temporary file in {}: {err}",
+                    tempfile::env::temp_dir().to_string_lossy()
+                ))
+            })?;
+
+        let stdout = OpenOptions::new()
+            .create(false)
+            .read(false)
+            .write(true)
+            .open(stdout_file.path())
+            .map_err(|err| {
+                self.plugin_error(format!(
+                    "failed to open temporary file for writing process output '{}': {err}",
+                    stdout_file.path().to_string_lossy()
+                ))
+            })?;
+        let stderr = OpenOptions::new()
+            .create(false)
+            .read(false)
+            .write(true)
+            .open(stderr_file.path())
+            .map_err(|err| {
+                self.plugin_error(format!(
+                    "failed to open temporary file for writing process output'{}': {err}",
+                    stderr_file.path().to_string_lossy()
+                ))
+            })?;
+
+        command.stdout(stdout);
+        command.stderr(stderr);
+
         debug!(
             target: "log plugins",
             "Fetching log using command: {}", command
         );
-        let output = self.execute(command, None).await?;
+        let status = self.status(command).await?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(self.plugin_error(format!("Get command error: {}", stderr)));
+        if !status.success() {
+            // we assume stderr is short enough to load in memory
+            let stderr = std::fs::read_to_string(stderr_file.path())?;
+            return Err(self.plugin_error(format!("Get command error: {stderr}",)));
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stdout = File::open(stdout_file.path()).map_err(|err| {
+            self.plugin_error(format!(
+                "failed to open temporary file for writing process output'{}': {err}",
+                stdout_file.path().to_string_lossy()
+            ))
+        })?;
+        let stdout = BufReader::new(stdout);
+
         let file = File::create(output_file_path).map_err(|err| {
             self.plugin_error(format!(
                 "Failed to create plugin output file at {} due to {}",
@@ -139,8 +200,14 @@ impl ExternalPluginCommand {
         let mut writer = std::io::BufWriter::new(&file);
 
         let mut filtered_lines = VecDeque::new();
-
         for line in stdout.lines() {
+            let line = line.map_err(|err| {
+                self.plugin_error(format!(
+                    "error reading output file: '{}': {err:?}",
+                    stdout_file.path().to_string_lossy()
+                ))
+            })?;
+
             if let Some(filter) = filter_text {
                 if !filter.is_empty() && !line.contains(filter) {
                     continue;

--- a/tests/RobotFramework/tests/cumulocity/log/huge_plugin.sh
+++ b/tests/RobotFramework/tests/cumulocity/log/huge_plugin.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euxo pipefail
+
+case "$1" in
+  list)
+    echo huge
+    ;;
+  get)
+    if [ "$2" = "huge" ]; then
+      # Emit ~50MB to stdout to simulate an oversized logfile
+      len=50M
+      dd if=/dev/zero bs=$len count=1 2>/dev/null | tr '\0' 'A'
+
+      # once the entire log is generated output a message so we know we can measure memory used
+      echo "script generated $len of data" >&2
+
+      # create a pipe and read it to pause executing, allowing test to measure memory usage and
+      # decide when the script should exit
+      mkfifo /tmp/huge-plugin-pipe
+      read -r _x < /tmp/huge-plugin-pipe
+
+      # finally exit with non-zero code so data isn't sent to c8y unnecessarily
+      rm /tmp/huge-plugin-pipe
+      exit 67
+    else
+      echo "Unknown log type" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    echo "Usage: $0 {list|get <type>}" >&2
+    exit 2
+    ;;
+esac

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_plugins.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_plugins.robot
@@ -335,6 +335,44 @@ Plugin dynamic filter addition
     ...    def_log::dummy_plugin
     ...    xyz_log::dummy_plugin
 
+Log operation shouldnt OOM on oversized output
+
+    [Documentation]    Install a plugin that emits a very large logfile and verify all of its output is not loaded into
+    ...                memory at once.
+
+    # install custom log plugin that generates lots of data on stdout, here 50MB
+    # but it shouldn't send all of it to c8y, so after outputting all this to stdout we print short
+    # message on stderr and exit.
+    # tedge shouldn't send any stdout/stderr data to the cloud until the plugin process exits.
+    ThinEdgeIO.Transfer To Device
+    ...    ${CURDIR}/huge_plugin.sh
+    ...    /usr/share/tedge/log-plugins/huge
+    Execute Command    chmod +x /usr/share/tedge/log-plugins/huge
+
+    # request logs
+    Should Contain Supported Log Types    huge::huge
+    ${start_timestamp}=    Get Current Date    UTC    -1 hours    result_format=%Y-%m-%dT%H:%M:%S+0000
+    ${end_timestamp}=    Get Current Date    UTC    +1 hours    result_format=%Y-%m-%dT%H:%M:%S+0000
+    ${operation}=    Create Log Request Operation
+    ...    ${start_timestamp}
+    ...    ${end_timestamp}
+    ...    log_type=huge::huge
+
+    # Wait until huge plugin creates a pipe which means stdout was filled and we can measure memory usage
+    Execute Command    ls /tmp/huge-plugin-pipe    retries=5    timeout=2
+
+    ${tedge_agent_rss_bytes}=    Execute Command    cmd=ps -o rss= -C tedge-agent    strip=True
+    Should Be True    ${tedge_agent_rss_bytes} < 20000    tedge-agent used too much (${tedge_agent_rss_bytes}>20MB) memory
+
+    # send message to plugin to exit
+    Execute Command    echo done > /tmp/huge-plugin-pipe
+
+    # make sure operation completed and tedge-agent is still running
+    # (?s:.) matches any character regardless of flags
+    # https://docs.python.org/3/library/re.html
+    Operation Should Be FAILED    ${operation}    failure_reason=(?s:.)*script generated(?s:.)*
+    Execute Command    systemctl is-active tedge-agent
+
 
 *** Keywords ***
 Custom Setup


### PR DESCRIPTION
## Proposed changes

When spawning an external log plugin process and running its "get" command, instead of using pipes to keep its output in memory, attach stdout to a file and read the file after process exits. This is done to avoid reading the entire output into memory as on some limited RAM environments it might be too big.


## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

- #4210

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

