### PR TITLE
feat: explain TLS failures that are Cumulocity's to fix

### DIFF
--- a/crates/common/certificate/src/parse_root_certificate/mod.rs
+++ b/crates/common/certificate/src/parse_root_certificate/mod.rs
@@ -247,7 +247,9 @@ pub fn read_cert_chain(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_matches::assert_matches;
     use std::io::Write;
+    use std::path::PathBuf;
     use tempfile::NamedTempFile;
     use tempfile::TempDir;
 
@@ -331,5 +333,52 @@ mod tests {
 
         let root_certs = new_root_store(temp_dir.path()).unwrap();
         assert_eq!(root_certs.len(), 3);
+    }
+
+    /// `tedge connect` relies on this to rule out an unpaired key when a handshake fails later, so
+    /// this test fails if a `rustls` upgrade or a change of crypto provider stops it happening
+    #[test]
+    fn a_key_that_does_not_belong_to_the_certificate_is_refused_before_connecting() {
+        let dir = TempDir::new().unwrap();
+        let (cert_path, _) = write_selfsigned_pair(dir.path(), "device-a");
+        let (_, other_key_path) = write_selfsigned_pair(dir.path(), "device-b");
+
+        let err = create_tls_config(&cert_path, &other_key_path, &cert_path)
+            .expect_err("a certificate and a key that do not belong together cannot be used");
+
+        assert_matches!(
+            err,
+            CertificateError::CertParse(rustls::Error::InconsistentKeys(
+                rustls::InconsistentKeys::KeyMismatch
+            )),
+            "an unpaired key has to be reported as one, and not as some other failure"
+        );
+    }
+
+    /// The counterpart of the above: a certificate and the key it was issued for are accepted, so
+    /// the comparison is not simply refusing everything
+    #[test]
+    fn a_certificate_and_its_own_key_are_accepted() {
+        let dir = TempDir::new().unwrap();
+        let (cert_path, key_path) = write_selfsigned_pair(dir.path(), "device-a");
+
+        create_tls_config(&cert_path, &key_path, &cert_path)
+            .expect("a certificate and the key it was issued for can be used");
+    }
+
+    /// Writes a fresh self-signed certificate and its private key, returning their paths
+    fn write_selfsigned_pair(dir: &Path, id: &str) -> (PathBuf, PathBuf) {
+        let pair = crate::KeyCertPair::new_selfsigned_certificate(
+            &crate::CsrTemplate::default(),
+            id,
+            &crate::KeyKind::New,
+        )
+        .expect("a self-signed certificate can be created");
+
+        let cert_path = dir.join(format!("{id}.crt"));
+        let key_path = dir.join(format!("{id}.key"));
+        fs::write(&cert_path, pair.certificate_pem_string().unwrap()).unwrap();
+        fs::write(&key_path, pair.private_key_pem_string().unwrap().as_str()).unwrap();
+        (cert_path, key_path)
     }
 }

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config/mqtt_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config/mqtt_config.rs
@@ -24,10 +24,10 @@ use mqtt_channel::read_password;
 use mqtt_channel::AuthenticationConfig;
 
 /// An MQTT authentication configuration for connecting to the remote cloud broker.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct MqttAuthConfigCloudBroker {
     pub ca_path: Utf8PathBuf,
-    pub client: Option<MqttAuthClientConfigCloudBroker>,
+    pub client: MqttAuthClientConfigCloudBroker,
 }
 
 /// MQTT TLS client authentication.
@@ -45,13 +45,10 @@ pub enum PrivateKeyType {
 
 impl MqttAuthConfigCloudBroker {
     pub fn to_rustls_client_config(self) -> anyhow::Result<rustls::ClientConfig> {
-        let Some(MqttAuthClientConfigCloudBroker {
+        let MqttAuthClientConfigCloudBroker {
             cert_file,
             private_key,
-        }) = self.client
-        else {
-            todo!("no client auth not supported yet");
-        };
+        } = self.client;
 
         let client_config = match private_key {
             PrivateKeyType::File(key_file) => {
@@ -188,7 +185,7 @@ impl TEdgeConfig {
 
         Ok(MqttAuthConfigCloudBroker {
             ca_path: cloud.root_cert_path().to_path_buf(),
-            client: Some(client_auth),
+            client: client_auth,
         })
     }
 

--- a/crates/core/tedge/src/cli/connect/c8y.rs
+++ b/crates/core/tedge/src/cli/connect/c8y.rs
@@ -18,6 +18,7 @@ use certificate::parse_root_certificate::create_tls_config_without_client_cert;
 use rumqttc::tokio_rustls::rustls::AlertDescription;
 use rumqttc::tokio_rustls::rustls::CertificateError;
 use rumqttc::tokio_rustls::rustls::Error;
+use rumqttc::tokio_rustls::rustls::InvalidMessage;
 use rumqttc::AsyncClient;
 use rumqttc::ConnectionError;
 use rumqttc::Event;
@@ -37,7 +38,24 @@ use tedge_config::tedge_toml::ProfileName;
 use tedge_config::TEdgeConfig;
 use tracing::debug;
 
+/// Reported for an error raised before the broker accepted the MQTT connection
+const HANDSHAKE_ERROR_CONTEXT: &str = "Connection error while connecting to Cumulocity";
+
+/// Reported for an error raised once the broker had accepted the MQTT connection
 const CONNECTION_ERROR_CONTEXT: &str = "Connection error while creating device in Cumulocity";
+
+/// Says which stage an otherwise unexplained error came from, so that a bare I/O error at least
+/// tells the user whether the connection was ever established
+fn error_context(connected: bool) -> &'static str {
+    if connected {
+        CONNECTION_ERROR_CONTEXT
+    } else {
+        HANDSHAKE_ERROR_CONTEXT
+    }
+}
+
+/// The message `rustls` reports when it has no room left to buffer an incoming message
+const BUFFER_FULL_MESSAGE: &str = "message buffer full";
 
 // Connect directly to the c8y cloud over mqtt and publish device create message.
 pub async fn create_device_with_direct_connection(
@@ -85,6 +103,11 @@ pub async fn create_device_with_direct_connection(
         .network_options
         .set_connection_timeout(CONNECTION_TIMEOUT.as_secs());
 
+    // Tracks whether the TLS handshake is behind us, so that errors can be attributed to the right
+    // stage. A ConnAck is the first event the broker sends us, so it is the earliest point at which
+    // we know the handshake succeeded
+    let mut connected = false;
+
     loop {
         match eventloop.poll().await {
             Ok(Event::Incoming(Packet::ConnAck(connack))) => {
@@ -92,6 +115,7 @@ pub async fn create_device_with_direct_connection(
                     "Received ConnAck ({:?}), session_present={:?}",
                     connack.code, connack.session_present
                 );
+                connected = true;
                 // Connection established, publish device creation message
                 publish_device_create_message(
                     &mut client,
@@ -116,41 +140,77 @@ pub async fn create_device_with_direct_connection(
                 // No acknowledgment received for device creation message even after 5s (keep alive interval)
                 bail!("Timed-out waiting for device creation acknowledgment from Cumulocity")
             }
-            Err(ConnectionError::Io(err)) if err.kind() == std::io::ErrorKind::InvalidData => {
-                if let Some(Error::AlertReceived(alert_description)) = err
-                    .get_ref()
-                    .and_then(|custom_err| custom_err.downcast_ref::<Error>())
-                {
-                    if let AlertDescription::CertificateUnknown = alert_description {
-                        // Either the device cert is not uploaded to c8y or
-                        // another cert is set in device.cert_path
-                        bail!("The device certificate is not trusted by Cumulocity. Upload the certificate using `tedge cert upload c8y`");
-                    } else if let AlertDescription::HandshakeFailure = alert_description {
-                        // Non-paired private key is set in device.key_path
-                        bail!(
-                            "The private key is not paired with the certificate. Check your 'device.key_path'."
-                        );
-                    }
-                }
-                return Err(err).context(CONNECTION_ERROR_CONTEXT);
-            }
-            Err(ConnectionError::Tls(TlsError::Io(err)))
-                if err.kind() == std::io::ErrorKind::InvalidData =>
-            {
-                match err
-                    .get_ref()
-                    .and_then(|custom_err| custom_err.downcast_ref::<Error>())
-                {
-                    Some(Error::InvalidCertificate(CertificateError::UnknownIssuer)) => {
-                        bail!("Cumulocity certificate is not trusted by the device. Check your 'c8y.root_cert_path'.");
-                    }
-                    _ => return Err(err).context(CONNECTION_ERROR_CONTEXT),
+            Err(ConnectionError::Io(err) | ConnectionError::Tls(TlsError::Io(err))) => {
+                match diagnose_tls_error(&err, &address.host().to_string(), connected) {
+                    Some(explanation) => bail!("{explanation}"),
+                    None => return Err(err).context(error_context(connected)),
                 }
             }
-            Err(err) => return Err(err).context(CONNECTION_ERROR_CONTEXT),
+            Err(err) => return Err(err).context(error_context(connected)),
             _ => {}
         }
     }
+}
+
+/// Recognises `rustls` refusing to buffer any more of an over-large message
+///
+/// `rustls` gives up without constructing a `rustls::Error`, so there is nothing to downcast to
+/// and the message has to be matched instead. A test below checks this still matches what the
+/// current `rustls` version reports. The same message is used whether or not a handshake is in
+/// progress, and the two cases have different size limits, so the caller must establish which of
+/// them applies
+fn is_buffer_full(err: &std::io::Error) -> bool {
+    err.get_ref()
+        .is_some_and(|inner| inner.to_string() == BUFFER_FULL_MESSAGE)
+}
+
+/// Explains a TLS error in terms of what the user can do about it
+///
+/// Returns `None` for anything unrecognised, leaving the caller to report the error as it is.
+/// `connected` tells us whether the broker has accepted the MQTT connection, and hence whether the
+/// TLS handshake is behind us
+fn diagnose_tls_error(err: &std::io::Error, host: &str, connected: bool) -> Option<String> {
+    if err.kind() != std::io::ErrorKind::InvalidData {
+        return None;
+    }
+
+    match err
+        .get_ref()
+        .and_then(|custom_err| custom_err.downcast_ref::<Error>())
+    {
+        // Either the device cert is not uploaded to c8y or
+        // another cert is set in device.cert_path
+        Some(Error::AlertReceived(AlertDescription::CertificateUnknown)) => Some(
+            "The device certificate is not trusted by Cumulocity. Upload the certificate using `tedge cert upload c8y`".into(),
+        ),
+        // Non-paired private key is set in device.key_path
+        Some(Error::AlertReceived(AlertDescription::HandshakeFailure)) => Some(
+            "The private key is not paired with the certificate. Check your 'device.key_path'.".into(),
+        ),
+        Some(Error::InvalidCertificate(CertificateError::UnknownIssuer)) => Some(
+            "Cumulocity certificate is not trusted by the device. Check your 'c8y.root_cert_path'.".into(),
+        ),
+        // A single handshake message that announces more than `rustls` will buffer
+        Some(Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge)) if !connected => {
+            Some(oversized_handshake(host))
+        }
+        // A handshake that fills the buffer before any one message completes. Only a handshake
+        // can reach the larger of the two buffer limits, so both diagnoses hold only while the
+        // connection is still being established
+        _ if !connected && is_buffer_full(err) => Some(oversized_handshake(host)),
+        _ => None,
+    }
+}
+
+/// Explains a handshake too large for `rustls` to accept, however it broke the limit
+fn oversized_handshake(host: &str) -> String {
+    format!(
+        "Cumulocity sent a TLS handshake that is too large for thin-edge.io to accept (over 64 KB).\n\
+        The likely cause is the server listing the client certificates it will accept, \
+        which it should not be sending.\n\
+        Whatever the cause, this is not something that can be fixed on this device. \
+        Please report it to Cumulocity support, quoting the host {host}."
+    )
 }
 
 // Check the connection by using the jwt token retrieval over the mqtt.
@@ -433,6 +493,11 @@ pub(crate) fn decode_jwt_token(token: &str) -> Result<String, ConnectError> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use rumqttc::tokio_rustls::rustls::ClientConfig;
+    use rumqttc::tokio_rustls::rustls::ClientConnection;
+    use rumqttc::tokio_rustls::rustls::RootCertStore;
+    use std::io::Cursor;
+    use std::sync::Arc;
     use test_case::test_case;
 
     #[test]
@@ -495,5 +560,175 @@ mod test {
                 assert_eq!(error_msg, expected_error_msg)
             }
         }
+    }
+
+    #[test]
+    fn blames_cumulocity_for_a_handshake_too_large_to_buffer() {
+        let explanation = diagnose_tls_error(&oversized_handshake_error(), HOST, false)
+            .expect("an oversized handshake is diagnosed");
+
+        assert!(
+            explanation.contains("too large"),
+            "should say what went wrong: {explanation}"
+        );
+        assert!(
+            explanation.contains("Cumulocity support") && explanation.contains(HOST),
+            "should say who to report it to: {explanation}"
+        );
+    }
+
+    /// The other way `rustls` refuses an over-large handshake: rather than filling the buffer, a
+    /// single message announces more than it will ever accept
+    #[test]
+    fn blames_cumulocity_for_a_handshake_message_that_announces_too_much() {
+        let err = std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
+        );
+
+        let explanation = diagnose_tls_error(&err, HOST, false)
+            .expect("an over-large handshake message is diagnosed");
+
+        assert_eq!(explanation, oversized_handshake(HOST));
+    }
+
+    #[test]
+    fn does_not_blame_the_handshake_for_an_over_large_message_after_connecting() {
+        let err = std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
+        );
+
+        assert_eq!(diagnose_tls_error(&err, HOST, true), None);
+    }
+
+    /// `rustls` reports a full buffer the same way once the handshake is done, but then it means a
+    /// single over-long record rather than an over-long handshake, so the diagnosis must not apply
+    #[test]
+    fn does_not_blame_the_handshake_for_a_full_buffer_after_connecting() {
+        assert_eq!(
+            diagnose_tls_error(&oversized_handshake_error(), HOST, true),
+            None
+        );
+    }
+
+    #[test]
+    fn advises_uploading_the_certificate_when_cumulocity_does_not_trust_it() {
+        let err = alert(AlertDescription::CertificateUnknown);
+
+        let explanation =
+            diagnose_tls_error(&err, HOST, false).expect("a rejected certificate is diagnosed");
+
+        assert!(
+            explanation.contains("tedge cert upload c8y"),
+            "{explanation}"
+        );
+    }
+
+    #[test]
+    fn advises_checking_the_key_path_when_the_key_does_not_match_the_certificate() {
+        let err = alert(AlertDescription::HandshakeFailure);
+
+        let explanation =
+            diagnose_tls_error(&err, HOST, false).expect("an unpaired private key is diagnosed");
+
+        assert!(explanation.contains("device.key_path"), "{explanation}");
+    }
+
+    #[test]
+    fn advises_checking_the_root_cert_path_when_the_device_does_not_trust_cumulocity() {
+        let err = std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            Error::InvalidCertificate(CertificateError::UnknownIssuer),
+        );
+
+        let explanation =
+            diagnose_tls_error(&err, HOST, false).expect("an untrusted server is diagnosed");
+
+        assert!(explanation.contains("c8y.root_cert_path"), "{explanation}");
+    }
+
+    #[test]
+    fn leaves_an_unrecognised_error_to_be_reported_verbatim() {
+        let err = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "connection refused");
+
+        assert_eq!(diagnose_tls_error(&err, HOST, false), None);
+    }
+
+    #[test]
+    fn error_context_says_whether_the_connection_was_ever_established() {
+        assert_ne!(error_context(true), error_context(false));
+    }
+
+    const HOST: &str = "example.cumulocity.com";
+
+    /// The largest handshake flight `rustls` will buffer, as a guard against denial-of-service
+    ///
+    /// Mirrors `MAX_HANDSHAKE_SIZE` in `rustls`, which is not publicly exported
+    const MAX_HANDSHAKE_SIZE: usize = 0xffff;
+
+    /// Wraps a TLS alert the way `rustls` surfaces it through `read_tls`
+    fn alert(description: AlertDescription) -> std::io::Error {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            Error::AlertReceived(description),
+        )
+    }
+
+    /// Drives a real [`ClientConnection`] into rejecting an over-large handshake
+    ///
+    /// Going through `rustls` rather than hand-building the error means an upgrade that changes
+    /// how the refusal is reported fails these tests instead of silently losing the diagnosis
+    fn oversized_handshake_error() -> std::io::Error {
+        // Must be called before any use of `ClientConfig::builder()`
+        let _ = rumqttc::tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+
+        let config = ClientConfig::builder()
+            .with_root_certificates(RootCertStore::empty())
+            .with_no_client_auth();
+        let mut connection =
+            ClientConnection::new(Arc::new(config), "example.com".try_into().unwrap())
+                .expect("a client connection can be created");
+        connection
+            .write_tls(&mut std::io::sink())
+            .expect("the client hello can be flushed");
+
+        let mut flight = Cursor::new(oversized_handshake_flight());
+        loop {
+            match connection.read_tls(&mut flight) {
+                Ok(0) => panic!("rustls buffered the whole flight without complaining"),
+                Ok(_) => connection
+                    .process_new_packets()
+                    .expect("the partial flight is not rejected on its content"),
+                Err(err) => break err,
+            };
+        }
+    }
+
+    /// Frames a single `Certificate` handshake message into plaintext TLS records
+    ///
+    /// The message declares just under [`MAX_HANDSHAKE_SIZE`] bytes of payload, so once its own
+    /// header and the record headers are counted, the flight can never fit in the buffer and
+    /// `rustls` gives up part way through
+    fn oversized_handshake_flight() -> Vec<u8> {
+        const HANDSHAKE_RECORD: u8 = 22;
+        const TLS_1_2_VERSION: [u8; 2] = [0x03, 0x03];
+        const MAX_RECORD_PAYLOAD: usize = 16_384;
+        const CERTIFICATE_MESSAGE: u8 = 11;
+
+        let payload_len = MAX_HANDSHAKE_SIZE - 1;
+        let mut message = vec![CERTIFICATE_MESSAGE];
+        // A handshake message length is 3 bytes wide
+        message.extend_from_slice(&(payload_len as u32).to_be_bytes()[1..]);
+        message.resize(message.len() + payload_len, 0);
+
+        let mut flight = Vec::new();
+        for chunk in message.chunks(MAX_RECORD_PAYLOAD) {
+            flight.push(HANDSHAKE_RECORD);
+            flight.extend_from_slice(&TLS_1_2_VERSION);
+            flight.extend_from_slice(&(chunk.len() as u16).to_be_bytes());
+            flight.extend_from_slice(chunk);
+        }
+        flight
     }
 }

--- a/crates/core/tedge/src/cli/connect/c8y.rs
+++ b/crates/core/tedge/src/cli/connect/c8y.rs
@@ -14,10 +14,16 @@ use c8y_api::smartrest::message::get_smartrest_template_id;
 use c8y_api::smartrest::message_ids::GET_DEVICE_MANAGED_OBJECT_ID;
 use c8y_api::smartrest::message_ids::GET_DEVICE_MANAGED_OBJECT_ID_RESPONSE;
 use c8y_api::smartrest::message_ids::JWT_TOKEN;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use certificate::parse_root_certificate::create_tls_config_without_client_cert;
+use certificate::PemCertificate;
+use certificate::ValidityStatus;
 use rumqttc::tokio_rustls::rustls::AlertDescription;
 use rumqttc::tokio_rustls::rustls::CertificateError;
 use rumqttc::tokio_rustls::rustls::Error;
+use rumqttc::tokio_rustls::rustls::InconsistentKeys;
+use rumqttc::tokio_rustls::rustls::InvalidMessage;
 use rumqttc::AsyncClient;
 use rumqttc::ConnectionError;
 use rumqttc::Event;
@@ -29,28 +35,74 @@ use rumqttc::QoS;
 use rumqttc::QoS::AtLeastOnce;
 use rumqttc::TlsError;
 use rumqttc::Transport;
+use std::time::Duration;
 use tedge_config::models::auth_method::AuthType;
 use tedge_config::tedge_toml::mapper_config::C8yMapperConfig;
 use tedge_config::tedge_toml::mapper_config::C8yMapperSpecificConfig;
 use tedge_config::tedge_toml::MqttAuthConfigCloudBroker;
+use tedge_config::tedge_toml::PrivateKeyType;
 use tedge_config::tedge_toml::ProfileName;
 use tedge_config::TEdgeConfig;
 use tracing::debug;
 
+/// Reported for an error raised before the broker accepted the MQTT connection
+const HANDSHAKE_ERROR_CONTEXT: &str = "Connection error while connecting to Cumulocity";
+
+/// Reported for an error raised once the broker had accepted the MQTT connection
 const CONNECTION_ERROR_CONTEXT: &str = "Connection error while creating device in Cumulocity";
+
+/// How far a connection attempt had got when it failed
+///
+/// Several readings of an error hold only while the handshake is still going on, and the same
+/// error means something else afterwards
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Stage {
+    /// The TLS handshake is still in progress
+    Handshaking,
+    /// The broker has accepted the MQTT connection, so the handshake succeeded
+    Connected,
+}
+
+/// Says which stage an otherwise unexplained error came from, so that a bare I/O error at least
+/// tells the user whether the connection was ever established
+fn error_context(stage: Stage) -> &'static str {
+    match stage {
+        Stage::Connected => CONNECTION_ERROR_CONTEXT,
+        Stage::Handshaking => HANDSHAKE_ERROR_CONTEXT,
+    }
+}
+
+/// The message `rustls` reports when it has no room left to buffer an incoming message
+const BUFFER_FULL_MESSAGE: &str = "message buffer full";
 
 // Connect directly to the c8y cloud over mqtt and publish device create message.
 pub async fn create_device_with_direct_connection(
     bridge_config: &BridgeConfig,
+    profile: Option<&ProfileName>,
     device_type: &str,
     // TODO: put into general authentication struct
     mqtt_auth_config: MqttAuthConfigCloudBroker,
 ) -> anyhow::Result<()> {
     let address = bridge_config.address.clone();
+    let host = address.host().to_string();
+    // A proxy is only used by the built-in bridge.
+    let proxy = bridge_config
+        .proxy
+        .as_ref()
+        .filter(|_| bridge_config.bridge_location == BridgeLocation::BuiltIn)
+        .map(|proxy| format!("{}:{}", proxy.0.addr, proxy.0.port));
+    let connection = ConnectionDetails::new(
+        &host,
+        &bridge_config.remote_clientid,
+        profile,
+        &mqtt_auth_config,
+        bridge_config.auth_type,
+        proxy,
+    );
 
     let mut mqtt_options = MqttOptions::new(
         bridge_config.remote_clientid.clone(),
-        address.host().to_string(),
+        host.clone(),
         address.port().into(),
     );
     mqtt_options.set_keep_alive(std::time::Duration::from_secs(5));
@@ -68,7 +120,14 @@ pub async fn create_device_with_direct_connection(
         );
         create_tls_config_without_client_cert(&bridge_config.bridge_root_cert_path)?
     } else {
-        mqtt_auth_config.to_rustls_client_config()?
+        mqtt_auth_config.to_rustls_client_config().map_err(|err| {
+            match classify_config_error(&err) {
+                // The explanation is what the user reads; the error it was drawn from stays as its
+                // source, so nothing is lost if the reading is wrong
+                Some(failure) => err.context(failure.explain(&connection, None)),
+                None => err,
+            }
+        })?
     };
     mqtt_options.set_transport(Transport::tls_with_config(tls_config.into()));
 
@@ -85,6 +144,11 @@ pub async fn create_device_with_direct_connection(
         .network_options
         .set_connection_timeout(CONNECTION_TIMEOUT.as_secs());
 
+    // Tracks whether the TLS handshake is behind us, so that errors can be attributed to the right
+    // stage. A ConnAck is the first event the broker sends us, so it is the earliest point at which
+    // we know the handshake succeeded
+    let mut stage = Stage::Handshaking;
+
     loop {
         match eventloop.poll().await {
             Ok(Event::Incoming(Packet::ConnAck(connack))) => {
@@ -92,6 +156,7 @@ pub async fn create_device_with_direct_connection(
                     "Received ConnAck ({:?}), session_present={:?}",
                     connack.code, connack.session_present
                 );
+                stage = Stage::Connected;
                 // Connection established, publish device creation message
                 publish_device_create_message(
                     &mut client,
@@ -116,41 +181,441 @@ pub async fn create_device_with_direct_connection(
                 // No acknowledgment received for device creation message even after 5s (keep alive interval)
                 bail!("Timed-out waiting for device creation acknowledgment from Cumulocity")
             }
-            Err(ConnectionError::Io(err)) if err.kind() == std::io::ErrorKind::InvalidData => {
-                if let Some(Error::AlertReceived(alert_description)) = err
-                    .get_ref()
-                    .and_then(|custom_err| custom_err.downcast_ref::<Error>())
-                {
-                    if let AlertDescription::CertificateUnknown = alert_description {
-                        // Either the device cert is not uploaded to c8y or
-                        // another cert is set in device.cert_path
-                        bail!("The device certificate is not trusted by Cumulocity. Upload the certificate using `tedge cert upload c8y`");
-                    } else if let AlertDescription::HandshakeFailure = alert_description {
-                        // Non-paired private key is set in device.key_path
-                        bail!(
-                            "The private key is not paired with the certificate. Check your 'device.key_path'."
-                        );
+            Err(ConnectionError::Io(err) | ConnectionError::Tls(TlsError::Io(err))) => {
+                let Some(failure) = classify_tls_error(&err, &connection, stage) else {
+                    return Err(err).context(error_context(stage));
+                };
+
+                let validity = match (failure, connection.certificate()) {
+                    (TlsFailure::DeviceCertificateRejected, Some(credentials)) => {
+                        certificate_validity(&credentials.cert_path).await
                     }
-                }
-                return Err(err).context(CONNECTION_ERROR_CONTEXT);
+                    _ => None,
+                };
+
+                return Err(err).context(failure.explain(&connection, validity));
             }
-            Err(ConnectionError::Tls(TlsError::Io(err)))
-                if err.kind() == std::io::ErrorKind::InvalidData =>
-            {
-                match err
-                    .get_ref()
-                    .and_then(|custom_err| custom_err.downcast_ref::<Error>())
-                {
-                    Some(Error::InvalidCertificate(CertificateError::UnknownIssuer)) => {
-                        bail!("Cumulocity certificate is not trusted by the device. Check your 'c8y.root_cert_path'.");
-                    }
-                    _ => return Err(err).context(CONNECTION_ERROR_CONTEXT),
-                }
-            }
-            Err(err) => return Err(err).context(CONNECTION_ERROR_CONTEXT),
+            Err(err) => return Err(err).context(error_context(stage)),
             _ => {}
         }
     }
+}
+
+/// Recognises `rustls` refusing to buffer any more of an over-large message
+///
+/// `rustls` gives up without constructing a `rustls::Error`, so there is nothing to downcast to
+/// and the message has to be matched instead. A test below checks this still matches what the
+/// current `rustls` version reports. The same message is used whether or not a handshake is in
+/// progress, and the two cases have different size limits, so the caller must establish which of
+/// them applies
+fn is_buffer_full(err: &std::io::Error) -> bool {
+    err.get_ref()
+        .is_some_and(|inner| inner.to_string() == BUFFER_FULL_MESSAGE)
+}
+
+/// The files and settings a connection attempt used, so that a diagnosis can name them
+///
+/// Nothing secret is held here: the PKCS#11 PIN is never read, and neither is the key URI, which
+/// may carry a `pin-value` attribute of its own. The messages name the setting that holds the URI
+/// instead of quoting its value
+struct ConnectionDetails {
+    /// Host of the Cumulocity MQTT endpoint
+    host: String,
+
+    /// Identity the device claims, which is the common name of its certificate
+    device_id: String,
+
+    /// Prefix of this connection's `tedge config` keys: `c8y`, or `c8y.profiles.<name>`
+    config_prefix: String,
+
+    root_cert_path: Utf8PathBuf,
+
+    client: ClientAuth,
+
+    /// Address of the proxy the connection is made through
+    proxy: Option<String>,
+}
+
+/// What the connection offered to authenticate itself
+enum ClientAuth {
+    /// A certificate and its private key
+    Certificate(ClientCredentials),
+
+    /// A username and password, with no certificate of the device's own
+    UsernameAndPassword,
+}
+
+/// The certificate and private key a connection presented to Cumulocity
+struct ClientCredentials {
+    cert_path: Utf8PathBuf,
+    key: KeyLocation,
+}
+
+/// Where a private key lives, which decides both what to print and which setting to name
+enum KeyLocation {
+    File(Utf8PathBuf),
+    /// A PKCS#11 token, chosen by `<prefix>.device.key_uri` rather than `<prefix>.device.key_path`
+    Token,
+}
+
+impl ConnectionDetails {
+    /// Reads the connection details from the authentication config the connection itself uses
+    ///
+    /// The paths come from `mqtt_auth_config` rather than from `bridge_config`, as those are the
+    /// files actually presented: when reconnecting to validate a renewed certificate, the caller
+    /// swaps in the new certificate there
+    fn new(
+        host: &str,
+        device_id: &str,
+        profile: Option<&ProfileName>,
+        mqtt_auth_config: &MqttAuthConfigCloudBroker,
+        auth_type: AuthType,
+        proxy: Option<String>,
+    ) -> Self {
+        let client = &mqtt_auth_config.client;
+        Self {
+            host: host.to_owned(),
+            device_id: device_id.to_owned(),
+            config_prefix: match profile {
+                None => "c8y".into(),
+                Some(profile) => format!("c8y.profiles.{profile}"),
+            },
+            root_cert_path: mqtt_auth_config.ca_path.clone(),
+            client: match auth_type {
+                // The certificate settings still hold paths under basic auth, but the connection
+                // does not send them, so they are not part of what it presented
+                AuthType::Basic => ClientAuth::UsernameAndPassword,
+                AuthType::Certificate => ClientAuth::Certificate(ClientCredentials {
+                    cert_path: client.cert_file.clone(),
+                    key: match &client.private_key {
+                        PrivateKeyType::File(path) => KeyLocation::File(path.clone()),
+                        PrivateKeyType::Cryptoki(_) => KeyLocation::Token,
+                    },
+                }),
+            },
+            proxy,
+        }
+    }
+
+    /// Names the `tedge config` key that sets one of this connection's values
+    fn config_key(&self, key: &str) -> String {
+        format!("{}.{key}", self.config_prefix)
+    }
+
+    /// The certificate this connection presented, if certificate authentication is in use
+    fn certificate(&self) -> Option<&ClientCredentials> {
+        match &self.client {
+            ClientAuth::Certificate(client) => Some(client),
+            ClientAuth::UsernameAndPassword => None,
+        }
+    }
+}
+
+/// What a failed connection attempt was, as far as it can be established from the error
+///
+/// Deciding this is kept apart from wording it, so that what the code concluded can be checked
+/// without reading prose, and the prose can be checked without producing a TLS failure
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TlsFailure {
+    /// A private key that does not belong to the certificate configured with it
+    UnpairedPrivateKey,
+
+    /// The server rejected the device certificate
+    DeviceCertificateRejected,
+
+    /// A handshake the remote endpoint refused without saying why
+    HandshakeRejected,
+
+    /// The device rejected the certificate Cumulocity presented
+    UntrustedServer,
+
+    /// A handshake larger than `rustls` will accept, however it broke the limit
+    OversizedHandshake,
+}
+
+/// Reads an error from building the client configuration as one of the failures we can explain
+///
+/// `rustls` compares a private key read from a file with the public key in the certificate sent
+/// alongside it, and refuses the configuration if they do not match. That happens before anything
+/// is sent, which is why an unpaired key is established here rather than guessed at from a
+/// handshake that failed
+fn classify_config_error(err: &anyhow::Error) -> Option<TlsFailure> {
+    // `CertificateError::CertParse` is transparent, so the `rustls` error it holds is not a link in
+    // the chain of its own: it has to be reached through the variant rather than downcast to
+    match err
+        .chain()
+        .find_map(|cause| cause.downcast_ref::<certificate::CertificateError>())?
+    {
+        certificate::CertificateError::CertParse(Error::InconsistentKeys(
+            InconsistentKeys::KeyMismatch,
+        )) => Some(TlsFailure::UnpairedPrivateKey),
+        _ => None,
+    }
+}
+
+/// Reads a TLS error as one of the failures we can explain
+///
+/// Returns `None` for anything unrecognised, leaving the caller to report the error as it is
+fn classify_tls_error(
+    err: &std::io::Error,
+    connection: &ConnectionDetails,
+    stage: Stage,
+) -> Option<TlsFailure> {
+    if err.kind() != std::io::ErrorKind::InvalidData {
+        return None;
+    }
+
+    match err
+        .get_ref()
+        .and_then(|custom_err| custom_err.downcast_ref::<Error>())
+    {
+        // Only classify this as a device-certificate rejection when the connection sent one.
+        Some(Error::AlertReceived(AlertDescription::CertificateUnknown)) => connection
+            .certificate()
+            .map(|_| TlsFailure::DeviceCertificateRejected),
+        Some(Error::AlertReceived(AlertDescription::HandshakeFailure)) => {
+            Some(TlsFailure::HandshakeRejected)
+        }
+        Some(Error::InvalidCertificate(CertificateError::UnknownIssuer)) => {
+            Some(TlsFailure::UntrustedServer)
+        }
+        // A single handshake message that announces more than `rustls` will buffer
+        Some(Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge))
+            if stage == Stage::Handshaking =>
+        {
+            Some(TlsFailure::OversizedHandshake)
+        }
+        // A handshake that fills the buffer before any one message completes. Only a handshake
+        // can reach the larger of the two buffer limits, so both readings hold only while the
+        // connection is still being established
+        _ if stage == Stage::Handshaking && is_buffer_full(err) => {
+            Some(TlsFailure::OversizedHandshake)
+        }
+        _ => None,
+    }
+}
+
+/// Reads how much life a certificate has left, as far as the file can be read at all
+///
+/// A certificate that cannot be read leaves the failure to be explained without it, rather than
+/// replacing one unexplained failure with another
+async fn certificate_validity(path: &Utf8Path) -> Option<ValidityStatus> {
+    let pem = tokio::fs::read_to_string(path).await.ok()?;
+
+    PemCertificate::from_pem_string(&pem)
+        .ok()?
+        .still_valid()
+        .ok()
+}
+
+impl TlsFailure {
+    /// Explains the failure in terms of what the user can do about it
+    fn explain(self, connection: &ConnectionDetails, validity: Option<ValidityStatus>) -> String {
+        match self {
+            Self::DeviceCertificateRejected => rejected_certificate(connection, validity),
+            Self::UnpairedPrivateKey => unpaired_private_key(connection),
+            Self::HandshakeRejected => handshake_rejected(connection),
+            Self::UntrustedServer => untrusted_server(connection),
+            Self::OversizedHandshake => oversized_handshake(connection),
+        }
+    }
+}
+
+/// Renders a duration in the units a certificate's lifetime is set in
+fn in_days(duration: Duration) -> String {
+    match duration.as_secs() / (24 * 60 * 60) {
+        0 => "less than a day".to_owned(),
+        1 => "1 day".to_owned(),
+        days => format!("{days} days"),
+    }
+}
+
+/// Explains Cumulocity rejecting the device certificate, using its validity when readable.
+fn rejected_certificate(
+    connection: &ConnectionDetails,
+    validity: Option<ValidityStatus>,
+) -> String {
+    let Some(credentials) = connection.certificate() else {
+        return handshake_rejected(connection);
+    };
+    let cert_path = &credentials.cert_path;
+    let cert_key = connection.config_key("device.cert_path");
+    let ConnectionDetails {
+        host, device_id, ..
+    } = connection;
+    let certificate = format!(
+        "The certificate sent was {cert_path} (set by '{cert_key}'), which identifies this device \
+        as '{device_id}'."
+    );
+
+    match validity {
+        Some(ValidityStatus::Expired { since }) => {
+            let ago = in_days(since);
+            format!(
+                "The device certificate expired {ago} ago, so {host} rejected it.\n\
+                \n\
+                {certificate}\n\
+                \n\
+                Renew the certificate with `tedge cert renew --ca self-signed`, then upload the \
+                renewed certificate with `tedge cert upload c8y`."
+            )
+        }
+        Some(ValidityStatus::NotValidYet { valid_in }) => {
+            let ahead = in_days(valid_in);
+            format!(
+                "The device certificate is not valid until {ahead} from now, so {host} rejected \
+                it.\n\
+                \n\
+                {certificate}\n\
+                \n\
+                Check the clock on this device and the service that keeps it in sync. If the \
+                clock is correct, renew the certificate with `tedge cert renew --ca self-signed` \
+                and upload it with `tedge cert upload c8y`."
+            )
+        }
+        Some(ValidityStatus::Valid { .. }) | None => format!(
+            "Cumulocity did not recognise the device certificate.\n\
+            \n\
+            {certificate}\n\
+            \n\
+            Check that this is the certificate registered as trusted in the tenant at {host}. If \
+            it is not, upload it with `tedge cert upload c8y`."
+        ),
+    }
+}
+
+/// Explains rustls rejecting a certificate and file-based private key before connecting.
+fn unpaired_private_key(connection: &ConnectionDetails) -> String {
+    let Some(client) = connection.certificate() else {
+        return handshake_rejected(connection);
+    };
+    let cert_path = &client.cert_path;
+    let cert_key = connection.config_key("device.cert_path");
+    let (key, advice) = match &client.key {
+        KeyLocation::File(key_path) => (
+            format!(
+                "{key_path} (from '{}')",
+                connection.config_key("device.key_path")
+            ),
+            "`tedge cert create` always writes a matching pair, so they normally only come apart if \
+            one of those settings now points somewhere else, or if one of the two files has since \
+            been replaced on its own.\n\
+            \n\
+            Run `tedge cert renew --ca self-signed` to issue a certificate for the key this device \
+            holds, then `tedge cert upload c8y` to add it to the tenant. That keeps the device \
+            identity, where `tedge cert create` would refuse to overwrite what is already there."
+                .to_owned(),
+        ),
+        KeyLocation::Token => (
+            format!(
+                "an HSM private key (selected by '{}')",
+                connection.config_key("device.key_uri")
+            ),
+            format!(
+                "So check that '{cert_key}' names the certificate that was issued for the key held \
+                in the HSM, and not another certificate."
+            ),
+        ),
+    };
+
+    format!(
+        "The configured private key does not belong to the device certificate.\n\
+        \n\
+        This connection is configured to use:\n\
+        \x20 certificate: {cert_path} (from '{cert_key}')\n\
+        \x20 private key: {key}\n\
+        \n\
+        These two have to be a matching pair: the certificate has to be the one issued for that \
+        exact key.\n\
+        \n\
+        {advice}"
+    )
+}
+
+fn handshake_rejected(connection: &ConnectionDetails) -> String {
+    let host = &connection.host;
+    let mut explanation = format!(
+        "{host} refused the TLS handshake without giving a reason.\n\
+        \n\
+        Check that `{host}` is the correct MQTT endpoint for this tenant. If it is, ask the \
+        Cumulocity administrator to check the tenant's TLS configuration and server logs."
+    );
+
+    if let Some(ClientCredentials {
+        cert_path,
+        key: KeyLocation::Token,
+    }) = connection.certificate()
+    {
+        explanation.push_str(&format!(
+            "\n\
+            \n\
+            This connection uses an HSM private key. Check that `{}` points to the certificate \
+            issued for the key selected by `{}`. The certificate supplied was {cert_path}.",
+            connection.config_key("device.cert_path"),
+            connection.config_key("device.key_uri")
+        ));
+    }
+
+    if let Some(proxy) = &connection.proxy {
+        explanation.push_str(&format!(
+            "\n\
+            \n\
+            This connection goes through proxy `{proxy}`, which may also be involved. Include its \
+            address when asking your network administrator or Cumulocity administrator for help."
+        ));
+    }
+
+    explanation
+}
+
+/// Explains the device refusing the certificate presented by the remote endpoint
+fn untrusted_server(connection: &ConnectionDetails) -> String {
+    let root_cert_key = connection.config_key("root_cert_path");
+    let ConnectionDetails {
+        host,
+        root_cert_path,
+        ..
+    } = connection;
+    format!(
+        "The device does not trust the certificate presented by {host}: it is signed by a \
+        certificate authority the device does not know.\n\
+        \n\
+        This check is about the remote endpoint's identity, not the device's — the certificate and key \
+        created by `tedge cert create` play no part in it. The authorities the device trusts are \
+        read from {root_cert_path} (set by '{root_cert_key}').\n\
+        \n\
+        Check that:\n\
+        \x20 * {root_cert_path} is the right file or directory — on most Linux systems the \
+        system's own CA certificates are in /etc/ssl/certs\n\
+        \x20 * the authority that signed the certificate presented on this connection is among \
+        those it holds"
+    )
+}
+
+fn oversized_handshake(connection: &ConnectionDetails) -> String {
+    let host = &connection.host;
+    let mut explanation = format!(
+        "Cumulocity sent a TLS handshake larger than the 64 KB thin-edge.io can accept.\n\
+        \n\
+        The likely cause is an unnecessarily large `certificate_authorities` list. This must be \
+        corrected on the Cumulocity side; changing this device's certificate or configuration \
+        will not fix it.\n\
+        \n\
+        Contact Cumulocity support and quote the MQTT host `{host}`."
+    );
+
+    if let Some(proxy) = &connection.proxy {
+        explanation.push_str(&format!(
+            "\n\
+            \n\
+            This connection goes through proxy `{proxy}`, which may be responsible for the \
+            oversized handshake. Ask whoever manages that proxy to check it; if it is only \
+            forwarding the connection, contact Cumulocity support and quote both `{host}` and \
+            `{proxy}`."
+        ));
+    }
+
+    explanation
 }
 
 // Check the connection by using the jwt token retrieval over the mqtt.
@@ -433,6 +898,12 @@ pub(crate) fn decode_jwt_token(token: &str) -> Result<String, ConnectError> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use rumqttc::tokio_rustls::rustls::ClientConfig;
+    use rumqttc::tokio_rustls::rustls::ClientConnection;
+    use rumqttc::tokio_rustls::rustls::RootCertStore;
+    use std::io::Cursor;
+    use std::sync::Arc;
+    use tedge_config::tedge_toml::MqttAuthClientConfigCloudBroker;
     use test_case::test_case;
 
     #[test]
@@ -495,5 +966,680 @@ mod test {
                 assert_eq!(error_msg, expected_error_msg)
             }
         }
+    }
+
+    #[test]
+    fn reads_a_full_buffer_during_the_handshake_as_an_oversized_handshake() {
+        assert_eq!(
+            classify_tls_error(
+                &oversized_handshake_error(),
+                &connection(),
+                Stage::Handshaking
+            ),
+            Some(TlsFailure::OversizedHandshake)
+        );
+    }
+
+    /// The other way `rustls` refuses an over-large handshake: rather than filling the buffer, a
+    /// single message announces more than it will ever accept
+    #[test]
+    fn reads_a_handshake_message_that_announces_too_much_as_an_oversized_handshake() {
+        let err = std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
+        );
+
+        assert_eq!(
+            classify_tls_error(&err, &connection(), Stage::Handshaking),
+            Some(TlsFailure::OversizedHandshake)
+        );
+    }
+
+    #[test]
+    fn does_not_read_an_over_large_message_after_connecting_as_a_handshake_failure() {
+        let err = std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
+        );
+
+        assert_eq!(
+            classify_tls_error(&err, &connection(), Stage::Connected),
+            None
+        );
+    }
+
+    /// `rustls` reports a full buffer the same way once the handshake is done, but then it means a
+    /// single over-long record rather than an over-long handshake, so the reading must not apply
+    #[test]
+    fn does_not_read_a_full_buffer_after_connecting_as_a_handshake_failure() {
+        assert_eq!(
+            classify_tls_error(
+                &oversized_handshake_error(),
+                &connection(),
+                Stage::Connected
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn reads_a_certificate_unknown_alert_as_a_certificate_cumulocity_does_not_hold() {
+        assert_eq!(
+            classify_tls_error(
+                &alert(AlertDescription::CertificateUnknown),
+                &connection(),
+                Stage::Handshaking,
+            ),
+            Some(TlsFailure::DeviceCertificateRejected)
+        );
+    }
+
+    #[test]
+    fn reads_a_handshake_failure_as_a_bare_refusal_when_the_key_is_on_a_token() {
+        let connection = ConnectionDetails {
+            client: ClientAuth::Certificate(ClientCredentials {
+                cert_path: CERT_PATH.into(),
+                key: KeyLocation::Token,
+            }),
+            ..connection()
+        };
+
+        assert_eq!(
+            classify_tls_error(
+                &alert(AlertDescription::HandshakeFailure),
+                &connection,
+                Stage::Handshaking
+            ),
+            Some(TlsFailure::HandshakeRejected)
+        );
+    }
+
+    /// A key read from a file has already been compared with its certificate, so a handshake that
+    /// fails afterwards cannot be blamed on the two not belonging together
+    #[test]
+    fn reads_a_handshake_failure_as_a_bare_refusal_when_the_key_is_a_file() {
+        assert_eq!(
+            classify_tls_error(
+                &alert(AlertDescription::HandshakeFailure),
+                &connection(),
+                Stage::Handshaking
+            ),
+            Some(TlsFailure::HandshakeRejected)
+        );
+    }
+
+    #[test]
+    fn does_not_blame_a_certificate_that_was_never_sent() {
+        let connection = ConnectionDetails {
+            client: ClientAuth::UsernameAndPassword,
+            ..connection()
+        };
+
+        assert_eq!(
+            classify_tls_error(
+                &alert(AlertDescription::CertificateUnknown),
+                &connection,
+                Stage::Handshaking
+            ),
+            None
+        );
+        assert_eq!(
+            classify_tls_error(
+                &alert(AlertDescription::HandshakeFailure),
+                &connection,
+                Stage::Handshaking
+            ),
+            Some(TlsFailure::HandshakeRejected)
+        );
+    }
+
+    /// A certificate the tenant may well hold, and would reject all the same
+    #[tokio::test]
+    async fn reads_the_validity_of_an_expired_certificate() {
+        let dir = tempfile::tempdir().unwrap();
+        let (cert_path, _) = write_selfsigned_pair_valid_for(dir.path(), "device-a", 0);
+        let connection = ConnectionDetails {
+            client: ClientAuth::Certificate(ClientCredentials {
+                cert_path,
+                key: KeyLocation::File(KEY_PATH.into()),
+            }),
+            ..connection()
+        };
+
+        assert!(matches!(
+            certificate_validity(&connection.certificate().unwrap().cert_path).await,
+            Some(ValidityStatus::Expired { .. })
+        ));
+    }
+
+    /// The state a device with a clock set behind the real date ends up in
+    #[tokio::test]
+    async fn reads_the_validity_of_a_certificate_that_starts_later() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = write_certificate_valid_from(dir.path(), "device-a", 2);
+        let connection = ConnectionDetails {
+            client: ClientAuth::Certificate(ClientCredentials {
+                cert_path,
+                key: KeyLocation::File(KEY_PATH.into()),
+            }),
+            ..connection()
+        };
+
+        assert!(matches!(
+            certificate_validity(&connection.certificate().unwrap().cert_path).await,
+            Some(ValidityStatus::NotValidYet { .. })
+        ));
+    }
+
+    /// A certificate in date leaves the alert to say what it says, as does one that cannot be read
+    #[tokio::test]
+    async fn reads_the_validity_of_an_in_date_certificate() {
+        let dir = tempfile::tempdir().unwrap();
+        let (cert_path, _) = write_selfsigned_pair_valid_for(dir.path(), "device-a", 365);
+        let connection = ConnectionDetails {
+            client: ClientAuth::Certificate(ClientCredentials {
+                cert_path,
+                key: KeyLocation::File(KEY_PATH.into()),
+            }),
+            ..connection()
+        };
+
+        assert!(matches!(
+            certificate_validity(&connection.certificate().unwrap().cert_path).await,
+            Some(ValidityStatus::Valid { .. })
+        ));
+    }
+
+    #[test]
+    fn a_proxy_does_not_change_oversized_handshake_classification() {
+        let connection = ConnectionDetails {
+            proxy: Some(PROXY.into()),
+            ..connection()
+        };
+
+        assert_eq!(
+            classify_tls_error(
+                &oversized_handshake_error(),
+                &connection,
+                Stage::Handshaking
+            ),
+            Some(TlsFailure::OversizedHandshake)
+        );
+    }
+
+    /// Starts from the configuration a device would be left in, rather than from an error assumed
+    /// to arise from it: two certificates are created, and the key of one is offered with the
+    /// certificate of the other
+    #[test]
+    fn reads_a_key_that_does_not_belong_to_its_certificate_as_an_unpaired_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let (cert_path, _) = write_selfsigned_pair(dir.path(), "device-a");
+        let (_, other_key_path) = write_selfsigned_pair(dir.path(), "device-b");
+
+        let err = MqttAuthConfigCloudBroker {
+            ca_path: cert_path.clone(),
+            client: MqttAuthClientConfigCloudBroker {
+                cert_file: cert_path,
+                private_key: PrivateKeyType::File(other_key_path),
+            },
+        }
+        .to_rustls_client_config()
+        .expect_err("a certificate and a key that do not belong together cannot be used");
+
+        assert_eq!(
+            classify_config_error(&err),
+            Some(TlsFailure::UnpairedPrivateKey)
+        );
+    }
+
+    /// A configuration that fails for some other reason is left to report itself
+    #[test]
+    fn leaves_an_unrecognised_configuration_error_unclassified() {
+        let dir = tempfile::tempdir().unwrap();
+        let (cert_path, key_path) = write_selfsigned_pair(dir.path(), "device-a");
+        std::fs::write(&cert_path, "not a certificate").unwrap();
+
+        let err = MqttAuthConfigCloudBroker {
+            ca_path: cert_path.clone(),
+            client: MqttAuthClientConfigCloudBroker {
+                cert_file: cert_path,
+                private_key: PrivateKeyType::File(key_path),
+            },
+        }
+        .to_rustls_client_config()
+        .expect_err("a certificate file that holds no certificate cannot be used");
+
+        assert_eq!(classify_config_error(&err), None);
+    }
+
+    #[test]
+    fn reads_an_unknown_issuer_as_a_server_the_device_does_not_trust() {
+        let err = std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            Error::InvalidCertificate(CertificateError::UnknownIssuer),
+        );
+
+        assert_eq!(
+            classify_tls_error(&err, &connection(), Stage::Handshaking),
+            Some(TlsFailure::UntrustedServer)
+        );
+    }
+
+    #[test]
+    fn leaves_an_unrecognised_error_unclassified() {
+        let err = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "connection refused");
+
+        assert_eq!(
+            classify_tls_error(&err, &connection(), Stage::Handshaking),
+            None
+        );
+    }
+
+    #[test]
+    fn explains_a_valid_but_rejected_certificate_exactly() {
+        assert_eq!(
+            TlsFailure::DeviceCertificateRejected.explain(
+                &connection(),
+                Some(ValidityStatus::Valid {
+                    expired_in: Duration::from_secs(86400),
+                }),
+            ),
+            "Cumulocity did not recognise the device certificate.\n\n\
+             The certificate sent was /etc/tedge/device-certs/tedge-certificate.pem (set by \
+             'c8y.device.cert_path'), which identifies this device as 'test-device'.\n\n\
+             Check that this is the certificate registered as trusted in the tenant at \
+             example.cumulocity.com. If it is not, upload it with `tedge cert upload c8y`."
+        );
+    }
+
+    #[test]
+    fn explains_an_unreadable_rejected_certificate_exactly() {
+        assert_eq!(
+            TlsFailure::DeviceCertificateRejected.explain(&connection(), None),
+            "Cumulocity did not recognise the device certificate.\n\n\
+             The certificate sent was /etc/tedge/device-certs/tedge-certificate.pem (set by \
+             'c8y.device.cert_path'), which identifies this device as 'test-device'.\n\n\
+             Check that this is the certificate registered as trusted in the tenant at \
+             example.cumulocity.com. If it is not, upload it with `tedge cert upload c8y`."
+        );
+    }
+
+    #[test]
+    fn explains_an_expired_rejected_certificate_exactly() {
+        assert_eq!(
+            TlsFailure::DeviceCertificateRejected.explain(
+                &connection(),
+                Some(ValidityStatus::Expired {
+                    since: Duration::from_secs(3 * 86400),
+                }),
+            ),
+            "The device certificate expired 3 days ago, so example.cumulocity.com rejected it.\n\n\
+             The certificate sent was /etc/tedge/device-certs/tedge-certificate.pem (set by \
+             'c8y.device.cert_path'), which identifies this device as 'test-device'.\n\n\
+             Renew the certificate with `tedge cert renew --ca self-signed`, then upload the \
+             renewed certificate with `tedge cert upload c8y`."
+        );
+    }
+
+    #[test]
+    fn explains_a_future_rejected_certificate_exactly() {
+        assert_eq!(
+            TlsFailure::DeviceCertificateRejected.explain(
+                &connection(),
+                Some(ValidityStatus::NotValidYet {
+                    valid_in: Duration::from_secs(2 * 86400),
+                }),
+            ),
+            "The device certificate is not valid until 2 days from now, so \
+             example.cumulocity.com rejected it.\n\n\
+             The certificate sent was /etc/tedge/device-certs/tedge-certificate.pem (set by \
+             'c8y.device.cert_path'), which identifies this device as 'test-device'.\n\n\
+             Check the clock on this device and the service that keeps it in sync. If the clock \
+             is correct, renew the certificate with `tedge cert renew --ca self-signed` and \
+             upload it with `tedge cert upload c8y`."
+        );
+    }
+
+    #[test]
+    fn names_both_files_that_have_to_match_when_the_key_does_not_match_the_certificate() {
+        let explanation = TlsFailure::UnpairedPrivateKey.explain(&connection(), None);
+
+        assert!(
+            explanation.contains(CERT_PATH) && explanation.contains(KEY_PATH),
+            "should name both files sent: {explanation}"
+        );
+        assert!(
+            explanation.contains("'c8y.device.cert_path'")
+                && explanation.contains("'c8y.device.key_path'"),
+            "should name the settings that chose them: {explanation}"
+        );
+    }
+
+    #[test]
+    fn names_the_profiled_settings_when_the_connection_uses_a_profile() {
+        let connection = ConnectionDetails {
+            config_prefix: "c8y.profiles.staging".into(),
+            ..connection()
+        };
+
+        let explanation = TlsFailure::UnpairedPrivateKey.explain(&connection, None);
+
+        assert!(
+            explanation.contains("'c8y.profiles.staging.device.key_path'"),
+            "should name the profile's own setting: {explanation}"
+        );
+    }
+
+    #[test]
+    fn explains_a_generic_handshake_rejection_exactly() {
+        assert_eq!(
+            TlsFailure::HandshakeRejected.explain(&connection(), None),
+            "example.cumulocity.com refused the TLS handshake without giving a reason.\n\n\
+             Check that `example.cumulocity.com` is the correct MQTT endpoint for this tenant. If \
+             it is, ask the Cumulocity administrator to check the tenant's TLS configuration and \
+             server logs."
+        );
+    }
+
+    #[test]
+    fn adds_simple_proxy_triage_to_a_handshake_rejection() {
+        let connection = ConnectionDetails {
+            proxy: Some(PROXY.into()),
+            ..connection()
+        };
+
+        assert_eq!(
+            TlsFailure::HandshakeRejected.explain(&connection, None),
+            "example.cumulocity.com refused the TLS handshake without giving a reason.\n\n\
+             Check that `example.cumulocity.com` is the correct MQTT endpoint for this tenant. If \
+             it is, ask the Cumulocity administrator to check the tenant's TLS configuration and \
+             server logs.\n\n\
+             This connection goes through proxy `proxy.example.com:3128`, which may also be \
+             involved. Include its address when asking your network administrator or Cumulocity \
+             administrator for help."
+        );
+    }
+
+    #[test]
+    fn gives_hsm_advice_with_profiled_keys_without_disclosing_the_uri() {
+        let connection = ConnectionDetails {
+            config_prefix: "c8y.profiles.staging".into(),
+            client: ClientAuth::Certificate(ClientCredentials {
+                cert_path: CERT_PATH.into(),
+                key: KeyLocation::Token,
+            }),
+            ..connection()
+        };
+
+        assert_eq!(
+            TlsFailure::HandshakeRejected.explain(&connection, None),
+            "example.cumulocity.com refused the TLS handshake without giving a reason.\n\n\
+             Check that `example.cumulocity.com` is the correct MQTT endpoint for this tenant. If \
+             it is, ask the Cumulocity administrator to check the tenant's TLS configuration and \
+             server logs.\n\n\
+             This connection uses an HSM private key. Check that \
+             `c8y.profiles.staging.device.cert_path` points to the certificate issued for the key \
+             selected by `c8y.profiles.staging.device.key_uri`. The certificate supplied was \
+             /etc/tedge/device-certs/tedge-certificate.pem."
+        );
+    }
+
+    #[test]
+    fn explains_a_direct_oversized_handshake_exactly() {
+        assert_eq!(
+            TlsFailure::OversizedHandshake.explain(&connection(), None),
+            "Cumulocity sent a TLS handshake larger than the 64 KB thin-edge.io can accept.\n\n\
+             The likely cause is an unnecessarily large `certificate_authorities` list. This \
+             must be corrected on the Cumulocity side; changing this device's certificate or \
+             configuration will not fix it.\n\n\
+             Contact Cumulocity support and quote the MQTT host `example.cumulocity.com`."
+        );
+    }
+
+    #[test]
+    fn adds_simple_proxy_triage_to_an_oversized_handshake() {
+        let connection = ConnectionDetails {
+            proxy: Some(PROXY.into()),
+            ..connection()
+        };
+
+        assert_eq!(
+            TlsFailure::OversizedHandshake.explain(&connection, None),
+            "Cumulocity sent a TLS handshake larger than the 64 KB thin-edge.io can accept.\n\n\
+             The likely cause is an unnecessarily large `certificate_authorities` list. This \
+             must be corrected on the Cumulocity side; changing this device's certificate or \
+             configuration will not fix it.\n\n\
+             Contact Cumulocity support and quote the MQTT host `example.cumulocity.com`.\n\n\
+             This connection goes through proxy `proxy.example.com:3128`, which may be responsible \
+             for the oversized handshake. Ask whoever manages that proxy to check it; if it is \
+             only forwarding the connection, contact Cumulocity support and quote both \
+             `example.cumulocity.com` and `proxy.example.com:3128`."
+        );
+    }
+
+    #[test]
+    fn points_at_the_root_certificates_when_the_device_does_not_trust_cumulocity() {
+        let explanation = TlsFailure::UntrustedServer.explain(&connection(), None);
+
+        assert!(
+            explanation.contains(ROOT_CERT_PATH) && explanation.contains("'c8y.root_cert_path'"),
+            "should name the authorities in use and the setting that chose them: {explanation}"
+        );
+        assert!(
+            explanation.contains("tedge cert create"),
+            "should say the device's own certificate is not at fault: {explanation}"
+        );
+    }
+
+    #[test]
+    fn error_context_says_whether_the_connection_was_ever_established() {
+        assert_ne!(
+            error_context(Stage::Connected),
+            error_context(Stage::Handshaking)
+        );
+    }
+
+    /// The certificate presented is the one the connection is configured with, which is not always
+    /// the one named by `device.cert_path`: reconnecting to validate a renewed certificate sends
+    /// the new one instead
+    #[test]
+    fn reads_the_certificate_from_the_authentication_config() {
+        let mqtt_auth_config = MqttAuthConfigCloudBroker {
+            ca_path: ROOT_CERT_PATH.into(),
+            client: MqttAuthClientConfigCloudBroker {
+                cert_file: format!("{CERT_PATH}.new").into(),
+                private_key: PrivateKeyType::File(KEY_PATH.into()),
+            },
+        };
+
+        let connection = ConnectionDetails::new(
+            HOST,
+            DEVICE_ID,
+            None,
+            &mqtt_auth_config,
+            AuthType::Certificate,
+            None,
+        );
+
+        let explanation = TlsFailure::DeviceCertificateRejected.explain(&connection, None);
+
+        assert!(
+            explanation.contains(&format!("{CERT_PATH}.new")),
+            "should name the certificate actually sent: {explanation}"
+        );
+    }
+
+    #[test]
+    fn qualifies_the_settings_with_the_profile_the_connection_uses() {
+        let profile: ProfileName = "staging".parse().unwrap();
+
+        let connection = ConnectionDetails::new(
+            HOST,
+            DEVICE_ID,
+            Some(&profile),
+            &MqttAuthConfigCloudBroker {
+                ca_path: ROOT_CERT_PATH.into(),
+                client: MqttAuthClientConfigCloudBroker {
+                    cert_file: CERT_PATH.into(),
+                    private_key: PrivateKeyType::File(KEY_PATH.into()),
+                },
+            },
+            AuthType::Certificate,
+            None,
+        );
+
+        assert_eq!(
+            connection.config_key("device.key_path"),
+            "c8y.profiles.staging.device.key_path"
+        );
+    }
+
+    const HOST: &str = "example.cumulocity.com";
+    const DEVICE_ID: &str = "test-device";
+    const CERT_PATH: &str = "/etc/tedge/device-certs/tedge-certificate.pem";
+    const KEY_PATH: &str = "/etc/tedge/device-certs/tedge-private-key.pem";
+    const ROOT_CERT_PATH: &str = "/etc/ssl/certs";
+    const PROXY: &str = "proxy.example.com:3128";
+
+    /// A connection authenticated with a certificate and key held in files, as `tedge cert create`
+    /// leaves them
+    fn connection() -> ConnectionDetails {
+        ConnectionDetails {
+            host: HOST.into(),
+            device_id: DEVICE_ID.into(),
+            config_prefix: "c8y".into(),
+            root_cert_path: ROOT_CERT_PATH.into(),
+            client: ClientAuth::Certificate(ClientCredentials {
+                cert_path: CERT_PATH.into(),
+                key: KeyLocation::File(KEY_PATH.into()),
+            }),
+            proxy: None,
+        }
+    }
+
+    /// The largest handshake flight `rustls` will buffer, as a guard against denial-of-service
+    ///
+    /// Mirrors `MAX_HANDSHAKE_SIZE` in `rustls`, which is not publicly exported
+    const MAX_HANDSHAKE_SIZE: usize = 0xffff;
+
+    /// Writes a fresh self-signed certificate and its private key, returning their paths
+    ///
+    /// Each call produces its own key, so a certificate from one call and a key from another are
+    /// exactly the unpaired configuration a device can end up in
+    fn write_selfsigned_pair(dir: &std::path::Path, id: &str) -> (Utf8PathBuf, Utf8PathBuf) {
+        write_selfsigned_pair_valid_for(
+            dir,
+            id,
+            certificate::CsrTemplate::default().validity_period_days,
+        )
+    }
+
+    /// Writes a certificate that stops being valid after the given number of days
+    ///
+    /// Certificates are dated from yesterday, so a lifetime of no days at all is one that has run
+    /// out — the state a device is left in when nothing renewed its certificate in time
+    fn write_selfsigned_pair_valid_for(
+        dir: &std::path::Path,
+        id: &str,
+        days: u32,
+    ) -> (Utf8PathBuf, Utf8PathBuf) {
+        let pair = certificate::KeyCertPair::new_selfsigned_certificate(
+            &certificate::CsrTemplate {
+                validity_period_days: days,
+                ..Default::default()
+            },
+            id,
+            &certificate::KeyKind::New,
+        )
+        .expect("a self-signed certificate can be created");
+
+        let cert_path = Utf8PathBuf::try_from(dir.join(format!("{id}.crt"))).unwrap();
+        let key_path = Utf8PathBuf::try_from(dir.join(format!("{id}.key"))).unwrap();
+        std::fs::write(&cert_path, pair.certificate_pem_string().unwrap()).unwrap();
+        std::fs::write(&key_path, pair.private_key_pem_string().unwrap().as_str()).unwrap();
+        (cert_path, key_path)
+    }
+
+    /// Writes a certificate that only becomes valid in the future, as a device whose clock is set
+    /// behind the real date sees its own
+    ///
+    /// Built with `rcgen` directly: `tedge` has no way to issue one, which is the point — nothing
+    /// short of a wrong clock produces it
+    fn write_certificate_valid_from(dir: &std::path::Path, id: &str, days: i64) -> Utf8PathBuf {
+        let key = rcgen::KeyPair::generate().expect("a key pair can be generated");
+        let mut params =
+            rcgen::CertificateParams::new(vec![id.to_owned()]).expect("valid certificate params");
+        params.not_before = time::OffsetDateTime::now_utc() + time::Duration::days(days);
+        params.not_after = params.not_before + time::Duration::days(1);
+        let certificate = params.self_signed(&key).expect("a self-signed certificate");
+
+        let cert_path = Utf8PathBuf::try_from(dir.join(format!("{id}-later.crt"))).unwrap();
+        std::fs::write(&cert_path, certificate.pem()).unwrap();
+        cert_path
+    }
+
+    /// Wraps a TLS alert the way `rustls` surfaces it through `read_tls`
+    fn alert(description: AlertDescription) -> std::io::Error {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            Error::AlertReceived(description),
+        )
+    }
+
+    /// Drives a real [`ClientConnection`] into rejecting an over-large handshake
+    ///
+    /// Going through `rustls` rather than hand-building the error means an upgrade that changes
+    /// how the refusal is reported fails these tests instead of silently losing the diagnosis
+    fn oversized_handshake_error() -> std::io::Error {
+        // Must be called before any use of `ClientConfig::builder()`
+        let _ = rumqttc::tokio_rustls::rustls::crypto::ring::default_provider().install_default();
+
+        let config = ClientConfig::builder()
+            .with_root_certificates(RootCertStore::empty())
+            .with_no_client_auth();
+        let mut connection =
+            ClientConnection::new(Arc::new(config), "example.com".try_into().unwrap())
+                .expect("a client connection can be created");
+        connection
+            .write_tls(&mut std::io::sink())
+            .expect("the client hello can be flushed");
+
+        let mut flight = Cursor::new(oversized_handshake_flight());
+        loop {
+            match connection.read_tls(&mut flight) {
+                Ok(0) => panic!("rustls buffered the whole flight without complaining"),
+                Ok(_) => connection
+                    .process_new_packets()
+                    .expect("the partial flight is not rejected on its content"),
+                Err(err) => break err,
+            };
+        }
+    }
+
+    /// Frames a single `Certificate` handshake message into plaintext TLS records
+    ///
+    /// The message declares just under [`MAX_HANDSHAKE_SIZE`] bytes of payload, so once its own
+    /// header and the record headers are counted, the flight can never fit in the buffer and
+    /// `rustls` gives up part way through
+    fn oversized_handshake_flight() -> Vec<u8> {
+        const HANDSHAKE_RECORD: u8 = 22;
+        const TLS_1_2_VERSION: [u8; 2] = [0x03, 0x03];
+        const MAX_RECORD_PAYLOAD: usize = 16_384;
+        const CERTIFICATE_MESSAGE: u8 = 11;
+
+        let payload_len = MAX_HANDSHAKE_SIZE - 1;
+        let mut message = vec![CERTIFICATE_MESSAGE];
+        // A handshake message length is 3 bytes wide
+        message.extend_from_slice(&(payload_len as u32).to_be_bytes()[1..]);
+        message.resize(message.len() + payload_len, 0);
+
+        let mut flight = Vec::new();
+        for chunk in message.chunks(MAX_RECORD_PAYLOAD) {
+            flight.push(HANDSHAKE_RECORD);
+            flight.extend_from_slice(&TLS_1_2_VERSION);
+            flight.extend_from_slice(&(chunk.len() as u16).to_be_bytes());
+            flight.extend_from_slice(chunk);
+        }
+        flight
     }
 }

--- a/crates/core/tedge/src/cli/connect/c8y.rs
+++ b/crates/core/tedge/src/cli/connect/c8y.rs
@@ -14,6 +14,7 @@ use c8y_api::smartrest::message::get_smartrest_template_id;
 use c8y_api::smartrest::message_ids::GET_DEVICE_MANAGED_OBJECT_ID;
 use c8y_api::smartrest::message_ids::GET_DEVICE_MANAGED_OBJECT_ID_RESPONSE;
 use c8y_api::smartrest::message_ids::JWT_TOKEN;
+use camino::Utf8PathBuf;
 use certificate::parse_root_certificate::create_tls_config_without_client_cert;
 use rumqttc::tokio_rustls::rustls::AlertDescription;
 use rumqttc::tokio_rustls::rustls::CertificateError;
@@ -34,6 +35,7 @@ use tedge_config::models::auth_method::AuthType;
 use tedge_config::tedge_toml::mapper_config::C8yMapperConfig;
 use tedge_config::tedge_toml::mapper_config::C8yMapperSpecificConfig;
 use tedge_config::tedge_toml::MqttAuthConfigCloudBroker;
+use tedge_config::tedge_toml::PrivateKeyType;
 use tedge_config::tedge_toml::ProfileName;
 use tedge_config::TEdgeConfig;
 use tracing::debug;
@@ -60,15 +62,23 @@ const BUFFER_FULL_MESSAGE: &str = "message buffer full";
 // Connect directly to the c8y cloud over mqtt and publish device create message.
 pub async fn create_device_with_direct_connection(
     bridge_config: &BridgeConfig,
+    profile: Option<&ProfileName>,
     device_type: &str,
     // TODO: put into general authentication struct
     mqtt_auth_config: MqttAuthConfigCloudBroker,
 ) -> anyhow::Result<()> {
     let address = bridge_config.address.clone();
+    let host = address.host().to_string();
+    let connection = ConnectionDetails::new(
+        &host,
+        &bridge_config.remote_clientid,
+        profile,
+        &mqtt_auth_config,
+    );
 
     let mut mqtt_options = MqttOptions::new(
         bridge_config.remote_clientid.clone(),
-        address.host().to_string(),
+        host.clone(),
         address.port().into(),
     );
     mqtt_options.set_keep_alive(std::time::Duration::from_secs(5));
@@ -141,7 +151,7 @@ pub async fn create_device_with_direct_connection(
                 bail!("Timed-out waiting for device creation acknowledgment from Cumulocity")
             }
             Err(ConnectionError::Io(err) | ConnectionError::Tls(TlsError::Io(err))) => {
-                match diagnose_tls_error(&err, &address.host().to_string(), connected) {
+                match diagnose_tls_error(&err, &connection, connected) {
                     Some(explanation) => bail!("{explanation}"),
                     None => return Err(err).context(error_context(connected)),
                 }
@@ -164,12 +174,89 @@ fn is_buffer_full(err: &std::io::Error) -> bool {
         .is_some_and(|inner| inner.to_string() == BUFFER_FULL_MESSAGE)
 }
 
+/// The files and settings a connection attempt used, so that a diagnosis can name them
+///
+/// Nothing secret is held here: the PKCS#11 PIN is never read, and neither is the key URI, which
+/// may carry a `pin-value` attribute of its own. The messages name the setting that holds the URI
+/// instead of quoting its value
+struct ConnectionDetails {
+    /// Host of the Cumulocity MQTT endpoint
+    host: String,
+
+    /// Identity the device claims, which is the common name of its certificate
+    device_id: String,
+
+    /// Prefix of this connection's `tedge config` keys: `c8y`, or `c8y.profiles.<name>`
+    config_prefix: String,
+
+    root_cert_path: Utf8PathBuf,
+
+    /// Absent under basic auth, where the device sends no certificate of its own
+    client: Option<ClientCredentials>,
+}
+
+/// The certificate and private key a connection presented to Cumulocity
+struct ClientCredentials {
+    cert_path: Utf8PathBuf,
+    key: KeyLocation,
+}
+
+/// Where a private key lives, which decides both what to print and which setting to name
+enum KeyLocation {
+    File(Utf8PathBuf),
+    /// A PKCS#11 token, chosen by `<prefix>.device.key_uri` rather than `<prefix>.device.key_path`
+    Token,
+}
+
+impl ConnectionDetails {
+    /// Reads the connection details from the authentication config the connection itself uses
+    ///
+    /// The paths come from `mqtt_auth_config` rather than from `bridge_config`, as those are the
+    /// files actually presented: when reconnecting to validate a renewed certificate, the caller
+    /// swaps in the new certificate there
+    fn new(
+        host: &str,
+        device_id: &str,
+        profile: Option<&ProfileName>,
+        mqtt_auth_config: &MqttAuthConfigCloudBroker,
+    ) -> Self {
+        Self {
+            host: host.to_owned(),
+            device_id: device_id.to_owned(),
+            config_prefix: match profile {
+                None => "c8y".into(),
+                Some(profile) => format!("c8y.profiles.{profile}"),
+            },
+            root_cert_path: mqtt_auth_config.ca_path.clone(),
+            client: mqtt_auth_config
+                .client
+                .as_ref()
+                .map(|client| ClientCredentials {
+                    cert_path: client.cert_file.clone(),
+                    key: match &client.private_key {
+                        PrivateKeyType::File(path) => KeyLocation::File(path.clone()),
+                        PrivateKeyType::Cryptoki(_) => KeyLocation::Token,
+                    },
+                }),
+        }
+    }
+
+    /// Names the `tedge config` key that sets one of this connection's values
+    fn config_key(&self, key: &str) -> String {
+        format!("{}.{key}", self.config_prefix)
+    }
+}
+
 /// Explains a TLS error in terms of what the user can do about it
 ///
 /// Returns `None` for anything unrecognised, leaving the caller to report the error as it is.
 /// `connected` tells us whether the broker has accepted the MQTT connection, and hence whether the
 /// TLS handshake is behind us
-fn diagnose_tls_error(err: &std::io::Error, host: &str, connected: bool) -> Option<String> {
+fn diagnose_tls_error(
+    err: &std::io::Error,
+    connection: &ConnectionDetails,
+    connected: bool,
+) -> Option<String> {
     if err.kind() != std::io::ErrorKind::InvalidData {
         return None;
     }
@@ -178,36 +265,129 @@ fn diagnose_tls_error(err: &std::io::Error, host: &str, connected: bool) -> Opti
         .get_ref()
         .and_then(|custom_err| custom_err.downcast_ref::<Error>())
     {
-        // Either the device cert is not uploaded to c8y or
-        // another cert is set in device.cert_path
-        Some(Error::AlertReceived(AlertDescription::CertificateUnknown)) => Some(
-            "The device certificate is not trusted by Cumulocity. Upload the certificate using `tedge cert upload c8y`".into(),
-        ),
-        // Non-paired private key is set in device.key_path
-        Some(Error::AlertReceived(AlertDescription::HandshakeFailure)) => Some(
-            "The private key is not paired with the certificate. Check your 'device.key_path'.".into(),
-        ),
-        Some(Error::InvalidCertificate(CertificateError::UnknownIssuer)) => Some(
-            "Cumulocity certificate is not trusted by the device. Check your 'c8y.root_cert_path'.".into(),
-        ),
+        // Either the device certificate is not among the tenant's trusted certificates, or the
+        // connection is using a certificate other than the one that is
+        Some(Error::AlertReceived(AlertDescription::CertificateUnknown)) => connection
+            .client
+            .as_ref()
+            .map(|client| unknown_certificate(connection, client)),
+        // Most often a private key that does not belong to the certificate sent alongside it
+        Some(Error::AlertReceived(AlertDescription::HandshakeFailure)) => connection
+            .client
+            .as_ref()
+            .map(|client| unpaired_private_key(connection, client)),
+        Some(Error::InvalidCertificate(CertificateError::UnknownIssuer)) => {
+            Some(untrusted_server(connection))
+        }
         // A single handshake message that announces more than `rustls` will buffer
         Some(Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge)) if !connected => {
-            Some(oversized_handshake(host))
+            Some(oversized_handshake(&connection.host))
         }
         // A handshake that fills the buffer before any one message completes. Only a handshake
         // can reach the larger of the two buffer limits, so both diagnoses hold only while the
         // connection is still being established
-        _ if !connected && is_buffer_full(err) => Some(oversized_handshake(host)),
+        _ if !connected && is_buffer_full(err) => Some(oversized_handshake(&connection.host)),
         _ => None,
     }
+}
+
+/// Explains Cumulocity rejecting a device certificate it does not hold as trusted
+fn unknown_certificate(connection: &ConnectionDetails, client: &ClientCredentials) -> String {
+    let cert_path = &client.cert_path;
+    let cert_key = connection.config_key("device.cert_path");
+    let ConnectionDetails {
+        host, device_id, ..
+    } = connection;
+    format!(
+        "Cumulocity did not recognise the device certificate.\n\
+        \n\
+        The certificate sent was {cert_path} (set by '{cert_key}'), \
+        which identifies this device as '{device_id}'.\n\
+        \n\
+        Cumulocity accepts a device certificate only if the tenant at {host} already holds it as a \
+        trusted certificate. So either this certificate has not been added there yet, \
+        or the tenant holds a different certificate for '{device_id}'.\n\
+        \n\
+        Run `tedge cert upload c8y` to add this certificate to the tenant's trusted certificates."
+    )
+}
+
+/// Explains Cumulocity aborting the handshake, most often over a key that is not the certificate's
+fn unpaired_private_key(connection: &ConnectionDetails, client: &ClientCredentials) -> String {
+    let cert_path = &client.cert_path;
+    let cert_key = connection.config_key("device.cert_path");
+    let (key, advice) = match &client.key {
+        KeyLocation::File(key_path) => (
+            format!(
+                "{key_path} (from '{}')",
+                connection.config_key("device.key_path")
+            ),
+            "`tedge cert create` always writes a matching pair, so they normally only come apart if \
+            one of those settings now points somewhere else, or if one of the two files has since \
+            been replaced on its own.\n\
+            \n\
+            Creating a fresh pair with `tedge cert create` and adding the new certificate to \
+            Cumulocity with `tedge cert upload c8y` will resolve it."
+                .to_owned(),
+        ),
+        KeyLocation::Token => (
+            format!(
+                "on a PKCS#11 token (named by '{}')",
+                connection.config_key("device.key_uri")
+            ),
+            format!(
+                "So check that '{cert_key}' names the certificate that was issued for the key held \
+                on that token, and not another certificate."
+            ),
+        ),
+    };
+
+    format!(
+        "Cumulocity aborted the TLS handshake. The usual cause is a private key that does not \
+        belong to the device certificate sent with it.\n\
+        \n\
+        This connection used:\n\
+        \x20 certificate: {cert_path} (from '{cert_key}')\n\
+        \x20 private key: {key}\n\
+        \n\
+        These two have to be a matching pair: the certificate has to be the one issued for that \
+        exact key.\n\
+        \n\
+        {advice}"
+    )
+}
+
+/// Explains the device refusing the certificate Cumulocity presented
+fn untrusted_server(connection: &ConnectionDetails) -> String {
+    let root_cert_key = connection.config_key("root_cert_path");
+    let ConnectionDetails {
+        host,
+        root_cert_path,
+        ..
+    } = connection;
+    format!(
+        "The device does not trust the certificate presented by {host}: it is signed by a \
+        certificate authority the device does not know.\n\
+        \n\
+        This check is about Cumulocity's identity, not the device's — the certificate and key \
+        created by `tedge cert create` play no part in it. The authorities the device trusts are \
+        read from {root_cert_path} (set by '{root_cert_key}').\n\
+        \n\
+        Check that:\n\
+        \x20 * {root_cert_path} is the right file or directory — on most Linux systems the \
+        system's own CA certificates are in /etc/ssl/certs\n\
+        \x20 * the authority that signed Cumulocity's certificate is among those it holds: if the \
+        connection passes through a proxy that terminates TLS, or the tenant is served by a \
+        private authority, that authority's certificate has to be added there"
+    )
 }
 
 /// Explains a handshake too large for `rustls` to accept, however it broke the limit
 fn oversized_handshake(host: &str) -> String {
     format!(
         "Cumulocity sent a TLS handshake that is too large for thin-edge.io to accept (over 64 KB).\n\
-        The likely cause is the server listing the client certificates it will accept, \
-        which it should not be sending.\n\
+        The likely cause is the certificate request listing, as `certificate_authorities`, \
+        the client certificates the server will accept, which it should not be sending.\n\
         Whatever the cause, this is not something that can be fixed on this device. \
         Please report it to Cumulocity support, quoting the host {host}."
     )
@@ -498,6 +678,7 @@ mod test {
     use rumqttc::tokio_rustls::rustls::RootCertStore;
     use std::io::Cursor;
     use std::sync::Arc;
+    use tedge_config::tedge_toml::MqttAuthClientConfigCloudBroker;
     use test_case::test_case;
 
     #[test]
@@ -564,7 +745,7 @@ mod test {
 
     #[test]
     fn blames_cumulocity_for_a_handshake_too_large_to_buffer() {
-        let explanation = diagnose_tls_error(&oversized_handshake_error(), HOST, false)
+        let explanation = diagnose_tls_error(&oversized_handshake_error(), &connection(), false)
             .expect("an oversized handshake is diagnosed");
 
         assert!(
@@ -586,7 +767,7 @@ mod test {
             Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
         );
 
-        let explanation = diagnose_tls_error(&err, HOST, false)
+        let explanation = diagnose_tls_error(&err, &connection(), false)
             .expect("an over-large handshake message is diagnosed");
 
         assert_eq!(explanation, oversized_handshake(HOST));
@@ -599,7 +780,7 @@ mod test {
             Error::InvalidMessage(InvalidMessage::HandshakePayloadTooLarge),
         );
 
-        assert_eq!(diagnose_tls_error(&err, HOST, true), None);
+        assert_eq!(diagnose_tls_error(&err, &connection(), true), None);
     }
 
     /// `rustls` reports a full buffer the same way once the handshake is done, but then it means a
@@ -607,52 +788,135 @@ mod test {
     #[test]
     fn does_not_blame_the_handshake_for_a_full_buffer_after_connecting() {
         assert_eq!(
-            diagnose_tls_error(&oversized_handshake_error(), HOST, true),
+            diagnose_tls_error(&oversized_handshake_error(), &connection(), true),
             None
         );
     }
 
     #[test]
-    fn advises_uploading_the_certificate_when_cumulocity_does_not_trust_it() {
+    fn names_the_certificate_cumulocity_did_not_recognise_and_how_to_have_it_trusted() {
         let err = alert(AlertDescription::CertificateUnknown);
 
-        let explanation =
-            diagnose_tls_error(&err, HOST, false).expect("a rejected certificate is diagnosed");
+        let explanation = diagnose_tls_error(&err, &connection(), false)
+            .expect("a rejected certificate is diagnosed");
 
         assert!(
-            explanation.contains("tedge cert upload c8y"),
-            "{explanation}"
+            explanation.contains(CERT_PATH) && explanation.contains("'c8y.device.cert_path'"),
+            "should name the certificate sent and the setting that chose it: {explanation}"
+        );
+        assert!(
+            explanation.contains("trusted certificate")
+                && explanation.contains("tedge cert upload c8y"),
+            "should say how to have Cumulocity trust it: {explanation}"
         );
     }
 
     #[test]
-    fn advises_checking_the_key_path_when_the_key_does_not_match_the_certificate() {
+    fn names_both_files_that_have_to_match_when_the_key_does_not_match_the_certificate() {
         let err = alert(AlertDescription::HandshakeFailure);
 
-        let explanation =
-            diagnose_tls_error(&err, HOST, false).expect("an unpaired private key is diagnosed");
+        let explanation = diagnose_tls_error(&err, &connection(), false)
+            .expect("an unpaired private key is diagnosed");
 
-        assert!(explanation.contains("device.key_path"), "{explanation}");
+        assert!(
+            explanation.contains(CERT_PATH) && explanation.contains(KEY_PATH),
+            "should name both files sent: {explanation}"
+        );
+        assert!(
+            explanation.contains("'c8y.device.cert_path'")
+                && explanation.contains("'c8y.device.key_path'"),
+            "should name the settings that chose them: {explanation}"
+        );
     }
 
     #[test]
-    fn advises_checking_the_root_cert_path_when_the_device_does_not_trust_cumulocity() {
+    fn names_the_key_uri_setting_when_the_key_is_held_on_a_token() {
+        let err = alert(AlertDescription::HandshakeFailure);
+        let connection = ConnectionDetails {
+            client: Some(ClientCredentials {
+                cert_path: CERT_PATH.into(),
+                key: KeyLocation::Token,
+            }),
+            ..connection()
+        };
+
+        let explanation = diagnose_tls_error(&err, &connection, false)
+            .expect("an unpaired private key is diagnosed");
+
+        assert!(
+            explanation.contains("'c8y.device.key_uri'")
+                && !explanation.contains("device.key_path"),
+            "should name the setting that chose the token: {explanation}"
+        );
+        assert!(
+            !explanation.contains("pkcs11:"),
+            "should not echo the key URI, which can hold a PIN: {explanation}"
+        );
+    }
+
+    #[test]
+    fn names_the_profiled_settings_when_the_connection_uses_a_profile() {
+        let err = alert(AlertDescription::HandshakeFailure);
+        let connection = ConnectionDetails {
+            config_prefix: "c8y.profiles.staging".into(),
+            ..connection()
+        };
+
+        let explanation = diagnose_tls_error(&err, &connection, false)
+            .expect("an unpaired private key is diagnosed");
+
+        assert!(
+            explanation.contains("'c8y.profiles.staging.device.key_path'"),
+            "should name the profile's own setting: {explanation}"
+        );
+    }
+
+    /// Under basic auth the device sends no certificate of its own, so neither alert can be about
+    /// one, and the raw error is more honest than a guess
+    #[test]
+    fn does_not_blame_the_device_certificate_when_none_was_sent() {
+        let connection = ConnectionDetails {
+            client: None,
+            ..connection()
+        };
+
+        for description in [
+            AlertDescription::CertificateUnknown,
+            AlertDescription::HandshakeFailure,
+        ] {
+            assert_eq!(
+                diagnose_tls_error(&alert(description), &connection, false),
+                None,
+                "{description:?} should not be diagnosed without a client certificate"
+            );
+        }
+    }
+
+    #[test]
+    fn points_at_the_root_certificates_when_the_device_does_not_trust_cumulocity() {
         let err = std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             Error::InvalidCertificate(CertificateError::UnknownIssuer),
         );
 
-        let explanation =
-            diagnose_tls_error(&err, HOST, false).expect("an untrusted server is diagnosed");
+        let explanation = diagnose_tls_error(&err, &connection(), false)
+            .expect("an untrusted server is diagnosed");
 
-        assert!(explanation.contains("c8y.root_cert_path"), "{explanation}");
+        assert!(
+            explanation.contains(ROOT_CERT_PATH) && explanation.contains("'c8y.root_cert_path'"),
+            "should name the authorities in use and the setting that chose them: {explanation}"
+        );
+        assert!(
+            explanation.contains("tedge cert create"),
+            "should say the device's own certificate is not at fault: {explanation}"
+        );
     }
 
     #[test]
     fn leaves_an_unrecognised_error_to_be_reported_verbatim() {
         let err = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "connection refused");
 
-        assert_eq!(diagnose_tls_error(&err, HOST, false), None);
+        assert_eq!(diagnose_tls_error(&err, &connection(), false), None);
     }
 
     #[test]
@@ -660,7 +924,70 @@ mod test {
         assert_ne!(error_context(true), error_context(false));
     }
 
+    /// The certificate presented is the one the connection is configured with, which is not always
+    /// the one named by `device.cert_path`: reconnecting to validate a renewed certificate sends
+    /// the new one instead
+    #[test]
+    fn reads_the_certificate_from_the_authentication_config() {
+        let mqtt_auth_config = MqttAuthConfigCloudBroker {
+            ca_path: ROOT_CERT_PATH.into(),
+            client: Some(MqttAuthClientConfigCloudBroker {
+                cert_file: format!("{CERT_PATH}.new").into(),
+                private_key: PrivateKeyType::File(KEY_PATH.into()),
+            }),
+        };
+
+        let connection = ConnectionDetails::new(HOST, DEVICE_ID, None, &mqtt_auth_config);
+
+        let explanation = diagnose_tls_error(
+            &alert(AlertDescription::CertificateUnknown),
+            &connection,
+            false,
+        )
+        .expect("a rejected certificate is diagnosed");
+        assert!(
+            explanation.contains(&format!("{CERT_PATH}.new")),
+            "should name the certificate actually sent: {explanation}"
+        );
+    }
+
+    #[test]
+    fn qualifies_the_settings_with_the_profile_the_connection_uses() {
+        let profile: ProfileName = "staging".parse().unwrap();
+
+        let connection = ConnectionDetails::new(
+            HOST,
+            DEVICE_ID,
+            Some(&profile),
+            &MqttAuthConfigCloudBroker::default(),
+        );
+
+        assert_eq!(
+            connection.config_key("device.key_path"),
+            "c8y.profiles.staging.device.key_path"
+        );
+    }
+
     const HOST: &str = "example.cumulocity.com";
+    const DEVICE_ID: &str = "test-device";
+    const CERT_PATH: &str = "/etc/tedge/device-certs/tedge-certificate.pem";
+    const KEY_PATH: &str = "/etc/tedge/device-certs/tedge-private-key.pem";
+    const ROOT_CERT_PATH: &str = "/etc/ssl/certs";
+
+    /// A connection authenticated with a certificate and key held in files, as `tedge cert create`
+    /// leaves them
+    fn connection() -> ConnectionDetails {
+        ConnectionDetails {
+            host: HOST.into(),
+            device_id: DEVICE_ID.into(),
+            config_prefix: "c8y".into(),
+            root_cert_path: ROOT_CERT_PATH.into(),
+            client: Some(ClientCredentials {
+                cert_path: CERT_PATH.into(),
+                key: KeyLocation::File(KEY_PATH.into()),
+            }),
+        }
+    }
 
     /// The largest handshake flight `rustls` will buffer, as a guard against denial-of-service
     ///

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -405,8 +405,13 @@ impl ConnectCommand {
                         .clone_into(&mut client_config.cert_file)
                 }
 
-                create_device_with_direct_connection(_bridge_config, device_type, mqtt_auth_config)
-                    .await
+                create_device_with_direct_connection(
+                    _bridge_config,
+                    profile_name.as_deref(),
+                    device_type,
+                    mqtt_auth_config,
+                )
+                .await
             }
             #[cfg(feature = "aws")]
             Cloud::Aws(_) => Ok(()),
@@ -1090,6 +1095,7 @@ impl ConnectCommand {
                     let spinner = Spinner::start("Creating device in Cumulocity cloud");
                     let res = create_device_with_direct_connection(
                         bridge_config,
+                        profile_name.as_deref(),
                         &tedge_config.device.ty,
                         mqtt_auth_config,
                     )

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -1454,11 +1454,11 @@ Each cloud profile requires either a unique URL or unique device ID, so it corre
             let config = TEdgeConfig::load(ttd.path()).await.unwrap();
 
             let err = validate_config(&config, &cloud).unwrap_err();
-            pretty_assertions::assert_eq!(err.to_string(), format!("You have matching URLs and device IDs for different profiles.
+            pretty_assertions::assert_eq!(err.to_string(), "You have matching URLs and device IDs for different profiles.
 
 c8y.url, c8y.profiles.new.url are set to the same value, but so are c8y.device.id, c8y.profiles.new.device.id.
 
-Each cloud profile requires either a unique URL or unique device ID, so it corresponds to a unique device in the associated cloud."))
+Each cloud profile requires either a unique URL or unique device ID, so it corresponds to a unique device in the associated cloud.")
         }
 
         #[tokio::test]
@@ -1476,11 +1476,11 @@ Each cloud profile requires either a unique URL or unique device ID, so it corre
             let config = TEdgeConfig::load(ttd.path()).await.unwrap();
 
             let err = validate_config(&config, &cloud).unwrap_err();
-            pretty_assertions::assert_eq!(err.to_string(), format!("You have matching URLs and device IDs for different profiles.
+            pretty_assertions::assert_eq!(err.to_string(), "You have matching URLs and device IDs for different profiles.
 
 c8y.url, c8y.profiles.new.url are set to the same value, but so are c8y.device.id, c8y.profiles.new.device.id.
 
-Each cloud profile requires either a unique URL or unique device ID, so it corresponds to a unique device in the associated cloud."))
+Each cloud profile requires either a unique URL or unique device ID, so it corresponds to a unique device in the associated cloud.")
         }
 
         #[tokio::test]

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -389,7 +389,7 @@ impl ConnectCommand {
         &self,
         tedge_config: &TEdgeConfig,
         _bridge_config: &BridgeConfig,
-        _certificate_shift: &CertificateShift,
+        certificate_shift: &CertificateShift,
     ) -> anyhow::Result<()> {
         match &self.cloud {
             #[cfg(feature = "c8y")]
@@ -399,14 +399,17 @@ impl ConnectCommand {
                     tedge_config.mapper_config::<C8yMapperSpecificConfig>(profile_name)?;
                 let mut mqtt_auth_config =
                     tedge_config.mqtt_auth_config_cloud_broker(&c8y_config)?;
-                if let Some(client_config) = mqtt_auth_config.client.as_mut() {
-                    _certificate_shift
-                        .new_cert_path
-                        .clone_into(&mut client_config.cert_file)
-                }
+                certificate_shift
+                    .new_cert_path
+                    .clone_into(&mut mqtt_auth_config.client.cert_file);
 
-                create_device_with_direct_connection(_bridge_config, device_type, mqtt_auth_config)
-                    .await
+                create_device_with_direct_connection(
+                    _bridge_config,
+                    profile_name.as_deref(),
+                    device_type,
+                    mqtt_auth_config,
+                )
+                .await
             }
             #[cfg(feature = "aws")]
             Cloud::Aws(_) => Ok(()),
@@ -1090,6 +1093,7 @@ impl ConnectCommand {
                     let spinner = Spinner::start("Creating device in Cumulocity cloud");
                     let res = create_device_with_direct_connection(
                         bridge_config,
+                        profile_name.as_deref(),
                         &tedge_config.device.ty,
                         mqtt_auth_config,
                     )
@@ -1454,11 +1458,11 @@ Each cloud profile requires either a unique URL or unique device ID, so it corre
             let config = TEdgeConfig::load(ttd.path()).await.unwrap();
 
             let err = validate_config(&config, &cloud).unwrap_err();
-            pretty_assertions::assert_eq!(err.to_string(), format!("You have matching URLs and device IDs for different profiles.
+            pretty_assertions::assert_eq!(err.to_string(), "You have matching URLs and device IDs for different profiles.
 
 c8y.url, c8y.profiles.new.url are set to the same value, but so are c8y.device.id, c8y.profiles.new.device.id.
 
-Each cloud profile requires either a unique URL or unique device ID, so it corresponds to a unique device in the associated cloud."))
+Each cloud profile requires either a unique URL or unique device ID, so it corresponds to a unique device in the associated cloud.")
         }
 
         #[tokio::test]
@@ -1476,11 +1480,11 @@ Each cloud profile requires either a unique URL or unique device ID, so it corre
             let config = TEdgeConfig::load(ttd.path()).await.unwrap();
 
             let err = validate_config(&config, &cloud).unwrap_err();
-            pretty_assertions::assert_eq!(err.to_string(), format!("You have matching URLs and device IDs for different profiles.
+            pretty_assertions::assert_eq!(err.to_string(), "You have matching URLs and device IDs for different profiles.
 
 c8y.url, c8y.profiles.new.url are set to the same value, but so are c8y.device.id, c8y.profiles.new.device.id.
 
-Each cloud profile requires either a unique URL or unique device ID, so it corresponds to a unique device in the associated cloud."))
+Each cloud profile requires either a unique URL or unique device ID, so it corresponds to a unique device in the associated cloud.")
         }
 
         #[tokio::test]

--- a/crates/core/tedge_mapper/src/custom/mapper.rs
+++ b/crates/core/tedge_mapper/src/custom/mapper.rs
@@ -221,10 +221,10 @@ pub async fn build_cloud_mqtt_options(
             if tls_enabled {
                 let tls_config = MqttAuthConfigCloudBroker {
                     ca_path: ca_path.clone(),
-                    client: Some(MqttAuthClientConfigCloudBroker {
+                    client: MqttAuthClientConfigCloudBroker {
                         cert_file: cert_path.clone(),
                         private_key: PrivateKeyType::File(key_path.clone()),
-                    }),
+                    },
                 }
                 .to_rustls_client_config()
                 .context("Failed to create MQTT TLS config")?;

--- a/tests/RobotFramework/tests/tedge_connect/oversized_handshake_server.sh
+++ b/tests/RobotFramework/tests/tedge_connect/oversized_handshake_server.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Serves a TLS handshake that is too large for rustls to buffer, standing in for a
+# Cumulocity instance that answers with an over-long CertificateRequest.
+#
+# This is not a TLS implementation. rustls enforces its 64 KB handshake limit while
+# buffering, before parsing or validating anything, so a socket that writes one
+# well-framed but over-large handshake message is enough. No key or certificate is
+# needed, and no ServerHello.
+#
+# Which of rustls' two limits is hit depends on the size the message declares:
+#
+#   buffer-full  declares 65534 bytes, within the limit, but the framing overhead means
+#                the buffer fills before the message completes, giving the io::Error
+#                "message buffer full"
+#   too-large    declares 65536 bytes, over the limit on its own, giving the
+#                rustls::Error HandshakePayloadTooLarge
+#
+# Usage: oversized_handshake_server.sh [buffer-full|too-large] [port]
+set -eu
+
+MODE="${1:-buffer-full}"
+PORT="${2:-18883}"
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# Every byte below is written with `printf '%b'`, which expands escapes in its argument
+# rather than in the format string. That takes `echo`-style octal, meaning `\0` followed
+# by up to three octal digits
+case "$MODE" in
+    buffer-full)
+        # A handshake message length is 3 bytes wide: 0x00 0xff 0xfe
+        DECLARED_BYTES='\0000\0377\0376'
+        DECLARED=65534
+        ;;
+    too-large)
+        # 0x01 0x00 0x00
+        DECLARED_BYTES='\0001\0000\0000'
+        DECLARED=65536
+        ;;
+    *)
+        echo "unknown mode: $MODE" >&2
+        exit 2
+        ;;
+esac
+
+CERTIFICATE_MESSAGE='\0013'
+HANDSHAKE_RECORD='\0026'
+TLS_1_2_VERSION='\0003\0003'
+MAX_RECORD_PAYLOAD=16384
+
+# The message itself: a Certificate handshake message whose payload is zeroes. An
+# incomplete message is never parsed, and one rustls refuses outright is not parsed
+# either, so the contents do not matter
+{
+    printf '%b' "$CERTIFICATE_MESSAGE$DECLARED_BYTES"
+    head -c "$DECLARED" /dev/zero
+} > "$WORKDIR/message"
+
+# Fragment it across TLS records, each carrying at most MAX_RECORD_PAYLOAD bytes
+total=$(wc -c < "$WORKDIR/message")
+offset=0
+while [ "$offset" -lt "$total" ]; do
+    remaining=$((total - offset))
+    if [ "$remaining" -gt "$MAX_RECORD_PAYLOAD" ]; then
+        chunk=$MAX_RECORD_PAYLOAD
+    else
+        chunk=$remaining
+    fi
+
+    # A record length is 2 bytes wide, big endian
+    high=$(printf '%03o' $((chunk / 256)))
+    low=$(printf '%03o' $((chunk % 256)))
+    printf '%b' "$HANDSHAKE_RECORD$TLS_1_2_VERSION\\0$high\\0$low"
+    tail -c "+$((offset + 1))" "$WORKDIR/message" | head -c "$chunk"
+
+    offset=$((offset + chunk))
+done > "$WORKDIR/flight"
+
+echo "serving $(wc -c < "$WORKDIR/flight") bytes on port $PORT, declaring $DECLARED" >&2
+
+# One connection per client, and keep listening: `tedge connect` may reconnect. Leaving
+# the connection open until the client closes it means the client reports the handshake
+# rather than an unexpected end of file
+while true; do
+    nc -l "$PORT" < "$WORKDIR/flight" || true
+done

--- a/tests/RobotFramework/tests/tedge_connect/tedge_connect_oversized_handshake.robot
+++ b/tests/RobotFramework/tests/tedge_connect/tedge_connect_oversized_handshake.robot
@@ -1,0 +1,69 @@
+*** Settings ***
+Documentation       `tedge connect c8y` should explain a TLS handshake that is too large for rustls
+...                 to buffer, and say that it is Cumulocity's to fix rather than the device's.
+...                 A local socket stands in for the broker: rustls enforces the limit while
+...                 buffering, so no certificate or ServerHello is needed to provoke the failure.
+
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+
+Suite Setup         Custom Setup
+Suite Teardown      Get Suite Logs
+
+Test Tags           theme:c8y    theme:tls    adapter:docker
+
+
+*** Variables ***
+${SERVER_PORT}      18883
+
+
+*** Test Cases ***
+Explains a handshake that fills the buffer before completing
+    ${stderr}=    Connect To Oversized Handshake Server    buffer-full
+    Should Contain    ${stderr}    too large for thin-edge.io to accept
+    Should Contain    ${stderr}    Cumulocity support
+    Should Contain    ${stderr}    localhost
+
+Explains a handshake message that announces more than the limit
+    ${stderr}=    Connect To Oversized Handshake Server    too-large
+    Should Contain    ${stderr}    too large for thin-edge.io to accept
+    Should Contain    ${stderr}    Cumulocity support
+
+Does not suggest the certificates or the configuration are at fault
+    ${stderr}=    Connect To Oversized Handshake Server    buffer-full
+    Should Not Contain    ${stderr}    tedge cert upload
+    Should Not Contain    ${stderr}    device.key_path
+    Should Not Contain    ${stderr}    c8y.root_cert_path
+
+
+*** Keywords ***
+Custom Setup
+    # The device needs a certificate to offer, but must not be connected: the address is
+    # about to be pointed at the local socket instead of the tenant
+    ${DEVICE_SN}=    Setup    connect=${False}
+    Set Suite Variable    $DEVICE_SN
+
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/oversized_handshake_server.sh    /usr/bin/
+    Execute Command    sudo chmod +x /usr/bin/oversized_handshake_server.sh
+    Execute Command    sudo tedge config set c8y.mqtt localhost:${SERVER_PORT}
+
+Connect To Oversized Handshake Server
+    [Arguments]    ${mode}
+    Start Oversized Handshake Server    ${mode}
+    ${stderr}=    Execute Command    sudo tedge connect c8y
+    ...    exp_exit_code=!0    stdout=${False}    stderr=${True}    timeout=120
+    [Teardown]    Stop Oversized Handshake Server
+    RETURN    ${stderr}
+
+Start Oversized Handshake Server
+    [Arguments]    ${mode}
+    Execute Command
+    ...    nohup oversized_handshake_server.sh ${mode} ${SERVER_PORT} >/tmp/handshake-server.log 2>&1 &
+    Wait Until Keyword Succeeds    10x    1s    Server Should Be Listening
+
+Server Should Be Listening
+    Execute Command    netstat -ltn | grep ':${SERVER_PORT} '
+
+Stop Oversized Handshake Server
+    Execute Command    pkill -f oversized_handshake_server.sh    ignore_exit_code=${True}
+    Execute Command    pkill -f 'nc -l ${SERVER_PORT}'    ignore_exit_code=${True}

--- a/tests/RobotFramework/tests/tedge_connect/tedge_connect_oversized_handshake.robot
+++ b/tests/RobotFramework/tests/tedge_connect/tedge_connect_oversized_handshake.robot
@@ -1,0 +1,70 @@
+*** Settings ***
+Documentation       `tedge connect c8y` should explain a TLS handshake that is too large for rustls
+...                 to buffer, and say that it is Cumulocity's to fix rather than the device's.
+...                 A local socket stands in for the broker: rustls enforces the limit while
+...                 buffering, so no certificate or ServerHello is needed to provoke the failure.
+
+Resource            ../../resources/common.resource
+Library             ThinEdgeIO
+
+Suite Setup         Custom Setup
+Suite Teardown      Get Suite Logs
+
+Test Tags           theme:c8y    theme:tls    adapter:docker
+
+
+*** Variables ***
+${SERVER_PORT}      18883
+
+
+*** Test Cases ***
+Explains a handshake that fills the buffer before completing
+    ${stderr}=    Connect To Oversized Handshake Server    buffer-full
+    Should Contain    ${stderr}    larger than the 64 KB thin-edge.io can accept
+    Should Contain    ${stderr}    certificate_authorities
+    Should Contain    ${stderr}    Cumulocity support
+    Should Contain    ${stderr}    localhost
+
+Explains a handshake message that announces more than the limit
+    ${stderr}=    Connect To Oversized Handshake Server    too-large
+    Should Contain    ${stderr}    larger than the 64 KB thin-edge.io can accept
+    Should Contain    ${stderr}    Cumulocity support
+
+Does not suggest the certificates or the configuration are at fault
+    ${stderr}=    Connect To Oversized Handshake Server    buffer-full
+    Should Not Contain    ${stderr}    tedge cert upload
+    Should Not Contain    ${stderr}    device.key_path
+    Should Not Contain    ${stderr}    c8y.root_cert_path
+
+
+*** Keywords ***
+Custom Setup
+    # The device needs a certificate to offer, but must not be connected: the address is
+    # about to be pointed at the local socket instead of the tenant
+    ${DEVICE_SN}=    Setup    connect=${False}
+    Set Suite Variable    $DEVICE_SN
+
+    ThinEdgeIO.Transfer To Device    ${CURDIR}/oversized_handshake_server.sh    /usr/bin/
+    Execute Command    sudo chmod +x /usr/bin/oversized_handshake_server.sh
+    Execute Command    sudo tedge config set c8y.mqtt localhost:${SERVER_PORT}
+
+Connect To Oversized Handshake Server
+    [Arguments]    ${mode}
+    Start Oversized Handshake Server    ${mode}
+    ${stderr}=    Execute Command    sudo tedge connect c8y
+    ...    exp_exit_code=!0    stdout=${False}    stderr=${True}    timeout=120
+    [Teardown]    Stop Oversized Handshake Server
+    RETURN    ${stderr}
+
+Start Oversized Handshake Server
+    [Arguments]    ${mode}
+    Execute Command
+    ...    nohup oversized_handshake_server.sh ${mode} ${SERVER_PORT} >/tmp/handshake-server.log 2>&1 &
+    Wait Until Keyword Succeeds    10x    1s    Server Should Be Listening
+
+Server Should Be Listening
+    Execute Command    netstat -ltn | grep ':${SERVER_PORT} '
+
+Stop Oversized Handshake Server
+    Execute Command    pkill -f oversized_handshake_server.sh    ignore_exit_code=${True}
+    Execute Command    pkill -f 'nc -l ${SERVER_PORT}'    ignore_exit_code=${True}


### PR DESCRIPTION
## Proposed changes
Improves the error messages when we encounter TLS errors connecting to Cumulocity, as the latest reported issue simply had an error message of "message buffer full". The aim is to give as much information as we possibly can, so the user can identify a Cumulocity platform issue and not require us to diagnose it as such for them. The `"message buffer full"` error (AFAICT) not meant to be exposed to users and is an edge-case where it fails to report the intended error type `HandshakePayloadTooLarge`. I've created a ticket for that on rustls: https://github.com/rustls/rustls/issues/3176.

The changes here only affect `tedge connect c8y`, not the bridge or anything else that might encounter issues communicating with Cumulocity. We could try adding similar logic to the bridge and/or `tedge connect --test`, where we could check for the problem if the connection is broken (and we therefore have nothing to lose by trying a direct connection and checking there's at least a valid TLS handshake).

error message before (handshake message 65534 bytes):
```
$ tedge connect c8y
[...]
Creating device in Cumulocity cloud... ✗
error: Connection error while creating device in Cumulocity: message buffer full
```

error message before (handshake message 65536 bytes)
```
$ tedge connect c8y
[...]
Creating device in Cumulocity cloud... ✗
error: Connection error while creating device in Cumulocity: received corrupt message of type HandshakePayloadTooLarge
```

error message after (same for both):
```
$ tedge connect c8y
[...]
Creating device in Cumulocity cloud... ✗
error: Cumulocity sent a TLS handshake that is too large for thin-edge.io to accept (over 64 KB).
The likely cause is the server listing the client certificates it will accept, which it should not be sending.
Whatever the cause, this is not something that can be fixed on this device. Please report it to Cumulocity support, quoting the host localhost.
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

