### PR TITLE
ci: set GITHUB_TOKEN env variable when installing tools to prevent Github rate limiting

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -135,6 +135,8 @@ jobs:
     name: Run format checks
     runs-on: ubuntu-24.04
     needs: changes
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     if: ${{ github.event_name == 'pull_request' }}
 
     steps:


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Some failures during CI runs were observed when installing Rust tools via `cargo-bininstall`. The most likely cause is running into Github rate limiting due to a token not being set (as cargo-bininstall uses Github API to detect versions and download links, see [docs](https://github.com/cargo-bins/cargo-binstall/blob/e00d2c94cc0067b77737821097a62d91c0301baa/HELP.md?plain=1#L175))


```
INFO has_release_artifact{release=GhRelease { repo: GhRepo { owner: "nextest-rs", repo: "nextest" }, tag: "cargo-nextest-0.9.140" } artifact_name="cargo-nextest-0.9.140-x86_64-unknown-linux-gnu.tar.gz"}:do_send_request{request=Request { method: GET, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("api.github.com")), port: None, path: "/repos/nextest-rs/nextest/releases/tags/cargo-nextest-0.9.140", query: None, fragment: None }, headers: {"accept": "application/vnd.github+json", "x-github-api-version": "2022-11-28"} } url=[https://api.github.com/repos/nextest-rs/nextest/releases/tags/cargo-nextest-0.9.140}:](https://api.github.com/repos/nextest-rs/nextest/releases/tags/cargo-nextest-0.9.140%7D:) Received status code 403 Forbidden, will wait for 120s and retry
 INFO has_release_artifact{release=GhRelease { repo: GhRepo { owner: "EmbarkStudios", repo: "cargo-deny" }, tag: "0.20.2" } artifact_name="cargo-deny-x86_64-unknown-linux-gnu-v0.20.2.tar"}:do_send_request{request=Request { method: GET, url: Url { scheme: "https", cannot_be_a_base: false, username: "", password: None, host: Some(Domain("api.github.com")), port: None, path: "/repos/EmbarkStudios/cargo-deny/releases/tags/0.20.2", query: None, fragment: None }, headers: {"accept": "application/vnd.github+json", "x-github-api-version": "2022-11-28"} } url=[https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/tags/0.20.2}:](https://api.github.com/repos/EmbarkStudios/cargo-deny/releases/tags/0.20.2%7D:) Received status code 403 Forbidden, will wait for 120s and retry
```

Examples of failed runs:

* https://github.com/thin-edge/thin-edge.io/actions/runs/30025999875/job/89270532564?pr=4243

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

