### PR TITLE
fix: avoid reading external plugin stdout to memory

### DIFF
--- a/crates/core/tedge_agent/src/operation_workflows/actor.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/actor.rs
@@ -396,7 +396,7 @@ impl WorkflowActor {
                     }
                 };
                 let output = self.script_runner.await_response(command).await?;
-                log_file.log_script_output(&output).await;
+                log_file.log_script_output(output.as_ref()).await;
 
                 let new_state = state.update_with_script_output(script_name, output, handlers);
                 self.publish_command_state(new_state, &mut log_file).await
@@ -412,7 +412,7 @@ impl WorkflowActor {
                 // Run the command, but ignore its result
                 let command = Execute::new(script.command, script.args);
                 let output = self.script_runner.await_response(command).await?;
-                log_file.log_script_output(&output).await;
+                log_file.log_script_output(output.as_ref()).await;
                 Ok(())
             }
             OperationAction::Download(input_excerpt, handlers) => {
@@ -514,7 +514,7 @@ impl WorkflowActor {
                     Some(script) => {
                         let command = Execute::new(script.command.clone(), script.args);
                         let output = self.script_runner.await_response(command).await?;
-                        log_file.log_script_output(&output).await;
+                        log_file.log_script_output(output.as_ref()).await;
                         match extract_json_output(&script.command, output) {
                             Ok(init_state) => init_state,
                             Err(reason) => {

--- a/crates/core/tedge_api/src/workflow/log/command_log.rs
+++ b/crates/core/tedge_api/src/workflow/log/command_log.rs
@@ -1,4 +1,5 @@
 use super::logged_command::LoggedCommand;
+use crate::workflow::log::logged_command::CommandOutput;
 use crate::workflow::CommandId;
 use crate::workflow::GenericCommandState;
 use crate::workflow::OperationAction;
@@ -7,7 +8,6 @@ use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use log::error;
 use log::info;
-use std::process::Output;
 use time::format_description;
 use time::OffsetDateTime;
 use tokio::fs::File;
@@ -160,14 +160,17 @@ Action:   {action}
             .await
     }
 
-    pub async fn log_script_output(&mut self, result: &Result<Output, std::io::Error>) {
+    pub async fn log_script_output(
+        &mut self,
+        result: Result<impl Into<CommandOutput<'_>>, &std::io::Error>,
+    ) {
         self.log_command_and_output("", result).await
     }
 
     pub async fn log_command_and_output(
         &mut self,
         command_line: &str,
-        result: &Result<Output, std::io::Error>,
+        result: Result<impl Into<CommandOutput<'_>>, &std::io::Error>,
     ) {
         if let Err(err) = self.write_script_output(command_line, result).await {
             error!("Fail to log to {}: {err}", self.path)
@@ -193,7 +196,7 @@ Action:   {action}
     pub async fn write_script_output(
         &mut self,
         command_line: &str,
-        result: &Result<Output, std::io::Error>,
+        result: Result<impl Into<CommandOutput<'_>>, &std::io::Error>,
     ) -> Result<(), std::io::Error> {
         let file = self.open().await?;
         let mut writer = BufWriter::new(file);

--- a/crates/core/tedge_api/src/workflow/log/logged_command.rs
+++ b/crates/core/tedge_api/src/workflow/log/logged_command.rs
@@ -1,5 +1,6 @@
 use crate::CommandLog;
 use std::ffi::OsStr;
+use std::io::Cursor;
 use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
 use std::process::ExitStatus;
@@ -8,6 +9,8 @@ use std::process::Stdio;
 use std::time::Duration;
 use tedge_utils::signals::terminate_process;
 use tedge_utils::signals::Signal;
+use tokio::io::AsyncBufRead;
+use tokio::io::AsyncBufReadExt as _;
 use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Child;
@@ -52,7 +55,7 @@ impl LoggingChild {
         let outcome = self.inner_child.wait_with_output().await;
         if let Some(command_log) = command_log {
             command_log
-                .log_command_and_output(&self.command_line, &outcome)
+                .log_command_and_output(&self.command_line, outcome.as_ref())
                 .await;
         }
         outcome
@@ -72,7 +75,7 @@ impl LoggingChild {
             }
         };
         command_log
-            .log_command_and_output(&command_line, &outcome)
+            .log_command_and_output(&command_line, outcome.as_ref())
             .await;
         outcome
     }
@@ -219,7 +222,7 @@ impl LoggedCommand {
         let outcome = self.command.output().await;
         if let Some(command_log) = command_log {
             command_log
-                .log_command_and_output(&self.to_string(), &outcome)
+                .log_command_and_output(&self.to_string(), outcome.as_ref())
                 .await;
         }
         outcome
@@ -251,7 +254,7 @@ impl LoggedCommand {
 
     pub async fn log_outcome(
         command_line: &str,
-        result: &Result<Output, std::io::Error>,
+        result: Result<impl Into<CommandOutput<'_>>, &std::io::Error>,
         logger: &mut (impl AsyncWrite + Unpin),
     ) -> Result<(), std::io::Error> {
         if !command_line.is_empty() {
@@ -260,8 +263,10 @@ impl LoggedCommand {
                 .await?;
         }
 
-        match result.as_ref() {
+        match result {
             Ok(output) => {
+                let output: CommandOutput<'_> = output.into();
+
                 if let Some(code) = &output.status.code() {
                     let exit_code_msg = if *code == 0 { "OK" } else { "ERROR" };
                     logger
@@ -273,19 +278,24 @@ impl LoggedCommand {
                         .write_all(format!("Killed by signal: {signal}\n\n").as_bytes())
                         .await?
                 }
+
                 // Log stderr then stdout, so the flow reads chronologically
                 // as the stderr is used for log messages and the stdout is used for results
-                if !output.stderr.is_empty() {
+                let mut stderr = output.stderr;
+                if !stderr.fill_buf().await?.is_empty() {
                     logger.write_all(b"stderr <<EOF\n").await?;
-                    logger.write_all(&output.stderr).await?;
-                    logger.write_all(b"EOF\n\n").await?;
+                    tokio::io::copy_buf(&mut stderr, logger).await?;
+                    logger.write_all(b"EOF\n").await?;
                 } else {
-                    logger.write_all(b"stderr (EMPTY)\n\n").await?;
+                    logger.write_all(b"stderr (EMPTY)\n").await?;
                 }
 
-                if !output.stdout.is_empty() {
+                logger.write_all(b"\n").await?;
+
+                let mut stdout = output.stdout;
+                if !stdout.fill_buf().await?.is_empty() {
                     logger.write_all(b"stdout <<EOF\n").await?;
-                    logger.write_all(&output.stdout).await?;
+                    tokio::io::copy_buf(&mut stdout, logger).await?;
                     logger.write_all(b"EOF\n").await?;
                 } else {
                     logger.write_all(b"stdout (EMPTY)\n").await?;
@@ -300,5 +310,22 @@ impl LoggedCommand {
 
         logger.flush().await?;
         Ok(())
+    }
+}
+
+/// A command output that allows reading from it, no matter if output was captured to memory or attached to a file.
+pub struct CommandOutput<'a> {
+    pub status: ExitStatus,
+    pub stdout: Box<dyn AsyncBufRead + Unpin + Send + 'a>,
+    pub stderr: Box<dyn AsyncBufRead + Unpin + Send + 'a>,
+}
+
+impl<'a> From<&'a std::process::Output> for CommandOutput<'a> {
+    fn from(output: &'a std::process::Output) -> Self {
+        Self {
+            status: output.status,
+            stdout: Box::new(Cursor::new(&output.stdout[..])),
+            stderr: Box::new(Cursor::new(&output.stderr[..])),
+        }
     }
 }

--- a/crates/core/tedge_api/src/workflow/log/mod.rs
+++ b/crates/core/tedge_api/src/workflow/log/mod.rs
@@ -1,3 +1,3 @@
 pub(crate) mod command_log;
 pub mod log_dir;
-pub(crate) mod logged_command;
+pub mod logged_command;

--- a/crates/extensions/tedge_config_manager/src/plugin.rs
+++ b/crates/extensions/tedge_config_manager/src/plugin.rs
@@ -2,15 +2,16 @@ use crate::actor::ConfigOperationStep;
 use crate::error::ConfigManagementError;
 use camino::Utf8Path;
 use serde_json::Value;
-use std::fs::File;
-use std::io::Write;
+use std::fs::OpenOptions;
 use std::path::PathBuf;
 use std::process::Output;
 use std::sync::Arc;
 use tedge_api::workflow::extract_script_output;
+use tedge_api::workflow::log::logged_command::CommandOutput;
 use tedge_api::CommandLog;
 use tedge_api::LoggedCommand;
 use tedge_config::SudoCommandBuilder;
+use tokio::io::BufReader;
 
 pub const LIST: &str = "list";
 const GET: &str = "get";
@@ -110,13 +111,90 @@ impl ExternalPlugin {
         let mut command = self.command(GET)?;
         command.arg(config_type);
 
-        let output = self.execute(command, command_log).await?;
-        let mut file = File::create(target_file_path).map_err(|err| {
+        let stderr_file =
+            tempfile::NamedTempFile::new_in(self.tmp_dir.as_std_path()).map_err(|err| {
+                self.plugin_error(format!(
+                    "Failed to create temporary file in {}: {err}",
+                    self.tmp_dir
+                ))
+            })?;
+
+        let target_dir = target_file_path.parent().ok_or_else(|| {
+            self.plugin_error(format!("Invalid target file path: '{target_file_path}'"))
+        })?;
+
+        let target_file =
+            tempfile::NamedTempFile::new_in(target_dir.as_std_path()).map_err(|err| {
+                self.plugin_error(format!(
+                    "Failed to create temporary plugin output file in {target_dir}: {err}",
+                    target_dir = target_dir.as_std_path().display()
+                ))
+            })?;
+
+        let target_stdout = target_file.reopen().map_err(|err| {
             self.plugin_error(format!(
-                "Failed to create plugin output file at {target_file_path} due to {err}",
+                "Failed to open temporary plugin output file '{}': {err}",
+                target_file.path().to_string_lossy()
             ))
         })?;
-        file.write_all(&output.stdout)?;
+
+        let stderr = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(stderr_file.path())
+            .map_err(|err| {
+                self.plugin_error(format!(
+                    "failed to open temporary file for writing process output '{}': {err}",
+                    stderr_file.path().to_string_lossy()
+                ))
+            })?;
+
+        command.stdout(target_stdout);
+        command.stderr(stderr);
+
+        let status = command
+            .status()
+            .await
+            .map_err(|err| self.plugin_error(err))?;
+
+        if !status.success() {
+            let stderr = std::fs::read_to_string(stderr_file.path()).map_err(|err| {
+                self.plugin_error(format!(
+                    "failed to read plugin error output from '{}': {err}",
+                    stderr_file.path().to_string_lossy()
+                ))
+            })?;
+            return Err(ConfigManagementError::PluginError {
+                plugin_name: self.name.clone(),
+                reason: format!("Command execution failed: {}", stderr),
+            });
+        }
+
+        if let Some(command_log) = command_log {
+            command_log
+                .log_command_and_output(
+                    GET,
+                    Ok(CommandOutput {
+                        status,
+                        stdout: Box::new(BufReader::new(
+                            tokio::fs::File::open(target_file.path()).await?,
+                        )),
+                        stderr: Box::new(BufReader::new(
+                            tokio::fs::File::open(stderr_file.path()).await?,
+                        )),
+                    }),
+                )
+                .await;
+        }
+
+        target_file
+            .persist(target_file_path.as_std_path())
+            .map_err(|err| {
+                self.plugin_error(format!(
+                    "Failed to persist plugin output file to {target_file_path}: {err}",
+                ))
+            })?;
 
         Ok(())
     }

--- a/crates/extensions/tedge_log_manager/src/plugin.rs
+++ b/crates/extensions/tedge_log_manager/src/plugin.rs
@@ -134,14 +134,14 @@ impl ExternalPluginCommand {
             tempfile::NamedTempFile::new_in(self.tmp_dir.as_std_path()).map_err(|err| {
                 self.plugin_error(format!(
                     "Failed to create temporary file in {}: {err}",
-                    tempfile::env::temp_dir().to_string_lossy()
+                    self.tmp_dir.as_str()
                 ))
             })?;
         let stderr_file =
             tempfile::NamedTempFile::new_in(self.tmp_dir.as_std_path()).map_err(|err| {
                 self.plugin_error(format!(
                     "Failed to create temporary file in {}: {err}",
-                    tempfile::env::temp_dir().to_string_lossy()
+                    self.tmp_dir.as_str()
                 ))
             })?;
 

--- a/tests/RobotFramework/tests/cumulocity/configuration/config_operation_plugins.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/config_operation_plugins.robot
@@ -90,6 +90,39 @@ Dynamic plugin install and remove
     ...    timeout=30
     ...    failure_reason=.*Plugin not found.*
 
+Config operation shouldnt OOM on oversized output
+
+    [Documentation]    Install a plugin that emits a very large config and verify all of its output is not loaded into
+    ...                memory at once.
+
+    # install custom config plugin that generates lots of data on stdout, here 50MB
+    # but it shouldn't send all of it to c8y, so after outputting all this to stdout we print short
+    # message on stderr and exit.
+    # tedge shouldn't send any stdout/stderr data to the cloud until the plugin process exits.
+    ThinEdgeIO.Transfer To Device
+    ...    ${CURDIR}/plugins/huge
+    ...    /usr/share/tedge/config-plugins/huge
+    Execute Command    chmod +x /usr/share/tedge/config-plugins/huge
+
+    # request config
+    Should Contain Supported Configuration Types    huge::huge
+    ${operation}=    Cumulocity.Get Configuration    huge::huge
+
+    # Wait until huge plugin creates a pipe which means stdout was filled and we can measure memory usage
+    Execute Command    ls /tmp/huge-config-plugin-pipe    retries=5    timeout=2
+
+    ${tedge_agent_rss_bytes}=    Execute Command    cmd=ps -o rss= -C tedge-agent    strip=True
+    Should Be True    ${tedge_agent_rss_bytes} < 20000    tedge-agent used too much (${tedge_agent_rss_bytes}>20MB) memory
+
+    # send message to plugin to exit
+    Execute Command    echo done > /tmp/huge-config-plugin-pipe
+
+    # make sure operation completed and tedge-agent is still running
+    # (?s:.) matches any character regardless of flags
+    # https://docs.python.org/3/library/re.html
+    Operation Should Be FAILED    ${operation}    failure_reason=(?s:.)*script generated(?s:.)*
+    Execute Command    systemctl is-active tedge-agent
+
 
 *** Keywords ***
 Custom Setup

--- a/tests/RobotFramework/tests/cumulocity/configuration/config_operation_plugins.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/config_operation_plugins.robot
@@ -70,6 +70,10 @@ Dynamic plugin install and remove
     ${operation}=    Cumulocity.Get Configuration    dummy_config::dummy_plugin
     Operation Should Be SUCCESSFUL    ${operation}    timeout=30
 
+    # Verify operation stdout is logged
+    ${operation_logfile}=    Execute Command    ls -t /var/log/tedge/agent/workflow-config_snapshot-* | head -1    strip=True
+    Execute Command    grep "Dummy content" ${operation_logfile}    exp_exit_code=0    retries=0    timeout=0
+
     ${config_url}=    Cumulocity.Create Inventory Binary
     ...    dummy_config
     ...    dummy_config

--- a/tests/RobotFramework/tests/cumulocity/configuration/plugins/huge
+++ b/tests/RobotFramework/tests/cumulocity/configuration/plugins/huge
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euxo pipefail
+
+case "$1" in
+  list)
+    echo huge
+    ;;
+  get)
+    if [ "$2" = "huge" ]; then
+      # Emit ~50MB to stdout to simulate an oversized config file
+      len=50M
+      dd if=/dev/zero bs=$len count=1 2>/dev/null | tr '\0' 'A'
+
+      # once the entire config is generated output a message so we know we can measure memory used
+      echo "script generated $len of data" >&2
+
+      # create a pipe and read it to pause executing, allowing test to measure memory usage and
+      # decide when the script should exit
+      mkfifo /tmp/huge-config-plugin-pipe
+      read -r _x < /tmp/huge-config-plugin-pipe
+
+      # finally exit with non-zero code so data isn't sent to c8y unnecessarily
+      rm /tmp/huge-config-plugin-pipe
+      exit 67
+    else
+      echo "Unknown config type: $2" >&2
+      exit 2
+    fi
+    ;;
+  *)
+    echo "Usage: $0 {list|get <type>}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION


## Proposed changes

Similar to 5fda661, stream result of external config plugin instead of loading everything to memory. Not as impactful as log plugin, because usually people won't be having config files bigger than available RAM, but nevertheless behaviour was changed to keep consistency between the two plugins.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/pull/4222#pullrequestreview-4561595928

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

