### PR TITLE
fix: extend cloud bridge connection timeout for slow HSM/TPM signing

### DIFF
--- a/crates/extensions/tedge_mqtt_bridge/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/lib.rs
@@ -71,6 +71,14 @@ pub use persist::BridgeConfigVisitor;
 
 const MAX_PACKET_SIZE: usize = 268435455; // maximum allowed MQTT payload size
 
+/// Connection timeout for the cloud bridge connection.
+///
+/// This must be generous enough to accommodate a slow TLS handshake when the client private key is
+/// held on an HSM/TPM: signing the `CertificateVerify` (and reading the key type beforehand) can
+/// take several seconds on slow tokens, and rumqttc's default connection timeout (5s) is not enough,
+/// causing the connection attempt to abort with `NetworkTimeout` before the handshake completes.
+const CLOUD_CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);
+
 macro_rules! log_event {
     // Default case - log as info
     ($prefix:ident, $fmt:literal $($args:tt)*) => {
@@ -151,9 +159,15 @@ impl MqttBridgeActorBuilder {
         let in_flight: u16 = 100;
         cloud_config.set_inflight(in_flight * 5);
         let (local_client, local_event_loop) =
-            LoggingAsyncClient::new(local_config, in_flight.into(), "local".into());
-        let (cloud_client, cloud_event_loop) =
-            LoggingAsyncClient::new(cloud_config, in_flight.into(), "cloud".into());
+            LoggingAsyncClient::new(local_config, in_flight.into(), "local".into(), None);
+        // The cloud connection may sign the TLS handshake using a key on an HSM/TPM, which can be
+        // slow, so give it a longer connection timeout than rumqttc's default (see the constant).
+        let (cloud_client, cloud_event_loop) = LoggingAsyncClient::new(
+            cloud_config,
+            in_flight.into(),
+            "cloud".into(),
+            Some(CLOUD_CONNECTION_TIMEOUT),
+        );
 
         let local_topics: Vec<_> = rules
             .local_subscriptions()

--- a/crates/extensions/tedge_mqtt_bridge/src/mqtt_logging.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/mqtt_logging.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::time::Duration;
 
 use bytes::Bytes;
 use rumqttc::AsyncClient;
@@ -30,8 +31,21 @@ pub struct LoggingAsyncClient {
 impl LoggingAsyncClient {
     /// Creates a new `LoggingAsyncClient` and `LoggingEventLoop`, setting up the
     /// internal channel for communication and storing the log prefix.
-    pub fn new(options: MqttOptions, cap: usize, log_prefix: String) -> (Self, LoggingEventLoop) {
-        let (client, eventloop) = AsyncClient::new(options, cap);
+    ///
+    /// When `connection_timeout` is set, it overrides rumqttc's default connection timeout. This is
+    /// used for the cloud connection, whose TLS handshake can be slow when signing with an HSM/TPM.
+    pub fn new(
+        options: MqttOptions,
+        cap: usize,
+        log_prefix: String,
+        connection_timeout: Option<Duration>,
+    ) -> (Self, LoggingEventLoop) {
+        let (client, mut eventloop) = AsyncClient::new(options, cap);
+        if let Some(connection_timeout) = connection_timeout {
+            eventloop
+                .network_options
+                .set_connection_timeout(connection_timeout.as_secs());
+        }
         let (log_tx, log_rx) = tokio::sync::mpsc::unbounded_channel();
 
         (
@@ -169,5 +183,39 @@ impl MqttEvents for LoggingEventLoop {
 
     fn set_pending(&mut self, requests: Vec<Request>) {
         self.inner.pending = requests.into_iter().collect();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_options() -> MqttOptions {
+        MqttOptions::new("test-client", "localhost", 1883)
+    }
+
+    #[test]
+    fn applies_connection_timeout_when_set() {
+        let (_client, eventloop) = LoggingAsyncClient::new(
+            dummy_options(),
+            10,
+            "cloud".into(),
+            Some(Duration::from_secs(60)),
+        );
+        assert_eq!(eventloop.inner.network_options().connection_timeout(), 60);
+    }
+
+    #[test]
+    fn keeps_default_connection_timeout_when_unset() {
+        // Baseline: the default connection timeout of an untouched rumqttc event loop.
+        let (_client, default_eventloop) = AsyncClient::new(dummy_options(), 10);
+        let default_timeout = default_eventloop.network_options().connection_timeout();
+
+        let (_client, eventloop) =
+            LoggingAsyncClient::new(dummy_options(), 10, "local".into(), None);
+        assert_eq!(
+            eventloop.inner.network_options().connection_timeout(),
+            default_timeout
+        );
     }
 }


### PR DESCRIPTION
## Problem

The built-in MQTT bridge cannot establish its cloud connection when the device private key is stored on a slow HSM/TPM (observed on a real device with a TPM2).

The bridge creates its cloud connection's rumqttc `EventLoop` with the default `NetworkOptions`, whose connection timeout is **5 seconds**. When the client private key lives on an HSM/TPM, the TLS handshake has to sign the `CertificateVerify` (and read the key type beforehand) through the token, which can take several seconds. On an Infineon SLB9673 TPM (via `tedge-p11-server`) this took ~5s per handshake, so the handshake overran the 5s window and rumqttc aborted with `NetworkTimeout` the moment the signature completed:

```
DEBUG tedge_p11::proxy::client: Sign complete
WARN  MQTT bridge: [cloud] Connection error: NetworkTimeout
INFO  MQTT bridge: [cloud] Waiting 40s until attempting reconnection to broker
```

The bridge then loops on reconnect and never comes up. The signature itself is valid — the only error is the timing `NetworkTimeout`.

## Fix

Give the cloud connection a **60s** connection timeout (matching the `CONNECTION_TIMEOUT` already used by `tedge connect`'s connectivity check). The local connection is unchanged and keeps rumqttc's default.

## Testing

- Added unit tests asserting the cloud client applies the 60s timeout and the local client keeps rumqttc's default.
- Verified on real hardware (Infineon SLB9673 TPM + `tedge-p11-server`): before the fix the c8y bridge looped on `NetworkTimeout`; after the fix the bridge connects on the first attempt (`{"status":"up"}`) and stays connected with no reconnect churn.

## Notes

The 60s value is a hardcoded constant, consistent with the existing `CONNECTION_TIMEOUT` used by `tedge connect`. It could be made configurable (e.g. under `mqtt.bridge`) if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
