### PR TITLE
fix: Retry on a more precise set of HTTP status codes

### DIFF
--- a/crates/common/certificate/src/cloud_root_certificate/http_client.rs
+++ b/crates/common/certificate/src/cloud_root_certificate/http_client.rs
@@ -8,6 +8,7 @@
 //! allowing components to opt-out or opt-in to other config options.
 
 use reqwest::Identity;
+use reqwest::StatusCode;
 
 use super::CloudHttpConfig;
 
@@ -68,6 +69,19 @@ impl HttpClientBuilder {
         };
         builder.build()
     }
+}
+
+pub fn is_status_retryable(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::REQUEST_TIMEOUT
+            | StatusCode::TOO_EARLY
+            | StatusCode::TOO_MANY_REQUESTS
+            | StatusCode::INTERNAL_SERVER_ERROR
+            | StatusCode::BAD_GATEWAY
+            | StatusCode::SERVICE_UNAVAILABLE
+            | StatusCode::GATEWAY_TIMEOUT
+    )
 }
 
 #[cfg(test)]

--- a/crates/common/download/src/download.rs
+++ b/crates/common/download/src/download.rs
@@ -5,6 +5,7 @@ use crate::error::ErrContext;
 use anyhow::anyhow;
 use backoff::future::retry_notify;
 use backoff::ExponentialBackoff;
+use certificate::http_client;
 use certificate::CloudHttpConfig;
 use http::StatusCode;
 use nix::sys::statvfs;
@@ -355,12 +356,15 @@ impl Downloader {
                 .send()
                 .await
                 .and_then(|response| {
-                    if response.status() != StatusCode::RANGE_NOT_SATISFIABLE {
-                        response.error_for_status()
-                    } else {
-                        // if range not satisfiable, request should be retried with different range
-                        // (or without)
+                    if response.status() == StatusCode::RANGE_NOT_SATISFIABLE && range_start != 0 {
+                        // if we did request a range, but the server says it's not satisfiable, then
+                        // don't return an error so the caller can retry with a different range (or
+                        // without)
                         Ok(response)
+                    } else {
+                        // if other status code or this is the first request and server returns
+                        // RANGE_NOT_SATISFIABLE, then it shouldn't be retried
+                        response.error_for_status()
                     }
                 })
                 .map_err(reqwest_err_to_backoff)
@@ -380,7 +384,7 @@ fn reqwest_err_to_backoff(err: reqwest::Error) -> backoff::Error<reqwest::Error>
         return backoff::Error::transient(err);
     }
     if let Some(status) = err.status() {
-        if status.is_server_error() {
+        if http_client::is_status_retryable(status) {
             return backoff::Error::transient(err);
         }
     }

--- a/crates/common/download/src/download/partial_response.rs
+++ b/crates/common/download/src/download/partial_response.rs
@@ -43,8 +43,9 @@ pub(super) fn response_range_start(
             Ok(PartialResponse::PartialContent(pos))
         }
 
-        // Resource could've been modified such that range we requested is invalid (e.g. because new resource is
-        // smaller)
+        // Resource could've been modified such that range we requested is invalid (e.g. because new
+        // resource is smaller), unless this is the first request where we didn't even request a
+        // range, then the server shouldn't return this status code (then just return an error).
         StatusCode::RANGE_NOT_SATISFIABLE => Ok(PartialResponse::ResourceModified),
 
         // We don't expect to receive any other 200-299 status code, but if we

--- a/crates/common/download/src/download/tests.rs
+++ b/crates/common/download/src/download/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use axum::Router;
+use http::StatusCode;
 use hyper::header::AUTHORIZATION;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::PrivateKeyDer;
@@ -19,18 +20,8 @@ async fn downloader_has_user_agent() {
     let _mock1 = server
         .mock("GET", "/some_file.txt")
         .with_status(200)
-        // the downloader incorrectly tries to retry when it gets 501 Not Implemented status from
-        // mockito, so currently we can't use `.match_headers()` because match needs to succeed and
-        // return 200. So for now do the check in the assert in the body closure, can remove when
-        // downloader stops retrying for 501.
-        .with_body_from_request(|r| {
-            let user_agent = r.header("user-agent")[0];
-            assert_eq!(
-                user_agent.to_str().unwrap(),
-                certificate::http_client::USER_AGENT
-            );
-            b"hello".to_vec()
-        })
+        .match_header("user-agent", certificate::http_client::USER_AGENT)
+        .with_body(b"hello")
         .create_async()
         .await;
 
@@ -468,6 +459,100 @@ async fn downloader_error_shows_certificate_required_error_when_appropriate() {
     let err = anyhow::Error::new(err);
 
     assert!(dbg!(format!("{err:#}")).contains("received fatal alert: CertificateRequired"));
+}
+
+#[tokio::test]
+async fn should_retry_for_statuses() {
+    let retryable = [
+        StatusCode::REQUEST_TIMEOUT,
+        StatusCode::TOO_EARLY,
+        StatusCode::TOO_MANY_REQUESTS,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        StatusCode::BAD_GATEWAY,
+        StatusCode::SERVICE_UNAVAILABLE,
+        StatusCode::GATEWAY_TIMEOUT,
+    ];
+
+    let non_retryable = [
+        // 4xx
+        StatusCode::BAD_REQUEST,
+        StatusCode::UNAUTHORIZED,
+        StatusCode::PAYMENT_REQUIRED,
+        StatusCode::FORBIDDEN,
+        StatusCode::NOT_FOUND,
+        StatusCode::METHOD_NOT_ALLOWED,
+        StatusCode::NOT_ACCEPTABLE,
+        StatusCode::PROXY_AUTHENTICATION_REQUIRED,
+        StatusCode::CONFLICT,
+        StatusCode::GONE,
+        StatusCode::LENGTH_REQUIRED,
+        StatusCode::PRECONDITION_FAILED,
+        StatusCode::PAYLOAD_TOO_LARGE,
+        StatusCode::URI_TOO_LONG,
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        StatusCode::RANGE_NOT_SATISFIABLE,
+        StatusCode::EXPECTATION_FAILED,
+        StatusCode::IM_A_TEAPOT,
+        StatusCode::MISDIRECTED_REQUEST,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        StatusCode::LOCKED,
+        StatusCode::FAILED_DEPENDENCY,
+        StatusCode::UPGRADE_REQUIRED,
+        StatusCode::PRECONDITION_REQUIRED,
+        StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
+        StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS,
+        // 5xx
+        StatusCode::NOT_IMPLEMENTED,
+        StatusCode::HTTP_VERSION_NOT_SUPPORTED,
+        StatusCode::VARIANT_ALSO_NEGOTIATES,
+        StatusCode::INSUFFICIENT_STORAGE,
+        StatusCode::LOOP_DETECTED,
+        StatusCode::NOT_EXTENDED,
+        StatusCode::NETWORK_AUTHENTICATION_REQUIRED,
+    ];
+    let statuses = retryable.into_iter().chain(non_retryable);
+
+    let mut server = mockito::Server::new_async().await;
+    for status in statuses {
+        let mock = server
+            .mock("GET", format!("/{}", status.as_u16()).as_str())
+            .with_status(status.as_u16().into());
+        let mock = if retryable.contains(&status) {
+            mock.expect(2)
+        } else {
+            mock.expect(1)
+        };
+        let mock = mock.create_async().await;
+
+        let res = attempt_download(&server, format!("/{}", status.as_u16()).as_str()).await;
+        assert!(matches!(res, Err(DownloadError::Request(_))), "{res:?}");
+
+        mock.assert_async().await;
+    }
+}
+
+async fn attempt_download(
+    server: &mockito::ServerGuard,
+    resource: &str,
+) -> Result<(), DownloadError> {
+    let target_dir_path = TempDir::new().unwrap();
+    let target_path = target_dir_path.path().join("test_download");
+
+    let mut target_url = server.url();
+    target_url.push_str(resource);
+
+    let url = DownloadInfo::new(&target_url);
+
+    let mut downloader = Downloader::new(target_path, None, CloudHttpConfig::test_value());
+    // tweaked to exactly 1 retry
+    downloader.set_backoff(ExponentialBackoff {
+        initial_interval: Duration::from_millis(5),
+        multiplier: 10.0,
+        randomization_factor: f64::EPSILON,
+        max_elapsed_time: Some(Duration::from_millis(50)),
+        ..Default::default()
+    });
+    downloader.download(&url).await
 }
 
 fn create_file_with_size(size: usize) -> Result<NamedTempFile, anyhow::Error> {

--- a/crates/common/upload/src/upload.rs
+++ b/crates/common/upload/src/upload.rs
@@ -3,6 +3,7 @@ use backoff::future::retry_notify;
 use backoff::ExponentialBackoff;
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
+use certificate::http_client;
 use certificate::CloudHttpConfig;
 use mime::Mime;
 use mime_guess::MimeGuess;
@@ -11,12 +12,27 @@ use reqwest::header::CONTENT_TYPE;
 use reqwest::multipart;
 use reqwest::Body;
 use reqwest::Identity;
+use reqwest::StatusCode;
 use std::time::Duration;
 use tokio::fs::File;
 use tokio_util::codec::BytesCodec;
 use tokio_util::codec::FramedRead;
+use tracing::debug;
 use tracing::info;
 use tracing::warn;
+
+/// Path prefixes for which retry for status 500 is disabled. This is to avoid retrying for e.g.
+/// File Transfer Service, for which we currently test that on 500 we shouldn't retry.
+///
+/// The optimal solution would be for components interacting with the FTS to call a wrapper API
+/// which would handle the exceptions from the generic HTTP client, but for now we disable retry for
+/// these paths. This is not ideal because these paths could theoretically be used by some other,
+/// possibly remote services, but it's acceptable for now as a workaround.
+const DISABLED_500_RETRY_PATHS: [&str; 2] = ["/te/v1/files/", "/tedge/file-transfer/"];
+
+fn is_fts_path(path: &str) -> bool {
+    DISABLED_500_RETRY_PATHS.iter().any(|p| path.starts_with(p))
+}
 
 fn default_backoff() -> ExponentialBackoff {
     // Default retry is an exponential retry with a limit of 5 minutes total.
@@ -260,17 +276,24 @@ impl Uploader {
                     }
                 })?
                 .error_for_status()
-                .map_err(|err| match err.status() {
-                    // 4xx and 500/501 server-side errors are permanent and retrying won't help
-                    Some(status)
-                        if status.is_client_error()
-                            || status == reqwest::StatusCode::INTERNAL_SERVER_ERROR
-                            || status == reqwest::StatusCode::NOT_IMPLEMENTED =>
-                    {
-                        backoff::Error::Permanent(UploadError::Network(err))
+                .map_err(|err| {
+                    let path = err.url().map(|url| url.path()).unwrap_or_default();
+                    match err.status() {
+                        Some(StatusCode::INTERNAL_SERVER_ERROR) if is_fts_path(path) => {
+                            debug!(
+                                "Path '{path}' is in the list of paths for which retry for status 500 is disabled, so not retrying"
+                            );
+                            backoff::Error::permanent(UploadError::Network(err))
+                        }
+                        Some(status) => {
+                            if http_client::is_status_retryable(status) {
+                                backoff::Error::transient(UploadError::Network(err))
+                            } else {
+                                backoff::Error::permanent(UploadError::Network(err))
+                            }
+                        }
+                        _ => backoff::Error::transient(UploadError::Network(err)),
                     }
-                    // 502/503/504 are gateway/overload conditions that may resolve on retry.
-                    _ => backoff::Error::transient(UploadError::Network(err)),
                 })
         };
 
@@ -313,14 +336,8 @@ mod tests {
         let _mock1 = server
             .mock("PUT", "/some_file.txt")
             .with_status(201)
-            .with_body_from_request(|r| {
-                let user_agent = r.header("user-agent")[0];
-                assert_eq!(
-                    user_agent.to_str().unwrap(),
-                    certificate::http_client::USER_AGENT
-                );
-                b"hello".to_vec()
-            })
+            .match_header("user-agent", certificate::http_client::USER_AGENT)
+            .with_body("hello")
             .create();
 
         let mut target_url = server.url();
@@ -565,6 +582,120 @@ mod tests {
 
         assert_eq!(source_content.len(), target_content.len());
         assert_eq!(source_content, target_content);
+    }
+
+    #[tokio::test]
+    async fn should_retry_for_statuses() {
+        let retryable = [
+            StatusCode::REQUEST_TIMEOUT,
+            StatusCode::TOO_EARLY,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::BAD_GATEWAY,
+            StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::GATEWAY_TIMEOUT,
+        ];
+
+        let non_retryable = [
+            // 4xx
+            StatusCode::BAD_REQUEST,
+            StatusCode::UNAUTHORIZED,
+            StatusCode::PAYMENT_REQUIRED,
+            StatusCode::FORBIDDEN,
+            StatusCode::NOT_FOUND,
+            StatusCode::METHOD_NOT_ALLOWED,
+            StatusCode::NOT_ACCEPTABLE,
+            StatusCode::PROXY_AUTHENTICATION_REQUIRED,
+            StatusCode::CONFLICT,
+            StatusCode::GONE,
+            StatusCode::LENGTH_REQUIRED,
+            StatusCode::PRECONDITION_FAILED,
+            StatusCode::PAYLOAD_TOO_LARGE,
+            StatusCode::URI_TOO_LONG,
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            StatusCode::RANGE_NOT_SATISFIABLE,
+            StatusCode::EXPECTATION_FAILED,
+            StatusCode::IM_A_TEAPOT,
+            StatusCode::MISDIRECTED_REQUEST,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            StatusCode::LOCKED,
+            StatusCode::FAILED_DEPENDENCY,
+            StatusCode::UPGRADE_REQUIRED,
+            StatusCode::PRECONDITION_REQUIRED,
+            StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE,
+            StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS,
+            // 5xx
+            StatusCode::NOT_IMPLEMENTED,
+            StatusCode::HTTP_VERSION_NOT_SUPPORTED,
+            StatusCode::VARIANT_ALSO_NEGOTIATES,
+            StatusCode::INSUFFICIENT_STORAGE,
+            StatusCode::LOOP_DETECTED,
+            StatusCode::NOT_EXTENDED,
+            StatusCode::NETWORK_AUTHENTICATION_REQUIRED,
+        ];
+        let statuses = retryable.into_iter().chain(non_retryable);
+
+        let mut server = mockito::Server::new_async().await;
+        for status in statuses {
+            let mock = server
+                .mock("PUT", format!("/{}", status.as_u16()).as_str())
+                .with_status(status.as_u16().into());
+            let mock = if retryable.contains(&status) {
+                mock.expect(2)
+            } else {
+                mock.expect(1)
+            };
+            let mock = mock.create_async().await;
+
+            let res = attempt_upload(&server, format!("/{}", status.as_u16()).as_str()).await;
+            assert!(matches!(res, Err(UploadError::Network(_))), "{res:?}");
+
+            mock.assert_async().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn should_not_retry_for_fts_500() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("PUT", "/te/v1/files/test")
+            .with_status(500)
+            .expect(1)
+            .create_async()
+            .await;
+        let UploadError::Network(err) = attempt_upload(&server, "/te/v1/files/test")
+            .await
+            .unwrap_err()
+        else {
+            panic!("should be 500")
+        };
+        assert_eq!(err.status().unwrap(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    async fn attempt_upload(
+        server: &mockito::ServerGuard,
+        resource: &str,
+    ) -> Result<(), UploadError> {
+        let ttd = TempTedgeDir::new();
+        let file = ttd
+            .file("file_upload.txt")
+            .with_raw_content("Hello, world!");
+
+        let mut target_url = server.url();
+        target_url.push_str(resource);
+
+        let url = UploadInfo::new(&target_url).set_method(UploadMethod::PUT);
+
+        let mut uploader = Uploader::new(file.utf8_path_buf(), None, CloudHttpConfig::test_value());
+        // tweaked to exactly 1 retry
+        uploader.set_backoff(ExponentialBackoff {
+            initial_interval: Duration::from_millis(5),
+            multiplier: 10.0,
+            randomization_factor: f64::EPSILON,
+            max_elapsed_time: Some(Duration::from_millis(50)),
+            ..Default::default()
+        });
+        uploader.upload(&url).await
     }
 
     async fn write_to_file_with_size(file: &mut File, size: usize) {


### PR DESCRIPTION
## Proposed changes

Previously we treated all server errors (5xx) as retryable and client errors (4xx) as non-retryable, which was incorrect. Now, the downloader will retry when receiving these response status codes:

- 408 Request Timeout
- 425 Too Early
- 429 Too Many Requests (*)
- 500 Internal Server Error
- 502 Bad Gateway
- 503 Service Unavailable (*)
- 504 Gateway Timeout

For other status codes, request will not be retried.

For statuses marked (*) we could additionally respect the Retry-After header if it's in the response, but that currently isn't being done yet.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

