### PR TITLE
fix: resolve clippy warnings

### DIFF
--- a/crates/common/download/src/download.rs
+++ b/crates/common/download/src/download.rs
@@ -177,7 +177,7 @@ impl Downloader {
         // Move the downloaded file to the final destination
         debug!(
             "Moving downloaded file from {:?} to {:?}",
-            &tmp_target_path, &target_file_path
+            tmp_target_path, target_file_path
         );
 
         file.persist(target_file_path)
@@ -250,7 +250,7 @@ impl Downloader {
     /// Builds a temporary filename the file will be downloaded into.
     async fn temp_filename(&self) -> Result<PathBuf, DownloadError> {
         if self.target_filename.is_relative() {
-            return Err(FileError::InvalidFileName {
+            Err(FileError::InvalidFileName {
                 path: self.target_filename.clone(),
                 source: anyhow!("Path can't be relative"),
             })?;

--- a/crates/common/upload/src/upload.rs
+++ b/crates/common/upload/src/upload.rs
@@ -168,7 +168,7 @@ impl Uploader {
         let operation = || async {
             let file = File::open(&self.source_filename)
                 .await
-                .context(format!("Can't open a file {:?}", &self.source_filename))
+                .context(format!("Can't open a file {:?}", self.source_filename))
                 .map_err(backoff::Error::Permanent)?;
 
             let file_length = file
@@ -176,7 +176,7 @@ impl Uploader {
                 .await
                 .context(format!(
                     "Can't read a file {:?} metadata",
-                    &self.source_filename
+                    self.source_filename
                 ))
                 .map_err(backoff::Error::Permanent)?
                 .len();

--- a/crates/core/plugin_sm/src/plugin.rs
+++ b/crates/core/plugin_sm/src/plugin.rs
@@ -210,8 +210,8 @@ pub trait Plugin {
                 .write(
                     format!(
                         "----- $ Downloading: {} to {} \n",
-                        &url.url(),
-                        &downloader.filename().to_string_lossy().to_string()
+                        url.url(),
+                        downloader.filename().to_string_lossy()
                     )
                     .as_bytes(),
                 )
@@ -230,9 +230,7 @@ pub trait Plugin {
         {
             error!(target: "SM plugins", "Download error: {err:#?}");
             if let Some(ref mut logger) = command_log {
-                logger
-                    .write(format!("error: {}\n", &err).as_bytes())
-                    .await?;
+                logger.write(format!("error: {}\n", err).as_bytes()).await?;
             }
             return Err(err);
         }
@@ -254,7 +252,7 @@ pub trait Plugin {
             })
         {
             if let Some(logger) = command_log {
-                logger.write(format!("warn: {}\n", &err).as_bytes()).await?;
+                logger.write(format!("warn: {}\n", err).as_bytes()).await?;
             }
         }
         Ok(())

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -327,11 +327,11 @@ impl ConnectCommand {
             eprintln!("Offline mode. Skipping new device certificate validation");
             eprintln!(
                 "  => use current certificate {}",
-                &certificate_shift.active_cert_path
+                certificate_shift.active_cert_path
             );
             eprintln!(
                 "  => ignoring new certificate {}",
-                &certificate_shift.new_cert_path
+                certificate_shift.new_cert_path
             );
             return Ok(false);
         }
@@ -343,7 +343,7 @@ impl ConnectCommand {
             let banner = if attempt == 1 {
                 format!(
                     "Validating new certificate: {}",
-                    &certificate_shift.new_cert_path
+                    certificate_shift.new_cert_path
                 )
             } else {
                 format!("Validating new certificate: attempt {attempt} of {max_attempts}")
@@ -364,7 +364,7 @@ impl ConnectCommand {
             eprintln!("Error validating the new certificate: {err}");
             eprintln!(
                 "  => keep using the current certificate unchanged {}",
-                &certificate_shift.active_cert_path
+                certificate_shift.active_cert_path
             );
             return Ok(false);
         }

--- a/crates/core/tedge/src/cli/mqtt/subscribe.rs
+++ b/crates/core/tedge/src/cli/mqtt/subscribe.rs
@@ -96,7 +96,7 @@ async fn subscribe(cmd: &MqttSubscribeCommand) -> Result<(), anyhow::Error> {
         let line = if cmd.hide_topic {
             format!("{payload}\n")
         } else {
-            format!("[{}] {payload}\n", &message.topic)
+            format!("[{}] {payload}\n", message.topic)
         };
         let _ = stdout.write_all(line.as_bytes()).await;
         let _ = stdout.flush().await;

--- a/crates/core/tedge/src/cli/upload/c8y.rs
+++ b/crates/core/tedge/src/cli/upload/c8y.rs
@@ -52,7 +52,7 @@ impl Command for C8yUpload {
 
     async fn execute(&self, _: TEdgeConfig) -> Result<(), MaybeFancy<Error>> {
         if !path_exists(&self.file).await {
-            return Err(anyhow!("Failed to open file: {:?}", self.file))?;
+            Err(anyhow!("Failed to open file: {:?}", self.file))?;
         }
         let internal_id = self.get_internal_id().await?;
         let event_id = self.create_event(&internal_id).await?;

--- a/crates/core/tedge_agent/src/operation_workflows/actor.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/actor.rs
@@ -161,7 +161,7 @@ impl WorkflowActor {
     /// Only the former will be actually processed with [Self::process_command_update].
     async fn process_mqtt_message(&mut self, message: MqttMessage) -> Result<(), RuntimeError> {
         let Ok((_, channel)) = self.mqtt_schema.entity_channel_of(&message.topic) else {
-            log::error!("Unknown topic: {}", &message.topic.name);
+            log::error!("Unknown topic: {}", message.topic.name);
             return Ok(());
         };
         match channel {
@@ -231,7 +231,7 @@ impl WorkflowActor {
             return Ok(());
         }
         let Ok(state) = GenericCommandState::from_command_message(&message) else {
-            log::error!("Invalid command payload: {}", &message.topic.name);
+            log::error!("Invalid command payload: {}", message.topic.name);
             return Ok(());
         };
         let step = state.status.clone();

--- a/crates/core/tedge_agent/src/state_repository/state.rs
+++ b/crates/core/tedge_agent/src/state_repository/state.rs
@@ -212,7 +212,7 @@ mod tests {
 
         let data = tokio::fs::read_to_string(&format!(
             "{}/.agent/current-operation",
-            &temp_dir.temp_dir.path().to_str().unwrap()
+            temp_dir.temp_dir.path().to_str().unwrap()
         ))
         .await
         .unwrap();

--- a/crates/core/tedge_api/src/workflow/log/logged_command.rs
+++ b/crates/core/tedge_api/src/workflow/log/logged_command.rs
@@ -303,7 +303,7 @@ impl LoggedCommand {
             }
             Err(err) => {
                 logger
-                    .write_all(format!("error: {}\n", &err).as_bytes())
+                    .write_all(format!("error: {}\n", err).as_bytes())
                     .await?;
             }
         }

--- a/crates/core/tedge_api/src/workflow/mod.rs
+++ b/crates/core/tedge_api/src/workflow/mod.rs
@@ -282,7 +282,7 @@ impl OperationWorkflow {
         }
 
         let main_operation = operation.to_string();
-        for (_, action) in states.iter() {
+        for action in states.values() {
             match action {
                 // A `builtin:<operation>` can only be invoked from the same `<operation>`
                 OperationAction::BuiltInOperation(builtin_operation, _)

--- a/crates/core/tedge_mapper/src/lib.rs
+++ b/crates/core/tedge_mapper/src/lib.rs
@@ -360,7 +360,7 @@ async fn flow_registry(
             "failed to create flow directory '{}': {err}",
             flows_dir.as_ref()
         );
-        return Err(err)?;
+        Err(err)?;
     };
 
     let mut flows = match mapper_config {

--- a/crates/extensions/c8y_firmware_manager/src/worker.rs
+++ b/crates/extensions/c8y_firmware_manager/src/worker.rs
@@ -257,7 +257,7 @@ impl FirmwareManagerWorker {
             self.create_file_transfer_symlink(child_id, &file_cache_key, &cache_file_path)?;
         let file_transfer_url = format!(
             "http://{}/te/v1/files/{child_id}/firmware_update/{file_cache_key}",
-            &self.config.local_http_host
+            self.config.local_http_host
         );
         let file_sha256 = try_digest(symlink_path.as_path())?;
 

--- a/crates/extensions/c8y_mapper_ext/src/inventory.rs
+++ b/crates/extensions/c8y_mapper_ext/src/inventory.rs
@@ -357,7 +357,7 @@ mod tests {
         assert!(
             inventory_messages.is_empty(),
             "Expected no converted messages, but received {:?}",
-            &inventory_messages
+            inventory_messages
         );
 
         // Assert that the same payload with different key order is also ignored
@@ -369,7 +369,7 @@ mod tests {
         assert!(
             inventory_messages.is_empty(),
             "Expected no converted messages, but received {:?}",
-            &inventory_messages
+            inventory_messages
         );
     }
 

--- a/crates/extensions/c8y_mapper_ext/src/operations/convert.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/convert.rs
@@ -90,7 +90,7 @@ impl CumulocityConverter {
         let tedge_url = format!(
             "{}://{}/te/v1/files/{}/config_snapshot/{}-{}",
             self.config.tedge_http_protocol.as_str(),
-            &self.config.tedge_http_host,
+            self.config.tedge_http_host,
             target.external_id.as_ref(),
             config_upload_request.config_type.replace('/', ":"),
             cmd_id
@@ -130,7 +130,7 @@ impl CumulocityConverter {
         let tedge_url = format!(
             "{}://{}/te/v1/files/{}/log_upload/{}-{}",
             self.config.tedge_http_protocol.as_str(),
-            &self.config.tedge_http_host,
+            self.config.tedge_http_host,
             target.external_id.as_ref(),
             log_request.log_file,
             cmd_id

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/config_snapshot.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/config_snapshot.rs
@@ -97,7 +97,7 @@ impl OperationContext {
                 let tedge_file_url = format!(
                     "{}://{}/te/v1/files/{external_id}/config_snapshot/{config_filename}",
                     self.tedge_http_protocol.as_str(),
-                    &self.tedge_http_host,
+                    self.tedge_http_host,
                     external_id = target.external_id.as_ref()
                 );
                 Cow::Owned(tedge_file_url)

--- a/crates/extensions/c8y_mapper_ext/src/operations/upload.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/upload.rs
@@ -86,7 +86,7 @@ impl OperationContext {
         {
             let log_path = command.get_log_path().unwrap();
             let event_type = format!("{}_op_log", op_type);
-            let event_text = format!("{} operation log", &op_type);
+            let event_text = format!("{} operation log", op_type);
             let _upload_url = self
                 .upload_file(
                     external_id,

--- a/crates/extensions/collectd_ext/src/collectd.rs
+++ b/crates/extensions/collectd_ext/src/collectd.rs
@@ -179,7 +179,7 @@ impl Batchable for CollectdMessage {
     type Key = String;
 
     fn key(&self) -> Self::Key {
-        format!("{}/{}", &self.metric_group_key, &self.metric_key)
+        format!("{}/{}", self.metric_group_key, self.metric_key)
     }
 
     fn event_time(&self) -> OffsetDateTime {

--- a/crates/extensions/tedge_config_manager/src/actor.rs
+++ b/crates/extensions/tedge_config_manager/src/actor.rs
@@ -416,7 +416,7 @@ impl ConfigManagerWorker {
         Ok(format!(
             "{}://{}/te/v1/files/{}/{}/{}-{}",
             self.config.tedge_http_protocol.as_str(),
-            &self.config.tedge_http_host,
+            self.config.tedge_http_host,
             device_name,
             operation_type,
             config_type.replace('/', ":"),

--- a/crates/extensions/tedge_mqtt_bridge/tests/test_broker/mod.rs
+++ b/crates/extensions/tedge_mqtt_bridge/tests/test_broker/mod.rs
@@ -517,7 +517,7 @@ impl TestMqttBroker {
         // Cleanup: Remove client's sender from shared maps when connection closes.
         client_senders.lock().await.remove(&client_id);
         let mut subs_guard = subscriptions.lock().await;
-        for (_filter, senders) in subs_guard.iter_mut() {
+        for senders in subs_guard.values_mut() {
             senders.retain(|(_, s)| !s.same_channel(&tx));
         }
         // Remove empty topic filter entries

--- a/crates/tests/tedge_test_utils/src/fs.rs
+++ b/crates/tests/tedge_test_utils/src/fs.rs
@@ -206,13 +206,13 @@ mod tests {
 
         assert!(Path::new(&format!(
             "{}/c8y/c8y-log-plugin.toml",
-            &tedge_dir.temp_dir.path().to_str().unwrap()
+            tedge_dir.temp_dir.path().to_str().unwrap()
         ))
         .exists());
 
         assert!(Path::new(&format!(
             "{}/operations/c8y/c8y_Restart",
-            &tedge_dir.temp_dir.path().to_str().unwrap()
+            tedge_dir.temp_dir.path().to_str().unwrap()
         ))
         .exists());
         Ok(())
@@ -231,7 +231,7 @@ mod tests {
             });
         let file_path = &format!(
             "{}/c8y/c8y-log-plugin.toml",
-            &tedge_dir.temp_dir.path().to_str().unwrap()
+            tedge_dir.temp_dir.path().to_str().unwrap()
         );
         assert!(Path::new(&file_path).exists());
 
@@ -261,13 +261,13 @@ mod tests {
 
         assert!(Path::new(&format!(
             "{}/operations/c8y/c8y_Restart",
-            &ttd.temp_dir.path().to_str().unwrap()
+            ttd.temp_dir.path().to_str().unwrap()
         ))
         .exists());
 
         assert!(Path::new(&format!(
             "{}/operations/c8y/c8y_SoftwareUpdate",
-            &ttd.temp_dir.path().to_str().unwrap()
+            ttd.temp_dir.path().to_str().unwrap()
         ))
         .exists());
         Ok(())

--- a/plugins/tedge_apt_plugin/src/lib.rs
+++ b/plugins/tedge_apt_plugin/src/lib.rs
@@ -219,15 +219,15 @@ fn get_installer(
 
         (None, Some(file_path)) => {
             let mut package = PackageMetadata::try_new(file_path)?;
-            package.validate_package(&[&format!("Package: {}", &module)])?;
+            package.validate_package(&[&format!("Package: {}", module)])?;
             Ok((format!("{}", package.file_path().display()), Some(package)))
         }
 
         (Some(version), Some(file_path)) => {
             let mut package = PackageMetadata::try_new(file_path)?;
             package.validate_package(&[
-                &format!("Version: {}", &version),
-                &format!("Package: {}", &module),
+                &format!("Version: {}", version),
+                &format!("Package: {}", module),
             ])?;
 
             Ok((format!("{}", package.file_path().display()), Some(package)))

--- a/plugins/tedge_apt_plugin/src/module_check.rs
+++ b/plugins/tedge_apt_plugin/src/module_check.rs
@@ -138,7 +138,7 @@ new Debian package, version 2.0.
         };
 
         // Fail
-        let res = meta_info.metadata_contains_all(&[&format!("Version: {}", &"1.5.1")]);
+        let res = meta_info.metadata_contains_all(&[&format!("Version: {}", "1.5.1")]);
         assert!(
             res.is_err(),
             "expected error as there is a version mismatch"
@@ -150,7 +150,7 @@ new Debian package, version 2.0.
         );
 
         // Pass
-        let res = meta_info.metadata_contains_all(&[&format!("Version: {}", &"1:1.5.1")]);
+        let res = meta_info.metadata_contains_all(&[&format!("Version: {}", "1:1.5.1")]);
         assert!(res.is_ok());
     }
 
@@ -173,7 +173,7 @@ new Debian package, version 2.0.
             remove_modified: false,
         };
 
-        let res = meta_info.metadata_contains_all(&[&format!("Package: {}", &"someapp")]);
+        let res = meta_info.metadata_contains_all(&[&format!("Package: {}", "someapp")]);
         assert!(
             res.is_err(),
             "expected a clean error rather than a panic when the field is missing"
@@ -207,7 +207,7 @@ new Debian package, version 2.0.
             remove_modified: false,
         };
 
-        let res = meta_info.metadata_contains_all(&[&format!("Package: {}", &"wrongname")]);
+        let res = meta_info.metadata_contains_all(&[&format!("Package: {}", "wrongname")]);
         assert!(
             res.is_err(),
             "expected an error as the package name differs"


### PR DESCRIPTION
## Proposed changes

Fix a lot of clippy warnings since `cargo clippy` started [failing](https://github.com/thin-edge/thin-edge.io/actions/runs/29026505640/job/86147520830?pr=4245) on the latest release `clippy 0.1.97 (2d8144b788 2026-07-07)`.

Note: Because our `cargo clippy` job fails immediately after detecting a warning due to `RUSTFLAGS: -D warnings`, the linked failed GitHub Actions job didn't show all warnings. I hope we can find a solution for that.

## Why the warnings suddenly appeared (summarized by Claude)

Our `cargo-clippy` CI job installs the toolchain via `dtolnay/rust-toolchain@stable` (`.github/workflows/pull-request-checks.yml:184`) with **no version pinned**, so it always resolves to whatever the current latest stable release is. Rust/Clippy **1.97.0** shipped on 2026-07-07, and the very next PR run picked it up automatically.

All ~48 warnings introduced by this bump collapse into just **3 clippy lints**:

| Lint | Count | What it flags |
|---|---|---|
| `useless_borrows_in_formatting` | 41 | A `&` reference passed into `format!`/`println!`/`error!`/etc. that isn't needed (e.g. `format!("{}", &err)`) |
| `needless_return_with_question_mark` | 3 | `return Err(x)?;` where the trailing `?` already returns, making `return` redundant |
| `for_kv_map` | 2 | Iterating a `HashMap`/`BTreeMap` with `for (_, v) in map.iter())` when `map.values()` says the same thing |

None of these are *new* lints — all three have existed in clippy's `style` group (warn-by-default) for a long time, and the patterns they flag have quietly existed in our codebase for a while. What changed in 1.97.0 is that clippy's detection for these lints was broadened/fixed to catch more cases than before, so a large batch of pre-existing, previously-undetected instances lit up in one go — spread across many unrelated crates, which is why it looked like "everything" broke at once rather than one crate.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

