### PR TITLE
fix: stop duplicate downloads and executing messages for config_update

### DIFF
--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -5,7 +5,6 @@ use crate::entity_manager::server::EntityStoreServer;
 use crate::entity_manager::server::EntityStoreServerConfig;
 use crate::http_server::actor::HttpServerBuilder;
 use crate::http_server::actor::HttpServerConfig;
-use crate::operation_file_cache::FileCacheActorBuilder;
 use crate::operation_workflows::OperationConfig;
 use crate::operation_workflows::WorkflowActorBuilder;
 use crate::restart_manager::builder::RestartManagerBuilder;
@@ -88,7 +87,6 @@ pub(crate) struct AgentConfig {
     pub service: TEdgeConfigReaderService,
     pub identity: Option<Identity>,
     pub cloud_root_certs: CloudHttpConfig,
-    pub fts_url: Arc<str>,
     pub is_sudo_enabled: bool,
     pub capabilities: Capabilities,
     pub log_plugin_dirs: Vec<Utf8PathBuf>,
@@ -182,11 +180,6 @@ impl AgentConfig {
             config_snapshot: tedge_config.agent.enable.config_snapshot,
             log_upload: tedge_config.agent.enable.log_upload,
         };
-        let fts_url = format!(
-            "{}:{}",
-            tedge_config.http.client.host, tedge_config.http.client.port
-        )
-        .into();
 
         let entity_auto_register = tedge_config.agent.entity_store.auto_register;
         let entity_store_clean_start = tedge_config.agent.entity_store.clean_start;
@@ -225,7 +218,6 @@ impl AgentConfig {
             tedge_http_protocol,
             identity,
             cloud_root_certs,
-            fts_url,
             is_sudo_enabled,
             service: tedge_config.service.clone(),
             capabilities,
@@ -471,17 +463,8 @@ impl Agent {
             )
             .await?;
 
-            let operation_file_cache_builder = FileCacheActorBuilder::new(
-                mqtt_schema,
-                self.config.fts_url.clone(),
-                self.config.data_dir.clone(),
-                &mut downloader_actor_builder,
-                &mut mqtt_actor_builder,
-            );
-
             runtime.spawn(file_transfer_server_builder).await?;
             runtime.spawn(entity_store_actor_builder).await?;
-            runtime.spawn(operation_file_cache_builder).await?;
         } else {
             info!("Running as a child device: File Transfer Service disabled");
         }

--- a/crates/core/tedge_agent/src/lib.rs
+++ b/crates/core/tedge_agent/src/lib.rs
@@ -27,7 +27,6 @@ mod agent;
 mod device_profile_manager;
 mod entity_manager;
 mod http_server;
-mod operation_file_cache;
 mod operation_workflows;
 mod restart_manager;
 mod software_manager;

--- a/crates/core/tedge_agent/src/operation_file_cache/mod.rs
+++ b/crates/core/tedge_agent/src/operation_file_cache/mod.rs
@@ -1,3 +1,8 @@
+//! This actor is not used. For the reason, see the PR \#4231
+//!
+//! However, the file caching mechanism itself is still a valid idea for future improvements
+//! (Issue \#2798) so this implementation is kept for future reference.
+
 //! Inspects incoming operation requests for URLs to files and downloads them into the File Transfer
 //! Service, so that they can be downloaded more quickly by the child devices.
 //!

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_operation.robot
@@ -91,6 +91,28 @@ Set configuration with broken url
     Main Device    ${PARENT_SN}    ${PARENT_SN}    CONFIG1    /etc/config1.json    invalid://hellö.zip
     Child Device    ${CHILD_SN}    ${PARENT_SN}:device:${CHILD_SN}    CONFIG1    /etc/config1.json    invalid://hellö.zip
 
+Set Configuration Without Duplicate Executing Messages
+    [Documentation]    Regression test for \#4160: the legacy FileCacheActor was reacting
+    ...    to config_update commands and causing a duplicate "executing" status message.
+    [Tags]    \#4160
+    Cumulocity.Set Device    ${PARENT_SN}
+    ThinEdgeIO.Set Device Context    ${PARENT_SN}
+
+    ${config_url}=    Cumulocity.Create Inventory Binary
+    ...    config1-regression
+    ...    CONFIG1
+    ...    file=${CURDIR}/config1-version2.json
+    ${start_time}=    Get Unix Timestamp
+    ${operation}=    Cumulocity.Set Configuration    CONFIG1    url=${config_url}
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=60
+
+    Should Have MQTT Messages
+    ...    te/+/+/+/+/cmd/config_update/+
+    ...    date_from=${start_time}
+    ...    message_contains="status":"executing"
+    ...    minimum=1
+    ...    maximum=1
+
 Set Configuration Should Restart Service
     Cumulocity.Set Device    ${PARENT_SN}
     ThinEdgeIO.Set Device Context    ${PARENT_SN}


### PR DESCRIPTION
## Proposed changes
The `FileCacheActor` was reacting to all `config_update` MQTT messages even though it was no longer needed, causing duplicate downloads and duplicate `executing` status messages for each `config_update` operation. So, this PR removes the actor entirely. 

### duplicated `executing` messages
Since the `config_update` operation moved to workflow-based execution, "executing" status message should be sent once only by the workflow. However, this part of the code of `FileCacheActor` re-publishes the message with `tedgeUrl` field with `executing` status.

```rust
async fn process_download(&mut self, download: IdDownloadResult) -> Result<(), RuntimeError> {
        ...
        operation.tedge_url = Some(tedge_url);

        let mqtt_message = MqttMessage::new(
            &Topic::new(&topic).unwrap(),
            serde_json::to_string(&operation).unwrap(),
        );
        self.mqtt_sender.send(mqtt_message).await.unwrap();
}
```

Two duplicated messages were found.
```
[te/device/main///cmd/config_update/c8y-mapper-71321] {"status":"init","remoteUrl":"http://172.19.0.2:8001/c8y/inventory/binaries/1572237","serverUrl":"https://t297258651.preprod.c8y.io/inventory/binaries/1572237","type":"CONFIG1"}
[te/device/main///cmd/config_update/c8y-mapper-71321] {"@version":"a06b31b0a7ae2db61fb0777bcde70a178aca12cf8c89b910a6410feed1a263c2","logPath":"/var/log/tedge/agent/workflow-config_update-c8y-mapper-71321.log","remoteUrl":"http://172.19.0.2:8001/c8y/inventory/binaries/1572237","serverUrl":"https://t297258651.preprod.c8y.io/inventory/binaries/1572237","status":"executing","type":"CONFIG1"}
[te/device/main///cmd/config_update/c8y-mapper-71321] {"@version":"a06b31b0a7ae2db61fb0777bcde70a178aca12cf8c89b910a6410feed1a263c2","logPath":"/var/log/tedge/agent/workflow-config_update-c8y-mapper-71321.log","remoteUrl":"http://172.19.0.2:8001/c8y/inventory/binaries/1572237","serverUrl":"https://t297258651.preprod.c8y.io/inventory/binaries/1572237","status":"download","type":"CONFIG1"}
[te/device/main///cmd/config_update/c8y-mapper-71321] {"status":"executing","tedgeUrl":"http://172.19.0.2:8000/te/v1/files/device_main__/config_update/CONFIG1-c8y-mapper-71321","remoteUrl":"http://172.19.0.2:8001/c8y/inventory/binaries/1572237","serverUrl":"https://t297258651.preprod.c8y.io/inventory/binaries/1572237","type":"CONFIG1","logPath":"/var/log/tedge/agent/workflow-config_update-c8y-mapper-71321.log"}
[c8y/s/us] 504,71321
[c8y/s/us] 504,71321
```

### duplicated downloads of the same file
The `FileCacheActor` downloads a file and stores it to `/var/tedge/cache`, while the `download` step of the workflow also downloads the file. The former download is not used by anywhere. 

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
* #4160
* #4224

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

