### PR TITLE
chore: Replace hardcoded rust version in build-workflow.yml with logic to resolve MSRV from Cargo.toml

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -147,9 +147,6 @@ jobs:
           - aarch64-apple-darwin
           - x86_64-apple-darwin
 
-        rust_channel:
-          - "1.85"
-
         include:
           - target: aarch64-unknown-linux-musl
             build_with: auto
@@ -212,6 +209,13 @@ jobs:
           fetch-depth: 0
           allow-unsafe-pr-checkout: true
 
+      - name: Retrieve MSRV from workspace Cargo.toml
+        id: rust_version
+        uses: SebRollen/toml-action@v1.2.0
+        with:
+          file: Cargo.toml
+          field: "workspace.package.rust-version"
+
       # Install nfpm used to for linux packaging
       - uses: actions/setup-go@v7
         with:
@@ -222,7 +226,7 @@ jobs:
       - uses: taiki-e/install-action@just
       - name: build
         run: |
-          just release ${{ matrix.target }} --toolchain ${{ matrix.rust_channel }} --build-with ${{ matrix.build_with }}
+          just release ${{ matrix.target }} --toolchain ${{ steps.rust_version.outputs.value }} --build-with ${{ matrix.build_with }}
 
       - name: Upload packages as zip
         # https://github.com/marketplace/actions/upload-a-build-artifact


### PR DESCRIPTION
## Proposed changes
We _should_ be able to make MSRV bumps in PRs without needing to change the build workflow, but there is one remaining point in which the workflow currently hardcodes the rust toolchain version. This PR removes that hardcoding in favour of reading the value from Cargo.toml, which is what we do elsewhere.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

