### PR TITLE
chore: Don't attempt to use apt-get on non debian-derivative distributions

### DIFF
--- a/mk/install-build-tools.sh
+++ b/mk/install-build-tools.sh
@@ -279,12 +279,12 @@ fi
 
 case "${OSTYPE-}" in
 linux*)
-  if [ -n "$use_clang" ]; then
+  if [ -n "$use_clang" ] && command -V apt-get >/dev/null 2>&1; then
     ubuntu_codename=$(lsb_release --codename --short)
     llvm_version=20
     # Import GPG key
     # check if gpg file already exists and is identical
-    TMP_GPG_FILE=$(mktemp) 
+    TMP_GPG_FILE=$(mktemp)
     cat mk/llvm-snapshot.gpg.key | gpg --yes --dearmor -o "$TMP_GPG_FILE"
     if ! cmp --silent "$TMP_GPG_FILE" /usr/share/keyrings/llvm-snapshot.gpg; then
       sudo mkdir -p /usr/share/keyrings


### PR DESCRIPTION
## Proposed changes
I'm currently running fedora, but this is incompatible with `install-build-tools.sh` as this tries to `apt install` an llvm toolchain on any linux package. This PR gates that step with a check that `apt` actually exists, so other distributions don't fail. It doesn't attempt to install an equivalent package for said distributions, it merely avoids doing the steps which are guaranteed to fail.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

