### PR TITLE
fix: avoid `:` in workflow log file names for FAT32 compatibility

### DIFF
--- a/crates/common/tedge_utils/src/timestamp.rs
+++ b/crates/common/tedge_utils/src/timestamp.rs
@@ -7,8 +7,24 @@ use std::fmt;
 use std::fmt::Formatter;
 use std::str::FromStr;
 use strum::Display;
+use time::format_description;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
+
+/// Formats the current UTC time in an RFC-3339-like representation that avoids `:`,
+/// which is not a valid character in file names on FAT32.
+///
+/// Use this to build file names (e.g. log files) that must remain valid across all
+/// commonly used file systems.
+pub fn now_filename_safe_format() -> String {
+    let format = format_description::parse(
+        "[year]-[month]-[day]T[hour]-[minute]-[second].[subsecond digits:9]Z",
+    )
+    .expect("valid time format description");
+    OffsetDateTime::now_utc()
+        .format(&format)
+        .expect("a valid OffsetDateTime can always be formatted with this format description")
+}
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Deserialize, Serialize, Document, Display)]
 #[serde(rename_all = "kebab-case")]
@@ -200,6 +216,12 @@ fn invalid_iso8601(value: &str, err: impl fmt::Display) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn filename_safe_timestamp_contains_no_colon() {
+        let timestamp = now_filename_safe_format();
+        assert!(!timestamp.contains(':'), "{timestamp} contains ':'");
+    }
 
     #[test]
     fn time_format_deserialize() {

--- a/crates/core/tedge_api/src/mqtt_topics.rs
+++ b/crates/core/tedge_api/src/mqtt_topics.rs
@@ -12,8 +12,6 @@ use std::convert::Infallible;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::str::FromStr;
-use time::format_description;
-use time::OffsetDateTime;
 
 const ENTITY_ID_SEGMENTS: usize = 4;
 
@@ -960,12 +958,12 @@ impl IdGenerator {
     }
 
     pub fn new_id(&self) -> String {
+        // `cmd_id` ends up as part of a log file name (see `CommandLog::new`), so the
+        // timestamp must not contain `:`, which is not a valid character on FAT32
         format!(
             "{}-{}",
             self.prefix,
-            OffsetDateTime::now_utc()
-                .format(&format_description::well_known::Rfc3339)
-                .unwrap(),
+            tedge_utils::timestamp::now_filename_safe_format(),
         )
     }
 
@@ -994,6 +992,14 @@ mod tests {
     use test_case::test_case;
 
     const MQTT_ROOT: &str = "test_te";
+
+    #[test]
+    fn generated_ids_are_valid_fat32_file_names() {
+        // cmd_id ends up as part of a log file name (see `CommandLog::new`), so it must not
+        // contain `:`, which is not a valid character on FAT32
+        let id = IdGenerator::new("c8y-mapper").new_id();
+        assert!(!id.contains(':'), "{id} contains ':'");
+    }
 
     #[test]
     fn parses_full_correct_topic() {

--- a/crates/core/tedge_api/src/workflow/log/log_dir.rs
+++ b/crates/core/tedge_api/src/workflow/log/log_dir.rs
@@ -6,8 +6,6 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 use std::vec;
 use tedge_utils::paths::ManagedDir;
-use time::format_description;
-use time::OffsetDateTime;
 use tracing::info;
 use tracing::warn;
 
@@ -70,11 +68,12 @@ impl OperationLogs {
         operation_name: String,
         cmd_id: String,
     ) -> Result<CommandLog, OperationLogsError> {
-        let now = OffsetDateTime::now_utc();
+        // The timestamp becomes part of the log file name, so it must not contain `:`,
+        // which is not a valid character on FAT32.
         let file_name = format!(
             "{}-{}.log",
             operation_name,
-            now.format(&format_description::well_known::Rfc3339)?
+            tedge_utils::timestamp::now_filename_safe_format()
         );
         let file_path = self.log_dir.path().join(file_name);
 
@@ -255,6 +254,13 @@ mod tests {
 
         // The new log has been created
         assert!(new_log.path.exists());
+
+        // The new log file name is valid on FAT32 (no `:` in the generated timestamp)
+        let file_name = new_log
+            .path
+            .file_name()
+            .expect("log file should have a file name");
+        assert!(!file_name.contains(':'), "{file_name} contains ':'");
 
         // Outdated logs are removed
         assert!(!update_log_1.exists());


### PR DESCRIPTION
Command IDs and custom-operation log file names embedded the current time as RFC3339 (e.g. `2026-07-21T08:00:00Z`), which is invalid in a file name on FAT32. Format the timestamp with `-` instead of `:` so log files under /var/log/tedge/agent/ can be written to FAT32 filesystems. The `-` character was chosen because the `tedge diag collect` tarball naming was already following that format.

Log rotation matches files by operation-name substring and sorts by filesystem metadata rather than parsing the timestamp out of the file name, so old (`:`) and new (`-`) log files coexist safely during the transition.

The FAT32-safe timestamp formatting is extracted into `tedge_utils::timestamp::now_as_filename_safe_timestamp`, shared between tedge_api's workflow/command log naming and `tedge diag collect`'s tarball naming.

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3165

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

