### PR TITLE
fix: announce c8y supported operations only after the built-in bridge is up

### DIFF
--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -9,6 +9,7 @@ use c8y_auth_proxy::actor::C8yAuthProxyBuilder;
 use c8y_mapper_ext::actor::C8yMapperBuilder;
 use c8y_mapper_ext::availability::AvailabilityBuilder;
 use c8y_mapper_ext::availability::AvailabilityConfig;
+use c8y_mapper_ext::bridge_readiness::BridgeMonitorBuilder;
 use c8y_mapper_ext::config::C8yMapperConfig;
 use c8y_mapper_ext::converter::CumulocityConverter;
 use mqtt_channel::Config;
@@ -97,6 +98,7 @@ impl TEdgeComponent for CumulocityMapper {
             self.profile.clone(),
         )?;
         let auth_method = auth_method(&c8y_config);
+        let mut bridge_subscribed = None;
         if tedge_config.mqtt.bridge.built_in {
             let (tc, cloud_config, reconnect_message_mapper) = mqtt_bridge_config(
                 &tedge_config,
@@ -107,20 +109,18 @@ impl TEdgeComponent for CumulocityMapper {
                 auth_method,
             )
             .await?;
-            runtime
-                .spawn(
-                    MqttBridgeActorBuilder::new(
-                        &tedge_config,
-                        &c8y_mapper_config.bridge_service_name,
-                        &c8y_mapper_config.bridge_health_topic,
-                        tc,
-                        cloud_config,
-                        Some(reconnect_message_mapper),
-                        c8y_config.mapper.mqtt.max_payload_size.0 as usize,
-                    )
-                    .await,
-                )
-                .await?;
+            let bridge_builder = MqttBridgeActorBuilder::new(
+                &tedge_config,
+                &c8y_mapper_config.bridge_service_name,
+                &c8y_mapper_config.bridge_health_topic,
+                tc,
+                cloud_config,
+                Some(reconnect_message_mapper),
+                c8y_config.mapper.mqtt.max_payload_size.0 as usize,
+            )
+            .await;
+            bridge_subscribed = Some(bridge_builder.local_subscriptions_ready());
+            runtime.spawn(bridge_builder).await?;
         } else if tedge_config.proxy.address.or_none().is_some() {
             warn!("`proxy.address` is configured without the built-in bridge enabled. The bridge MQTT connection to the cloud will {} communicate via the configured proxy.", "not".bold())
         }
@@ -149,6 +149,17 @@ impl TEdgeComponent for CumulocityMapper {
             &c8y_config,
         )?);
 
+        // Holds back the connection shared by the actors below until the bridge can relay what
+        // they publish to the cloud topics. See the bridge_readiness module.
+        let bridge_monitor = match bridge_subscribed {
+            Some(subscribed) => BridgeMonitorBuilder::built_in(subscribed, &mut mqtt_actor),
+            None => BridgeMonitorBuilder::in_broker(
+                &mut service_monitor_actor,
+                &c8y_mapper_config,
+                &mut mqtt_actor,
+            ),
+        };
+
         C8yMapperBuilder::init(&c8y_mapper_config).await?;
         let mut c8y_mapper_actor = C8yMapperBuilder::try_new(
             c8y_mapper_config,
@@ -157,7 +168,6 @@ impl TEdgeComponent for CumulocityMapper {
             &mut uploader_actor,
             &mut downloader_actor,
             &mut fs_watch_actor,
-            &mut service_monitor_actor,
         )?;
 
         let availability_actor = if c8y_config.cloud_specific.availability.enable {
@@ -181,6 +191,7 @@ impl TEdgeComponent for CumulocityMapper {
         flows_mapper.connect_cmd(&mut cmd_watcher_actor);
         c8y_mapper_actor.set_flow_context(flows_mapper.context_handle());
 
+        runtime.spawn(bridge_monitor).await?;
         runtime.spawn(flows_mapper).await?;
         runtime.spawn(cmd_watcher_actor).await?;
         runtime.spawn(mqtt_actor).await?;

--- a/crates/extensions/c8y_mapper_ext/src/actor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/actor.rs
@@ -2,7 +2,6 @@ use super::config::C8yMapperConfig;
 use super::converter::CumulocityConverter;
 use super::dynamic_discovery::process_inotify_events;
 use crate::entity_cache::UpdateOutcome;
-use crate::service_monitor::is_c8y_bridge_established;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use c8y_http_proxy::handle::C8YHttpProxy;
@@ -58,7 +57,6 @@ pub struct C8yMapperActor {
     converter: CumulocityConverter,
     messages: SimpleMessageBox<C8yMapperInput, C8yMapperOutput>,
     mqtt_publisher: LoggingSender<MqttMessage>,
-    bridge_status_messages: SimpleMessageBox<MqttMessage, MqttMessage>,
     message_handlers: HashMap<ChannelFilter, Vec<LoggingSender<MqttMessage>>>,
 }
 
@@ -69,19 +67,9 @@ impl Actor for C8yMapperActor {
     }
 
     async fn run(mut self) -> Result<(), RuntimeError> {
-        if !self.converter.config.bridge_in_mapper {
-            // Wait till the c8y bridge is established
-            while let Some(message) = self.bridge_status_messages.recv().await {
-                if is_c8y_bridge_established(
-                    &message,
-                    &self.converter.config.mqtt_schema,
-                    &self.converter.config.bridge_health_topic,
-                ) {
-                    break;
-                }
-            }
-        }
-
+        // Nothing published here reaches the cloud before the bridge can relay it: the mapper shares
+        // its connection to the broker with the other actors of this process, and that connection is
+        // not opened until then. See the bridge_readiness module.
         let init_messages = self.converter.init_messages();
         for init_message in init_messages.into_iter() {
             self.mqtt_publisher.send(init_message).await?;
@@ -106,14 +94,12 @@ impl C8yMapperActor {
         converter: CumulocityConverter,
         messages: SimpleMessageBox<C8yMapperInput, C8yMapperOutput>,
         mqtt_publisher: LoggingSender<MqttMessage>,
-        bridge_status_messages: SimpleMessageBox<MqttMessage, MqttMessage>,
         message_handlers: HashMap<ChannelFilter, Vec<LoggingSender<MqttMessage>>>,
     ) -> Self {
         Self {
             converter,
             messages,
             mqtt_publisher,
-            bridge_status_messages,
             message_handlers,
         }
     }
@@ -343,7 +329,6 @@ pub struct C8yMapperBuilder {
     http_client: ClientMessageBox<HttpRequest, HttpResult>,
     downloader: ClientMessageBox<IdDownloadRequest, IdDownloadResult>,
     uploader: ClientMessageBox<IdUploadRequest, IdUploadResult>,
-    bridge_monitor_builder: SimpleMessageBoxBuilder<MqttMessage, MqttMessage>,
     message_handlers: HashMap<ChannelFilter, Vec<LoggingSender<MqttMessage>>>,
     flow_context: Option<FlowContextHandle>,
 }
@@ -357,7 +342,6 @@ impl C8yMapperBuilder {
         uploader: &mut impl Service<IdUploadRequest, IdUploadResult>,
         downloader: &mut impl Service<IdDownloadRequest, IdDownloadResult>,
         fs_watcher: &mut impl MessageSource<FsWatchEvent, PathBuf>,
-        service_monitor: &mut (impl MessageSource<MqttMessage, TopicFilter> + MessageSink<MqttMessage>),
     ) -> Result<Self, FileError> {
         let box_builder: SimpleMessageBoxBuilder<C8yMapperInput, C8yMapperOutput> =
             SimpleMessageBoxBuilder::new("CumulocityMapper", 16);
@@ -376,14 +360,6 @@ impl C8yMapperBuilder {
             &box_builder.get_sender(),
         );
 
-        let bridge_monitor_builder: SimpleMessageBoxBuilder<MqttMessage, MqttMessage> =
-            SimpleMessageBoxBuilder::new("ServiceMonitor", 1);
-
-        service_monitor.connect_sink(
-            config.bridge_health_topic.clone().into(),
-            &bridge_monitor_builder,
-        );
-
         let message_handlers = HashMap::new();
 
         Ok(Self {
@@ -394,7 +370,6 @@ impl C8yMapperBuilder {
             http_client,
             uploader,
             downloader,
-            bridge_monitor_builder,
             message_handlers,
             flow_context: None,
         })
@@ -453,13 +428,11 @@ impl Builder<C8yMapperActor> for C8yMapperBuilder {
         .map_err(|err| RuntimeError::ActorError(Box::new(err)))?;
 
         let message_box = self.box_builder.build();
-        let bridge_monitor_box = self.bridge_monitor_builder.build();
 
         Ok(C8yMapperActor::new(
             converter,
             message_box,
             mqtt_publisher,
-            bridge_monitor_box,
             self.message_handlers,
         ))
     }

--- a/crates/extensions/c8y_mapper_ext/src/actor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/actor.rs
@@ -3,6 +3,7 @@ use super::converter::CumulocityConverter;
 use super::dynamic_discovery::process_inotify_events;
 use crate::entity_cache::UpdateOutcome;
 use crate::service_monitor::is_c8y_bridge_established;
+use crate::service_monitor::is_c8y_bridge_up;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use c8y_http_proxy::handle::C8YHttpProxy;
@@ -69,8 +70,44 @@ impl Actor for C8yMapperActor {
     }
 
     async fn run(mut self) -> Result<(), RuntimeError> {
-        if !self.converter.config.bridge_in_mapper {
-            // Wait till the c8y bridge is established
+        if self.converter.config.bridge_in_mapper {
+            // With the built-in bridge, the mapper and the bridge start together. Keep
+            // processing the main loop immediately (so local/offline handling is not
+            // blocked on the cloud connection), but defer the init messages until the
+            // bridge is first up. Publishing the supported operations (`114`) earlier
+            // races with the bridge subscribing locally: on a fresh session such an early
+            // publish to `c8y/s/us` is dropped before the bridge subscribes, so the
+            // operations would never reach the cloud. Waiting for the bridge to be up
+            // guarantees the local subscription is in place and sends them exactly once.
+            let mut init_sent = false;
+            loop {
+                tokio::select! {
+                    // Only watch the bridge status until the init messages are sent
+                    status = self.bridge_status_messages.recv(), if !init_sent => {
+                        match status {
+                            Some(message) if is_c8y_bridge_up(
+                                &message,
+                                &self.converter.config.mqtt_schema,
+                                &self.converter.config.bridge_health_topic,
+                            ) => {
+                                self.publish_init_messages().await?;
+                                init_sent = true;
+                            }
+                            // A non-`up` status (e.g. `down`): keep waiting for `up`
+                            Some(_) => {}
+                            // The status channel is closed: stop watching it
+                            None => init_sent = true,
+                        }
+                    }
+                    event = self.messages.recv() => {
+                        let Some(event) = event else { break };
+                        self.process_input(event).await?;
+                    }
+                }
+            }
+        } else {
+            // With an external bridge, wait till it is established before announcing
+            // anything, then process the main loop.
             while let Some(message) = self.bridge_status_messages.recv().await {
                 if is_c8y_bridge_established(
                     &message,
@@ -80,21 +117,11 @@ impl Actor for C8yMapperActor {
                     break;
                 }
             }
-        }
 
-        let init_messages = self.converter.init_messages();
-        for init_message in init_messages.into_iter() {
-            self.mqtt_publisher.send(init_message).await?;
-        }
+            self.publish_init_messages().await?;
 
-        while let Some(event) = self.messages.recv().await {
-            match event {
-                C8yMapperInput::MqttMessage(message) => {
-                    self.process_mqtt_message(message).await?;
-                }
-                C8yMapperInput::FsWatchEvent(event) => {
-                    self.process_file_watch_event(event).await?;
-                }
+            while let Some(event) = self.messages.recv().await {
+                self.process_input(event).await?;
             }
         }
         Ok(())
@@ -116,6 +143,29 @@ impl C8yMapperActor {
             bridge_status_messages,
             message_handlers,
         }
+    }
+
+    /// Publish the messages the mapper emits once, on startup (or, for the built-in
+    /// bridge, once the bridge is up): the supported operations and a request for any
+    /// pending operations.
+    async fn publish_init_messages(&mut self) -> Result<(), RuntimeError> {
+        let init_messages = self.converter.init_messages();
+        for init_message in init_messages.into_iter() {
+            self.mqtt_publisher.send(init_message).await?;
+        }
+        Ok(())
+    }
+
+    async fn process_input(&mut self, event: C8yMapperInput) -> Result<(), RuntimeError> {
+        match event {
+            C8yMapperInput::MqttMessage(message) => {
+                self.process_mqtt_message(message).await?;
+            }
+            C8yMapperInput::FsWatchEvent(event) => {
+                self.process_file_watch_event(event).await?;
+            }
+        }
+        Ok(())
     }
 
     /// Processing an incoming message involves the following steps, if the message follows MQTT topic scheme v1:

--- a/crates/extensions/c8y_mapper_ext/src/bridge_readiness.rs
+++ b/crates/extensions/c8y_mapper_ext/src/bridge_readiness.rs
@@ -1,0 +1,390 @@
+//! Tracks whether the bridge to the cloud can relay the messages published to it
+//!
+//! On a fresh session the bridge holds no subscription on the local broker, so anything published
+//! to the cloud topics before it does is discarded rather than forwarded. The mapper holds back its
+//! own connection to the broker until then, so that no actor sharing it publishes too early.
+//!
+//! The bridge either runs in this process, where it signals directly once it holds the
+//! subscriptions it relays, or runs in the broker, where the only sign of it is the health message
+//! it publishes. Either way the wait happens once, not on every reconnection: the bridge keeps its
+//! session on the local broker, so from then on the broker queues what it cannot deliver instead of
+//! discarding it.
+
+use crate::config::C8yMapperConfig;
+use crate::service_monitor::is_c8y_bridge_established;
+use async_trait::async_trait;
+use std::convert::Infallible;
+use std::time::Duration;
+use tedge_actors::Actor;
+use tedge_actors::Builder;
+use tedge_actors::DynSender;
+use tedge_actors::MessageReceiver;
+use tedge_actors::MessageSink;
+use tedge_actors::MessageSource;
+use tedge_actors::RuntimeError;
+use tedge_actors::RuntimeRequest;
+use tedge_actors::RuntimeRequestSink;
+use tedge_actors::SimpleMessageBox;
+use tedge_actors::SimpleMessageBoxBuilder;
+use tedge_api::mqtt_topics::MqttSchema;
+use tedge_mqtt_ext::GateConnection;
+use tedge_mqtt_ext::MqttMessage;
+use tedge_mqtt_ext::Topic;
+use tedge_mqtt_ext::TopicFilter;
+use tokio::sync::watch;
+
+/// Bounds how long the mapper holds back its connection to the broker waiting for the bridge
+///
+/// The bridge is expected to come up long before this timeout, but if the mapper waits indefinitely
+/// for a broken bridge to start, it will be very difficult for a user to understand why the mapper
+/// is not publishing anything to the cloud. Therefore, we bound the wait, and start the mapper with
+/// a warning if the bridge was not seen in time.
+pub const MAX_BRIDGE_WAIT: Duration = Duration::from_secs(30);
+
+/// Watches the bridge on behalf of the actors publishing cloud-bound messages of their own
+pub struct BridgeMonitorBuilder {
+    source: BridgeSource,
+
+    /// Carries the health messages of a bridge running in the broker, and the shutdown request
+    /// whichever bridge is monitored
+    messages: SimpleMessageBoxBuilder<MqttMessage, MqttMessage>,
+
+    ready: watch::Sender<bool>,
+}
+
+/// How the bridge being monitored makes itself known
+enum BridgeSource {
+    /// The built-in bridge signals when it holds the subscriptions it relays
+    BuiltIn(watch::Receiver<bool>),
+
+    /// A bridge running in the broker is only known by the health message it publishes
+    InBroker {
+        mqtt_schema: MqttSchema,
+        health_topic: Topic,
+    },
+}
+
+impl BridgeMonitorBuilder {
+    /// Monitors the built-in bridge running in this process, on behalf of `connection`
+    pub fn built_in(
+        subscribed: watch::Receiver<bool>,
+        connection: &mut impl GateConnection,
+    ) -> Self {
+        Self::with_source(BridgeSource::BuiltIn(subscribed), connection)
+    }
+
+    /// Monitors a bridge running in the broker, through the health topic it publishes to
+    ///
+    /// `service_monitor` is a dedicated MQTT client, as the bridge has to be seen before anything
+    /// is published through `connection`, the one the mapper shares with the other actors
+    pub fn in_broker(
+        service_monitor: &mut (impl MessageSource<MqttMessage, TopicFilter> + MessageSink<MqttMessage>),
+        config: &C8yMapperConfig,
+        connection: &mut impl GateConnection,
+    ) -> Self {
+        let builder = Self::with_source(
+            BridgeSource::InBroker {
+                mqtt_schema: config.mqtt_schema.clone(),
+                health_topic: config.bridge_health_topic.clone(),
+            },
+            connection,
+        );
+        service_monitor.connect_sink(config.bridge_health_topic.clone().into(), &builder.messages);
+        builder
+    }
+
+    /// Holds `connection` back until the bridge can relay what is published through it
+    ///
+    /// The readiness handed over only ever goes from `false` to `true`. A sender dropped while
+    /// still `false` means the bridge was never seen and nothing is left to see it, which releases
+    /// the connection rather than leaving it closed for good.
+    fn with_source(source: BridgeSource, connection: &mut impl GateConnection) -> Self {
+        let (ready, _) = watch::channel(false);
+        connection.connect_when(ready.subscribe(), MAX_BRIDGE_WAIT);
+        Self {
+            source,
+            messages: SimpleMessageBoxBuilder::new("BridgeMonitor", 1),
+            ready,
+        }
+    }
+}
+
+impl RuntimeRequestSink for BridgeMonitorBuilder {
+    fn get_signal_sender(&self) -> DynSender<RuntimeRequest> {
+        self.messages.get_signal_sender()
+    }
+}
+
+impl Builder<BridgeMonitorActor> for BridgeMonitorBuilder {
+    type Error = Infallible;
+
+    fn try_build(self) -> Result<BridgeMonitorActor, Self::Error> {
+        Ok(self.build())
+    }
+
+    fn build(self) -> BridgeMonitorActor {
+        BridgeMonitorActor {
+            source: self.source,
+            messages: self.messages.build(),
+            ready: self.ready,
+        }
+    }
+}
+
+pub struct BridgeMonitorActor {
+    source: BridgeSource,
+    messages: SimpleMessageBox<MqttMessage, MqttMessage>,
+    ready: watch::Sender<bool>,
+}
+
+#[async_trait]
+impl Actor for BridgeMonitorActor {
+    fn name(&self) -> &str {
+        "BridgeMonitor"
+    }
+
+    async fn run(mut self) -> Result<(), RuntimeError> {
+        if !self.wait_until_bridge_is_ready().await {
+            return Ok(());
+        }
+        self.ready.send_replace(true);
+
+        // The readiness never goes back on itself, so there is nothing left to watch. This actor
+        // stays for as long as the messages it subscribed to keep coming: the broker republishes
+        // the bridge health on every reconnection, and dropping the receiver would fail the MQTT
+        // actor publishing to it.
+        while self.messages.recv().await.is_some() {}
+        Ok(())
+    }
+}
+
+impl BridgeMonitorActor {
+    /// Waits until the bridge can relay cloud-bound messages, returning `false` if it never can
+    async fn wait_until_bridge_is_ready(&mut self) -> bool {
+        match &mut self.source {
+            // The built-in bridge raises this once it has a session with the local broker holding
+            // the subscriptions it relays. From then on the broker queues the cloud-bound messages
+            // it cannot deliver rather than discarding them.
+            BridgeSource::BuiltIn(subscribed) => loop {
+                if *subscribed.borrow_and_update() {
+                    return true;
+                }
+                tokio::select! {
+                    // The bridge stopped without ever subscribing
+                    outcome = subscribed.changed() => if outcome.is_err() {
+                        return false;
+                    },
+
+                    // Nothing is published here for the built-in bridge, so this only resolves
+                    // when the runtime asks the monitor to shut down
+                    message = self.messages.recv() => if message.is_none() {
+                        return false;
+                    },
+                }
+            },
+
+            // A health message is the first sign that the broker has loaded the bridge
+            // configuration, and so that it is queuing the cloud-bound messages published to it
+            // even while the cloud is unreachable
+            BridgeSource::InBroker {
+                mqtt_schema,
+                health_topic,
+            } => loop {
+                let Some(message) = self.messages.recv().await else {
+                    // Shut down before the bridge was seen
+                    return false;
+                };
+                if is_c8y_bridge_established(&message, mqtt_schema, health_topic) {
+                    return true;
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::test_mapper_config;
+    use serde_json::json;
+    use std::time::Duration;
+    use tedge_actors::test_helpers::WithTimeout;
+    use tedge_actors::Sender;
+    use tedge_test_utils::fs::TempTedgeDir;
+
+    const TEST_TIMEOUT: Duration = Duration::from_millis(500);
+
+    #[test]
+    fn a_monitored_connection_is_held_back_as_soon_as_the_monitor_is_built() {
+        let (_subscribed, monitored) = watch::channel(false);
+        let mut connection = GatedConnection::default();
+
+        let _monitor = BridgeMonitorBuilder::built_in(monitored, &mut connection);
+
+        assert!(
+            !*connection.readiness().borrow(),
+            "the bridge has yet to be seen, so the connection stays closed"
+        );
+        assert_eq!(connection.released_after(), MAX_BRIDGE_WAIT);
+    }
+
+    #[tokio::test]
+    async fn built_in_bridge_is_not_ready_until_it_is_subscribed() {
+        let (subscribed, monitored) = watch::channel(false);
+        let mut connection = GatedConnection::default();
+        let _shutdown =
+            spawn_bridge_monitor(BridgeMonitorBuilder::built_in(monitored, &mut connection));
+        let mut readiness = connection.readiness();
+
+        assert!(
+            readiness
+                .changed()
+                .with_timeout(TEST_TIMEOUT)
+                .await
+                .is_err(),
+            "the bridge is not subscribed, so nothing may be published to the cloud yet"
+        );
+
+        subscribed.send_replace(true);
+        assert!(is_ready(&mut readiness).await);
+    }
+
+    #[tokio::test]
+    async fn built_in_bridge_is_never_ready_once_it_has_stopped() {
+        let (subscribed, monitored) = watch::channel(false);
+        let mut connection = GatedConnection::default();
+        let _shutdown =
+            spawn_bridge_monitor(BridgeMonitorBuilder::built_in(monitored, &mut connection));
+        let mut readiness = connection.readiness();
+
+        drop(subscribed);
+
+        assert!(
+            !is_ready(&mut readiness).await,
+            "a bridge that stopped before subscribing will never relay anything"
+        );
+    }
+
+    /// Whoever waits on the readiness has to be released when the runtime shuts the process down,
+    /// however far the bridge got
+    #[tokio::test]
+    async fn a_bridge_never_seen_is_never_ready_once_the_monitor_is_shut_down() {
+        let (_subscribed, monitored) = watch::channel(false);
+        let mut connection = GatedConnection::default();
+        let mut shutdown =
+            spawn_bridge_monitor(BridgeMonitorBuilder::built_in(monitored, &mut connection));
+        let mut readiness = connection.readiness();
+
+        shutdown.send(RuntimeRequest::Shutdown).await.unwrap();
+
+        assert!(!is_ready(&mut readiness).await);
+    }
+
+    #[tokio::test]
+    async fn bridge_in_broker_is_ready_once_it_publishes_its_health() {
+        let ttd = TempTedgeDir::new();
+        let config = test_mapper_config(&ttd);
+        let health_topic = config.bridge_health_topic.clone();
+
+        let mut service_monitor: SimpleMessageBoxBuilder<MqttMessage, MqttMessage> =
+            SimpleMessageBoxBuilder::new("ServiceMonitor", 1);
+        let mut connection = GatedConnection::default();
+        let monitor =
+            BridgeMonitorBuilder::in_broker(&mut service_monitor, &config, &mut connection);
+        let _shutdown = spawn_bridge_monitor(monitor);
+        let mut readiness = connection.readiness();
+        let mut service_monitor = service_monitor.build();
+
+        assert!(
+            readiness.changed().with_timeout(TEST_TIMEOUT).await.is_err(),
+            "the broker has given no sign of the bridge, so nothing may be published to the cloud yet"
+        );
+
+        // The bridge in the broker is a mosquitto bridge, whose health payload is 1 or 0
+        service_monitor
+            .send(MqttMessage::new(&health_topic, "1"))
+            .await
+            .unwrap();
+
+        assert!(is_ready(&mut readiness).await);
+    }
+
+    #[tokio::test]
+    async fn bridge_in_broker_ignores_the_health_of_other_services() {
+        let ttd = TempTedgeDir::new();
+        let config = test_mapper_config(&ttd);
+
+        let mut service_monitor: SimpleMessageBoxBuilder<MqttMessage, MqttMessage> =
+            SimpleMessageBoxBuilder::new("ServiceMonitor", 1);
+        let mut connection = GatedConnection::default();
+        let monitor =
+            BridgeMonitorBuilder::in_broker(&mut service_monitor, &config, &mut connection);
+        let _shutdown = spawn_bridge_monitor(monitor);
+        let mut readiness = connection.readiness();
+        let mut service_monitor = service_monitor.build();
+
+        service_monitor
+            .send(MqttMessage::new(
+                &Topic::new_unchecked("te/device/main/service/tedge-agent/status/health"),
+                json!({"status": "up"}).to_string(),
+            ))
+            .await
+            .unwrap();
+
+        assert!(
+            readiness
+                .changed()
+                .with_timeout(TEST_TIMEOUT)
+                .await
+                .is_err(),
+            "only the bridge's own health says whether the bridge can relay messages"
+        );
+    }
+
+    /// Spawns a monitor, returning the handle to shut it down
+    fn spawn_bridge_monitor(builder: BridgeMonitorBuilder) -> DynSender<RuntimeRequest> {
+        let signal_sender = builder.get_signal_sender();
+        tokio::spawn(builder.build().run());
+        signal_sender
+    }
+
+    /// Waits for the bridge to be ready, returning `false` if the monitor gave up on it first
+    async fn is_ready(readiness: &mut watch::Receiver<bool>) -> bool {
+        readiness
+            .wait_for(|ready| *ready)
+            .with_timeout(TEST_TIMEOUT)
+            .await
+            .expect("the monitor makes up its mind about the bridge")
+            .is_ok()
+    }
+
+    /// Stands in for the MQTT connection a monitor is built for, recording how it is held back
+    #[derive(Default)]
+    struct GatedConnection {
+        held_back_on: Option<(watch::Receiver<bool>, Duration)>,
+    }
+
+    impl GateConnection for GatedConnection {
+        fn connect_when(&mut self, ready: watch::Receiver<bool>, timeout: Duration) {
+            self.held_back_on = Some((ready, timeout));
+        }
+    }
+
+    impl GatedConnection {
+        /// The readiness this connection waits on, panicking if it was never held back at all
+        fn readiness(&self) -> watch::Receiver<bool> {
+            self.held_back().0.clone()
+        }
+
+        /// How long this connection waits before giving up on the bridge and connecting anyway
+        fn released_after(&self) -> Duration {
+            self.held_back().1
+        }
+
+        fn held_back(&self) -> &(watch::Receiver<bool>, Duration) {
+            self.held_back_on
+                .as_ref()
+                .expect("the monitor holds back the connection it is built for")
+        }
+    }
+}

--- a/crates/extensions/c8y_mapper_ext/src/lib.rs
+++ b/crates/extensions/c8y_mapper_ext/src/lib.rs
@@ -3,6 +3,7 @@ use tedge_flows::FlowRegistryExt;
 pub mod actor;
 pub mod alarm_converter;
 pub mod availability;
+pub mod bridge_readiness;
 pub mod config;
 pub mod converter;
 pub mod dynamic_discovery;

--- a/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/service_monitor.rs
@@ -23,6 +23,25 @@ pub fn is_c8y_bridge_established(
     }
 }
 
+/// Whether the given message reports that the c8y bridge connection is `up`.
+///
+/// Unlike [`is_c8y_bridge_established`], this requires the connection to actually be up
+/// (not merely a valid `up`/`down` status). This matters for the built-in bridge, whose
+/// cloud connection is the slow half to come up: once it is up, the bridge's local
+/// subscriptions are guaranteed to be in place, so it is safe to publish messages that
+/// must reach the cloud (e.g. the supported operations).
+pub fn is_c8y_bridge_up(
+    message: &MqttMessage,
+    mqtt_schema: &MqttSchema,
+    bridge_service_topic: &Topic,
+) -> bool {
+    if let Ok(health_status) = HealthStatus::try_from_health_status_message(message, mqtt_schema) {
+        &message.topic == bridge_service_topic && health_status.status == Status::Up
+    } else {
+        false
+    }
+}
+
 pub(crate) fn convert_health_status_message(
     mqtt_schema: &MqttSchema,
     entity: &CloudEntityMetadata,

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -89,6 +89,49 @@ async fn mapper_publishes_init_messages_on_startup() {
     assert_received_contains_str(&mut mqtt, [("c8y/s/us", "114"), ("c8y/s/us", "500")]).await;
 }
 
+/// With the built-in bridge, the mapper must not publish its init messages (notably the
+/// `114` supported operations) before the bridge is up: an early publish to `c8y/s/us`
+/// races with the bridge subscribing locally and can be dropped on a fresh session, so the
+/// supported operations would never reach the cloud. The init messages must be deferred
+/// until the bridge reports `up` and then sent exactly once.
+#[tokio::test]
+async fn builtin_bridge_mapper_defers_init_messages_until_bridge_is_up() {
+    let ttd = TempTedgeDir::new();
+
+    // Configure the mapper to use the built-in bridge
+    let base = test_mapper_config(&ttd);
+    let bridge_health_topic =
+        Topic::new_unchecked("te/device/main/service/tedge-mapper-bridge-c8y/status/health");
+    let config = C8yMapperConfig {
+        bridge_in_mapper: true,
+        bridge_service_name: format!("tedge-mapper-bridge-{}", base.bridge_config.c8y_prefix),
+        bridge_health_topic: bridge_health_topic.clone(),
+        ..base
+    };
+
+    let builders = c8y_mapper_builder(&ttd, config, true).await;
+    let actor = builders.c8y.build();
+    tokio::spawn(async move { actor.run().await });
+    let flows_actor = builders.flows.build();
+    tokio::spawn(async move { flows_actor.run().await });
+    let mut service_monitor = builders.service_monitor.build();
+
+    let mut mqtt = builders
+        .mqtt
+        .build()
+        .with_timeout(Duration::from_millis(500));
+
+    // While the bridge is not up, no init message is published
+    assert!(mqtt.recv().await.is_none());
+
+    // Once the built-in bridge is up, the init messages are published
+    service_monitor
+        .send(MqttMessage::new(&bridge_health_topic, r#"{"status":"up"}"#))
+        .await
+        .unwrap();
+    assert_received_contains_str(&mut mqtt, [("c8y/s/us", "114"), ("c8y/s/us", "500")]).await;
+}
+
 #[tokio::test]
 async fn mapper_converts_agent_twin_to_c8y_agent_fragment() {
     let ttd = TempTedgeDir::new();

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -3161,7 +3161,6 @@ pub(crate) async fn spawn_c8y_mapper_actor_with_config(
     config: C8yMapperConfig,
     init: bool,
 ) -> TestHandle {
-    let bridge_health_topic = config.bridge_health_topic.clone();
     let builders = c8y_mapper_builder(tmp_dir, config, init).await;
 
     let actor = builders.c8y.build();
@@ -3169,10 +3168,6 @@ pub(crate) async fn spawn_c8y_mapper_actor_with_config(
 
     let actor = builders.flows.build();
     tokio::spawn(async move { actor.run().await });
-
-    let mut service_monitor_box = builders.service_monitor.build();
-    let bridge_status_msg = MqttMessage::new(&bridge_health_topic, "1");
-    service_monitor_box.send(bridge_status_msg).await.unwrap();
 
     TestHandle {
         mqtt: builders.mqtt.build(),
@@ -3193,7 +3188,6 @@ pub(crate) struct TestHandleBuilder {
     pub ul: FakeServerBoxBuilder<IdUploadRequest, IdUploadResult>,
     pub dl: FakeServerBoxBuilder<IdDownloadRequest, IdDownloadResult>,
     pub avail: SimpleMessageBoxBuilder<MqttMessage, MqttMessage>,
-    pub service_monitor: SimpleMessageBoxBuilder<MqttMessage, MqttMessage>,
 }
 
 pub(crate) async fn c8y_mapper_builder(
@@ -3216,9 +3210,6 @@ pub(crate) async fn c8y_mapper_builder(
         FakeServerBoxBuilder::default();
     let mut downloader_builder: FakeServerBoxBuilder<IdDownloadRequest, IdDownloadResult> =
         FakeServerBoxBuilder::default();
-    let mut service_monitor_builder: SimpleMessageBoxBuilder<MqttMessage, MqttMessage> =
-        SimpleMessageBoxBuilder::new("ServiceMonitor", 1);
-
     C8yMapperBuilder::init(&config).await.unwrap();
     let mut c8y_mapper_builder = C8yMapperBuilder::try_new(
         config,
@@ -3227,7 +3218,6 @@ pub(crate) async fn c8y_mapper_builder(
         &mut uploader_builder,
         &mut downloader_builder,
         &mut fs_watcher_builder,
-        &mut service_monitor_builder,
     )
     .unwrap();
 
@@ -3273,7 +3263,6 @@ pub(crate) async fn c8y_mapper_builder(
         ul: uploader_builder,
         dl: downloader_builder,
         avail: availability_box_builder,
-        service_monitor: service_monitor_builder,
     }
 }
 

--- a/crates/extensions/tedge_mqtt_bridge/src/health.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/health.rs
@@ -11,10 +11,12 @@ use rumqttc::QoS;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
 
-/// A tool for monitoring and publishing the health of the two bridge halves
+/// Publishes the overall health of the two bridge halves
 ///
-/// When [Self::monitor] runs, this will watch the status of the bridge halves, and notify the
-/// relevant MQTT topic about the overall health.
+/// The bridge is up only when both halves are up, i.e. both can relay the messages they are
+/// given. Consumers rely on that: `tedge connect` and the c8y mapper publish cloud-bound
+/// messages as soon as they see the bridge up, and on a fresh session such a message is
+/// dropped if the bridge has not subscribed yet.
 pub struct BridgeHealthMonitor {
     topic: String,
     rx_status: mpsc::Receiver<(&'static str, Status)>,
@@ -62,25 +64,24 @@ impl BridgeHealthMonitor {
 
 type NotificationRes = Result<Event, ConnectionError>;
 
-/// A client for [BridgeHealthMonitor]
+/// Logs the connection events of one bridge half
 ///
-/// This is used by each bridge half to log and notify the monitor of health status updates
-pub struct BridgeHealth {
+/// A failure is logged only when it differs from the previous one, so a broker that keeps
+/// refusing connections is reported once rather than on every reconnection attempt
+pub struct BridgeConnectionLog {
     name: &'static str,
-    tx_health: mpsc::Sender<(&'static str, Status)>,
     last_err: Option<String>,
 }
 
-impl BridgeHealth {
-    pub(crate) fn new(name: &'static str, tx_health: mpsc::Sender<(&'static str, Status)>) -> Self {
+impl BridgeConnectionLog {
+    pub(crate) fn new(name: &'static str) -> Self {
         Self {
             name,
-            tx_health,
-            last_err: Some("dummy error".into()),
+            last_err: None,
         }
     }
 
-    pub async fn update(&mut self, result: &NotificationRes) {
+    pub fn update(&mut self, result: &NotificationRes) {
         let name = self.name;
         let err = match result {
             Ok(event) => {
@@ -97,8 +98,6 @@ impl BridgeHealth {
                 log_event!(error: name, "MQTT bridge failed to connect to {name} broker: {err}");
             }
             self.last_err = err;
-            let status = self.last_err.as_ref().map_or(Status::Up, |_| Status::Down);
-            self.tx_health.send((name, status)).await.unwrap()
         }
     }
 }

--- a/crates/extensions/tedge_mqtt_bridge/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/lib.rs
@@ -49,7 +49,7 @@ use tracing::Instrument;
 
 pub type MqttConfig = mqtt_channel::Config;
 
-use crate::health::BridgeHealth;
+use crate::health::BridgeConnectionLog;
 use crate::health::BridgeHealthMonitor;
 use crate::mqtt_logging::LoggingAsyncClient;
 pub use mqtt_channel::DebugPayload;
@@ -139,7 +139,8 @@ impl<C: MqttClient + 'static> SubackTracker<C> {
         );
     }
 
-    fn handle_timeout(&mut self, name: &'static str, gate: &SubscriptionGateController) {
+    async fn handle_timeout(&mut self, readiness: &mut BridgeHalfReadiness) {
+        let name = readiness.name;
         if self.subscribe_round < MAX_SUBSCRIBE_ROUNDS {
             self.subscribe_round += 1;
             log_event!(warn: name,
@@ -161,7 +162,9 @@ impl<C: MqttClient + 'static> SubackTracker<C> {
                 needed = self.subacks_needed,
                 outstanding = self.outstanding_subs,
             );
-            gate.open();
+            // Forwarding resumes despite the missing acknowledgements, so the half is
+            // reported up rather than left down forever
+            readiness.ready().await;
             self.deadline = None;
             self.subscribe_round = 0;
         }
@@ -172,6 +175,7 @@ pub struct MqttBridgeActorBuilder {
     tasks: Vec<JoinHandle<()>>,
     signal_tx: futures_mpsc::Sender<RuntimeRequest>,
     signal_rx: futures_mpsc::Receiver<RuntimeRequest>,
+    local_subscriptions_ready: watch::Receiver<bool>,
 }
 
 impl MqttBridgeActorBuilder {
@@ -257,6 +261,7 @@ impl MqttBridgeActorBuilder {
             rules.converters_and_bidirectional_topic_filters();
         let (tx_status, monitor) =
             BridgeHealthMonitor::new(health_topic.name.clone(), &local_target);
+        let local_subscriptions_ready = local_gate_controller.watch();
         let cloud_tx = cloud_target.clone_sender();
         let local_tx = local_target.clone_sender();
         let monitor_task = tokio::spawn(
@@ -313,7 +318,14 @@ impl MqttBridgeActorBuilder {
             tasks,
             signal_tx,
             signal_rx,
+            local_subscriptions_ready,
         }
+    }
+
+    /// A signal used to prevent the mapper starting until the bridge is ready to receive messages
+    /// from the local broker
+    pub fn local_subscriptions_ready(&self) -> watch::Receiver<bool> {
+        self.local_subscriptions_ready.clone()
     }
 
     pub(crate) fn build_actor(self) -> MqttBridgeActor {
@@ -350,14 +362,13 @@ fn bidirectional_channel<Client: MqttClient + 'static>(
 
 /// Gates outbound publishes until a connection's subscriptions are acknowledged
 ///
-/// On a clean session the broker has no record of our subscriptions, so a message
-/// published before the relevant `SUBACK` could trigger a response on a topic we
-/// have not finished subscribing to. The gate lets a publisher hold outbound
-/// messages until the subscriptions for that connection are acknowledged.
+/// On a clean session the broker has no record of our subscriptions, so a message published
+/// before the relevant `SUBACK` could trigger a response on a topic we have not finished
+/// subscribing to.
 ///
-/// The reader ([SubscriptionGate]) is held by the publisher feeding a broker, while
-/// the writer ([SubscriptionGateController]) is held by the half bridge polling that
-/// broker's event loop — the half that receives the connection's `SUBACK`s.
+/// The reader ([SubscriptionGate]) is held by the publisher feeding a broker, while the writer
+/// ([SubscriptionGateController]) is held by the half bridge polling that broker's event loop —
+/// the half that receives the connection's `SUBACK`s.
 #[derive(Clone)]
 struct SubscriptionGate {
     open: watch::Receiver<bool>,
@@ -403,6 +414,69 @@ impl SubscriptionGateController {
     /// Holds outbound messages until the subscriptions are acknowledged again
     fn close(&self) {
         let _ = self.open.send(false);
+    }
+
+    /// Watches whether the subscriptions this gate tracks are acknowledged
+    fn watch(&self) -> watch::Receiver<bool> {
+        self.open.subscribe()
+    }
+}
+
+/// Tracks whether one bridge half is able to relay the messages it is given
+///
+/// A half is ready when it is connected to its broker and that connection's subscriptions are
+/// live. The gate and the health status of a half are driven from here together, so what the
+/// bridge forwards and what it reports can never disagree.
+struct BridgeHalfReadiness {
+    name: &'static str,
+    gate: SubscriptionGateController,
+    tx_health: mpsc::Sender<(&'static str, Status)>,
+    reported: Option<Status>,
+}
+
+impl BridgeHalfReadiness {
+    fn new(
+        name: &'static str,
+        gate: SubscriptionGateController,
+        tx_health: mpsc::Sender<(&'static str, Status)>,
+    ) -> Self {
+        Self {
+            name,
+            gate,
+            tx_health,
+            reported: None,
+        }
+    }
+
+    /// Releases the publishes held for this half and reports it as up
+    ///
+    /// The gate is opened before the status is sent, as the health message itself is published
+    /// through the buffer this gate holds back
+    async fn ready(&mut self) {
+        self.gate.open();
+        self.report(Status::Up).await
+    }
+
+    /// Holds back this half's publishes and reports it as down
+    async fn not_ready(&mut self) {
+        self.gate.close();
+        self.report(Status::Down).await
+    }
+
+    /// Holds back this half's publishes without reporting it as down
+    ///
+    /// A half that is still subscribing cannot relay messages, but it has either never been up
+    /// or already reported the failure that brought it down
+    fn hold_publishes(&self) {
+        self.gate.close()
+    }
+
+    /// Reports a change of status, skipping repeats so consumers only see transitions
+    async fn report(&mut self, status: Status) {
+        if self.reported != Some(status) {
+            self.reported = Some(status);
+            self.tx_health.send((self.name, status)).await.unwrap()
+        }
     }
 }
 
@@ -506,11 +580,9 @@ impl<Client: MqttClient + 'static> BridgeAsyncClient<Client> {
         let mut gate = self.gate.clone();
         tokio::spawn(
             async move {
-                // While the gate is closed (the target's subscriptions are not yet
-                // acknowledged on a clean session), outbound publishes are held here in
-                // order and flushed once the gate opens. Every publish goes through the
-                // buffer, so they are always forwarded in arrival order. Acks are never
-                // gated.
+                // Publishes held back by the gate are flushed once it opens. Every publish
+                // goes through this buffer, even when the gate is open, so they are always
+                // forwarded in arrival order.
                 let mut buffer: VecDeque<BridgeMessage> = VecDeque::new();
                 loop {
                     if gate.is_open() {
@@ -699,13 +771,12 @@ impl BridgeMessageSender {
 /// - The `half_bridge(cloud_event_loop,local_client)` receives cloud messages and publishes these message locally.
 /// - The `half_bridge(local_event_loop,cloud_client)` handles the acknowledgements: waiting for messages be acknowledged locally, before sending acks for the original messages.
 ///
-/// # Health topics
-/// The bridge will publish health information to `health_topic` (if supplied) on `target` to enable
-/// other components to establish bridge health. This is intended to be used the half with cloud
-/// event loop, so the status of this connection will be relayed to a relevant `te` topic like its
-/// mosquitto-based predecessor. The payload is either `1` (healthy) or `0` (unhealthy). When the
-/// connection is created, the last-will message is set to send the `0` payload when the connection
-/// is dropped.
+/// # Health
+/// Each half reports to [BridgeHealthMonitor] whether it is able to relay messages, which the
+/// monitor aggregates into the status published on the bridge health topic. A half is up once
+/// it is connected and its subscriptions are acknowledged, as until then anything it is asked
+/// to publish is held back (see [SubscriptionGate]). The local connection's last will covers
+/// the case where the bridge dies without reporting anything.
 #[allow(clippy::too_many_arguments)]
 async fn half_bridge(
     mut recv_event_loop: impl MqttEvents,
@@ -729,7 +800,8 @@ async fn half_bridge(
         reconnect_policy.reset_window.duration(),
     );
     let mut forward_pkid_to_received_msg = HashMap::<u16, Option<Publish>>::new();
-    let mut bridge_health = BridgeHealth::new(name, tx_health);
+    let mut readiness = BridgeHalfReadiness::new(name, gate, tx_health);
+    let mut connection_log = BridgeConnectionLog::new(name);
     let mut loop_breaker =
         MessageLoopBreaker::new(recv_client.clone(), bidirectional_topic_filters);
 
@@ -752,14 +824,14 @@ async fn half_bridge(
                 biased;
                 res = recv_event_loop.poll() => res,
                 _ = tokio::time::sleep_until(deadline) => {
-                    suback_tracker.handle_timeout(name, &gate);
+                    suback_tracker.handle_timeout(&mut readiness).await;
                     continue;
                 }
             }
         } else {
             recv_event_loop.poll().await
         };
-        bridge_health.update(&res).await;
+        connection_log.update(&res);
 
         let notification = match res {
             Ok(notification) => {
@@ -767,9 +839,9 @@ async fn half_bridge(
                 notification
             }
             Err(_) => {
-                // The connection is gone: hold outbound publishes until it is
-                // re-established and its subscriptions are acknowledged again.
-                gate.close();
+                // The connection is gone: hold outbound publishes until it is re-established
+                // and its subscriptions are acknowledged again
+                readiness.not_ready().await;
                 suback_tracker.deadline = None;
                 let time = backoff.backoff();
                 if !time.is_zero() {
@@ -815,22 +887,21 @@ async fn half_bridge(
                     self_tx.internal_publish(msg);
                 }
 
-                // Reset the subscription-acknowledgement tracking for this connection
-                // before the gate is (re)evaluated below.
+                // Reset the acknowledgement tracking before the readiness is re-evaluated below
                 suback_tracker.subscribe_round = 1;
                 suback_tracker.start_subscribe_round();
 
-                // Gate outbound publishes until this connection's subscriptions are
-                // acknowledged. On a resumed session the broker still holds our
-                // subscriptions, so it is safe to publish immediately; likewise when
-                // there are no subscriptions to wait for. The gate is opened only after
-                // the subscriptions above have been enqueued, so a publish woken by the
-                // gate opening cannot overtake them onto the wire.
+                // On a resumed session the broker still holds our subscriptions, so this half
+                // is ready as soon as it is connected; likewise when there is nothing to
+                // subscribe to. The subscriptions above are enqueued first, so a publish woken
+                // by the gate opening cannot overtake them onto the wire.
                 if conn_ack.session_present || suback_tracker.subacks_needed == 0 {
-                    gate.open();
+                    readiness.ready().await;
                     suback_tracker.deadline = None;
                 } else {
-                    gate.close();
+                    // Not reported as down: this half has either never been up, or the failure
+                    // that brought it down was reported when it happened
+                    readiness.hold_publishes();
                     suback_tracker.deadline = Some(tokio::time::Instant::now() + SUBACK_TIMEOUT);
                 }
 
@@ -929,7 +1000,7 @@ async fn half_bridge(
                 suback_tracker.outstanding_subs.insert(pkid);
             }
 
-            // Open the gate once the connection's subscriptions are acknowledged
+            // This half becomes ready once the connection's subscriptions are acknowledged
             Event::Incoming(Incoming::SubAck(suback)) => {
                 if !suback_tracker.outstanding_subs.remove(&suback.pkid) {
                     continue;
@@ -943,7 +1014,7 @@ async fn half_bridge(
                 }
                 suback_tracker.subacks_seen += suback.return_codes.len();
                 if suback_tracker.subacks_seen >= suback_tracker.subacks_needed {
-                    gate.open();
+                    readiness.ready().await;
                     suback_tracker.deadline = None;
                     suback_tracker.subscribe_round = 0;
                     log_event!(name, "All subscriptions acknowledged, forwarding resumed ({seen} return codes across {needed} filters)",
@@ -955,7 +1026,7 @@ async fn half_bridge(
 
             Event::Incoming(Incoming::Disconnect) => {
                 log_event!(info: name, "Connection closed by peer");
-                gate.close();
+                readiness.not_ready().await;
                 suback_tracker.deadline = None;
             }
 
@@ -1722,6 +1793,8 @@ mod tests {
 
         #[tokio::test]
         async fn health_success_is_published_on_connack() {
+            // This bridge is configured without subscriptions, so connecting is all it takes
+            // for a half to be able to relay messages
             let mut bridge = Bridge::default()
                 .with_local_events([inc!(connack)])
                 .process_all_events()
@@ -1770,6 +1843,81 @@ mod tests {
                 .await;
             assert_eq!(bridge.next_health_message(), Some(("local", Status::Down)));
             assert_eq!(bridge.next_health_message(), Some(("local", Status::Up)));
+        }
+
+        #[tokio::test]
+        async fn health_is_not_reported_until_the_subscriptions_are_acknowledged() {
+            let mut bridge = Bridge::default()
+                .with_subscription_topics(vec![SubscribeFilter::new(
+                    "s/ds".into(),
+                    QoS::AtLeastOnce,
+                )])
+                .with_local_events([inc!(clean_connack), out!(subscribe(1))])
+                .process_all_events()
+                .await;
+
+            assert_eq!(
+                bridge.next_health_message(),
+                None,
+                "a half that is still subscribing must not be reported as up, and it was never up
+                 to report as down"
+            );
+        }
+
+        #[tokio::test]
+        async fn health_is_up_once_the_subscriptions_are_acknowledged() {
+            let mut bridge = Bridge::default()
+                .with_subscription_topics(vec![SubscribeFilter::new(
+                    "s/ds".into(),
+                    QoS::AtLeastOnce,
+                )])
+                .with_local_events([inc!(clean_connack), out!(subscribe(1)), inc!(suback)])
+                .process_all_events()
+                .await;
+
+            assert_eq!(bridge.next_health_message(), Some(("local", Status::Up)));
+            assert_eq!(bridge.next_health_message(), None);
+        }
+
+        #[tokio::test]
+        async fn health_is_only_reported_when_it_changes() {
+            let mut bridge = Bridge::default()
+                .with_local_events([inc!(network_error), inc!(network_error), inc!(disconnect)])
+                .process_all_events()
+                .await;
+
+            assert_eq!(bridge.next_health_message(), Some(("local", Status::Down)));
+            assert_eq!(
+                bridge.next_health_message(),
+                None,
+                "repeated failures must not be reported over and over"
+            );
+        }
+
+        #[tokio::test]
+        async fn health_is_up_without_subacks_when_the_session_is_resumed() {
+            // The broker still holds the subscriptions of a resumed session
+            let mut bridge = Bridge::default()
+                .with_subscription_topics(vec![SubscribeFilter::new(
+                    "s/ds".into(),
+                    QoS::AtLeastOnce,
+                )])
+                .with_local_events([inc!(connack)])
+                .process_all_events()
+                .await;
+
+            assert_eq!(bridge.next_health_message(), Some(("local", Status::Up)));
+        }
+
+        #[tokio::test]
+        async fn health_is_down_again_after_a_peer_disconnect() {
+            let mut bridge = Bridge::default()
+                .with_local_events([inc!(connack), inc!(disconnect)])
+                .process_all_events()
+                .await;
+
+            assert_eq!(bridge.next_health_message(), Some(("local", Status::Up)));
+            assert_eq!(bridge.next_health_message(), Some(("local", Status::Down)));
         }
 
         #[tokio::test]
@@ -2435,6 +2583,33 @@ mod tests {
                     subscribe_rounds >= 2,
                     "expected multiple subscribe rounds, got {subscribe_rounds}"
                 );
+            }
+
+            #[tokio::test(start_paused = true)]
+            async fn health_is_up_after_exhausting_resubscribe_rounds() {
+                let subscription_topics = vec![
+                    SubscribeFilter::new("s/ds".into(), QoS::AtLeastOnce),
+                    SubscribeFilter::new("s/dat".into(), QoS::AtLeastOnce),
+                ];
+                // One SUBACK for two topics — this half never becomes subscribed
+                let local_events = [inc!(clean_connack), out!(subscribe(1)), inc!(suback)];
+
+                let mut bridge = Bridge::default()
+                    .with_subscription_topics(subscription_topics)
+                    .with_local_events(local_events)
+                    .process_all_events()
+                    .await;
+
+                assert_eq!(bridge.next_health_message(), None);
+
+                for _ in 0..MAX_SUBSCRIBE_ROUNDS {
+                    tokio::time::advance(SUBACK_TIMEOUT + Duration::from_millis(1)).await;
+                    settle().await;
+                }
+
+                // Messages are forwarded again once the retries are exhausted, so reporting
+                // this half as down would misrepresent what the bridge is doing
+                assert_eq!(bridge.next_health_message(), Some(("local", Status::Up)));
             }
 
             #[tokio::test(start_paused = true)]

--- a/crates/extensions/tedge_mqtt_ext/Cargo.toml
+++ b/crates/extensions/tedge_mqtt_ext/Cargo.toml
@@ -22,7 +22,11 @@ mqtt_channel = { workspace = true }
 serde_json = { workspace = true }
 tedge_actors = { workspace = true }
 tedge_utils = { workspace = true }
-tokio = { workspace = true, default_features = false, features = ["macros"] }
+tokio = { workspace = true, default_features = false, features = [
+    "macros",
+    "sync",
+    "time",
+] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/extensions/tedge_mqtt_ext/src/lib.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/lib.rs
@@ -41,6 +41,7 @@ use tedge_actors::Sequential;
 use tedge_actors::Server;
 use tedge_actors::ServerActorBuilder;
 use tedge_actors::ServerConfig;
+use tokio::sync::watch;
 use tracing::Instrument;
 use trie::MqtTrie;
 use trie::RankTopicFilter;
@@ -65,6 +66,7 @@ pub struct MqttActorBuilder {
         TrieInsertRequest,
         Box<dyn CloneSender<MqttMessage> + 'static>,
     )>,
+    connection_gate: Option<ConnectionGate>,
 }
 
 impl MqttRequest {
@@ -270,6 +272,7 @@ impl MqttActorBuilder {
             current_id: 0,
             dynamic_connect_sender,
             dynamic_connect_receiver,
+            connection_gate: None,
         }
     }
 
@@ -297,6 +300,7 @@ impl MqttActorBuilder {
                 tx: self.dynamic_connect_sender,
             },
             self.dynamic_connect_receiver,
+            self.connection_gate,
         )
     }
 }
@@ -674,9 +678,81 @@ pub struct MqttActor {
         TrieInsertRequest,
         Box<dyn CloneSender<MqttMessage> + 'static>,
     )>,
+    connection_gate: Option<ConnectionGate>,
+}
+
+/// A connection to the broker that can be held back until the client may act on what it receives
+///
+/// Implemented by [MqttActorBuilder]; taken as a parameter by whoever decides when the client may
+/// connect, so that the decision and its effect cannot be wired up apart from one another.
+pub trait GateConnection {
+    /// Delays the connection to the broker until the `ready` argument returns `true`. This is
+    /// intended to prevent the mapper from connecting to the broker before the bridge exists.
+    ///
+    /// The connection is opened anyway once `timeout` has elapsed, as a client that never connects
+    /// is worse than one connecting too early: the delay is a precaution, not a requirement.
+    fn connect_when(&mut self, ready: watch::Receiver<bool>, timeout: Duration);
+}
+
+impl GateConnection for MqttActorBuilder {
+    fn connect_when(&mut self, ready: watch::Receiver<bool>, timeout: Duration) {
+        self.connection_gate = Some(ConnectionGate { ready, timeout });
+    }
+}
+
+/// Holds back the connection to the broker until the client may act on what it receives
+///
+/// See [GateConnection::connect_when]
+struct ConnectionGate {
+    ready: watch::Receiver<bool>,
+    timeout: Duration,
+}
+
+/// Whether the actor may carry on connecting to the broker
+#[derive(Debug, PartialEq, Eq)]
+enum Gate {
+    Open,
+
+    /// The actor was shut down before the connection was opened
+    ShutDown,
+}
+
+impl ConnectionGate {
+    /// Waits for the signal to connect, or for the runtime to shut the actor down
+    async fn wait(mut self, signals: &mut FromPeers) -> Gate {
+        let max_wait = self.timeout;
+        let deadline = tokio::time::sleep(max_wait);
+        tokio::pin!(deadline);
+
+        loop {
+            if *self.ready.borrow_and_update() {
+                return Gate::Open;
+            }
+
+            tokio::select! {
+                outcome = self.ready.changed() => if outcome.is_err() {
+                    // Nothing will ever signal readiness now, so waiting any longer would leave
+                    // this client disconnected for good. This is also the ordinary path on
+                    // shutdown, whoever was to give the go-ahead having stopped first.
+                    tracing::info!("Connecting to the broker, as nothing is left to tell this client when to connect");
+                    return Gate::Open;
+                },
+
+                () = &mut deadline => {
+                    tracing::warn!("Connecting to the broker, as this client has been waiting {max_wait:?} for the go-ahead");
+                    return Gate::Open;
+                }
+
+                Some(RuntimeRequest::Shutdown) = signals.recv_signal() => {
+                    return Gate::ShutDown;
+                }
+            }
+        }
+    }
 }
 
 impl MqttActor {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         mqtt_config: mqtt_channel::Config,
         base_config: mqtt_channel::Config,
@@ -688,6 +764,7 @@ impl MqttActor {
             TrieInsertRequest,
             Box<dyn CloneSender<MqttMessage> + 'static>,
         )>,
+        connection_gate: Option<ConnectionGate>,
     ) -> Self {
         MqttActor {
             mqtt_config,
@@ -703,6 +780,7 @@ impl MqttActor {
             trie_service,
             dynamic_client_handle,
             dynamic_connect_receiver,
+            connection_gate,
         }
     }
 
@@ -718,6 +796,12 @@ impl Actor for MqttActor {
     }
 
     async fn run(mut self) -> Result<(), RuntimeError> {
+        if let Some(gate) = self.connection_gate.take() {
+            if gate.wait(&mut self.from_peers).await == Gate::ShutDown {
+                return Ok(());
+            }
+        }
+
         let mut mqtt_client = tokio::select! {
             connection = mqtt_channel::Connection::new(&self.mqtt_config) => {
                 connection.map_err(Box::new)?

--- a/crates/extensions/tedge_mqtt_ext/src/tests.rs
+++ b/crates/extensions/tedge_mqtt_ext/src/tests.rs
@@ -7,6 +7,7 @@ use tedge_actors::Builder;
 use tedge_actors::NoConfig;
 use tedge_actors::SimpleMessageBox;
 use tedge_actors::SimpleMessageBoxBuilder;
+use tokio::sync::watch;
 
 /// Prefixes a topic/session name with a module path and line number
 ///
@@ -549,6 +550,108 @@ async fn retrieve_retain_does_not_forward_last_will() {
         TryRecvError::Empty,
         "Last will should not be published by retrieve retain"
     );
+}
+
+/// A client publishing on topics nothing relays yet, or receiving messages it cannot act on, is
+/// better off waiting: what its peers publish meanwhile is held by their senders, and what the
+/// broker has for it stays queued in its session rather than being acknowledged and lost
+#[tokio::test]
+async fn the_connection_is_delayed_until_the_client_is_told_it_may_connect() {
+    let broker = mqtt_tests::test_mqtt_broker();
+    let topic = Topic::new_unchecked(uniquify!("published/by/the/client"));
+    let mut published = broker.messages_published_on(topic.name.as_str()).await;
+
+    let mut mqtt = MqttActorBuilder::new(
+        MqttConfig::default()
+            .with_port(broker.port)
+            .with_session_name(uniquify!("session")),
+    );
+    let (ready, connect_when) = watch::channel(false);
+    mqtt.connect_when(connect_when, Duration::from_secs(60));
+
+    let mut client: MqttClient = MqttClientBuilder::new("client", &TopicFilter::empty())
+        .with_connection(&mut mqtt)
+        .build();
+    tokio::spawn(mqtt_actor(mqtt));
+
+    const DELIVERY_TIMEOUT: Duration = Duration::from_secs(1);
+
+    client
+        .send(MqttMessage::new(&topic, "published while waiting"))
+        .await
+        .unwrap();
+    assert!(
+        tokio::time::timeout(DELIVERY_TIMEOUT, published.next())
+            .await
+            .is_err(),
+        "the client has not been told it may connect, so nothing reaches the broker yet"
+    );
+
+    ready.send_replace(true);
+
+    assert_eq!(
+        tokio::time::timeout(DELIVERY_TIMEOUT, published.next())
+            .await
+            .expect("the client connects once it is told it may"),
+        Some("published while waiting".to_string())
+    );
+}
+
+/// Whatever the client is waiting for may never come, and a client that never connects is worse
+/// than one connecting too early: nothing is lost by connecting, only relayed later than it should
+#[tokio::test]
+async fn the_connection_is_opened_anyway_once_the_wait_has_timed_out() {
+    let broker = mqtt_tests::test_mqtt_broker();
+    let topic = Topic::new_unchecked(uniquify!("published/by/the/client"));
+    let mut published = broker.messages_published_on(topic.name.as_str()).await;
+
+    let mut mqtt = MqttActorBuilder::new(
+        MqttConfig::default()
+            .with_port(broker.port)
+            .with_session_name(uniquify!("session")),
+    );
+    // Held for the whole test, as a dropped sender would end the wait of its own accord
+    let (_never_ready, connect_when) = watch::channel(false);
+    mqtt.connect_when(connect_when, Duration::from_millis(200));
+
+    let mut client: MqttClient = MqttClientBuilder::new("client", &TopicFilter::empty())
+        .with_connection(&mut mqtt)
+        .build();
+    tokio::spawn(mqtt_actor(mqtt));
+
+    client
+        .send(MqttMessage::new(&topic, "published while waiting"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), published.next())
+            .await
+            .expect("the client gives up waiting and connects"),
+        Some("published while waiting".to_string())
+    );
+}
+
+/// Waiting to connect must not keep the process from stopping
+#[tokio::test]
+async fn a_client_shut_down_while_waiting_to_connect_stops_without_connecting() {
+    let broker = mqtt_tests::test_mqtt_broker();
+    let mut mqtt = MqttActorBuilder::new(
+        MqttConfig::default()
+            .with_port(broker.port)
+            .with_session_name(uniquify!("session")),
+    );
+    let (_never_ready, connect_when) = watch::channel(false);
+    mqtt.connect_when(connect_when, Duration::from_secs(60));
+    let mut shutdown = mqtt.get_signal_sender();
+
+    let running = tokio::spawn(mqtt_actor(mqtt));
+    shutdown.send(RuntimeRequest::Shutdown).await.unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), running)
+        .await
+        .expect("the client stops rather than waiting for a signal that is never coming")
+        .unwrap();
 }
 
 async fn timeout<T>(fut: impl Future<Output = T>) -> T {

--- a/tests/RobotFramework/tests/cumulocity/mapper_recovery/mapper_startup_with_bridge.robot
+++ b/tests/RobotFramework/tests/cumulocity/mapper_recovery/mapper_startup_with_bridge.robot
@@ -1,0 +1,62 @@
+*** Settings ***
+Documentation       Anything the mapper publishes to the cloud topics before the bridge relays them is
+...                 discarded by the local broker rather than forwarded. The mapper therefore waits for
+...                 the bridge before connecting to the broker, which also leaves whatever was published
+...                 to it meanwhile queued in its session instead of consumed and dropped.
+...                 These tests use the built-in bridge, as it starts within the mapper process and so
+...                 races with it on every mapper restart.
+
+Resource            ../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Suite Setup         Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:mapper_recovery
+
+
+*** Test Cases ***
+Supported operations reach the cloud when the mapper restarts alongside the bridge
+    [Documentation]    The mapper announces the operations it supports as soon as it starts. On a fresh
+    ...    session the bridge holds no subscription on the cloud topics yet, so that announcement is
+    ...    lost unless the mapper waits for it.
+    # Leave the cloud with a truncated list, so only an announcement made after the restart restores it
+    Execute Command    tedge mqtt pub c8y/s/us '114,c8y_Restart'
+    Cumulocity.Should Not Contain Supported Operations    c8y_SoftwareUpdate
+
+    ${timestamp}=    Get Unix Timestamp
+    ThinEdgeIO.Restart Service    tedge-mapper-c8y
+    Service Health Status Should Be Up    tedge-mapper-c8y
+
+    Should Have MQTT Messages    c8y/s/us    message_contains=114,    date_from=${timestamp}
+    Cumulocity.Should Contain Supported Operations    c8y_Restart    c8y_SoftwareUpdate
+
+Telemetry published while the mapper is down reaches the cloud once it restarts
+    [Documentation]    A measurement published while the mapper is down stays queued in the mapper's
+    ...    session on the local broker. Holding back the connection rather than the conversion keeps it
+    ...    there until the bridge can relay what it converts to, so a mapper restarted meanwhile — as
+    ...    when the bridge is being set up — still delivers it.
+    ThinEdgeIO.Stop Service    tedge-mapper-c8y
+
+    Execute Command    tedge mqtt pub te/device/main///m/queued_while_down '{"temperature":21.5}'
+
+    ThinEdgeIO.Start Service    tedge-mapper-c8y
+    Service Health Status Should Be Up    tedge-mapper-c8y
+
+    Cumulocity.Device Should Have Measurements
+    ...    type=queued_while_down
+    ...    value=temperature
+    ...    series=temperature
+    ...    minimum=1
+    ...    maximum=1
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}=    Setup
+    Set Suite Variable    ${DEVICE_SN}
+    Execute Command    tedge config set mqtt.bridge.built_in true
+    Execute Command    tedge reconnect c8y
+    Device Should Exist    ${DEVICE_SN}
+    Service Health Status Should Be Up    tedge-mapper-c8y


### PR DESCRIPTION
## Proposed changes

Fixes a flaky failure of the `Mapper started early does not miss supported operations` test, where the device's managed object in Cumulocity is missing `c8y_SupportedOperations`.

The failure was observed during a manual test run of the entire test suite for another PR.

**Root cause:** the c8y mapper published its init messages — the `114` SetSupportedOperations — immediately on startup. With the built-in bridge (the default), this races the bridge's local subscription to `c8y/s/us`: on a fresh session the early publish is dropped before the bridge has subscribed, so the supported operations never reach the cloud. (Software list, sent a little later, still gets through — which matches the observed symptom.)

**Fix:** for the built-in bridge, keep processing the main loop immediately (so local/offline handling is not blocked), but defer the init messages until the bridge is first `up` — by which point the local subscription is established. The supported operations are then published exactly once (no duplicates in the normal case). The external (mosquitto) bridge path is unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

N/A — fixes an intermittent failure of the `#2689` system test.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

**Added test:** a deterministic unit test (`builtin_bridge_mapper_defers_init_messages_until_bridge_is_up`) that asserts the `114` is not published before the bridge is up and is then sent exactly once. It fails on the old behaviour and passes with the fix, so it captures the regression without any timing dependence.

**Verification / flake-finder:**

- Fixed binary, target test, normal speed: **15/15 passed**.
- Full `c8y_mapper_ext` unit suite: **304 passed**; clippy clean.

**A note on reproducing the flake locally:** a real failure had been observed beforehand (an ordinary once-off run while working on another PR), but it proved difficult to reproduce on demand — the race window is sub-second on a fast/idle host. Normal-speed flake-finder did not reproduce it across ~260 target-test executions and several conditions (up to 100 sequential iterations, CPU throttling, single-core pinning, and 8 concurrent containers on a 4-CPU VM). It was only **reliably** reproduced by temporarily injecting a short delay before the built-in bridge's local half connects, to widen the window on purpose. Under that temporary delay the before/after is clean and deterministic:

| Binary (identical injected delay) | Result |
| --- | --- |
| Before fix (init published immediately) | **FAIL** — `c8y_SupportedOperations` missing (exact original signature) |
| After fix (init deferred to bridge up) | **PASS** |

The temporary delay was only a diagnostic aid and is **not** part of this change.
