### PR TITLE
fix: add --connection-timeout to tedge mqtt pub/sub

### DIFF
--- a/crates/common/mqtt_channel/src/config.rs
+++ b/crates/common/mqtt_channel/src/config.rs
@@ -13,6 +13,7 @@ use std::io::BufReader;
 use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 use zeroize::Zeroizing;
 
 pub const MAX_PACKET_SIZE: usize = 268435455;
@@ -61,6 +62,17 @@ pub struct Config {
     ///
     /// Default: None
     pub initial_message: Option<InitMessageFn>,
+
+    /// Maximum time spent establishing the initial MQTT connection.
+    ///
+    /// When set, `Connection::new` gives up after this duration while still
+    /// failing to reach the broker, instead of retrying forever.
+    ///
+    /// A value of `None` or `Some(Duration::ZERO)` means no timeout (infinite
+    /// connection retries) — the historical behaviour.
+    ///
+    /// Default: `None`
+    pub connection_timeout: Option<Duration>,
 }
 
 #[derive(Debug, Clone)]
@@ -265,6 +277,7 @@ impl Default for Config {
             max_packet_size: 16 * 1024 * 1024,
             last_will_message: None,
             initial_message: None,
+            connection_timeout: None,
         }
     }
 }
@@ -374,6 +387,17 @@ impl Config {
     ) -> Self {
         Self {
             initial_message: Some(InitMessageFn::new(initial_message)),
+            ..self
+        }
+    }
+
+    /// Set the maximum time spent establishing the initial MQTT connection.
+    ///
+    /// Pass `None` or `Duration::ZERO` for no timeout (retry forever).
+    pub fn with_connection_timeout(self, connection_timeout: impl Into<Option<Duration>>) -> Self {
+        let connection_timeout = connection_timeout.into().filter(|d| !d.is_zero());
+        Self {
+            connection_timeout,
             ..self
         }
     }

--- a/crates/common/mqtt_channel/src/connection.rs
+++ b/crates/common/mqtt_channel/src/connection.rs
@@ -241,8 +241,28 @@ impl Connection {
             config.broker.host, config.broker.port, config.session_name
         );
 
+        // None / zero means retry forever (historical behaviour).
+        let connection_timeout = config.connection_timeout.filter(|d| !d.is_zero());
+        let started_at = tokio::time::Instant::now();
+
         loop {
-            match event_loop.poll().await {
+            if let Some(timeout) = connection_timeout {
+                if started_at.elapsed() >= timeout {
+                    return Err(MqttError::ConnectionTimeout { timeout });
+                }
+            }
+
+            let poll_result = if let Some(timeout) = connection_timeout {
+                let remaining = timeout.saturating_sub(started_at.elapsed());
+                match tokio::time::timeout(remaining, event_loop.poll()).await {
+                    Ok(result) => result,
+                    Err(_) => return Err(MqttError::ConnectionTimeout { timeout }),
+                }
+            } else {
+                event_loop.poll().await
+            };
+
+            match poll_result {
                 Ok(Event::Incoming(Packet::ConnAck(ack))) => {
                     if let Some(err) = MqttError::maybe_connection_error(&ack) {
                         return Err(err);
@@ -287,7 +307,16 @@ impl Connection {
                     // Errors on send are ignored: it just means the client has closed the receiving channel.
                     let _ = error_sender.send(err.into()).await;
 
-                    Connection::do_pause().await;
+                    if let Some(timeout) = connection_timeout {
+                        let remaining = timeout.saturating_sub(started_at.elapsed());
+                        if remaining.is_zero() {
+                            return Err(MqttError::ConnectionTimeout { timeout });
+                        }
+                        // Do not sleep past the connection deadline.
+                        sleep(remaining.min(Duration::from_secs(1))).await;
+                    } else {
+                        Connection::do_pause().await;
+                    }
                 }
                 _ => (),
             }

--- a/crates/common/mqtt_channel/src/errors.rs
+++ b/crates/common/mqtt_channel/src/errors.rs
@@ -1,5 +1,6 @@
 use rumqttc::tokio_rustls::rustls;
 use rumqttc::ConnectReturnCode;
+use std::time::Duration;
 
 /// An MQTT related error
 #[derive(thiserror::Error, Debug)]
@@ -24,6 +25,9 @@ pub enum MqttError {
 
     #[error("MQTT connection rejected: {0:?}")]
     ConnectionRejected(rumqttc::ConnectReturnCode),
+
+    #[error("MQTT connection timed out after {timeout:?}")]
+    ConnectionTimeout { timeout: Duration },
 
     #[error("MQTT subscription failure")]
     // The MQTT specs are mysterious on the possible cause of such a failure

--- a/crates/common/mqtt_channel/src/tests.rs
+++ b/crates/common/mqtt_channel/src/tests.rs
@@ -640,3 +640,40 @@ async fn connection_can_be_closed_after_last_will_published() -> Result<(), anyh
 
     Ok(())
 }
+
+#[tokio::test]
+async fn connection_times_out_when_broker_is_unavailable() {
+    // Unresolvable host: retries would hang forever without a connection timeout.
+    let mqtt_config = Config::default()
+        .with_host("invalid.invalid")
+        .with_port(1883)
+        .with_session_name(uniquify!("timeout_client"))
+        .with_connection_timeout(Duration::from_millis(500));
+
+    let started = std::time::Instant::now();
+    let result = Connection::new(&mqtt_config).await;
+    let elapsed = started.elapsed();
+
+    match result {
+        Err(MqttError::ConnectionTimeout { .. }) => {}
+        Ok(_) => panic!("expected ConnectionTimeout, but connection succeeded"),
+        Err(err) => panic!("expected ConnectionTimeout, got error: {err}"),
+    }
+    // Should fail fast well under the historical infinite-retry behaviour.
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "connection timeout took too long: {elapsed:?}"
+    );
+}
+
+#[test]
+fn zero_connection_timeout_disables_timeout() {
+    let config = Config::default().with_connection_timeout(Duration::ZERO);
+    assert_eq!(config.connection_timeout, None);
+
+    let config = Config::default().with_connection_timeout(None);
+    assert_eq!(config.connection_timeout, None);
+
+    let config = Config::default().with_connection_timeout(Duration::from_secs(10));
+    assert_eq!(config.connection_timeout, Some(Duration::from_secs(10)));
+}

--- a/crates/core/tedge/src/cli/mqtt/cli.rs
+++ b/crates/core/tedge/src/cli/mqtt/cli.rs
@@ -39,6 +39,10 @@ pub enum TEdgeMqttCli {
         /// Pause between repeated messages (e.g., 60s, 1h)
         #[clap(long, default_value = "1s")]
         sleep: SecondsOrHumanTime,
+        /// Give up connecting to the broker after this duration (e.g., 10s, 500ms).
+        /// Use 0 / 0s / 0ms for no timeout (retry forever).
+        #[clap(long, default_value = "10s")]
+        connection_timeout: SecondsOrHumanTime,
     },
 
     /// Subscribe a MQTT topic.
@@ -67,6 +71,10 @@ pub enum TEdgeMqttCli {
         /// the first non-retained message
         #[clap(long)]
         retained_only: bool,
+        /// Give up connecting to the broker after this duration (e.g., 10s, 500ms).
+        /// Use 0 / 0s / 0ms for no timeout (retry forever).
+        #[clap(long, default_value = "10s")]
+        connection_timeout: SecondsOrHumanTime,
     },
 }
 
@@ -88,6 +96,7 @@ impl BuildCommand for TEdgeMqttCli {
                     base64,
                     repeat,
                     sleep,
+                    connection_timeout,
                 } => MqttPublishCommand {
                     host: config.mqtt.client.host.clone(),
                     port: config.mqtt.client.port.into(),
@@ -100,6 +109,7 @@ impl BuildCommand for TEdgeMqttCli {
                     auth_config,
                     count: repeat.unwrap_or(1),
                     sleep: sleep.duration(),
+                    connection_timeout: optional_connection_timeout(connection_timeout),
                 }
                 .into_boxed(),
                 TEdgeMqttCli::Sub {
@@ -110,6 +120,7 @@ impl BuildCommand for TEdgeMqttCli {
                     duration,
                     count,
                     retained_only,
+                    connection_timeout,
                 } => MqttSubscribeCommand {
                     host: config.mqtt.client.host.clone(),
                     port: config.mqtt.client.port.into(),
@@ -122,12 +133,25 @@ impl BuildCommand for TEdgeMqttCli {
                     duration: duration.map(|v| v.duration()),
                     count,
                     retained_only,
+                    connection_timeout: optional_connection_timeout(connection_timeout),
                 }
                 .into_boxed(),
             }
         };
 
         Ok(cmd)
+    }
+}
+
+/// Map a CLI duration to an optional connection timeout.
+///
+/// Zero (including `0`, `0s`, `0ms`) means no timeout / infinite retries.
+fn optional_connection_timeout(timeout: SecondsOrHumanTime) -> Option<std::time::Duration> {
+    let duration = timeout.duration();
+    if duration.is_zero() {
+        None
+    } else {
+        Some(duration)
     }
 }
 
@@ -157,8 +181,12 @@ fn qos_completions() -> Vec<CompletionCandidate> {
 
 #[cfg(test)]
 mod tests {
+    use super::optional_connection_timeout;
     use super::parse_qos;
     use rumqttc::QoS;
+    use std::str::FromStr;
+    use std::time::Duration;
+    use tedge_config::models::SecondsOrHumanTime;
 
     #[test]
     fn test_parse_qos_at_most_once() {
@@ -179,5 +207,26 @@ mod tests {
         let input_qos = "2";
         let expected_qos = QoS::ExactlyOnce;
         assert_eq!(parse_qos(input_qos).unwrap(), expected_qos);
+    }
+
+    #[test]
+    fn zero_connection_timeout_means_infinite_retries() {
+        for input in ["0", "0s", "0ms"] {
+            let timeout = SecondsOrHumanTime::from_str(input).unwrap();
+            assert_eq!(
+                optional_connection_timeout(timeout),
+                None,
+                "input {input:?} should disable the connection timeout"
+            );
+        }
+    }
+
+    #[test]
+    fn non_zero_connection_timeout_is_preserved() {
+        let timeout = SecondsOrHumanTime::from_str("10s").unwrap();
+        assert_eq!(
+            optional_connection_timeout(timeout),
+            Some(Duration::from_secs(10))
+        );
     }
 }

--- a/crates/core/tedge/src/cli/mqtt/publish.rs
+++ b/crates/core/tedge/src/cli/mqtt/publish.rs
@@ -4,6 +4,7 @@ use base64::prelude::*;
 use mqtt_channel::MqttMessage;
 use mqtt_channel::PubChannel;
 use mqtt_channel::Topic;
+use std::time::Duration;
 use tedge_config::TEdgeConfig;
 use tedge_config::TEdgeMqttClientAuthConfig;
 use tracing::info;
@@ -22,7 +23,9 @@ pub struct MqttPublishCommand {
     pub base64: bool,
     pub auth_config: TEdgeMqttClientAuthConfig,
     pub count: u32,
-    pub sleep: std::time::Duration,
+    pub sleep: Duration,
+    /// Maximum time spent connecting to the broker. `None` means retry forever.
+    pub connection_timeout: Option<Duration>,
 }
 
 #[async_trait::async_trait]
@@ -56,7 +59,8 @@ fn build_config(cmd: &MqttPublishCommand) -> Result<mqtt_channel::Config, anyhow
         .with_session_prefix(cmd.client_id.clone())
         .with_clean_session(true)
         .with_max_packet_size(MAX_PACKET_SIZE)
-        .with_queue_capacity(DEFAULT_QUEUE_CAPACITY);
+        .with_queue_capacity(DEFAULT_QUEUE_CAPACITY)
+        .with_connection_timeout(cmd.connection_timeout);
     config.with_client_auth(cmd.auth_config.clone().try_into()?)?;
     Ok(config)
 }
@@ -125,7 +129,20 @@ mod tests {
             base64: false,
             auth_config: TEdgeMqttClientAuthConfig::default(),
             count: 1,
-            sleep: std::time::Duration::ZERO,
+            sleep: Duration::ZERO,
+            connection_timeout: Some(Duration::from_secs(10)),
         }
+    }
+
+    #[test]
+    fn build_config_applies_connection_timeout() {
+        let mut cmd = pub_command_with_client_id("tedge-pub-timeout");
+        cmd.connection_timeout = Some(Duration::from_secs(3));
+        let config = build_config(&cmd).unwrap();
+        assert_eq!(config.connection_timeout, Some(Duration::from_secs(3)));
+
+        cmd.connection_timeout = None;
+        let config = build_config(&cmd).unwrap();
+        assert_eq!(config.connection_timeout, None);
     }
 }

--- a/crates/core/tedge/src/cli/mqtt/subscribe.rs
+++ b/crates/core/tedge/src/cli/mqtt/subscribe.rs
@@ -25,6 +25,8 @@ pub struct MqttSubscribeCommand {
     pub duration: Option<Duration>,
     pub count: Option<u32>,
     pub retained_only: bool,
+    /// Maximum time spent connecting to the broker. `None` means retry forever.
+    pub connection_timeout: Option<Duration>,
 }
 
 #[derive(Clone, Debug)]
@@ -54,7 +56,8 @@ fn build_config(cmd: &MqttSubscribeCommand) -> Result<mqtt_channel::Config, anyh
         .with_clean_session(true)
         .with_subscriptions(topic)
         .with_max_packet_size(MAX_PACKET_SIZE)
-        .with_queue_capacity(DEFAULT_QUEUE_CAPACITY);
+        .with_queue_capacity(DEFAULT_QUEUE_CAPACITY)
+        .with_connection_timeout(cmd.connection_timeout);
     config.with_client_auth(cmd.auth_config.clone().try_into()?)?;
     Ok(config)
 }
@@ -161,6 +164,19 @@ mod tests {
             duration: None,
             count: None,
             retained_only: false,
+            connection_timeout: Some(Duration::from_secs(10)),
         }
+    }
+
+    #[test]
+    fn build_config_applies_connection_timeout() {
+        let mut cmd = sub_command_with_client_id("tedge-sub-timeout");
+        cmd.connection_timeout = Some(Duration::from_secs(3));
+        let config = build_config(&cmd).unwrap();
+        assert_eq!(config.connection_timeout, Some(Duration::from_secs(3)));
+
+        cmd.connection_timeout = None;
+        let config = build_config(&cmd).unwrap();
+        assert_eq!(config.connection_timeout, None);
     }
 }


### PR DESCRIPTION
### Summary
Add `--connection-timeout` to `tedge mqtt pub`/`sub` (default **10s**; `0` / `0s` / `0ms` = infinite retries) so commands fail fast when the broker is down.

This prevents `tedge diag collect` (and similar scripts) from waiting on the plugin's 60s timeout when MQTT is unavailable.

Related to #3828

### Changes
- `mqtt_channel::Config`: optional `connection_timeout` + `with_connection_timeout()`
- `Connection::open`: stop retrying after the deadline (also bounds `event_loop.poll` and the 1s pause)
- `MqttError::ConnectionTimeout` for a clear failure mode
- CLI flags on both `pub` and `sub` (human-friendly duration via existing `SecondsOrHumanTime`)

### Validation
```
cargo test -p mqtt_channel --lib -- --test-threads=1
# 33 passed

cargo test -p tedge --lib cli::mqtt -- --test-threads=1
# 9 passed (including connection-timeout unit tests)
```

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project contributor terms; AI output was not pasted unreviewed.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
https://github.com/thin-edge/thin-edge.io/issues/3828

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Default for long-lived services that use `mqtt_channel` remains **no timeout** (`None`). Only the CLI opts into a 10s default.