### PR TITLE
refactor(rust2024): fix rust-2024-incompatible-pat lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,3 +259,6 @@ overflow-checks = true
 [workspace.lints.clippy]
 get_first = "allow"
 uninlined_format_args = "allow"
+
+[workspace.lints.rust]
+rust_2024_incompatible_pat = "deny"

--- a/crates/common/tedge_config_macros/src/option.rs
+++ b/crates/common/tedge_config_macros/src/option.rs
@@ -97,7 +97,7 @@ impl<T> OptionalConfig<T> {
         T: Deref,
     {
         match self {
-            Self::Present { ref value, key } => OptionalConfig::Present {
+            Self::Present { value, key } => OptionalConfig::Present {
                 value: value.deref(),
                 key: key.clone(),
             },

--- a/crates/core/tedge_agent/src/operation_workflows/persist.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/persist.rs
@@ -346,7 +346,7 @@ impl WorkflowRepository {
         // If the resumed commands have been triggered by an agent without workflow version management
         // then these commands are assigned the current version of the operation workflow.
         // These currents versions have also to be marked as in use and persisted.
-        for (_, ref mut command) in commands.iter_mut() {
+        for (_, command) in commands.iter_mut() {
             if command.workflow_version().is_none() {
                 if let Some(operation) = command.operation() {
                     if let Some(current_version) = self.workflows.use_current_version(&operation) {

--- a/crates/extensions/tedge_flows/src/steps.rs
+++ b/crates/extensions/tedge_flows/src/steps.rs
@@ -260,8 +260,8 @@ impl FlowStep {
 impl StepHandler {
     pub fn set_config(&mut self, config: JsonValue) -> Result<(), ConfigError> {
         match self {
-            StepHandler::JsScript(_, ref mut c) => *c = config,
-            StepHandler::Transformer(_, ref mut builtin) => {
+            StepHandler::JsScript(_, c) => *c = config,
+            StepHandler::Transformer(_, builtin) => {
                 builtin.set_config(config)?;
             }
         }

--- a/plugins/c8y_remote_access_plugin/src/proxy.rs
+++ b/plugins/c8y_remote_access_plugin/src/proxy.rs
@@ -105,8 +105,8 @@ impl AsyncRead for MaybeTlsStream {
         buf: &mut tokio::io::ReadBuf<'_>,
     ) -> std::task::Poll<std::io::Result<()>> {
         match self.get_mut() {
-            Self::Plain(ref mut tcp) => Pin::new(tcp).poll_read(cx, buf),
-            Self::Rustls(ref mut tcp) => Pin::new(tcp).poll_read(cx, buf),
+            Self::Plain(tcp) => Pin::new(tcp).poll_read(cx, buf),
+            Self::Rustls(tcp) => Pin::new(tcp).poll_read(cx, buf),
         }
     }
 }
@@ -118,8 +118,8 @@ impl AsyncWrite for MaybeTlsStream {
         buf: &[u8],
     ) -> std::task::Poll<Result<usize, std::io::Error>> {
         match self.get_mut() {
-            Self::Plain(ref mut tcp) => Pin::new(tcp).poll_write(cx, buf),
-            Self::Rustls(ref mut tcp) => Pin::new(tcp).poll_write(cx, buf),
+            Self::Plain(tcp) => Pin::new(tcp).poll_write(cx, buf),
+            Self::Rustls(tcp) => Pin::new(tcp).poll_write(cx, buf),
         }
     }
 
@@ -128,8 +128,8 @@ impl AsyncWrite for MaybeTlsStream {
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), std::io::Error>> {
         match self.get_mut() {
-            Self::Plain(ref mut tcp) => Pin::new(tcp).poll_flush(cx),
-            Self::Rustls(ref mut tcp) => Pin::new(tcp).poll_flush(cx),
+            Self::Plain(tcp) => Pin::new(tcp).poll_flush(cx),
+            Self::Rustls(tcp) => Pin::new(tcp).poll_flush(cx),
         }
     }
 
@@ -138,8 +138,8 @@ impl AsyncWrite for MaybeTlsStream {
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), std::io::Error>> {
         match self.get_mut() {
-            Self::Plain(ref mut tcp) => Pin::new(tcp).poll_shutdown(cx),
-            Self::Rustls(ref mut tcp) => Pin::new(tcp).poll_shutdown(cx),
+            Self::Plain(tcp) => Pin::new(tcp).poll_shutdown(cx),
+            Self::Rustls(tcp) => Pin::new(tcp).poll_shutdown(cx),
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

Added `rust-2024-incompatible-pat = "deny"` and used `cargo fix` to automatically fix the lints.
The resolution removes `ref` and `ref mut` keywords so the resulting patterns use match ergonomics. Alternatively one could add `ref`/`mut`/`ref mut` keywords to other parts of the pattern, making it fully explicit.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#4226

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

