### PR TITLE
tests: fix flaky test in entity_store_compaction

### DIFF
--- a/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_compaction.robot
+++ b/tests/RobotFramework/tests/tedge_agent/http_server/entity_store_compaction.robot
@@ -20,10 +20,11 @@ Entity store log is compacted when redundancy threshold is exceeded
     ...    entries, which meets the compaction threshold. After compaction only one entry for
     ...    that topic is present in the file rather than 101.
     Write Entity Registration Many Times    compaction_count    101
-    ${count}=    Execute Command    grep -c "compaction_count" ${ENTITY_STORE}    strip=${True}
     # The compaction might trigger earlier than expected as services may have reregistered on startup,
     # but the count should be well below the threshold of 100 redundant entries
-    Should Be True    ${count} < 10
+
+    # do the comparison inside the command so grep is subject to retry if command completes before compaction
+    Execute Command    cmd=bash -c '[ $(grep -c "compaction_count" ${ENTITY_STORE}) -lt 10 ]'    strip=${True}
 
 Latest entity metadata is preserved after compaction
     [Documentation]    After compaction, entity metadata retains the most recently written


### PR DESCRIPTION
## Proposed changes

The test's check could run before compaction process is completed, failing it. I've observed in the test report, that after failure, entity store was 4 entities (and only 1 was the compaction_count device), so the compaction completed, just a little later.

To fix this, do the comparison using test in bash so it's subject to the retry policy. To confirm that it worked, I see the following in the report of some test runs after the fix:

```
cmd: ['/bin/sh', '-c', 'bash -c \'[ $(grep -c "compaction_count" /etc/tedge/.agent/entity_store.jsonl) -lt 10 ]\''], exit code: 1
...
cmd: ['/bin/sh', '-c', 'bash -c \'[ $(grep -c "compaction_count" /etc/tedge/.agent/entity_store.jsonl) -lt 10 ]\''], exit code: 0
```

The retry is applied once, the compaction completes, and the test succeeds.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

