### PR TITLE
spec: revise openspec config for clearer artifact generation

### DIFF
--- a/openspec/changes/expose-config-values/.openspec.yaml
+++ b/openspec/changes/expose-config-values/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/expose-config-values/design.md
+++ b/openspec/changes/expose-config-values/design.md
@@ -1,0 +1,129 @@
+## Context
+
+External processes cannot read thin-edge config values without filesystem access
+and the device certificate — the [proposal](./proposal.md) covers the full problem
+and motivating use cases.
+
+Two constraints shape the design:
+
+- **Ownership:** each config value has exactly one owner — the component that loads it.
+  No component reads another's config file or publishes on another's behalf.
+- **Safe by default:** config holds secrets (`device.key_pin`, credential-file paths),
+  so values must be opted in to exposure, never opted out.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Read selected config values without file or certificate access —
+  specifically the value the running process currently has loaded,
+  refreshed only on that component's restart.
+- Safe by default: a new setting is never exposed until explicitly marked.
+- Respect ownership: no component reads or republishes another's config.
+- Offer the same values via subscription-based MQTT and on-demand HTTP query.
+
+**Non-Goals:**
+- Live republish when `tedge.toml` changes without a restart —
+  components load config at startup; a future dynamic-reload feature
+  would republish after reload.
+- Letting external clients write config values back through the HTTP or MQTT
+  surface — the HTTP API is read-only, and config changes go through
+  `tedge config set` plus a component restart.
+- Exposing config values *from* child devices — this initial implementation
+  covers services on the main device only.
+  Child devices *reading* the main device's exposed config is a supported
+  use case (they subscribe to MQTT or query HTTP like any other client).
+- Broker ACLs / TLS for config topics — the self-correcting publisher handles
+  casual overwrites; stronger access control is orthogonal.
+
+## Decisions
+
+### Opt-in exposure, not opt-out
+
+Config holds secrets (`device.key_pin`, `cryptoki.pin`, credential-file paths).
+With an allowlist, a new setting stays hidden until a maintainer marks it.
+The worst case is a missing value, not a leaked secret.
+
+Alternative: opt-out (denylist). Rejected — a new setting would be exposed
+the moment it's added unless someone remembers to deny it.
+
+### Each component publishes only what it owns
+
+The agent publishes core/device settings;
+each mapper publishes only its own cloud settings under its own service topic.
+No component reads another's config file.
+
+Alternative: the agent reads all `mapper.toml` files and exposes everything
+centrally. Rejected — couples the agent to every cloud's config shape and
+profiles, breaking the rule that each setting's source of truth stays with
+its owner.
+
+### Allowlist marking is a per-field macro attribute
+
+`#[tedge_config(exposable)]` on each setting in `define_tedge_config!`,
+generating `ReadableKey::is_exposable()`.
+This follows the same pattern already used for `deprecated_key` and doc
+comments — the decision to expose lives next to the setting definition.
+
+### Per-value retained topics, not one aggregate document
+
+Each value gets its own retained MQTT message:
+`te/device/<device>/service/<service>/config/<key>`.
+`<key>` is the `tedge config` key kept as a single final topic segment
+(not split into `config/device/id`), so it maps straight back to a
+`tedge config` key with no extra parsing.
+
+A consumer subscribes to exactly the value(s) it needs.
+An empty retained payload means the value is unset or was removed.
+
+Alternative: splitting the key across topic segments. Rejected — variable
+depth and extra logic to reconstruct the key.
+
+### Mapper-published keys drop the cloud and profile qualifier
+
+`c8y.url` becomes `.../tedge-mapper-c8y/config/url`.
+The service topic already scopes the value; repeating the cloud/profile
+prefix in the key would be redundant.
+
+### Self-correcting publisher via wildcard subscription
+
+Each component subscribes to its own `config/+` and reconciles every
+message against expected state (`Some(value)` for an exposed+set key,
+absent for everything else):
+
+- Payload differs from expected value (including an empty payload on an
+  owned key) — republish the expected value.
+- Expected absent but payload is non-empty — clear with an empty retained
+  payload.
+- Payload matches expected state — no-op (terminates the loop).
+
+This does two jobs: corrects external overwrites within one round trip,
+and clears stale keys left behind by renames or upgrades (their expected
+state is absent, so the replayed retained message gets cleared).
+
+### Config stored parallel to twin data, not merged into it
+
+The entity store gets a `config` map on each entity, separate from
+`twin_data`. Config values come from one source of truth (the owning
+component's `tedge_config`) and nothing external can set them.
+Merging into twin data would blur that distinction.
+
+### Unexposed and non-existent keys are indistinguishable
+
+The agent collects config purely by subscribing to MQTT — it never knows
+which keys exist but are hidden vs. which don't exist at all.
+Both the MQTT view (no retained message) and the HTTP API (`404 Not Found`)
+treat the two cases identically, so the response leaks nothing about which
+non-exposed settings exist.
+
+## Risks / Trade-offs
+
+- The allowlist is the only safeguard against leaking a secret — there is no
+  value masking or secret newtype.
+  A forward-guarding CI test asserts known-secret keys are non-exposable,
+  so marking one fails CI.
+- A removed mapper profile's config topics can only be cleared when that
+  profile's entity is explicitly deregistered — the same gap twin data has
+  for a decommissioned profile.
+- A value only appears once its owner has published it at least once.
+  Consumers that need a value before the owning component starts must wait
+  on MQTT for the retained message to arrive.

--- a/openspec/changes/expose-config-values/proposal.md
+++ b/openspec/changes/expose-config-values/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+External processes — plugins, containerized components, child devices —
+cannot read thin-edge config values like `device.id` without filesystem access
+to `/etc/tedge` and the device certificate.
+The Cumulocity opcua-device-gateway, for example, needs `device.id` for its
+Cumulocity external ID and `c8y.http` for API calls;
+today it achieves this by mounting `/etc/tedge` and running `tedge config get`,
+which also requires the device certificate to be present.
+
+## Proposed solution
+
+Read a selected config value without any file or certificate access, either way:
+
+- **Subscribe** to its retained MQTT topic, scoped to the owning service:
+
+  ```
+  te/device/main/service/tedge-agent/config/device.id       -> my-device-01
+  te/device/main/service/tedge-mapper-c8y/config/url         -> example.cumulocity.com
+  ```
+
+- **Query** it over HTTP from the agent — a single value, or a whole service's
+  config as a JSON object:
+
+  ```console
+  $ curl http://tedge:8000/te/v1/entities/device/main/service/tedge-agent/config/device.id
+  my-device-01
+
+  $ curl http://tedge:8000/te/v1/entities/device/main/service/tedge-mapper-c8y/config
+  {"url":"example.cumulocity.com","device.id":"my-device-01"}
+  ```
+
+Only values a component maintainer has explicitly marked as exposable are ever
+published or served.
+The set never includes secrets (private keys, PINs, credential-file paths).
+
+## What Changes
+
+- Each owning component publishes its exposable config values as retained MQTT
+  messages, one per topic: `te/device/<device>/service/<service>/config/<key>`.
+  The agent publishes core/device settings;
+  each mapper publishes its own cloud settings with the cloud/profile prefix
+  stripped from the key.
+- The agent subscribes to every service's `config/+` topics and serves them as a
+  read-only HTTP view:
+  `GET .../config` (JSON object) and `GET .../config/<key>` (single value).
+  A key that isn't exposed and a key that doesn't exist both return `404`.
+- The exposed set is opt-in per setting — a new setting stays hidden until a
+  maintainer marks it.
+- Each publisher self-corrects by subscribing to its own `config/+` topics and
+  reconciling every message against expected state, correcting external overwrites
+  and clearing stale keys from prior versions.
+- Exposed values reflect the active/applied config (what the running process has
+  loaded), not a live mirror of the file on disk.
+
+## Capabilities
+
+### New Capabilities
+- `config-exposure`: opt-in allowlist, retained per-key MQTT topics, key-naming
+  and ownership rules, and the read-only HTTP view served by the agent
+
+### Modified Capabilities
+
+## Impact
+
+- `tedge_config_macros` — new `#[tedge_config(exposable)]` field attribute,
+  generates `ReadableKey::is_exposable()`
+- `tedge_config` — allowlist marking in `define_tedge_config!`,
+  `exposed_core_config()` / `exposed_cloud_config()` helpers
+- `tedge_api` — new `Channel::Config { key }` topic variant,
+  config storage on the entity store
+- New shared publisher crate used by the agent and all three mappers
+- `tedge_agent` — MQTT ingestion of config topics, new HTTP routes
+- Robot Framework end-to-end tests
+- Docs: MQTT topic reference and HTTP API reference

--- a/openspec/changes/expose-config-values/specs/config-exposure/spec.md
+++ b/openspec/changes/expose-config-values/specs/config-exposure/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Opt-in config exposure
+A configuration setting SHALL be published or served only if explicitly marked
+as exposable where it is defined.
+Settings holding sensitive material (private keys, PINs, credential-file paths)
+SHALL NOT be marked exposable.
+
+#### Scenario: Unmarked setting is never visible
+- **WHEN** a client queries a setting that has no exposable marking
+- **THEN** it SHALL NOT appear on any retained MQTT topic or HTTP response
+
+#### Scenario: Marked setting is published and served
+- **WHEN** a setting is marked exposable and has a value
+- **THEN** it SHALL appear as a retained MQTT message under its owner's service topic
+  and be available over the agent's HTTP API
+
+### Requirement: Per-key retained MQTT publication under the owning service
+Each exposable value SHALL be published as a retained message on
+`te/device/<device>/service/<service>/config/<key>`,
+where `<service>` is the owning component's service topic
+and `<key>` is the config key with the cloud/profile prefix stripped.
+An unset exposable value SHALL be published as an empty retained payload.
+Each component SHALL publish only the settings it owns — the agent publishes
+core/device settings, each mapper publishes only its own cloud settings.
+
+#### Scenario: Core and cloud settings on the right service topics
+- **WHEN** the agent starts with `device.id = my-device-01`
+  and the c8y mapper starts with `c8y.url = example.cumulocity.com`
+- **THEN** the agent SHALL publish retained on
+  `.../tedge-agent/config/device.id` with payload `my-device-01`
+- **AND** the c8y mapper SHALL publish retained on
+  `.../tedge-mapper-c8y/config/url` with payload `example.cumulocity.com`
+
+### Requirement: Read-only HTTP view served by the agent
+The agent SHALL subscribe to every service's `config/+` topics and serve
+them as:
+- `GET /te/v1/entities/<service-topic-id>/config` — JSON object of all
+  exposed values for that service
+- `GET /te/v1/entities/<service-topic-id>/config/<key>` — single value
+
+A key that is not exposed and a key that does not exist SHALL both return
+`404 Not Found`, indistinguishably.
+Writes (PUT/PATCH/DELETE) SHALL be rejected.
+
+#### Scenario: Whole-service and single-key queries
+- **WHEN** a client sends `GET .../tedge-mapper-c8y/config`
+- **THEN** the response SHALL be a JSON object of every exposed key-value pair
+- **WHEN** a client sends `GET .../tedge-agent/config/device.id`
+- **THEN** the response SHALL be the value `my-device-01`
+
+### Requirement: Self-correcting publisher
+Each component SHALL subscribe to its own `config/+` and reconcile every
+message against its expected state, so that:
+- an externally overwritten value is republished within one round trip
+- a key removed or demoted between versions is cleared
+- the component's own matching echo does not trigger further action
+
+#### Scenario: Externally overwritten value is corrected
+- **WHEN** a client publishes a different value on a component's own
+  `config/<key>` topic
+- **THEN** the owning component SHALL republish its own value on that topic

--- a/openspec/changes/expose-config-values/tasks.md
+++ b/openspec/changes/expose-config-values/tasks.md
@@ -1,0 +1,40 @@
+## 1. Macro: exposable attribute
+
+- [ ] 1.1 Add `exposable: bool` to `ConfigurableField` in `tedge_config_macros`
+- [ ] 1.2 Thread `exposable` through field types and generate `ReadableKey::is_exposable()`
+- [ ] 1.3 Add macro tests: exposable field, profiled exposable field, unmarked field
+
+## 2. Allowlist marking and collection helpers
+
+- [ ] 2.1 Mark the curated exposable set with `#[tedge_config(exposable)]` in `define_tedge_config!`
+- [ ] 2.2 Add `exposed_core_config()` and `exposed_cloud_config()` helpers returning key-value pairs
+- [ ] 2.3 Unit-test the helpers: core excludes cloud keys, cloud strips prefix, secrets never appear
+- [ ] 2.4 Add forward-guarding test asserting known-secret keys are non-exposable
+
+## 3. tedge_api: config channel and entity store
+
+- [ ] 3.1 Add `Channel::Config { key }` with parse/serialize/`ChannelFilter`
+- [ ] 3.2 Add `config` map to `EntityMetadata`, parallel to `twin_data`
+- [ ] 3.3 Add entity-store ingestion accessors for config values
+- [ ] 3.4 Unit-test channel round-tripping and entity-store accessors
+
+## 4. Shared retained-config publisher
+
+- [ ] 4.1 Add a shared publisher actor that publishes (key, optional value) pairs as retained messages
+- [ ] 4.2 Subscribe to own `config/+` and reconcile against expected state
+- [ ] 4.3 Unit-test publishing and tamper correction
+- [ ] 4.4 Unit-test stale-key clearing
+
+## 5. Agent and mapper integration
+
+- [ ] 5.1 Compute and publish the agent's exposed core config at startup
+- [ ] 5.2 Spawn the shared publisher for each mapper's cloud config
+- [ ] 5.3 Subscribe the agent's entity store to config channel, ingest messages
+- [ ] 5.4 Add HTTP routes: `GET .../config` and `GET .../config/<key>`
+- [ ] 5.5 Test HTTP routes: JSON response, single value, 404, rejected writes
+
+## 6. End-to-end tests and docs
+
+- [ ] 6.1 Robot Framework suite for agent retained topics and HTTP routes
+- [ ] 6.2 Extend suite for a bootstrapped c8y mapper
+- [ ] 6.3 Document the config MQTT channel and HTTP routes

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -9,12 +9,29 @@ schema: spec-driven
 #     We use conventional commits
 #     Domain: e-commerce platform
 
-# Per-artifact rules (optional)
-# Add custom rules for specific artifacts.
-# Example:
-#   rules:
-#     proposal:
-#       - Keep proposals under 500 words
-#       - Always include a "Non-goals" section
-#     tasks:
-#       - Break tasks into chunks of max 2 hours
+context: |
+  Writing style (all artifacts): plain, direct English.
+  Use semantic line breaks.
+  Clear, complete sentences. Prefer concise, but never at the cost of ambiguity.
+  Bullets for lists of items; short paragraphs for explanations and context.
+  No hedging or filler.
+  Avoid restating well known MQTT and thin-edge concepts.
+  State each decision and its reason. Skip elaboration unless a reader would
+  need to infer a non-obvious connection.
+  Never let terseness introduce ambiguity about scope — if a phrase could be
+  read two ways, spell out which reading is meant.
+
+rules:
+  proposal:
+    - After "Why", add a "Proposed solution" section that introduces the feature from the
+      user's point of view with short usage examples — before any internal mechanism.
+    - In "What Changes", lead with what the feature introduces — what a user or consumer
+      would interact with — before stating its properties or constraints (opt-in, security
+      model, correctness guarantees). Don't qualify something the reader hasn't met yet.
+  design:
+    - Do not restate the problem or motivation — that lives in the proposal. Link the
+      proposal instead of repeating its "Why".
+    - "Open with a brief Context: name the problem being solved (one sentence, link the
+      proposal for detail) and the constraints that shape the design decisions."
+    - Assume a reader who already knows the problem and the user-facing surface. Spend the
+      words on how it is built and why this design over the alternatives.


### PR DESCRIPTION
**NOT INTENDED TO BE MERGED** if we like these changes, they ought to be incorporated into #4241

Some suggested revisions to config.yaml along with an example of what the config exposure spec can be rewritten to according to those guidelines.

The goal of this is to revise the config so it cuts out unnecessary words making the specs hard to review without brevity at the expense of clarity. The initial proposal by @albinsuresh of how to revise the config resulted in some short but essentially redundant sentences, while leaving some key details completely unmentioned. I also found the phrasing by asking for short sentences unhelpful, my impression was a lot of connecting words were discarded, making the sentences hard to parse, but not really for much gain.

Both the suggested config changes and an attempt at rewriting the spec with those rules is included. I haven't reviewed or edited this version of the spec, it's straight from claude with the goal of producing the best possible environment for 

Key config changes:
- **"Short declarative sentences" → "Clear, complete sentences."** — The old rule produced sentence fragments that dropped the words connecting one idea to the next. Concise is good; ambiguous is not.
- **"Bullets over prose" → "Bullets for lists; paragraphs for context."** — Not everything is a list. When context needs to explain why two things are related, a short paragraph does that better than two bullets that lost their connection to each other.
- **"Skip elaboration" → qualified with "unless non-obvious connection"** — In my testing of the config, there were implicit context switches between sentences, e.g. it switched from talking about MQTT to talking about HTTP, but the only way I knew that was it started talking about `404`, no mention of HTTP.
- **Anti-ambiguity rule for scope statements** — A non-goal discussing "Child device config exposure" could mean exposing config from child devices (non-goal) or exposing config to child devices (goal). If a phrase reads two ways, spell out which one you mean.
- "What you can do" → "Proposed solution" — "You" had no clear referent.
- **Proposal ordering: introduce the capability before qualifying it** — The previous rule ("never lead with an implementation detail") was too narrow. The real problem: bullets described properties of the feature (opt-in, self-correcting) before the reader knew what the feature was.
- **Design Context: name the problem and constraints** — The old rule said "1-3 sentence orientation, then straight to decisions." Instead of imposing somewhat arbitrary rules on the agent, this guides the agent to the details we actually want. Simply imposing a sentence limit meant that it produced a small number of sentences that didn't serve any particular purpose.