### PR TITLE
feat: Allow `tedge run all` to run multiple mappers

### DIFF
--- a/crates/common/tedge_supervisor/src/lib.rs
+++ b/crates/common/tedge_supervisor/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! Serves two execution modes:
 //!
-//! - **Multi-unit** (`tedge run all`): hosts the agent and a mapper inside one process
-//!   so no external init system is required.
+//! - **Multi-unit** (`tedge run all`): hosts the agent and one or more mappers inside
+//!   one process so no external init system is required.
 //! - **Single-unit** (standalone `tedge-agent`, `tedge-mapper`): wraps one component
 //!   with the same signal handling and SIGHUP log-level reloading, but leaves crash
 //!   recovery to the init system: the first unit failure exits the process, exactly

--- a/crates/common/tedge_supervisor/src/lib.rs
+++ b/crates/common/tedge_supervisor/src/lib.rs
@@ -57,6 +57,18 @@ pub enum UnitKind {
     Mapper,
 }
 
+/// How the supervisor manages its units' lifecycle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SupervisorMode {
+    /// Multi-unit mode (`tedge run all`): crashed units are rebuilt in-process
+    /// under a bounded backoff, and SIGUSR1 restarts all mapper units.
+    MultiUnit,
+    /// Standalone mode (`tedge-agent`, `tedge-mapper`): the first unit failure
+    /// exits the process so the init system can restart it. SIGUSR1 is ignored
+    /// because restarts are the init system's responsibility.
+    Standalone,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct RestartPolicy {
     pub initial_backoff: Duration,
@@ -164,10 +176,7 @@ pub struct Supervisor {
     /// Refreshes log levels on SIGHUP; `None` when an override fixes them (see
     /// [`Command::ReloadLogLevels`]).
     log_reload: Option<LogLevelReloadHandle>,
-    /// Whether a failed unit is rebuilt in-process. Standalone processes disable
-    /// this and leave crash recovery to the init system instead: the first unit
-    /// failure exits the process.
-    restart_on_crash: bool,
+    mode: SupervisorMode,
     /// The failure the run loop exits with once every unit has drained.
     failure: Option<anyhow::Error>,
 }
@@ -190,16 +199,13 @@ impl Supervisor {
             // shorter internal cleanup timeout.
             drain_timeout: Duration::from_secs(75),
             log_reload: None,
-            restart_on_crash: true,
+            mode: SupervisorMode::MultiUnit,
             failure: None,
         }
     }
 
-    /// Sets whether a failed unit is rebuilt in-process (the default). When disabled,
-    /// the first unit failure exits the process instead, leaving crash recovery to
-    /// the init system.
-    pub fn with_restart_on_crash(mut self, restart_on_crash: bool) -> Self {
-        self.restart_on_crash = restart_on_crash;
+    pub fn with_mode(mut self, mode: SupervisorMode) -> Self {
+        self.mode = mode;
         self
     }
 
@@ -224,7 +230,7 @@ impl Supervisor {
     ) -> anyhow::Result<()> {
         Supervisor::new(vec![Unit::new(name, kind, factory, lock)])
             .with_log_reload(log_reload)
-            .with_restart_on_crash(false)
+            .with_mode(SupervisorMode::Standalone)
             .run()
             .await
     }
@@ -268,7 +274,7 @@ impl Supervisor {
                 self.running += 1;
                 info!(component = %name, "started");
             }
-            Err(err) if self.restart_on_crash => {
+            Err(err) if self.mode == SupervisorMode::MultiUnit => {
                 error!(component = %self.units[id].name, "failed to build: {err:#}");
                 self.schedule_restart_or_give_up(id);
             }
@@ -370,7 +376,7 @@ impl Supervisor {
                     )
                     .await;
                 }
-                Err(err) if self.restart_on_crash => {
+                Err(err) if self.mode == SupervisorMode::MultiUnit => {
                     error!(component = %name, "crashed: {err}");
                     self.schedule_restart_or_give_up(id);
                 }
@@ -426,6 +432,10 @@ impl Supervisor {
     }
 
     async fn restart_mappers(&mut self) {
+        if self.mode == SupervisorMode::Standalone {
+            info!("SIGUSR1: ignored (standalone process; restart via the service manager instead)");
+            return;
+        }
         info!("SIGUSR1: restarting all mapper components");
         self.restart_units(|unit| unit.kind == UnitKind::Mapper)
             .await;
@@ -932,7 +942,7 @@ mod tests {
             clean_exit_factory(builds.clone()),
             policy,
         )];
-        let supervisor = Supervisor::new(units).with_restart_on_crash(false);
+        let supervisor = Supervisor::new(units).with_mode(SupervisorMode::Standalone);
         let handle = tokio::spawn(supervisor.run_loop());
 
         timeout(Duration::from_secs(5), handle)
@@ -1083,7 +1093,7 @@ mod tests {
             crashing_factory(builds.clone()),
             policy,
         )];
-        let supervisor = Supervisor::new(units).with_restart_on_crash(false);
+        let supervisor = Supervisor::new(units).with_mode(SupervisorMode::Standalone);
         let handle = tokio::spawn(supervisor.run_loop());
 
         let result = timeout(Duration::from_secs(5), handle)
@@ -1112,7 +1122,7 @@ mod tests {
             failing_build_factory(builds.clone()),
             policy,
         )];
-        let supervisor = Supervisor::new(units).with_restart_on_crash(false);
+        let supervisor = Supervisor::new(units).with_mode(SupervisorMode::Standalone);
         let handle = tokio::spawn(supervisor.run_loop());
 
         let result = timeout(Duration::from_secs(5), handle)
@@ -1141,7 +1151,7 @@ mod tests {
             restart_required_factory(builds.clone()),
             policy,
         )];
-        let supervisor = Supervisor::new(units).with_restart_on_crash(false);
+        let supervisor = Supervisor::new(units).with_mode(SupervisorMode::Standalone);
         let handle = tokio::spawn(supervisor.run_loop());
 
         let result = timeout(Duration::from_secs(5), handle)
@@ -1261,6 +1271,40 @@ mod tests {
             builds.load(Ordering::SeqCst),
             1,
             "RestartMappers must not restart an agent-only supervisor"
+        );
+
+        commands.send(Command::ShutdownAll).await.unwrap();
+        timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("supervisor should exit after shutdown")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn restart_mappers_is_ignored_in_standalone_mode() {
+        let builds = Arc::new(AtomicUsize::new(0));
+        let policy = test_policy(1000);
+
+        let units = vec![make_unit(
+            "mapper",
+            UnitKind::Mapper,
+            healthy_factory(builds.clone()),
+            policy,
+        )];
+        let supervisor = Supervisor::new(units).with_mode(SupervisorMode::Standalone);
+        let commands = supervisor.commands();
+        let handle = tokio::spawn(supervisor.run_loop());
+
+        wait_until(|| builds.load(Ordering::SeqCst) == 1, "the mapper to start").await;
+
+        commands.send(Command::RestartMappers).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(
+            builds.load(Ordering::SeqCst),
+            1,
+            "RestartMappers must be ignored in standalone mode"
         );
 
         commands.send(Command::ShutdownAll).await.unwrap();

--- a/crates/core/tedge/src/cli/mod.rs
+++ b/crates/core/tedge/src/cli/mod.rs
@@ -65,7 +65,7 @@ pub struct TEdgeCli {
 
 #[derive(clap::Parser, Debug)]
 pub enum Component {
-    /// Run the agent and a mapper together under a single-process supervisor
+    /// Run the agent and mappers together under a single-process supervisor
     #[clap(hide = true)]
     All(crate::supervisor::RunAllOpt),
 

--- a/crates/core/tedge/src/supervisor.rs
+++ b/crates/core/tedge/src/supervisor.rs
@@ -2,6 +2,7 @@
 
 use anyhow::Context;
 use futures::FutureExt;
+use std::collections::HashSet;
 use tedge_agent::AgentOpt;
 use tedge_config::cli::CommonArgs;
 use tedge_config::log_init_reloadable_for_services;
@@ -12,12 +13,16 @@ use tedge_supervisor::Supervisor;
 use tedge_supervisor::Unit;
 use tedge_supervisor::UnitKind;
 
-/// `tedge run all` — run the agent and (optionally) a mapper under one supervisor.
+/// `tedge run all` — run the agent and mappers under one supervisor.
+///
+/// Mappers are specified as trailing positional arguments in `cloud[@profile]`
+/// format, e.g. `tedge run all c8y aws c8y@secondary`. When none are given, every
+/// mapper configured in `tedge.toml` (plus user-defined mapper directories) is run.
 #[derive(Debug, clap::Parser)]
 pub struct RunAllOpt {
-    /// The mapper to run alongside the agent (e.g. `c8y`, `aws`, `az`).
-    #[clap(subcommand)]
-    pub mapper: Option<MapperName>,
+    /// Mappers to run alongside the agent (e.g. `c8y`, `aws`, `c8y@profile`).
+    #[arg(num_args = 1..)]
+    pub mappers: Vec<String>,
 
     #[command(flatten)]
     pub common: CommonArgs,
@@ -25,16 +30,22 @@ pub struct RunAllOpt {
 
 /// Entry point for `tedge run all`: assembles the units and runs the supervisor.
 pub async fn run(opt: RunAllOpt) -> anyhow::Result<()> {
-    let log_services = log_service_names(opt.mapper.as_ref());
+    let config_dir = opt.common.config_dir.clone();
+    let tedge_config = TEdgeConfig::load(&config_dir).await?;
+
+    let mappers = if opt.mappers.is_empty() {
+        tedge_mapper::configured_mappers(&tedge_config).await
+    } else {
+        parse_mapper_args(&opt.mappers)?
+    };
+
+    let log_services = log_service_names(&mappers);
     let log_services: Vec<_> = log_services.iter().map(String::as_str).collect();
     let log_reload = log_init_reloadable_for_services(
         &log_services,
         &opt.common.log_args,
         &opt.common.config_dir,
     )?;
-
-    let config_dir = opt.common.config_dir.clone();
-    let tedge_config = TEdgeConfig::load(&config_dir).await?;
 
     let mut units: Vec<Unit> = Vec::new();
 
@@ -64,8 +75,8 @@ pub async fn run(opt: RunAllOpt) -> anyhow::Result<()> {
         ));
     }
 
-    // Mapper unit — optional, spawned after the agent.
-    if let Some(mapper) = opt.mapper {
+    // Mapper units — spawned after the agent in the order given.
+    for mapper in mappers {
         let name = mapper.to_string();
         let lock = tedge_mapper::acquire_lock(&name, &tedge_config)
             .with_context(|| format!("acquiring lock for {name}"))?;
@@ -88,14 +99,32 @@ pub async fn run(opt: RunAllOpt) -> anyhow::Result<()> {
         .await
 }
 
+/// Parses the mapper name args given on the command line, rejecting any mapper that is
+/// specified more than once (each mapper holds a per-service lock and MQTT identity,
+/// so a duplicate cannot run in the same process)
+fn parse_mapper_args(args: &[String]) -> anyhow::Result<Vec<MapperName>> {
+    let mut seen = HashSet::new();
+    let mut mappers = Vec::new();
+    for arg in args {
+        let mapper = MapperName::parse_cli_arg(arg)
+            .with_context(|| format!("parsing mapper spec '{arg}'"))?;
+        anyhow::ensure!(
+            seen.insert(mapper.to_string()),
+            "mapper '{arg}' is specified more than once"
+        );
+        mappers.push(mapper);
+    }
+    Ok(mappers)
+}
+
 /// One name per hosted unit — the `tedge` fallback and the generic `tedge-mapper`
 /// inheritance are resolved inside the filter. Keeping the list to the concrete
 /// components makes it single-element exactly when the supervisor hosts one unit
 /// and so runs it without a `component` span: the filter then applies that
 /// component's level process-wide instead of relying on span attribution.
-fn log_service_names(mapper: Option<&MapperName>) -> Vec<String> {
+fn log_service_names(mappers: &[MapperName]) -> Vec<String> {
     let mut services = vec![tedge_agent::AGENT_NAME.to_string()];
-    if let Some(mapper) = mapper {
+    for mapper in mappers {
         services.push(mapper.log_service_name().to_string());
     }
     services
@@ -108,10 +137,22 @@ mod tests {
     #[test]
     fn run_all_logging_considers_the_agent_and_mapper_components() {
         assert_eq!(
-            log_service_names(Some(&MapperName::Collectd)),
+            log_service_names(&[MapperName::Collectd]),
             vec![
                 tedge_agent::AGENT_NAME.to_string(),
                 "tedge-mapper-collectd".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn run_all_logging_includes_all_mappers() {
+        assert_eq!(
+            log_service_names(&[MapperName::Collectd, MapperName::C8y { profile: None }]),
+            vec![
+                tedge_agent::AGENT_NAME.to_string(),
+                "tedge-mapper-collectd".to_string(),
+                "tedge-mapper-c8y".to_string(),
             ]
         );
     }
@@ -122,8 +163,39 @@ mod tests {
         // agent's configured level into the process-wide default, matching the
         // supervisor dropping the `component` span when it hosts a single unit.
         assert_eq!(
-            log_service_names(None),
+            log_service_names(&[]),
             vec![tedge_agent::AGENT_NAME.to_string()]
         );
+    }
+
+    #[test]
+    fn trailing_arguments_parse_as_mapper_specs() {
+        use clap::Parser;
+        let opt = RunAllOpt::try_parse_from(["tedge-run-all", "c8y", "aws"]).unwrap();
+        assert_eq!(opt.mappers, ["c8y", "aws"]);
+    }
+
+    #[test]
+    fn distinct_mappers_and_profiles_are_accepted() {
+        let mappers = parse_mapper_args(&["c8y".to_string(), "c8y@secondary".to_string()]).unwrap();
+        let names: Vec<_> = mappers.iter().map(MapperName::to_string).collect();
+        assert_eq!(names, ["tedge-mapper-c8y", "tedge-mapper-c8y@secondary"]);
+    }
+
+    #[test]
+    fn duplicate_mapper_specs_are_rejected() {
+        let err = parse_mapper_args(&["c8y".to_string(), "c8y".to_string()]).unwrap_err();
+        assert!(
+            format!("{err}").contains("more than once"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn flags_after_a_mapper_spec_are_accepted() {
+        use clap::Parser;
+        let opt = RunAllOpt::try_parse_from(["tedge-run-all", "c8y", "--debug"]).unwrap();
+        assert_eq!(opt.mappers, ["c8y"]);
+        assert!(opt.common.log_args.debug);
     }
 }

--- a/crates/core/tedge_mapper/src/lib.rs
+++ b/crates/core/tedge_mapper/src/lib.rs
@@ -226,6 +226,89 @@ impl MapperName {
             MapperName::UserDefined(_) => "tedge-mapper",
         }
     }
+
+    /// Parses a `cloud[@profile]` string into a `MapperName`
+    pub fn parse_cli_arg(arg: &str) -> anyhow::Result<Self> {
+        let (cloud, profile) = match arg.split_once('@') {
+            Some((cloud, profile)) => (cloud, Some(profile.parse::<ProfileName>()?)),
+            None => (arg, None),
+        };
+        match cloud {
+            #[cfg(feature = "c8y")]
+            "c8y" => Ok(MapperName::C8y { profile }),
+            #[cfg(not(feature = "c8y"))]
+            "c8y" => anyhow::bail!("c8y mapper support is not compiled into this build"),
+            #[cfg(feature = "aws")]
+            "aws" => Ok(MapperName::Aws { profile }),
+            #[cfg(not(feature = "aws"))]
+            "aws" => anyhow::bail!("aws mapper support is not compiled into this build"),
+            #[cfg(feature = "azure")]
+            "az" => Ok(MapperName::Az { profile }),
+            #[cfg(not(feature = "azure"))]
+            "az" => anyhow::bail!("az mapper support is not compiled into this build"),
+            "collectd" => {
+                anyhow::ensure!(
+                    profile.is_none(),
+                    "collectd mapper does not support profiles"
+                );
+                Ok(MapperName::Collectd)
+            }
+            other => {
+                anyhow::ensure!(
+                    profile.is_none(),
+                    "user-defined mapper '{other}' does not support profiles"
+                );
+                validate_mapper_name(other)?;
+                Ok(MapperName::UserDefined(vec![other.to_string()]))
+            }
+        }
+    }
+}
+
+/// Returns all `MapperName`s whose cloud URL is configured in `tedge.toml`,
+/// plus any user-defined mappers discovered under the `mappers/` directory
+pub async fn configured_mappers(config: &TEdgeConfig) -> Vec<MapperName> {
+    let mut mappers = Vec::new();
+
+    #[cfg(feature = "c8y")]
+    {
+        use tedge_config::tedge_toml::mapper_config::C8yMapperSpecificConfig;
+        for (_, profile) in config.all_mapper_configs::<C8yMapperSpecificConfig>() {
+            mappers.push(MapperName::C8y { profile });
+        }
+    }
+
+    #[cfg(feature = "azure")]
+    {
+        use tedge_config::tedge_toml::mapper_config::AzMapperSpecificConfig;
+        for (_, profile) in config.all_mapper_configs::<AzMapperSpecificConfig>() {
+            mappers.push(MapperName::Az { profile });
+        }
+    }
+
+    #[cfg(feature = "aws")]
+    {
+        use tedge_config::tedge_toml::mapper_config::AwsMapperSpecificConfig;
+        for (_, profile) in config.all_mapper_configs::<AwsMapperSpecificConfig>() {
+            mappers.push(MapperName::Aws { profile });
+        }
+    }
+
+    let mappers_dir = config.root_dir().join("mappers");
+    let builtin_prefixes = ["c8y", "aws", "az", "collectd"];
+    for (name, _) in custom::config::scan_mappers_shallow(mappers_dir.as_ref()).await {
+        let base = name.split_once('.').map_or(name.as_str(), |(base, _)| base);
+        if builtin_prefixes.contains(&base) {
+            continue;
+        }
+        if let Err(err) = validate_mapper_name(&name) {
+            warn!("Skipping mapper directory '{name}': {err}");
+            continue;
+        }
+        mappers.push(MapperName::UserDefined(vec![name]));
+    }
+
+    mappers
 }
 
 pub async fn run(mapper_opt: MapperOpt, config: TEdgeConfig) -> anyhow::Result<()> {
@@ -455,6 +538,124 @@ mod tests {
         fn user_defined_display() {
             let name = MapperName::UserDefined(vec!["thingsboard".to_string()]);
             assert_eq!(name.to_string(), "tedge-mapper-thingsboard");
+        }
+    }
+
+    mod parse_spec {
+        use super::*;
+
+        #[test]
+        fn cloud_without_profile() {
+            let name = MapperName::parse_cli_arg("c8y").unwrap();
+            assert_eq!(name.to_string(), "tedge-mapper-c8y");
+        }
+
+        #[test]
+        fn cloud_with_profile() {
+            let name = MapperName::parse_cli_arg("c8y@secondary").unwrap();
+            assert_eq!(name.to_string(), "tedge-mapper-c8y@secondary");
+        }
+
+        #[test]
+        fn user_defined_mapper() {
+            let name = MapperName::parse_cli_arg("thingsboard").unwrap();
+            assert_eq!(name.to_string(), "tedge-mapper-thingsboard");
+        }
+
+        #[test]
+        fn collectd_rejects_profile() {
+            let err = MapperName::parse_cli_arg("collectd@foo").unwrap_err();
+            assert!(
+                format!("{err}").contains("does not support profiles"),
+                "unexpected error: {err}"
+            );
+        }
+
+        #[test]
+        fn user_defined_mapper_rejects_profile() {
+            let err = MapperName::parse_cli_arg("thingsboard@prod").unwrap_err();
+            assert!(
+                format!("{err}").contains("does not support profiles"),
+                "unexpected error: {err}"
+            );
+        }
+
+        #[test]
+        fn empty_spec_is_rejected() {
+            assert!(MapperName::parse_cli_arg("").is_err());
+        }
+
+        #[test]
+        fn empty_profile_is_rejected() {
+            assert!(MapperName::parse_cli_arg("c8y@").is_err());
+        }
+
+        #[test]
+        fn flag_like_spec_is_rejected() {
+            let err = MapperName::parse_cli_arg("--debug").unwrap_err();
+            assert!(
+                format!("{err}").contains("Invalid mapper name"),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    mod configured_mappers {
+        use super::*;
+        use tedge_test_utils::fs::TempTedgeDir;
+
+        #[tokio::test]
+        async fn includes_clouds_with_configured_urls() {
+            let ttd = TempTedgeDir::new();
+            ttd.dir("mappers")
+                .dir("c8y")
+                .file("mapper.toml")
+                .with_toml_content(toml::toml! {
+                    url = "example.com"
+                });
+
+            let config = TEdgeConfig::load(ttd.path()).await.unwrap();
+            assert_eq!(mapper_names(&config).await, ["tedge-mapper-c8y"]);
+        }
+
+        #[tokio::test]
+        async fn includes_user_defined_mapper_directories() {
+            let ttd = TempTedgeDir::new();
+            ttd.dir("mappers").dir("thingsboard");
+
+            let config = TEdgeConfig::load(ttd.path()).await.unwrap();
+            assert_eq!(mapper_names(&config).await, ["tedge-mapper-thingsboard"]);
+        }
+
+        #[tokio::test]
+        async fn skips_builtin_mapper_directories_including_profile_variants() {
+            let ttd = TempTedgeDir::new();
+            let mappers_dir = ttd.dir("mappers");
+            mappers_dir.dir("c8y");
+            mappers_dir.dir("c8y.secondary");
+            mappers_dir.dir("collectd");
+
+            let config = TEdgeConfig::load(ttd.path()).await.unwrap();
+            assert_eq!(mapper_names(&config).await, Vec::<String>::new());
+        }
+
+        #[tokio::test]
+        async fn skips_directories_with_invalid_mapper_names() {
+            let ttd = TempTedgeDir::new();
+            let mappers_dir = ttd.dir("mappers");
+            mappers_dir.dir("thingsboard.bak");
+            mappers_dir.dir("My-Mapper");
+
+            let config = TEdgeConfig::load(ttd.path()).await.unwrap();
+            assert_eq!(mapper_names(&config).await, Vec::<String>::new());
+        }
+
+        async fn mapper_names(config: &TEdgeConfig) -> Vec<String> {
+            configured_mappers(config)
+                .await
+                .iter()
+                .map(MapperName::to_string)
+                .collect()
         }
     }
 

--- a/tests/RobotFramework/tests/supervisor/standalone_signals.robot
+++ b/tests/RobotFramework/tests/supervisor/standalone_signals.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation       Live log-level reload for standalone tedge-agent and tedge-mapper.
+Documentation       Signal handling for standalone tedge-agent and tedge-mapper.
 ...                 On SIGHUP each standalone process re-reads its `[log]` level from
 ...                 `system.toml` and applies it without restarting, unless an explicit
 ...                 override (`--log-level`/`--debug`/`RUST_LOG`) is in effect.
@@ -8,6 +8,10 @@ Documentation       Live log-level reload for standalone tedge-agent and tedge-m
 ...                 `EntityStoreServer: recv` line only once the agent has been raised to
 ...                 `debug`; likewise the mapper's MQTT actor leaves an `MQTT recv` line
 ...                 for a published measurement.
+...
+...                 SIGUSR1 is the mapper-restart signal used by the `tedge run all`
+...                 supervisor. A standalone mapper must ignore it so that a stray signal
+...                 does not disrupt the service.
 
 Resource            ../../resources/common.resource
 Library             ThinEdgeIO
@@ -67,6 +71,15 @@ Mapper applies updated log levels on SIGHUP without restarting
     Wait Until Keyword Succeeds
     ...    30s    2s    Service Log Should Contain    tedge-mapper-c8y    MQTT recv    date_from=${after}
 
+    Service Not Restarted Since    tedge-mapper-c8y    ${before}
+
+SIGUSR1 does not restart the standalone mapper
+    ${before}=    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-mapper-c8y
+
+    Execute Command    cmd=systemctl kill --signal=SIGUSR1 tedge-mapper-c8y
+
+    Sleep    5s    reason=Give the mapper time to (not) react to SIGUSR1
     Service Not Restarted Since    tedge-mapper-c8y    ${before}
 
 Explicit override is not affected by SIGHUP
@@ -158,11 +171,13 @@ Get Service Logs
 
 Service Not Restarted Since
     [Arguments]    ${service}    ${before}
-    # SIGHUP must not restart the service: its health `up` message keeps the same `time`
-    # and `pid` (a restart would refresh both).
     ${now}=    Service Health Status Should Be Up    ${service}
-    Should Be Equal As Numbers    ${now["time"]}    ${before["time"]}
-    Should Be Equal As Integers    ${now["pid"]}    ${before["pid"]}
+    Should Be Equal As Numbers
+    ...    ${now["time"]}    ${before["time"]}
+    ...    msg=${service} was restarted (health timestamp changed from ${before["time"]} to ${now["time"]})
+    Should Be Equal As Integers
+    ...    ${now["pid"]}    ${before["pid"]}
+    ...    msg=${service} was restarted (PID changed from ${before["pid"]} to ${now["pid"]})
 
 Restore Log Levels
     # Restore the pristine system.toml and re-signal both services so the next test

--- a/tests/RobotFramework/tests/tedge_run_all/run_all_c8y.robot
+++ b/tests/RobotFramework/tests/tedge_run_all/run_all_c8y.robot
@@ -6,8 +6,10 @@ Documentation       Smoke tests for the single-process supervisor (`tedge run al
 ...                 with the standalone components, that SIGUSR1 really restarts
 ...                 the mapper (proven via the mapper's health `time`, which is refreshed
 ...                 on every restart, while its pid stays put — only the supervised task
-...                 is rebuilt, not the process), and that an update requiring an agent
-...                 restart exits the whole process for the service manager to restart it.
+...                 is rebuilt, not the process), that an update requiring an agent
+...                 restart exits the whole process for the service manager to restart it,
+...                 and that the supervisor can host multiple mappers (c8y + a custom
+...                 flows-only mapper) simultaneously.
 ...
 ...                 The device is registered once for the suite, but each test gets a
 ...                 freshly started supervisor and tears it down again afterwards, so the
@@ -109,6 +111,61 @@ SIGUSR1 restarts the mapper
     # The agent was never targeted by SIGUSR1 and stayed up throughout.
     Service Health Status Should Be Up    tedge-agent
 
+Multiple mappers run under a single supervisor
+    [Documentation]    The supervisor can host the c8y mapper and a custom flows-only mapper
+    ...    simultaneously. Both report healthy and function independently: the c8y mapper
+    ...    keeps talking to Cumulocity while the custom mapper processes its flow messages.
+    [Setup]    Start Multi-Mapper Supervisor
+
+    # All three components come up healthy inside the one process.
+    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-agent
+    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-mapper-c8y
+    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-mapper-test-echo
+
+    # The c8y mapper keeps the device talking to Cumulocity.
+    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-mapper-bridge-c8y
+    External Identity Should Exist    ${DEVICE_SN}
+
+    # The custom mapper processes flow messages independently of the c8y mapper.
+    ${start}=    Get Unix Timestamp
+    Execute Command    tedge mqtt pub custom/test/in '{"value":42}'
+    ${output}=    Should Have MQTT Messages
+    ...    custom/test/out
+    ...    minimum=1
+    ...    date_from=${start}
+    Should Contain    ${output[0]}    42
+
+    [Teardown]    Stop Multi-Mapper Supervisor
+
+SIGUSR1 restarts all mappers under a multi-mapper supervisor
+    [Documentation]    SIGUSR1 restarts every mapper hosted by the supervisor. Both mappers
+    ...    get a fresh health `time` while the process pid stays the same, proving each
+    ...    mapper task was rebuilt independently without restarting the whole process.
+    [Setup]    Start Multi-Mapper Supervisor
+
+    # Baseline: capture health timestamps from both mappers.
+    ${c8y_before}=    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-mapper-c8y
+    ${echo_before}=    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-mapper-test-echo
+
+    Execute Command    cmd=systemctl kill --signal=SIGUSR1 tedge-run-all.service
+
+    # Both mappers were restarted (fresh health timestamps, same pid).
+    Wait Until Keyword Succeeds
+    ...    60s    2s    Mapper Restarted Since    ${c8y_before}
+    Wait Until Keyword Succeeds
+    ...    60s    2s    Custom Mapper Restarted Since    ${echo_before}
+
+    # The agent was never targeted by SIGUSR1 and stayed up throughout.
+    Service Health Status Should Be Up    tedge-agent
+
+    [Teardown]    Stop Multi-Mapper Supervisor
+
 
 *** Keywords ***
 Register Device
@@ -168,3 +225,29 @@ Stop Supervisor
     # next one. The device registration from the suite setup is left untouched.
     Execute Command    systemctl stop tedge-run-all.service    ignore_exit_code=${True}
     Get Logs
+
+Create Custom Echo Mapper
+    # Create a flows-only custom mapper that echoes messages from custom/test/in to
+    # custom/test/out. No cloud credentials needed — it runs purely locally.
+    Execute Command    mkdir -p /etc/tedge/mappers/test-echo/flows && chown -R tedge:tedge /etc/tedge/mappers/test-echo
+    Execute Command
+    ...    cmd=printf 'input.mqtt.topics = ["custom/test/in"]\nsteps = []\n\n[output.mqtt]\ntopic = "custom/test/out"\n' > /etc/tedge/mappers/test-echo/flows/echo.toml
+    Execute Command    chown tedge:tedge /etc/tedge/mappers/test-echo/flows/echo.toml
+
+Remove Custom Echo Mapper
+    Execute Command    rm -rf /etc/tedge/mappers/test-echo
+
+Start Multi-Mapper Supervisor
+    Create Custom Echo Mapper
+    Execute Command
+    ...    cmd=systemd-run --unit=tedge-run-all --collect -p User=tedge -p Group=tedge /usr/bin/tedge run all c8y test-echo
+
+Stop Multi-Mapper Supervisor
+    Stop Supervisor
+    Remove Custom Echo Mapper
+
+Custom Mapper Restarted Since
+    [Arguments]    ${before}
+    ${now}=    Service Health Status Should Be Up    tedge-mapper-test-echo
+    Should Be True    ${now["time"]} > ${before["time"]}
+    Should Be Equal As Integers    ${now["pid"]}    ${before["pid"]}


### PR DESCRIPTION
## Proposed changes
Extends the `tedge run all` CLI to accept multiple arguments in order to run multiple mappers simultaneously, e.g.

```
tedge run all c8y tb c8y@profile
```

A bare `tedge run all` command now runs all mappers defined in `/etc/tedge/mappers`.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

