### PR TITLE
fix: treat empty tedge-p11-server env vars as unset

### DIFF
--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -204,12 +204,23 @@ async fn try_read_config(args: Args) -> anyhow::Result<ValidConfig> {
     let toml_path = args.config_dir.join("tedge.toml");
     let mut toml_config = TomlConfig::read_tedge_toml(&toml_path).await;
 
+    // Treat an empty env var / flag value the same as unset, so e.g. an empty
+    // TEDGE_DEVICE_CRYPTOKI_PIN falls back to tedge.toml instead of overriding it with "".
+    // (clap parses a set-but-empty env var as `Some("")`.) This matters for service managers
+    // that pass the variables unconditionally.
     let (pin, Some(module_path), socket_path, uri) = (
-        args.pin.unwrap_or_else(|| toml_config.pin()),
-        args.module_path.or_else(|| toml_config.module_path()),
+        args.pin
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| toml_config.pin()),
+        args.module_path
+            .filter(|p| !p.as_str().is_empty())
+            .or_else(|| toml_config.module_path()),
         args.socket_path
+            .filter(|p| !p.as_str().is_empty())
             .unwrap_or_else(|| toml_config.socket_path()),
-        args.uri.or_else(|| toml_config.uri()),
+        args.uri
+            .filter(|s| !s.is_empty())
+            .or_else(|| toml_config.uri()),
     ) else {
         anyhow::bail!("Missing configuration values. Please set them in `tedge.toml` or pass them as command-line arguments.")
     };
@@ -419,6 +430,33 @@ module_path = """#;
                 }
             }
         )
+    }
+
+    #[tokio::test]
+    async fn empty_env_values_fall_back_to_tedge_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_dir = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+        std::fs::write(
+            config_dir.join("tedge.toml"),
+            "[device.cryptoki]\nmodule_path = \"/lib/module.so\"\npin = \"123456\"\n",
+        )
+        .unwrap();
+
+        // An empty env var / flag value (as a service manager passes for an unset variable)
+        // must not override the configured value.
+        let args = Args {
+            socket_path: None,
+            module_path: None,
+            pin: Some(String::new()),
+            uri: Some(String::new()),
+            log_level: None,
+            config_dir,
+        };
+
+        let config = try_read_config(args).await.unwrap();
+        assert_eq!(config.pin, "123456"); // empty pin fell back to tedge.toml
+        assert_eq!(config.module_path.as_str(), "/lib/module.so");
+        assert_eq!(config.uri, None); // empty uri treated as unset
     }
 
     #[test]


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

In tedge-p11-server, treat empty environment variables as unset, and thus should fallback to the values read from any configuration file.

This helps users writing service definitions to more easily support env variables for custom settings without having to add conditionals based on whether the env variable is empty or not, and it aligns with the `tedge` cli behaviour (e.g. in the `tedge config get`, see below for an example):

```sh
# read value from file (or default)
$ tedge config get flows.stats.interval
1h

# ignore empty env variables
$ TEDGE_FLOWS_STATS_INTERVAL="" tedge config get flows.stats.interval
1h

# read value from non-empty env variable
$ TEDGE_FLOWS_STATS_INTERVAL="2h" tedge config get flows.stats.interval
2h
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

