### PR TITLE
fix: update log types on config updates

### DIFF
--- a/crates/core/tedge_agent/src/operation_workflows/actor.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/actor.rs
@@ -286,6 +286,16 @@ impl WorkflowActor {
             info!("Ignoring {operation} operation because it is disabled in agent capabilities");
             return Ok(());
         }
+
+        // Notify actors listening for the completion of this operation.
+        // Workflow operations built from `builtin:<op>:<step>` actions (e.g. the default
+        // config_update) never flow through `process_builtin_command_update`, so their
+        // completion must be signalled here; otherwise listeners such as the log manager
+        // (which re-scans supported log types on config/software updates) are never notified.
+        if state.is_finished() {
+            self.sync_listener_actors(&state).await?;
+        }
+
         let mut log_file = self.open_command_log(&state, &operation, &cmd_id).await;
 
         let action = match self.workflow_repository.get_action(&state) {
@@ -626,10 +636,7 @@ impl WorkflowActor {
         new_state: GenericCommandState,
     ) -> Result<(), RuntimeError> {
         if new_state.is_finished() {
-            self.sync_listener_actors(&new_state).await?;
-            self.finalize_builtin_command_update(new_state).await?;
-
-            Ok(())
+            self.finalize_builtin_command_update(new_state).await
         } else {
             // As not finalized, the builtin state is sent back
             // to the builtin operation actor for further processing.
@@ -664,9 +671,15 @@ impl WorkflowActor {
         command: &GenericCommandState,
     ) -> Result<(), RuntimeError> {
         if let Some(command) = command.operation() {
-            self.sync_signal_dispatcher
+            // Notifying listeners is best-effort: a listener that has shut down must not
+            // bring down the whole operation-processing actor.
+            if let Err(err) = self
+                .sync_signal_dispatcher
                 .sync_listener(command.as_str().into())
-                .await?;
+                .await
+            {
+                warn!("Failed to notify listeners on completion of {command} operation: {err}");
+            }
         }
         Ok(())
     }

--- a/crates/core/tedge_agent/src/operation_workflows/tests.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/tests.rs
@@ -26,6 +26,7 @@ use tedge_actors::RuntimeError;
 use tedge_actors::Sender;
 use tedge_actors::SimpleMessageBox;
 use tedge_actors::SimpleMessageBoxBuilder;
+use tedge_api::commands::CmdMetaSyncSignal;
 use tedge_api::commands::CommandStatus;
 use tedge_api::commands::RestartCommandPayload;
 use tedge_api::commands::SoftwareCommandMetadata;
@@ -46,6 +47,7 @@ use tedge_api::workflow::OperationStep;
 use tedge_api::workflow::OperationStepHandler;
 use tedge_api::workflow::OperationStepRequest;
 use tedge_api::workflow::OperationStepResponse;
+use tedge_api::workflow::SyncOnCommand;
 use tedge_api::RestartCommand;
 use tedge_api::SoftwareUpdateCommand;
 use tedge_downloader_ext::DownloadResponse;
@@ -746,6 +748,95 @@ action = "cleanup"
     Ok(())
 }
 
+#[tokio::test]
+async fn sync_signal_sent_to_listeners_on_successful_workflow_operation() -> Result<(), DynError> {
+    // A workflow-based `config_update` operation reaching its `successful` state must notify
+    // the actors listening for its completion. Unlike a monolithic builtin operation, this
+    // terminal state flows through `process_command_update` (not `process_builtin_command_update`),
+    // so this test guards the fix that emits the sync signal on that path.
+    let workflow = r#"
+operation = "config_update"
+
+[init]
+action = "proceed"
+on_success = "successful"
+
+[successful]
+action = "cleanup"
+"#;
+
+    let TestHandler {
+        mut mqtt_box,
+        mut sync_signal_box,
+        mut actor_handle,
+        ..
+    } = spawn_mqtt_operation_converter(
+        "device/main//",
+        vec![("config_update.toml".to_string(), workflow.to_string())],
+    )
+    .await?;
+
+    // Trigger the operation
+    let init_message = MqttMessage::new(
+        &Topic::new_unchecked("te/device/main///cmd/config_update/123"),
+        r#"{"status":"init"}"#,
+    );
+    mqtt_box.send(init_message).await?;
+
+    // The listener registered for `config_update` is notified once the workflow finishes
+    let signal =
+        recv_or_fail_on_actor_exit(&mut sync_signal_box, &mut actor_handle, "sync signal").await;
+    assert!(
+        signal.is_some(),
+        "expected a sync signal on operation completion"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn sync_signal_sent_to_listeners_on_failed_workflow_operation() -> Result<(), DynError> {
+    // Listeners must also be notified when the operation reaches its `failed` terminal state.
+    let workflow = r#"
+operation = "config_update"
+
+[init]
+action = "proceed"
+on_success = "failed"
+
+[failed]
+action = "cleanup"
+"#;
+
+    let TestHandler {
+        mut mqtt_box,
+        mut sync_signal_box,
+        mut actor_handle,
+        ..
+    } = spawn_mqtt_operation_converter(
+        "device/main//",
+        vec![("config_update.toml".to_string(), workflow.to_string())],
+    )
+    .await?;
+
+    // Trigger the operation
+    let init_message = MqttMessage::new(
+        &Topic::new_unchecked("te/device/main///cmd/config_update/123"),
+        r#"{"status":"init"}"#,
+    );
+    mqtt_box.send(init_message).await?;
+
+    // The listener registered for `config_update` is notified once the workflow finishes
+    let signal =
+        recv_or_fail_on_actor_exit(&mut sync_signal_box, &mut actor_handle, "sync signal").await;
+    assert!(
+        signal.is_some(),
+        "expected a sync signal on operation completion"
+    );
+
+    Ok(())
+}
+
 struct TestHandler {
     tmp_dir: Arc<TempTedgeDir>,
     actor_handle: JoinHandle<Result<(), RuntimeError>>,
@@ -759,6 +850,7 @@ struct TestHandler {
     config_box: TimedMessageBox<
         SimpleMessageBox<RequestEnvelope<OperationStepRequest, OperationStepResponse>, NoMessage>,
     >,
+    sync_signal_box: TimedMessageBox<SimpleMessageBox<CmdMetaSyncSignal, NoMessage>>,
 }
 
 async fn spawn_mqtt_operation_converter(
@@ -768,6 +860,8 @@ async fn spawn_mqtt_operation_converter(
     let mut software_builder = SoftwareActor(SimpleMessageBoxBuilder::new("Software", 5));
     let mut restart_builder = RestartActor(SimpleMessageBoxBuilder::new("Restart", 5));
     let mut config_builder = ConfigActorBuilder(SimpleMessageBoxBuilder::new("Config", 5));
+    let sync_listener_builder =
+        SyncListenerActorBuilder(SimpleMessageBoxBuilder::new("SyncListener", 5));
 
     let mut mqtt_builder: SimpleMessageBoxBuilder<MqttMessage, MqttMessage> =
         SimpleMessageBoxBuilder::new("MQTT", 5);
@@ -818,8 +912,14 @@ async fn spawn_mqtt_operation_converter(
     workflow_actor_builder.register_builtin_operation(&mut restart_builder);
     workflow_actor_builder.register_builtin_operation(&mut software_builder);
     workflow_actor_builder.register_builtin_operation_step_handler(&mut config_builder);
+    workflow_actor_builder
+        .register_sync_signal_sink(OperationType::ConfigUpdate, &sync_listener_builder);
 
     let config_box = config_builder.0.build().with_timeout(TEST_TIMEOUT_MS);
+    let sync_signal_box = sync_listener_builder
+        .0
+        .build()
+        .with_timeout(TEST_TIMEOUT_MS);
     let software_box = software_builder.0.build().with_timeout(TEST_TIMEOUT_MS);
     let restart_box = restart_builder.0.build().with_timeout(TEST_TIMEOUT_MS);
     let mqtt_box = mqtt_builder.build().with_timeout(TEST_TIMEOUT_MS);
@@ -843,6 +943,7 @@ async fn spawn_mqtt_operation_converter(
         _inotify_box,
         downloader_box,
         config_box,
+        sync_signal_box,
     })
 }
 
@@ -1016,5 +1117,22 @@ impl MessageSink<RequestEnvelope<OperationStepRequest, OperationStepResponse>>
         &self,
     ) -> DynSender<RequestEnvelope<OperationStepRequest, OperationStepResponse>> {
         self.0.get_sender()
+    }
+}
+
+// A fake actor that listens for sync signals emitted on the completion of `config_update`
+// operations, standing in for actors such as the log manager which re-scan their supported
+// types on config/software updates.
+struct SyncListenerActorBuilder(SimpleMessageBoxBuilder<CmdMetaSyncSignal, NoMessage>);
+
+impl MessageSink<CmdMetaSyncSignal> for SyncListenerActorBuilder {
+    fn get_sender(&self) -> DynSender<CmdMetaSyncSignal> {
+        self.0.get_sender()
+    }
+}
+
+impl SyncOnCommand for SyncListenerActorBuilder {
+    fn sync_on_commands(&self) -> Vec<OperationType> {
+        vec![OperationType::ConfigUpdate]
     }
 }

--- a/crates/extensions/tedge_log_manager/src/actor.rs
+++ b/crates/extensions/tedge_log_manager/src/actor.rs
@@ -5,6 +5,7 @@ use crate::config::PluginConfig;
 use crate::plugin_manager::ExternalPlugins;
 use async_trait::async_trait;
 use std::collections::HashMap;
+use std::path::Path;
 use tedge_actors::fan_in_message_type;
 use tedge_actors::Actor;
 use tedge_actors::ChannelError;
@@ -254,33 +255,49 @@ impl LogManagerActor {
     }
 
     async fn process_file_watch_events(&mut self, event: FsWatchEvent) -> Result<(), RuntimeError> {
-        let path = match event {
-            FsWatchEvent::Modified(path) => path,
-            FsWatchEvent::FileDeleted(path) => path,
+        if self.log_plugins_updated(&event) {
+            self.reload_supported_log_types().await?;
+        }
+        Ok(())
+    }
+
+    /// Whether a filesystem event might change the supported log types
+    ///
+    /// This can happen when:
+    /// - one of the log plugins under the plugin dirs is modified or deleted, or
+    /// - a whole plugin dir is removed, or
+    /// - plugin configuration file is updated
+    fn log_plugins_updated(&self, event: &FsWatchEvent) -> bool {
+        let directly_in_plugin_dir = |path: &Path| {
+            self.config
+                .plugin_dirs
+                .iter()
+                .any(|dir| path.parent() == Some(dir.as_std_path()))
+        };
+        let is_plugin_dir = |path: &Path| {
+            self.config
+                .plugin_dirs
+                .iter()
+                .any(|dir| dir.as_std_path() == path)
+        };
+        let is_plugin_config_file = |path: &Path| {
+            path.file_name()
+                .is_some_and(|name| name.eq(DEFAULT_PLUGIN_CONFIG_FILE_NAME))
+        };
+
+        match event {
+            FsWatchEvent::Modified(path) | FsWatchEvent::FileDeleted(path) => {
+                directly_in_plugin_dir(path) || is_plugin_config_file(path)
+            }
+            FsWatchEvent::DirectoryDeleted(path) => is_plugin_dir(path),
             // Creating new files and file moves and copies also emits `FsWatchEvent::Modified`
             // _most_ of the time, so we don't have to listen to `FileCreated`, if we did we'd have
             // duplicates.
             //
             // https://github.com/thin-edge/thin-edge.io/pull/2454#discussion_r1394358034
-            FsWatchEvent::FileCreated(_) => return Ok(()),
-            FsWatchEvent::DirectoryDeleted(_) => return Ok(()),
-            FsWatchEvent::DirectoryCreated(_) => return Ok(()),
-        };
-
-        let plugin_changed = self
-            .config
-            .plugin_dirs
-            .iter()
-            .any(|plugin_dir| path.starts_with(plugin_dir));
-        if plugin_changed
-            || path
-                .file_name()
-                .is_some_and(|name| name.eq(DEFAULT_PLUGIN_CONFIG_FILE_NAME))
-        {
-            self.reload_supported_log_types().await?;
+            // Sub-directory creations are also ignored.
+            FsWatchEvent::FileCreated(_) | FsWatchEvent::DirectoryCreated(_) => false,
         }
-
-        Ok(())
     }
 
     async fn reload_supported_log_types(&mut self) -> Result<(), RuntimeError> {

--- a/crates/extensions/tedge_log_manager/src/tests.rs
+++ b/crates/extensions/tedge_log_manager/src/tests.rs
@@ -23,6 +23,7 @@ use tedge_file_system_ext::FsWatchEvent;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::Topic;
 use tedge_mqtt_ext::TopicFilter;
+use tedge_test_utils::fs::with_exec_permission;
 use tedge_test_utils::fs::TempTedgeDir;
 use tedge_uploader_ext::UploadResponse;
 use tedge_utils::paths::TedgePaths;
@@ -198,6 +199,136 @@ async fn log_manager_reloads_log_types() -> Result<(), anyhow::Error> {
             MqttMessage::new(&log_reload_topic, r#"{"types":["type_one","type_two"]}"#)
                 .with_retain()
         )
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn log_manager_reloads_log_types_on_plugin_dir_removal() -> Result<(), anyhow::Error> {
+    let tempdir = prepare()?;
+    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+
+    let log_reload_topic = Topic::new_unchecked("te/device/main///cmd/log_upload");
+
+    // The `file` plugin from the fixture is reported on start-up.
+    assert_eq!(
+        mqtt.recv().await,
+        Some(
+            MqttMessage::new(&log_reload_topic, r#"{"types":["type_one","type_two"]}"#)
+                .with_retain()
+        )
+    );
+
+    // Events that must NOT trigger a reload: a nested sub-directory removal and a change to a
+    // file nested in a sub-directory.
+    // Plugins live directly under the plugin dir root, so neither is a plugin.
+    let nested_dir = tempdir.utf8_path().join("log-plugins").join("nested");
+    fs.send(FsWatchEvent::DirectoryDeleted(nested_dir.clone().into()))
+        .await?;
+    fs.send(FsWatchEvent::Modified(nested_dir.join("plugin").into()))
+        .await?;
+
+    // Removing the whole plugin directory (e.g. `rm -rf`) emits a single `DirectoryDeleted`
+    // for the directory itself, with no per-file `FileDeleted` events. The actor must still
+    // reload and publish the now-empty set of supported log types.
+    let plugin_dir = tempdir.utf8_path().join("log-plugins");
+    std::fs::remove_dir_all(&plugin_dir)?;
+    fs.send(FsWatchEvent::DirectoryDeleted(plugin_dir.into()))
+        .await?;
+
+    assert_eq!(
+        mqtt.recv().await,
+        Some(MqttMessage::new(&log_reload_topic, r#"{"types":[]}"#).with_retain())
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn log_manager_reloads_log_types_on_new_plugin_file() -> Result<(), anyhow::Error> {
+    let tempdir = prepare()?;
+    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+
+    let log_reload_topic = Topic::new_unchecked("te/device/main///cmd/log_upload");
+
+    // Let's ignore the init message sent on start
+    mqtt.skip(1).await;
+
+    // A new executable plugin dropped directly into the plugin dir must be picked up.
+    let plugin_path = tempdir.utf8_path().join("log-plugins").join("custom");
+    with_exec_permission(
+        &plugin_path,
+        "#!/bin/bash\ncase \"$1\" in\n    \"list\") echo \"app_log\" ;;\n    *) exit 1 ;;\nesac\n",
+    );
+    fs.send(FsWatchEvent::Modified(plugin_path.into())).await?;
+
+    // Types of the new plugin are suffixed with `::<plugin_name>` and sorted with the rest.
+    assert_eq!(
+        mqtt.recv().await,
+        Some(
+            MqttMessage::new(
+                &log_reload_topic,
+                r#"{"types":["app_log::custom","type_one","type_two"]}"#
+            )
+            .with_retain()
+        )
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn log_manager_reloads_log_types_on_plugin_file_deletion() -> Result<(), anyhow::Error> {
+    let tempdir = prepare()?;
+    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+
+    let log_reload_topic = Topic::new_unchecked("te/device/main///cmd/log_upload");
+
+    // Let's ignore the init message sent on start
+    mqtt.skip(1).await;
+
+    // Deleting the only plugin file (a direct child of the plugin dir) drops its types.
+    let plugin_path = tempdir.utf8_path().join("log-plugins").join("file");
+    std::fs::remove_file(&plugin_path)?;
+    fs.send(FsWatchEvent::FileDeleted(plugin_path.into()))
+        .await?;
+
+    assert_eq!(
+        mqtt.recv().await,
+        Some(MqttMessage::new(&log_reload_topic, r#"{"types":[]}"#).with_retain())
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn log_manager_reloads_log_types_on_plugin_config_change() -> Result<(), anyhow::Error> {
+    let tempdir = prepare()?;
+    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+
+    let log_reload_topic = Topic::new_unchecked("te/device/main///cmd/log_upload");
+
+    assert_eq!(
+        mqtt.recv().await,
+        Some(
+            MqttMessage::new(&log_reload_topic, r#"{"types":["type_one","type_two"]}"#)
+                .with_retain()
+        )
+    );
+
+    // Editing the plugin config file must be re-read on reload: exclude one of the file plugin's
+    // types and confirm the published set shrinks accordingly.
+    let config_path = tempdir.utf8_path().join("tedge-log-plugin.toml");
+    std::fs::write(
+        &config_path,
+        "[[plugins.file.filters]]\nexclude = \"type_two\"\n",
+    )?;
+    fs.send(FsWatchEvent::Modified(config_path.into())).await?;
+
+    assert_eq!(
+        mqtt.recv().await,
+        Some(MqttMessage::new(&log_reload_topic, r#"{"types":["type_one"]}"#).with_retain())
     );
 
     Ok(())

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_plugins.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_plugins.robot
@@ -39,7 +39,6 @@ Supported log types updated on software update
 
 Supported log types updated on config update
     [Documentation]    Updating any configuration should trigger supported log types update
-    Skip    msg=Skip until the false-positive passing is fixed see https://github.com/thin-edge/thin-edge.io/pull/4259
     ${config_url}=    Cumulocity.Create Inventory Binary
     ...    tedge-configuration-plugin
     ...    tedge-configuration-plugin
@@ -387,6 +386,9 @@ Custom Setup
     ...    ${CURDIR}/plugins/fake_plugin
     ...    /usr/share/tedge/log-plugins/fake_plugin
     Execute Command    chmod +x /usr/share/tedge/log-plugins/fake_plugin
+
+    # Wait for the log types to be registered first before starting tests
+    Should Contain Supported Log Types    software-management    fake_log::fake_plugin
 
 Create Log Request Operation
     [Arguments]    ${start_timestamp}

--- a/tests/RobotFramework/tests/cumulocity/log/log_operation_plugins.robot
+++ b/tests/RobotFramework/tests/cumulocity/log/log_operation_plugins.robot
@@ -254,7 +254,6 @@ Supported log types loaded when sudo disabled
     Should Contain Supported Log Types    dummy_log::dummy_plugin2
 
 Agent resilient to plugin dirs removal
-    Skip    msg=Skip until the false-positive passing is fixed see https://github.com/thin-edge/thin-edge.io/pull/4259
     ${date_from}=    Get Unix Timestamp
     Execute Command    rm -rf /usr/share/tedge/log-plugins
     Should Have MQTT Messages    c8y/s/us    date_from=${date_from}    message_pattern=118,


### PR DESCRIPTION
## Proposed changes

Fix a bug where the log types aren't being updated when the config is updated. The issue was found during a flaky test report where it was observed that the test was sometimes passing mistakenly due to matching against the log type message being published on startup, and not associated to the config update operation. The system test was refactored to ensure that it waits first for the initial log types to be published before running the tests.

Affected system tests:

* Supported log types updated on config update
* Agent resilient to plugin dirs removal

This worked earlier while config_update was handled by a builtin operation actor: its terminal state flowed through `process_builtin_command_update`, which emits the sync signal. Commit https://github.com/thin-edge/thin-edge.io/commit/e0dd2cda27c9339f9f179e96e1bac36c43aef6ec extracted config_update into an external workflow and that resulted in the regression. An external workflow operation reaches its terminal state via `process_command_update` instead, which never emitted the sync signal, so listeners were no longer notified and the log types stopped being reloaded on config_update.

With the fix, the sync signal is emitted whenever an operation reaches its final state in `process_command_update` as well (in addition to `process_builtin_command_update`), so workflow-based operations notify their listeners. Notifying listeners is now best-effort: a listener that has shut down must not bring down the operation-processing actor.

Status

* [x] Reliably reproduce the bug
* [x] Fix the code

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

