### PR TITLE
feat: config_snapshot workflow with get and upload steps

### DIFF
--- a/crates/core/tedge_agent/src/agent.rs
+++ b/crates/core/tedge_agent/src/agent.rs
@@ -289,6 +289,7 @@ impl Agent {
             &mut script_runner,
             &mut fs_watch_actor_builder,
             &mut downloader_actor_builder,
+            &mut uploader_actor_builder,
         );
         workflow_actor_builder.register_builtin_operation(&mut restart_actor_builder);
         workflow_actor_builder.register_builtin_operation(&mut software_update_builder);

--- a/crates/core/tedge_agent/src/operation_workflows/actor.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/actor.rs
@@ -45,6 +45,8 @@ use tedge_file_system_ext::FsWatchEvent;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::QoS;
 use tedge_script_ext::Execute;
+use tedge_uploader_ext::UploadRequest;
+use tedge_uploader_ext::UploadResult;
 use tokio::time::sleep;
 use tracing::error;
 use tracing::info;
@@ -52,6 +54,8 @@ use tracing::warn;
 
 type DownloaderRequest = (String, DownloadRequest);
 type DownloaderResult = (String, DownloadResult);
+type UploaderRequest = (String, UploadRequest);
+type UploaderResult = (String, UploadResult);
 
 /// A generic command state that is published by the [TedgeOperationConverterActor]
 /// to itself for further processing .i.e. after a state update
@@ -78,6 +82,7 @@ pub struct WorkflowActor {
     pub(crate) mqtt_publisher: LoggingSender<MqttMessage>,
     pub(crate) script_runner: ClientMessageBox<Execute, std::io::Result<Output>>,
     pub(crate) downloader: ClientMessageBox<DownloaderRequest, DownloaderResult>,
+    pub(crate) uploader: ClientMessageBox<UploaderRequest, UploaderResult>,
     pub(crate) tmp_dir: Utf8PathBuf,
 }
 
@@ -476,6 +481,93 @@ impl WorkflowActor {
                 };
                 let new_state = state
                     .update_with_builtin_action_result("download", result, handlers, &mut log_file)
+                    .await;
+                self.publish_command_state(new_state, &mut log_file).await
+            }
+            OperationAction::Upload(input_excerpt, handlers) => {
+                let step = &state.status;
+                info!("Processing {operation} operation {step} step with upload builtin action");
+
+                let input = input_excerpt.extract_value_from(&state);
+                let (url, url_source) =
+                    if let Some(url) = GenericCommandState::extract_text_property(&input, "url") {
+                        (url, "input.url")
+                    } else if let Some(url) = state.get_text_property("tedgeUrl") {
+                        (url, "tedgeUrl")
+                    } else {
+                        let err_state = state
+                            .update_with_builtin_action_result(
+                                "upload",
+                                Err("No valid URL found in input.url or tedgeUrl".to_string()),
+                                handlers,
+                                &mut log_file,
+                            )
+                            .await;
+                        return self.publish_command_state(err_state, &mut log_file).await;
+                    };
+
+                let (file_path, path_source) = if let Some(path) =
+                    GenericCommandState::extract_text_property(&input, "path")
+                {
+                    (path, "input.path")
+                } else if let Some(path) = state.get_text_property("path") {
+                    (path, "path")
+                } else {
+                    let err_state = state
+                        .update_with_builtin_action_result(
+                            "upload",
+                            Err("No valid file path found in input.path or path".to_string()),
+                            handlers,
+                            &mut log_file,
+                        )
+                        .await;
+                    return self.publish_command_state(err_state, &mut log_file).await;
+                };
+
+                log_file
+                    .log_info(&format!(
+                        "Uploading file from {} ({}) to URL from {} ({})",
+                        path_source, file_path, url_source, url
+                    ))
+                    .await;
+
+                let upload_path = match Utf8PathBuf::from(file_path) {
+                    path if path.as_str().is_empty() => {
+                        let err_state = state
+                            .update_with_builtin_action_result(
+                                "upload",
+                                Err("Upload file path is empty".to_string()),
+                                handlers,
+                                &mut log_file,
+                            )
+                            .await;
+                        return self.publish_command_state(err_state, &mut log_file).await;
+                    }
+                    path => path,
+                };
+
+                let upload_request = UploadRequest::new(url, &upload_path);
+                let (_topic, upload_result) = self
+                    .uploader
+                    .await_response((state.topic.name.clone(), upload_request))
+                    .await?;
+
+                let result = match upload_result {
+                    Ok(upload_response) => {
+                        log_file
+                            .log_info(&format!(
+                                "Uploaded {} to {}",
+                                upload_response.file_path, upload_response.url
+                            ))
+                            .await;
+
+                        // Keep `path` on the payload so config_snapshot can report it as successful
+                        Ok(json!({"path": upload_response.file_path}))
+                    }
+                    Err(err) => Err(format!("Upload failed: {}", err)),
+                };
+                let new_state = state
+                    .update_with_builtin_action_result("upload", result, handlers, &mut log_file)
                     .await;
                 self.publish_command_state(new_state, &mut log_file).await
             }

--- a/crates/core/tedge_agent/src/operation_workflows/builder.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/builder.rs
@@ -45,9 +45,13 @@ use tedge_file_system_ext::FsWatchEvent;
 use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::TopicFilter;
 use tedge_script_ext::Execute;
+use tedge_uploader_ext::UploadRequest;
+use tedge_uploader_ext::UploadResult;
 
 pub type DownloaderRequest = (String, DownloadRequest);
 pub type DownloaderResult = (String, DownloadResult);
+pub type UploaderRequest = (String, UploadRequest);
+pub type UploaderResult = (String, UploadResult);
 
 pub struct WorkflowActorBuilder {
     config: OperationConfig,
@@ -60,6 +64,7 @@ pub struct WorkflowActorBuilder {
     script_runner: ClientMessageBox<Execute, std::io::Result<Output>>,
     signal_sender: mpsc::Sender<RuntimeRequest>,
     downloader: ClientMessageBox<DownloaderRequest, DownloaderResult>,
+    uploader: ClientMessageBox<UploaderRequest, UploaderResult>,
     builtin_operation_step_executor: HashMap<
         (OperationType, OperationStep),
         ClientMessageBox<OperationStepRequest, OperationStepResponse>,
@@ -73,6 +78,7 @@ impl WorkflowActorBuilder {
         script_runner: &mut impl Service<Execute, std::io::Result<Output>>,
         fs_notify: &mut impl MessageSource<FsWatchEvent, PathBuf>,
         downloader: &mut impl Service<DownloaderRequest, DownloaderResult>,
+        uploader: &mut impl Service<UploaderRequest, UploaderResult>,
     ) -> Self {
         let (input_sender, input_receiver) = mpsc::unbounded();
         let (signal_sender, signal_receiver) = mpsc::channel(10);
@@ -103,6 +109,7 @@ impl WorkflowActorBuilder {
         let script_runner = ClientMessageBox::new(script_runner);
 
         let downloader = ClientMessageBox::new(downloader);
+        let uploader = ClientMessageBox::new(uploader);
 
         fs_notify.connect_sink(config.operations_dir.path().into(), &input_sender);
 
@@ -117,6 +124,7 @@ impl WorkflowActorBuilder {
             signal_sender,
             script_runner,
             downloader,
+            uploader,
             builtin_operation_step_executor: HashMap::new(),
         }
     }
@@ -221,6 +229,7 @@ impl Builder<WorkflowActor> for WorkflowActorBuilder {
             command_sender: self.command_sender,
             script_runner: self.script_runner,
             downloader: self.downloader,
+            uploader: self.uploader,
             tmp_dir: self.config.tmp_dir.root().into(),
         }
     }

--- a/crates/core/tedge_agent/src/operation_workflows/tests.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/tests.rs
@@ -1,5 +1,7 @@
 use crate::operation_workflows::builder::DownloaderRequest;
 use crate::operation_workflows::builder::DownloaderResult;
+use crate::operation_workflows::builder::UploaderRequest;
+use crate::operation_workflows::builder::UploaderResult;
 use crate::operation_workflows::builder::WorkflowActorBuilder;
 use crate::operation_workflows::config::OperationConfig;
 use crate::software_manager::actor::SoftwareCommand;
@@ -57,6 +59,7 @@ use tedge_mqtt_ext::MqttMessage;
 use tedge_mqtt_ext::Topic;
 use tedge_script_ext::Execute;
 use tedge_test_utils::fs::TempTedgeDir;
+use tedge_uploader_ext::UploadResponse;
 use tedge_utils::paths::TedgePaths;
 use tokio::task::JoinHandle;
 
@@ -630,6 +633,253 @@ action = "cleanup"
 }
 
 #[tokio::test]
+async fn upload_action() -> Result<(), DynError> {
+    let workflow = r#"
+operation = "config_snapshot"
+
+[init]
+action = "proceed"
+on_success = "upload"
+
+[upload]
+action = "upload"
+input.url = "${.payload.tedgeUrl}"
+on_success = "successful"
+on_error = "failed"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"
+"#;
+
+    let TestHandler {
+        mut mqtt_box,
+        mut uploader_box,
+        mut actor_handle,
+        ..
+    } = spawn_mqtt_operation_converter(
+        "device/main//",
+        vec![("config_snapshot.toml".to_string(), workflow.to_string())],
+    )
+    .await?;
+
+    let mqtt_message = MqttMessage::new(
+        &Topic::new_unchecked("te/device/main///cmd/config_snapshot/123"),
+        r#"{"status":"init","tedgeUrl":"http://example.com/upload","path":"/tmp/snapshot.conf","type":"tedge.toml"}"#,
+    );
+    mqtt_box.send(mqtt_message).await?;
+
+    let RequestEnvelope {
+        request: (topic, upload_request),
+        reply_to: _,
+    } = recv_or_fail_on_actor_exit(&mut uploader_box, &mut actor_handle, "upload request")
+        .await
+        .expect("upload request expected");
+    assert_eq!(topic, "te/device/main///cmd/config_snapshot/123");
+    assert_eq!(upload_request.url, "http://example.com/upload");
+    assert_eq!(upload_request.file_path.as_str(), "/tmp/snapshot.conf");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn upload_action_without_input_url() -> Result<(), DynError> {
+    let workflow = r#"
+operation = "config_snapshot"
+
+[init]
+action = "proceed"
+on_success = "upload"
+
+[upload]
+action = "upload"
+on_success = "successful"
+on_error = "failed"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"
+"#;
+
+    let TestHandler {
+        mut mqtt_box,
+        mut uploader_box,
+        mut actor_handle,
+        ..
+    } = spawn_mqtt_operation_converter(
+        "device/main//",
+        vec![("config_snapshot.toml".to_string(), workflow.to_string())],
+    )
+    .await?;
+
+    let mqtt_message = MqttMessage::new(
+        &Topic::new_unchecked("te/device/main///cmd/config_snapshot/123"),
+        r#"{"status":"init","tedgeUrl":"http://example.com/upload","path":"/tmp/snapshot.conf","type":"tedge.toml"}"#,
+    );
+    mqtt_box.send(mqtt_message).await?;
+
+    // Fall back to tedgeUrl and path from the payload when input is omitted
+    let RequestEnvelope {
+        request: (topic, upload_request),
+        mut reply_to,
+    } = recv_or_fail_on_actor_exit(&mut uploader_box, &mut actor_handle, "upload request")
+        .await
+        .expect("upload request expected");
+    assert_eq!(topic, "te/device/main///cmd/config_snapshot/123");
+    assert_eq!(upload_request.url, "http://example.com/upload");
+    assert_eq!(upload_request.file_path.as_str(), "/tmp/snapshot.conf");
+
+    reply_to
+        .send((
+            topic.clone(),
+            Ok(UploadResponse {
+                url: upload_request.url.clone(),
+                file_path: upload_request.file_path.clone(),
+            }),
+        ))
+        .await?;
+
+    let payload = recv_command_state_with_status(
+        &mut mqtt_box,
+        &mut actor_handle,
+        "te/device/main///cmd/config_snapshot/123",
+        "successful",
+    )
+    .await;
+    assert_eq!(
+        payload.get("path").and_then(|v| v.as_str()),
+        Some("/tmp/snapshot.conf")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn upload_action_missing_path() -> Result<(), DynError> {
+    let workflow = r#"
+operation = "config_snapshot"
+
+[init]
+action = "proceed"
+on_success = "upload"
+
+[upload]
+action = "upload"
+input.url = "${.payload.tedgeUrl}"
+on_success = "successful"
+on_error = "failed"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"
+"#;
+
+    let TestHandler {
+        mut mqtt_box,
+        mut uploader_box,
+        mut actor_handle,
+        ..
+    } = spawn_mqtt_operation_converter(
+        "device/main//",
+        vec![("config_snapshot.toml".to_string(), workflow.to_string())],
+    )
+    .await?;
+
+    let mqtt_message = MqttMessage::new(
+        &Topic::new_unchecked("te/device/main///cmd/config_snapshot/123"),
+        r#"{"status":"init","tedgeUrl":"http://example.com/upload","type":"tedge.toml"}"#,
+    );
+    mqtt_box.send(mqtt_message).await?;
+
+    assert_no_message_or_actor_exit(
+        &mut uploader_box,
+        &mut actor_handle,
+        "waiting for unexpected upload request",
+    )
+    .await;
+
+    let payload = recv_command_state_with_status(
+        &mut mqtt_box,
+        &mut actor_handle,
+        "te/device/main///cmd/config_snapshot/123",
+        "failed",
+    )
+    .await;
+    assert_eq!(
+        payload.get("reason").and_then(|v| v.as_str()),
+        Some("builtin 'upload' action failed with: No valid file path found in input.path or path",)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn config_snapshot_get_operation_step() -> Result<(), DynError> {
+    let workflow = r#"
+operation = "config_snapshot"
+
+[init]
+action = "proceed"
+on_success = "get"
+
+[get]
+action = "builtin:config_snapshot:get"
+on_success = "successful"
+on_error = "failed"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"
+"#;
+
+    let TestHandler {
+        mut mqtt_box,
+        mut config_box,
+        mut actor_handle,
+        ..
+    } = spawn_mqtt_operation_converter(
+        "device/main//",
+        vec![("config_snapshot.toml".to_string(), workflow.to_string())],
+    )
+    .await?;
+
+    let init_message = MqttMessage::new(
+        &Topic::new_unchecked("te/device/main///cmd/config_snapshot/123"),
+        r#"{"status":"init","tedgeUrl":"http://example.com/upload","type":"tedge.toml"}"#,
+    );
+    mqtt_box.send(init_message).await?;
+
+    let RequestEnvelope {
+        request,
+        reply_to: _,
+    } = recv_or_fail_on_actor_exit(
+        &mut config_box,
+        &mut actor_handle,
+        "builtin operation step request",
+    )
+    .await
+    .expect("expected builtin operation step request");
+
+    assert_eq!(request.command_step, "get");
+    assert_eq!(request.command_state.status, "get");
+    let command_payload = serde_json::to_value(&request.command_state.payload)?;
+    assert_eq!(
+        command_payload.get("type").and_then(|v| v.as_str()),
+        Some("tedge.toml")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn builtin_operation_step_action() -> Result<(), DynError> {
     let workflow = r#"
 operation = "config_update"
@@ -847,6 +1097,9 @@ struct TestHandler {
     downloader_box: TimedMessageBox<
         SimpleMessageBox<RequestEnvelope<DownloaderRequest, DownloaderResult>, NoMessage>,
     >,
+    uploader_box: TimedMessageBox<
+        SimpleMessageBox<RequestEnvelope<UploaderRequest, UploaderResult>, NoMessage>,
+    >,
     config_box: TimedMessageBox<
         SimpleMessageBox<RequestEnvelope<OperationStepRequest, OperationStepResponse>, NoMessage>,
     >,
@@ -875,6 +1128,10 @@ async fn spawn_mqtt_operation_converter(
         RequestEnvelope<DownloaderRequest, DownloaderResult>,
         NoMessage,
     > = SimpleMessageBoxBuilder::new("Downloader", 5);
+    let mut uploader_builder: SimpleMessageBoxBuilder<
+        RequestEnvelope<UploaderRequest, UploaderResult>,
+        NoMessage,
+    > = SimpleMessageBoxBuilder::new("Uploader", 5);
 
     let tmp_dir = Arc::new(TempTedgeDir::new());
     let tmp_path = Utf8Path::from_path(tmp_dir.path()).unwrap();
@@ -908,6 +1165,7 @@ async fn spawn_mqtt_operation_converter(
         &mut script_builder,
         &mut inotify_builder,
         &mut downloade_builder,
+        &mut uploader_builder,
     );
     workflow_actor_builder.register_builtin_operation(&mut restart_builder);
     workflow_actor_builder.register_builtin_operation(&mut software_builder);
@@ -924,6 +1182,7 @@ async fn spawn_mqtt_operation_converter(
     let restart_box = restart_builder.0.build().with_timeout(TEST_TIMEOUT_MS);
     let mqtt_box = mqtt_builder.build().with_timeout(TEST_TIMEOUT_MS);
     let downloader_box = downloade_builder.build().with_timeout(TEST_TIMEOUT_MS);
+    let uploader_box = uploader_builder.build().with_timeout(TEST_TIMEOUT_MS);
     let _inotify_box = inotify_builder.build().with_timeout(TEST_TIMEOUT_MS);
 
     let workflow_actor = workflow_actor_builder.build();
@@ -942,6 +1201,7 @@ async fn spawn_mqtt_operation_converter(
         restart_box,
         _inotify_box,
         downloader_box,
+        uploader_box,
         config_box,
         sync_signal_box,
     })
@@ -1106,7 +1366,10 @@ struct ConfigActorBuilder(
 
 impl OperationStepHandler for ConfigActorBuilder {
     fn supported_operation_steps(&self) -> Vec<(OperationType, OperationStep)> {
-        vec![(OperationType::ConfigUpdate, OperationStep::from("set"))]
+        vec![
+            (OperationType::ConfigUpdate, OperationStep::from("set")),
+            (OperationType::ConfigSnapshot, OperationStep::from("get")),
+        ]
     }
 }
 

--- a/crates/core/tedge_api/src/workflow/mod.rs
+++ b/crates/core/tedge_api/src/workflow/mod.rs
@@ -144,6 +144,20 @@ pub enum OperationAction {
     /// ```
     Download(StateExcerpt, ExitHandlers),
 
+    /// Generic upload action (reusable across operations)
+    ///
+    /// Uploads a local file to `input.url`. The local file path is taken from `input.path` when
+    /// provided, otherwise falls back to the `path` field already present on the command payload.
+    /// This action is operation-agnostic and can be used by config_snapshot, log_upload, etc.
+    ///
+    /// ```toml
+    /// action = "upload"
+    /// input.url = "${.payload.tedgeUrl}"
+    /// on_success = "<state>"
+    /// on_error = "<state>"
+    /// ```
+    Upload(StateExcerpt, ExitHandlers),
+
     /// Trigger an operation and move to the next state from where the outcome of the operation will be awaited
     ///
     /// ```toml
@@ -217,6 +231,7 @@ impl Display for OperationAction {
             OperationAction::Script(script, _) => script.to_string(),
             OperationAction::BgScript(script, _) => script.to_string(),
             OperationAction::Download(_, _) => "builtin download action".to_string(),
+            OperationAction::Upload(_, _) => "builtin upload action".to_string(),
             OperationAction::Operation(operation, maybe_script, _, _) => match maybe_script {
                 None => format!("execute {operation} as sub-operation"),
                 Some(script) => format!(

--- a/crates/core/tedge_api/src/workflow/toml_config.rs
+++ b/crates/core/tedge_api/src/workflow/toml_config.rs
@@ -202,6 +202,11 @@ impl TryFrom<(TomlOperationState, DefaultHandlers)> for OperationAction {
                     let input_excerpt = input.input.try_into()?;
                     Ok(OperationAction::Download(input_excerpt, handlers))
                 }
+                "upload" => {
+                    let handlers = ExitHandlers::try_from(input.handlers)?;
+                    let input_excerpt = input.input.try_into()?;
+                    Ok(OperationAction::Upload(input_excerpt, handlers))
+                }
                 _ => {
                     if let Some(builtin) = command.strip_prefix("builtin:") {
                         if let Some((operation, step)) = builtin.split_once(':') {
@@ -922,6 +927,87 @@ action = "cleanup"
                 assert_eq!(
                     handlers.state_update_on_exit("config_set", 0).status,
                     "successful"
+                );
+            }
+            other => panic!("Expected BuiltInOperationStep action, but got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_upload_action() {
+        let file = r#"
+operation = "config_snapshot"
+
+[init]
+action = "proceed"
+on_success = "upload"
+
+[upload]
+action = "upload"
+input.url = "${.payload.tedgeUrl}"
+on_success = "successful"
+on_error = "failed"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"
+"#;
+        let input: TomlOperationWorkflow = toml::from_str(file).unwrap();
+        let workflow = OperationWorkflow::try_from(input).unwrap();
+
+        match workflow.states.get("upload").unwrap() {
+            OperationAction::Upload(input_excerpt, handlers) => {
+                let expected_input = StateExcerpt::from(json!({
+                    "url": "${.payload.tedgeUrl}"
+                }));
+                assert_eq!(input_excerpt, &expected_input);
+                assert_eq!(
+                    handlers.state_update_on_exit("upload", 0).status,
+                    "successful"
+                );
+            }
+            other => panic!("Expected Upload action, but got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_config_snapshot_get_action() {
+        let file = r#"
+operation = "config_snapshot"
+
+[init]
+action = "proceed"
+on_success = "get"
+
+[get]
+action = "builtin:config_snapshot:get"
+on_success = "upload"
+on_error = "failed"
+
+[upload]
+action = "upload"
+on_success = "successful"
+on_error = "failed"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"
+"#;
+        let input: TomlOperationWorkflow = toml::from_str(file).unwrap();
+        let workflow = OperationWorkflow::try_from(input).unwrap();
+
+        match workflow.states.get("get").unwrap() {
+            OperationAction::BuiltInOperationStep(operation, step, input_excerpt, handlers) => {
+                assert_eq!(operation, "config_snapshot");
+                assert_eq!(step, "get");
+                assert_eq!(input_excerpt, &StateExcerpt::try_from(None).unwrap());
+                assert_eq!(
+                    handlers.state_update_on_exit("config_get", 0).status,
+                    "upload"
                 );
             }
             other => panic!("Expected BuiltInOperationStep action, but got {:?}", other),

--- a/crates/extensions/tedge_config_manager/src/actor.rs
+++ b/crates/extensions/tedge_config_manager/src/actor.rs
@@ -83,6 +83,8 @@ fn get_path_property<'a>(
 /// Represents the different steps for config management operations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ConfigOperationStep {
+    /// Retrieve configuration content for a snapshot (`config_snapshot` operation)
+    Get,
     Prepare,
     Set,
     Verify,
@@ -92,6 +94,7 @@ pub enum ConfigOperationStep {
 impl ConfigOperationStep {
     pub fn as_str(&self) -> &'static str {
         match self {
+            Self::Get => "get",
             Self::Prepare => "prepare",
             Self::Set => "set",
             Self::Verify => "verify",
@@ -99,7 +102,8 @@ impl ConfigOperationStep {
         }
     }
 
-    pub fn all() -> &'static [ConfigOperationStep] {
+    /// Steps registered for the `config_update` operation
+    pub fn update_steps() -> &'static [ConfigOperationStep] {
         &[Self::Prepare, Self::Set, Self::Verify, Self::Rollback]
     }
 }
@@ -109,6 +113,7 @@ impl FromStr for ConfigOperationStep {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "get" => Ok(Self::Get),
             "prepare" => Ok(Self::Prepare),
             "set" => Ok(Self::Set),
             "verify" => Ok(Self::Verify),
@@ -523,6 +528,7 @@ impl ConfigManagerWorker {
         };
 
         let result = match step {
+            ConfigOperationStep::Get => self.process_config_get_request(command).await,
             ConfigOperationStep::Prepare => self.process_config_prepare_request(command).await,
             ConfigOperationStep::Set => self.process_config_set_request(command).await,
             ConfigOperationStep::Verify => self.process_config_verify_request(command).await,
@@ -538,6 +544,68 @@ impl ConfigManagerWorker {
                 topic, error
             );
         }
+    }
+
+    async fn process_config_get_request(
+        &mut self,
+        command: GenericCommandState,
+    ) -> Result<Value, ConfigManagementError> {
+        let topic = command.topic.clone();
+        let cmd_id = self.extract_command_id(&topic)?;
+        let log_path = command.get_log_path();
+        let config_type = get_text_property(&command, "type")?;
+
+        let config_path = self
+            .execute_config_get_step(config_type, log_path, &cmd_id)
+            .await?;
+
+        // Ensure a tedgeUrl is available for the subsequent upload step.
+        // If the requester did not provide one, generate it the same way as the
+        // legacy monolithic snapshot handler.
+        let mut response = json!({"path": config_path.as_str()});
+        if command.get_text_property("tedgeUrl").is_none() {
+            let tedge_url = self.create_tedge_url_for_config_operation(&topic, config_type)?;
+            if let Some(obj) = response.as_object_mut() {
+                obj.insert("tedgeUrl".to_string(), json!(tedge_url));
+            }
+        }
+
+        Ok(response)
+    }
+
+    async fn execute_config_get_step(
+        &mut self,
+        config_type: &str,
+        log_path: Option<Utf8PathBuf>,
+        cmd_id: &str,
+    ) -> Result<Utf8PathBuf, ConfigManagementError> {
+        let (parsed_type, plugin_name) = parse_config_type(config_type);
+        let plugin = self.get_plugin(plugin_name)?;
+
+        let config_path = self.config.tmp_path.root().join(format!(
+            "config_snapshot-{}-{}-{}.conf",
+            config_type.replace(['/', ':', '\\'], "_"),
+            cmd_id,
+            OffsetDateTime::now_utc().unix_timestamp()
+        ));
+
+        let mut command_log = log_path.map(|path| {
+            CommandLog::from_log_path(
+                path,
+                OperationType::ConfigSnapshot.to_string(),
+                cmd_id.to_string(),
+            )
+        });
+
+        info!(
+            target: "config plugins",
+            "Retrieving config type: {} to file: {}", parsed_type, config_path
+        );
+        plugin
+            .get(parsed_type, &config_path, command_log.as_mut())
+            .await?;
+
+        Ok(config_path)
     }
 
     async fn process_config_prepare_request(

--- a/crates/extensions/tedge_config_manager/src/lib.rs
+++ b/crates/extensions/tedge_config_manager/src/lib.rs
@@ -102,15 +102,21 @@ impl ConfigManagerBuilder {
     }
 
     pub async fn init(config: &ConfigManagerConfig) -> Result<(), anyhow::Error> {
-        // Initialize config_update.toml with template pattern:
-        // - Always update config_update.toml.template with the latest template definition
-        // - Only update config_update.toml if it doesn't exist or hasn't been customized by the user
-        let workflow_definition = include_str!("resources/config_update.toml");
-
+        // Initialize config_update.toml and config_snapshot.toml with template pattern:
+        // - Always update *.toml.template with the latest template definition
+        // - Only update the active *.toml if it doesn't exist or hasn't been customized by the user
+        let config_update_workflow = include_str!("resources/config_update.toml");
         config
             .ops_dir
             .template_file("config_update.toml")?
-            .persist(workflow_definition)
+            .persist(config_update_workflow)
+            .await?;
+
+        let config_snapshot_workflow = include_str!("resources/config_snapshot.toml");
+        config
+            .ops_dir
+            .template_file("config_snapshot.toml")?
+            .persist(config_snapshot_workflow)
             .await?;
 
         if config.plugin_config_path.path().exists() {
@@ -310,10 +316,15 @@ impl SyncOnCommand for ConfigManagerBuilder {
 
 impl OperationStepHandler for ConfigManagerBuilder {
     fn supported_operation_steps(&self) -> Vec<(OperationType, OperationStep)> {
-        ConfigOperationStep::all()
+        let mut steps: Vec<(OperationType, OperationStep)> = ConfigOperationStep::update_steps()
             .iter()
             .map(|step| (OperationType::ConfigUpdate, step.as_str().into()))
-            .collect()
+            .collect();
+        steps.push((
+            OperationType::ConfigSnapshot,
+            ConfigOperationStep::Get.as_str().into(),
+        ));
+        steps
     }
 }
 

--- a/crates/extensions/tedge_config_manager/src/resources/config_snapshot.toml
+++ b/crates/extensions/tedge_config_manager/src/resources/config_snapshot.toml
@@ -1,0 +1,27 @@
+operation = "config_snapshot"
+on_error = "failed"
+
+[init]
+action = "proceed"
+on_success = "executing"
+
+[executing]
+action = "proceed"
+on_success = "get"
+
+[get]
+action = "builtin:config_snapshot:get"
+on_success = "upload"
+on_error = "failed"
+
+[upload]
+action = "upload"
+input.url = "${.payload.tedgeUrl}"
+on_success = "successful"
+on_error = "failed"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"

--- a/crates/extensions/tedge_config_manager/src/tests.rs
+++ b/crates/extensions/tedge_config_manager/src/tests.rs
@@ -673,6 +673,108 @@ async fn config_manager_processes_concurrently() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
+async fn execute_config_get_operation_step() -> Result<(), anyhow::Error> {
+    let tempdir = prepare()?;
+    let mut handle = spawn_config_manager_actor(&tempdir).await;
+
+    // Let's ignore the reload messages sent on start
+    handle.mqtt.skip(2).await;
+
+    let command_state = GenericCommandState::new(
+        Topic::new_unchecked("te/device/main///cmd/config_snapshot/1234"),
+        "get".to_string(),
+        json!({
+            "type": "type_two",
+            "tedgeUrl": "http://127.0.0.1:3000/te/v1/files/main/config_snapshot/type_two-1234",
+        }),
+    );
+
+    let step_request = OperationStepRequest {
+        command_step: "get".to_string(),
+        command_state,
+    };
+
+    let response = handle.steps.await_response(step_request).await?;
+    let payload = response.expect("get step should succeed");
+    let path = payload
+        .get("path")
+        .and_then(|v| v.as_str())
+        .expect("path should be present");
+    assert!(
+        path.contains("config_snapshot"),
+        "expected a snapshot temp path, got {path}"
+    );
+    // Mock file plugin writes the type's file name to stdout (see tests/data/file)
+    let content = read_to_string(path)?;
+    assert_eq!(content.trim(), "file_b");
+    // tedgeUrl already provided — must not be regenerated
+    assert!(payload.get("tedgeUrl").is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn execute_config_get_operation_step_generates_tedge_url() -> Result<(), anyhow::Error> {
+    let tempdir = prepare()?;
+    let mut handle = spawn_config_manager_actor(&tempdir).await;
+
+    // Let's ignore the reload messages sent on start
+    handle.mqtt.skip(2).await;
+
+    let command_state = GenericCommandState::new(
+        Topic::new_unchecked("te/device/main///cmd/config_snapshot/1234"),
+        "get".to_string(),
+        json!({
+            "type": "type_two",
+        }),
+    );
+
+    let step_request = OperationStepRequest {
+        command_step: "get".to_string(),
+        command_state,
+    };
+
+    let response = handle.steps.await_response(step_request).await?;
+    let payload = response.expect("get step should succeed");
+    assert!(payload.get("path").and_then(|v| v.as_str()).is_some());
+    let tedge_url = payload
+        .get("tedgeUrl")
+        .and_then(|v| v.as_str())
+        .expect("tedgeUrl should be generated when missing");
+    assert!(
+        tedge_url.contains("config_snapshot/type_two-1234"),
+        "unexpected tedgeUrl: {tedge_url}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn execute_config_get_operation_step_missing_type() -> Result<(), anyhow::Error> {
+    let tempdir = prepare()?;
+    let mut handle = spawn_config_manager_actor(&tempdir).await;
+
+    // Let's ignore the reload messages sent on start
+    handle.mqtt.skip(2).await;
+
+    let command_state = GenericCommandState::new(
+        Topic::new_unchecked("te/device/main///cmd/config_snapshot/1234"),
+        "get".to_string(),
+        json!({}),
+    );
+
+    let step_request = OperationStepRequest {
+        command_step: "get".to_string(),
+        command_state,
+    };
+
+    let response = handle.steps.await_response(step_request).await?;
+    assert_matches!(response, Err(err) if err.contains("Missing key: type"));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn execute_config_set_operation_step() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
     let mut handle = spawn_config_manager_actor(&tempdir).await;
@@ -871,22 +973,27 @@ async fn test_init_creates_config_and_template() -> anyhow::Result<()> {
 
     ConfigManagerBuilder::init(&config).await?;
 
-    let toml_file = config.ops_dir.path().join("config_update.toml");
-    let template_file = config.ops_dir.path().join("config_update.toml.template");
+    for operation in ["config_update", "config_snapshot"] {
+        let toml_file = config.ops_dir.path().join(format!("{operation}.toml"));
+        let template_file = config
+            .ops_dir
+            .path()
+            .join(format!("{operation}.toml.template"));
 
-    assert!(toml_file.exists(), "config_update.toml should exist");
-    assert!(
-        template_file.exists(),
-        "config_update.toml.template should exist"
-    );
+        assert!(toml_file.exists(), "{operation}.toml should exist");
+        assert!(
+            template_file.exists(),
+            "{operation}.toml.template should exist"
+        );
 
-    let toml_content = tokio::fs::read_to_string(&toml_file).await?;
-    let template_content = tokio::fs::read_to_string(&template_file).await?;
+        let toml_content = tokio::fs::read_to_string(&toml_file).await?;
+        let template_content = tokio::fs::read_to_string(&template_file).await?;
 
-    assert_eq!(
-        toml_content, template_content,
-        "Initial config and template should have identical content"
-    );
+        assert_eq!(
+            toml_content, template_content,
+            "Initial {operation} config and template should have identical content"
+        );
+    }
 
     Ok(())
 }

--- a/tests/RobotFramework/tests/cumulocity/configuration/config_operation_workflow/config_snapshot_custom_step.toml
+++ b/tests/RobotFramework/tests/cumulocity/configuration/config_operation_workflow/config_snapshot_custom_step.toml
@@ -1,0 +1,29 @@
+# Preserve the built-in get and upload steps while inserting a custom workflow step.
+operation = "config_snapshot"
+on_error = "failed"
+
+[init]
+action = "proceed"
+on_success = "executing"
+
+[executing]
+script = "sh -c 'echo custom-snapshot-workflow > /tmp/config_snapshot_workflow.log'"
+on_success = "get"
+on_error = "failed"
+
+[get]
+action = "builtin:config_snapshot:get"
+on_success = "upload"
+on_error = "failed"
+
+[upload]
+action = "upload"
+input.url = "${.payload.tedgeUrl}"
+on_success = "successful"
+on_error = "failed"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"

--- a/tests/RobotFramework/tests/cumulocity/configuration/config_operation_workflow/config_snapshot_workflow.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/config_operation_workflow/config_snapshot_workflow.robot
@@ -1,0 +1,77 @@
+*** Settings ***
+Resource            ../../../../resources/common.resource
+Library             Cumulocity
+Library             ThinEdgeIO
+
+Test Setup          Custom Setup
+Test Teardown       Get Logs
+
+Test Tags           theme:c8y    theme:configuration    theme:workflows
+
+
+*** Variables ***
+${DEVICE_SN}        None
+
+
+*** Test Cases ***
+Default Workflow
+    ${original_config}    Execute Command    cat /etc/tedge/operations/config_snapshot.toml
+    ${original_template}    Execute Command    cat /etc/tedge/operations/config_snapshot.toml.template
+
+    Should Be Equal    ${original_config}    ${original_template}
+
+    Snapshot Config And Verify
+
+Workflow Override With Custom Step
+    ${original_config}    Execute Command    cat /etc/tedge/operations/config_snapshot.toml
+    ${original_template}    Execute Command    cat /etc/tedge/operations/config_snapshot.toml.template
+
+    ThinEdgeIO.Transfer To Device
+    ...    ${CURDIR}/config_snapshot_custom_step.toml
+    ...    /etc/tedge/operations/config_snapshot.toml
+
+    ${updated_config}    Execute Command    cat /etc/tedge/operations/config_snapshot.toml
+    Should Not Be Equal    ${original_config}    ${updated_config}
+
+    Snapshot Config And Verify
+    File Should Contain    /tmp/config_snapshot_workflow.log    custom-snapshot-workflow
+
+    Execute Command    systemctl restart tedge-agent
+
+    ${config_after_restart}    Execute Command    cat /etc/tedge/operations/config_snapshot.toml
+    ${template_after_restart}    Execute Command    cat /etc/tedge/operations/config_snapshot.toml.template
+
+    Should Be Equal    ${config_after_restart}    ${updated_config}
+    Should Be Equal    ${template_after_restart}    ${original_template}
+    Should Not Be Equal    ${config_after_restart}    ${template_after_restart}
+
+Legacy Workflow
+    ThinEdgeIO.Transfer To Device
+    ...    ${CURDIR}/legacy_config_snapshot.toml
+    ...    /etc/tedge/operations/config_snapshot.toml
+
+    Snapshot Config And Verify
+
+
+*** Keywords ***
+Custom Setup
+    ${DEVICE_SN}    Setup    skip_bootstrap=False
+    Set Suite Variable    $DEVICE_SN
+    Device Should Exist    ${DEVICE_SN}
+
+    Execute Command    printf 'snapshot workflow test\n' > /etc/tedge/test.conf
+    Execute Command    rm -f /tmp/config_snapshot_workflow.log
+
+    ThinEdgeIO.Transfer To Device
+    ...    ${CURDIR}/tedge-configuration-plugin.toml
+    ...    /etc/tedge/plugins/tedge-configuration-plugin.toml
+    Should Contain Supported Configuration Types    test-conf
+
+Snapshot Config And Verify
+    ${operation}    Cumulocity.Get Configuration    test-conf
+    Operation Should Be SUCCESSFUL    ${operation}    timeout=30
+
+File Should Contain
+    [Arguments]    ${file_path}    ${expected_content}
+    ${output}    Execute Command    cat ${file_path}
+    Should Contain    ${output}    ${expected_content}

--- a/tests/RobotFramework/tests/cumulocity/configuration/config_operation_workflow/legacy_config_snapshot.toml
+++ b/tests/RobotFramework/tests/cumulocity/configuration/config_operation_workflow/legacy_config_snapshot.toml
@@ -1,0 +1,19 @@
+operation = "config_snapshot"
+
+[init]
+action = "proceed"
+on_success = "scheduled"
+
+[scheduled]
+operation = "builtin:config_snapshot"
+on_exec = "executing"
+
+[executing]
+action = "await-operation-completion"
+on_success = "successful"
+
+[successful]
+action = "cleanup"
+
+[failed]
+action = "cleanup"

--- a/tests/RobotFramework/tests/cumulocity/configuration/config_snapshot_error_handling.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/config_snapshot_error_handling.robot
@@ -31,7 +31,7 @@ Config snapshot fails immediately when file-transfer storage is not writable
     ${operation}=    Cumulocity.Get Configuration    tedge-configuration-plugin
     Operation Should Be FAILED
     ...    ${operation}
-    ...    failure_reason=config-manager failed uploading configuration snapshot.*
+    ...    failure_reason=.+Upload failed:.*
     ...    timeout=30
     [Teardown]    Run Keywords
     ...    Restore File-Transfer Directory Permissions

--- a/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
+++ b/tests/RobotFramework/tests/cumulocity/configuration/configuration_with_file_transfer_https.robot
@@ -62,7 +62,7 @@ Configuration operation fails when configuration-plugin does not supply client c
     Enable Certificate Authentication for File Transfer Service
     Disable HTTP Client Certificate for FTS client
     Get Configuration Should Fail
-    ...    failure_reason=config-manager failed uploading configuration snapshot:.+https://${FTS_IP}:8000/te/v1/files/
+    ...    failure_reason=.+Upload failed:.+https://${FTS_IP}:8000/te/v1/files/
     ...    external_id=${PARENT_SN}:device:${CHILD_SN}
     Update Configuration Should Fail
     ...    failure_reason=.+Download failed:.+https://${parent_ip}:8001/c8y/inventory/binaries/


### PR DESCRIPTION
## Proposed changes

Adds a persistent multi-state workflow for the `config_snapshot` operation, mirroring the `config_update` flow from #3950. `config_snapshot` had no persistent workflow definition, so the operation could not be driven through the standard operation state machine:

- Installs `config_snapshot.toml` (and `.template`) via the same ops-dir template pattern as `config_update`, so users can override individual steps while reusing the rest.
- Adds a `builtin:config_snapshot:get` step that calls the config plugin's `get` command and sets `path` (generating `tedgeUrl` when missing).
- Adds a generic `action = "upload"` step, symmetric to `download`, for uploading the retrieved file to `input.url` / `tedgeUrl`.
- The issue sample used `builtin:config_update:get`; corrected to `builtin:config_snapshot:get` to match the snapshot operation and existing plugin handlers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

Fixes #3999

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

Validation: `cargo test -p tedge_config_manager -p tedge_api -p tedge-agent --lib -- --test-threads=2` — tedge-agent: 107 tests passed; tedge_api: 231 tests passed; tedge_config_manager: 22 tests passed. Formatting/lint cleanliness is enforced on the latest head via CI (`check-build` green).

Two checklist caveats, for transparency: the first commit carries a `Signed-off-by` trailer, but the second (API-created fix preserving the config snapshot upload error contract) does not — I am happy to rebase with a sign-off if you want to keep separate commits. And `just format`/`just check` were verified through CI rather than a fresh local run.

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project contributor terms; AI output was not pasted unreviewed.
