### PR TITLE
fix: change retry behaviour for statuses c8y http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "tedge_config",
  "tedge_http_ext",
  "tedge_test_utils",
+ "test-case",
  "thiserror 2.0.12",
  "time",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5398,6 +5398,7 @@ name = "tedge_http_ext"
 version = "2.0.1"
 dependencies = [
  "async-trait",
+ "backoff",
  "certificate",
  "http 1.3.1",
  "http-body-util",

--- a/crates/extensions/c8y_http_proxy/Cargo.toml
+++ b/crates/extensions/c8y_http_proxy/Cargo.toml
@@ -31,6 +31,7 @@ tedge_actors = { workspace = true, features = ["test-helpers"] }
 tedge_config = { workspace = true, features = ["test"] }
 tedge_http_ext = { workspace = true, features = ["test_helpers"] }
 tedge_test_utils = { workspace = true }
+test-case = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["macros", "time", "test-util"] }
 

--- a/crates/extensions/c8y_http_proxy/src/tests.rs
+++ b/crates/extensions/c8y_http_proxy/src/tests.rs
@@ -8,13 +8,16 @@ use c8y_api::proxy_url::Protocol;
 use c8y_api::proxy_url::ProxyUrlGenerator;
 use http::StatusCode;
 use std::collections::HashMap;
+use std::time::Duration;
 use tedge_actors::test_helpers::FakeServerBox;
 use tedge_actors::Builder;
 use tedge_actors::MessageReceiver;
 use tedge_actors::Sender;
 use tedge_config::TEdgeConfig;
+use tedge_http_ext::backoff::exponential::ExponentialBackoff;
 use tedge_http_ext::test_helpers::HttpResponseBuilder;
 use tedge_http_ext::HttpActor;
+use tedge_http_ext::HttpError;
 use tedge_http_ext::HttpRequest;
 use tedge_http_ext::HttpRequestBuilder;
 use tedge_http_ext::HttpResult;
@@ -439,6 +442,64 @@ async fn request_internal_id_before_posting_software_list() {
         ),
     )
     .await;
+}
+#[tokio::test(start_paused = true)]
+#[test_case::test_case(501, 1; "don't retry when header is non-retryable")]
+#[test_case::test_case(500, 2; "retry when header is retryable")]
+async fn get_internal_id_retries_depending_on_response_status(
+    status: usize,
+    expected_retries: usize,
+) {
+    let external_id = "device-001";
+
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/c8y/identity/externalIds/c8y_Serial/device-001")
+        .with_status(status)
+        .expect(expected_retries)
+        .create_async()
+        .await;
+    let target_url = "remote.c8y.com".to_string();
+    let server_url = server.host_with_port();
+    let (proxy_host, proxy_port) = server_url.split_once(':').unwrap();
+    let proxy = ProxyUrlGenerator::new(
+        proxy_host.into(),
+        proxy_port.parse().unwrap(),
+        Protocol::Http,
+    );
+
+    let tedge_config = TEdgeConfig::load_toml_str("");
+    let tls_config = tedge_config.http.client_tls_config().unwrap();
+    let mut http_actor = HttpActor::new(tls_config)
+        .with_backoff(
+            // for test: tweaked to exactly 1 retry
+            ExponentialBackoff {
+                initial_interval: Duration::from_millis(5),
+                multiplier: 10.0,
+                randomization_factor: f64::EPSILON,
+                max_elapsed_time: Some(Duration::from_millis(50)),
+                ..Default::default()
+            },
+        )
+        .builder();
+
+    let config = C8YHttpConfig {
+        c8y_http_host: target_url.clone(),
+        c8y_mqtt_host: target_url,
+        device_id: external_id.into(),
+        proxy,
+    };
+    let mut proxy = C8YHttpProxy::new(config, &mut http_actor);
+
+    tokio::spawn(async move { http_actor.run().await });
+
+    let result = proxy.c8y_internal_id(external_id).await;
+    let status = StatusCode::from_u16(status as u16).unwrap();
+    assert!(matches!(
+        result.unwrap_err(),
+        crate::messages::C8YRestError::FromHttpError(HttpError::HttpStatusError { code, .. }) if code == status
+    ));
+    _mock.assert();
 }
 
 /// Return two handles:

--- a/crates/extensions/tedge_http_ext/Cargo.toml
+++ b/crates/extensions/tedge_http_ext/Cargo.toml
@@ -16,7 +16,8 @@ test_helpers = []
 
 [dependencies]
 async-trait = { workspace = true }
-certificate = { workspace = true }
+backoff = { workspace = true }
+certificate = { workspace = true, features = ["reqwest"] }
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true, default-features = false, features = [

--- a/crates/extensions/tedge_http_ext/src/actor.rs
+++ b/crates/extensions/tedge_http_ext/src/actor.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use backoff::ExponentialBackoff;
 use http::request;
 use http::HeaderValue;
+use http::StatusCode;
 use http_body_util::combinators::BoxBody;
 use http_body_util::BodyExt as _;
 use http_body_util::Empty;
@@ -52,6 +53,7 @@ impl Server for HttpService {
     async fn handle(&mut self, request: Self::Request) -> Self::Response {
         let mut request = request;
         request
+            .request
             .headers_mut()
             .entry(http::header::USER_AGENT)
             .or_insert_with(|| HeaderValue::from_static(USER_AGENT));
@@ -61,9 +63,10 @@ impl Server for HttpService {
         //
         // To work around that, we change actor request type to a request which is clonable, and
         // then clone the body before wrapping it into a BoxedBody.
-        let endpoint = request.uri().path().to_owned();
-        let method = request.method().to_owned();
-        let (parts, body) = request.into_parts();
+        let allowed_retry_statuses = request.retry_statuses;
+        let endpoint = request.request.uri().path().to_owned();
+        let method = request.request.method().to_owned();
+        let (parts, body) = request.request.into_parts();
 
         let backoff = self.backoff.clone();
         let operation = || {
@@ -83,7 +86,7 @@ impl Server for HttpService {
                         if response.status().is_client_error()
                             || response.status().is_server_error() =>
                     {
-                        if certificate::http_client::is_status_retryable(response.status()) {
+                        if is_status_retryable(response.status(), &allowed_retry_statuses) {
                             Err(backoff::Error::transient(HttpError::HttpStatusError {
                                 code: response.status(),
                                 endpoint,
@@ -117,4 +120,9 @@ fn to_backoff_error(err: hyper_util::client::legacy::Error) -> backoff::Error<Ht
     } else {
         backoff::Error::permanent(HttpError::HyperUtilError(err))
     }
+}
+
+fn is_status_retryable(status: StatusCode, allowed_retry_statuses: &[StatusCode]) -> bool {
+    allowed_retry_statuses.contains(&status)
+        || certificate::http_client::is_status_retryable(status)
 }

--- a/crates/extensions/tedge_http_ext/src/actor.rs
+++ b/crates/extensions/tedge_http_ext/src/actor.rs
@@ -104,7 +104,13 @@ impl Server for HttpService {
                 }
             }
         };
-        let response = backoff::future::retry(backoff, operation).await?;
+        let response = match &method {
+            m if m.is_idempotent() => backoff::future::retry(backoff, operation).await,
+            _ => operation().await.map_err(|err| match err {
+                backoff::Error::Permanent(err) | backoff::Error::Transient { err, .. } => err,
+            }),
+        };
+        let response = response?;
 
         Ok(HttpResponse {
             endpoint,

--- a/crates/extensions/tedge_http_ext/src/actor.rs
+++ b/crates/extensions/tedge_http_ext/src/actor.rs
@@ -1,10 +1,15 @@
+use crate::HttpError;
 use crate::HttpRequest;
 use crate::HttpResponse;
 use crate::HttpResult;
 use async_trait::async_trait;
+use backoff::ExponentialBackoff;
+use http::request;
 use http::HeaderValue;
 use http_body_util::combinators::BoxBody;
 use http_body_util::BodyExt as _;
+use http_body_util::Empty;
+use http_body_util::Full;
 use hyper::body::Bytes;
 use hyper_rustls::HttpsConnector;
 use hyper_rustls::HttpsConnectorBuilder;
@@ -19,10 +24,11 @@ use certificate::http_client::USER_AGENT;
 #[derive(Clone)]
 pub struct HttpService {
     client: Client<HttpsConnector<HttpConnector>, BoxBody<Bytes, hyper::Error>>,
+    backoff: ExponentialBackoff,
 }
 
 impl HttpService {
-    pub(crate) fn new(client_config: ClientConfig) -> Self {
+    pub(crate) fn new(client_config: ClientConfig, backoff: ExponentialBackoff) -> Self {
         let https = HttpsConnectorBuilder::new()
             .with_tls_config(client_config)
             .https_or_http()
@@ -30,7 +36,7 @@ impl HttpService {
             .enable_http2()
             .build();
         let client = Client::builder(TokioExecutor::new()).build(https);
-        HttpService { client }
+        HttpService { client, backoff }
     }
 }
 
@@ -50,10 +56,65 @@ impl Server for HttpService {
             .entry(http::header::USER_AGENT)
             .or_insert_with(|| HeaderValue::from_static(USER_AGENT));
 
+        // the dance below happens because HttpRequest is not clone, because BoxedBody is not clone,
+        // so we would not be able to clone the request to retry it.
+        //
+        // To work around that, we change actor request type to a request which is clonable, and
+        // then clone the body before wrapping it into a BoxedBody.
+        let endpoint = request.uri().path().to_owned();
+        let method = request.method().to_owned();
+        let (parts, body) = request.into_parts();
+
+        let backoff = self.backoff.clone();
+        let operation = || {
+            let body = match body.as_ref() {
+                Some(body) => Full::new(body.clone()).map_err(|i| match i {}).boxed(),
+                None => Empty::new().map_err(|i| match i {}).boxed(),
+            };
+            let request = request::Request::from_parts(parts.clone(), body);
+            let endpoint = endpoint.clone();
+            let method = method.clone();
+
+            async {
+                let response = self.client.request(request).await;
+                match response {
+                    Err(err) => Err(to_backoff_error(err)),
+                    Ok(response)
+                        if response.status().is_client_error()
+                            || response.status().is_server_error() =>
+                    {
+                        if certificate::http_client::is_status_retryable(response.status()) {
+                            Err(backoff::Error::transient(HttpError::HttpStatusError {
+                                code: response.status(),
+                                endpoint,
+                                method,
+                            }))
+                        } else {
+                            Err(backoff::Error::permanent(HttpError::HttpStatusError {
+                                code: response.status(),
+                                endpoint,
+                                method,
+                            }))
+                        }
+                    }
+                    Ok(response) => Ok(response),
+                }
+            }
+        };
+        let response = backoff::future::retry(backoff, operation).await?;
+
         Ok(HttpResponse {
-            endpoint: request.uri().path().to_owned(),
-            method: request.method().to_owned(),
-            response: self.client.request(request).await?.map(|b| b.boxed()),
+            endpoint,
+            method,
+            response: response.map(|b| b.boxed()),
         })
+    }
+}
+
+fn to_backoff_error(err: hyper_util::client::legacy::Error) -> backoff::Error<HttpError> {
+    if err.is_connect() {
+        backoff::Error::transient(HttpError::HyperUtilError(err))
+    } else {
+        backoff::Error::permanent(HttpError::HyperUtilError(err))
     }
 }

--- a/crates/extensions/tedge_http_ext/src/lib.rs
+++ b/crates/extensions/tedge_http_ext/src/lib.rs
@@ -7,6 +7,9 @@ mod tests;
 #[cfg(feature = "test_helpers")]
 pub mod test_helpers;
 
+use std::time::Duration;
+
+use backoff::ExponentialBackoff;
 pub use messages::*;
 
 use actor::*;
@@ -18,6 +21,7 @@ use tedge_actors::ServerConfig;
 pub struct HttpActor {
     config: ServerConfig,
     tls_client_config: rustls::ClientConfig,
+    backoff: ExponentialBackoff,
 }
 
 impl HttpActor {
@@ -25,12 +29,18 @@ impl HttpActor {
         Self {
             config: <_>::default(),
             tls_client_config,
+            backoff: ExponentialBackoff {
+                initial_interval: Duration::from_secs(2),
+                max_elapsed_time: Some(Duration::from_secs(30)),
+                randomization_factor: 0.1,
+                ..Default::default()
+            },
         }
     }
 
     pub fn builder(&self) -> ServerActorBuilder<HttpService, Concurrent> {
         ServerActorBuilder::new(
-            HttpService::new(self.tls_client_config.clone()),
+            HttpService::new(self.tls_client_config.clone(), self.backoff.clone()),
             &self.config,
             Concurrent,
         )
@@ -48,5 +58,9 @@ impl HttpActor {
             config: self.config.with_max_concurrency(max_concurrency),
             ..self
         }
+    }
+
+    pub fn with_backoff(self, backoff: ExponentialBackoff) -> Self {
+        Self { backoff, ..self }
     }
 }

--- a/crates/extensions/tedge_http_ext/src/lib.rs
+++ b/crates/extensions/tedge_http_ext/src/lib.rs
@@ -17,6 +17,8 @@ use tedge_actors::Concurrent;
 use tedge_actors::ServerActorBuilder;
 use tedge_actors::ServerConfig;
 
+pub use backoff;
+
 #[derive(Debug)]
 pub struct HttpActor {
     config: ServerConfig,

--- a/crates/extensions/tedge_http_ext/src/messages.rs
+++ b/crates/extensions/tedge_http_ext/src/messages.rs
@@ -1,8 +1,12 @@
+use std::ops::Deref;
+use std::ops::DerefMut;
+
 use async_trait::async_trait;
 use http::header::HeaderName;
 use http::header::HeaderValue;
 use http::HeaderMap;
 use http::Method;
+use http::StatusCode;
 use http_body_util::combinators::BoxBody;
 use http_body_util::BodyExt;
 use hyper::body::Bytes;
@@ -35,7 +39,27 @@ pub enum HttpError {
 }
 
 type Body = BoxBody<Bytes, hyper::Error>;
-pub type HttpRequest = http::Request<Option<Bytes>>;
+#[derive(Debug)]
+pub struct HttpRequest {
+    pub(crate) request: http::Request<Option<Bytes>>,
+    /// Response status codes for which request should be retried.
+    ///
+    /// If empty, a default set of retryable statuses will be used.
+    pub(crate) retry_statuses: Vec<StatusCode>,
+}
+
+impl Deref for HttpRequest {
+    type Target = http::Request<Option<Bytes>>;
+    fn deref(&self) -> &Self::Target {
+        &self.request
+    }
+}
+
+impl DerefMut for HttpRequest {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.request
+    }
+}
 
 #[derive(Debug)]
 pub struct HttpResponse {
@@ -58,13 +82,19 @@ pub type HttpBytes = hyper::body::Bytes;
 pub struct HttpRequestBuilder {
     inner: http::request::Builder,
     body: Result<Bytes, HttpError>,
+    retry_statuses: Vec<StatusCode>,
 }
 
 impl HttpRequestBuilder {
     /// Build the request
     pub fn build(self) -> Result<HttpRequest, HttpError> {
-        self.body
-            .and_then(|body| self.inner.body(Some(body)).map_err(HttpError::from))
+        let request = self
+            .body
+            .and_then(|body| self.inner.body(Some(body)).map_err(HttpError::from));
+        request.map(|request| HttpRequest {
+            request,
+            retry_statuses: self.retry_statuses,
+        })
     }
 
     /// Start to build a GET request
@@ -76,6 +106,7 @@ impl HttpRequestBuilder {
         HttpRequestBuilder {
             inner: hyper::Request::get(uri),
             body: Ok(Bytes::new()),
+            retry_statuses: vec![],
         }
     }
 
@@ -88,6 +119,7 @@ impl HttpRequestBuilder {
         HttpRequestBuilder {
             inner: hyper::Request::post(uri),
             body: Ok(Bytes::new()),
+            retry_statuses: vec![],
         }
     }
 
@@ -100,6 +132,7 @@ impl HttpRequestBuilder {
         HttpRequestBuilder {
             inner: hyper::Request::put(uri),
             body: Ok(Bytes::new()),
+            retry_statuses: vec![],
         }
     }
 
@@ -112,6 +145,7 @@ impl HttpRequestBuilder {
         HttpRequestBuilder {
             inner: hyper::Request::delete(uri),
             body: Ok(Bytes::new()),
+            retry_statuses: vec![],
         }
     }
 
@@ -151,6 +185,14 @@ impl HttpRequestBuilder {
         let body = content.into();
         HttpRequestBuilder {
             body: Ok(body),
+            ..self
+        }
+    }
+
+    pub fn retry_statuses(self, retry_statuses: impl Into<Vec<StatusCode>>) -> Self {
+        let retry_statuses = retry_statuses.into();
+        Self {
+            retry_statuses,
             ..self
         }
     }

--- a/crates/extensions/tedge_http_ext/src/messages.rs
+++ b/crates/extensions/tedge_http_ext/src/messages.rs
@@ -1,5 +1,3 @@
-use std::convert::Infallible;
-
 use async_trait::async_trait;
 use http::header::HeaderName;
 use http::header::HeaderValue;
@@ -7,8 +5,6 @@ use http::HeaderMap;
 use http::Method;
 use http_body_util::combinators::BoxBody;
 use http_body_util::BodyExt;
-use http_body_util::Empty;
-use http_body_util::Full;
 use hyper::body::Bytes;
 use serde::de::DeserializeOwned;
 use thiserror::Error;
@@ -39,7 +35,7 @@ pub enum HttpError {
 }
 
 type Body = BoxBody<Bytes, hyper::Error>;
-pub type HttpRequest = http::Request<Body>;
+pub type HttpRequest = http::Request<Option<Bytes>>;
 
 #[derive(Debug)]
 pub struct HttpResponse {
@@ -61,18 +57,14 @@ pub type HttpBytes = hyper::body::Bytes;
 /// An Http Request builder
 pub struct HttpRequestBuilder {
     inner: http::request::Builder,
-    body: Result<Body, HttpError>,
-}
-
-fn infallible<T>(i: Infallible) -> T {
-    match i {}
+    body: Result<Bytes, HttpError>,
 }
 
 impl HttpRequestBuilder {
     /// Build the request
     pub fn build(self) -> Result<HttpRequest, HttpError> {
         self.body
-            .and_then(|body| self.inner.body(body).map_err(|err| err.into()))
+            .and_then(|body| self.inner.body(Some(body)).map_err(HttpError::from))
     }
 
     /// Start to build a GET request
@@ -83,7 +75,7 @@ impl HttpRequestBuilder {
     {
         HttpRequestBuilder {
             inner: hyper::Request::get(uri),
-            body: Ok(Empty::new().map_err(infallible).boxed()),
+            body: Ok(Bytes::new()),
         }
     }
 
@@ -95,7 +87,7 @@ impl HttpRequestBuilder {
     {
         HttpRequestBuilder {
             inner: hyper::Request::post(uri),
-            body: Ok(Empty::new().map_err(infallible).boxed()),
+            body: Ok(Bytes::new()),
         }
     }
 
@@ -107,7 +99,7 @@ impl HttpRequestBuilder {
     {
         HttpRequestBuilder {
             inner: hyper::Request::put(uri),
-            body: Ok(Empty::new().map_err(infallible).boxed()),
+            body: Ok(Bytes::new()),
         }
     }
 
@@ -119,7 +111,7 @@ impl HttpRequestBuilder {
     {
         HttpRequestBuilder {
             inner: hyper::Request::delete(uri),
-            body: Ok(Empty::new().map_err(infallible).boxed()),
+            body: Ok(Bytes::new()),
         }
     }
 
@@ -149,15 +141,18 @@ impl HttpRequestBuilder {
     /// Send a JSON body
     pub fn json<T: serde::Serialize + ?Sized>(self, json: &T) -> Self {
         let body = serde_json::to_vec(json)
-            .map(|bytes| Full::new(Bytes::from(bytes)).map_err(infallible).boxed())
-            .map_err(|err| err.into());
+            .map(Bytes::from)
+            .map_err(HttpError::from);
         HttpRequestBuilder { body, ..self }
     }
 
     /// Send a  body
-    pub fn body(self, content: impl Into<Body>) -> Self {
-        let body = Ok(content.into());
-        HttpRequestBuilder { body, ..self }
+    pub fn body(self, content: impl Into<Bytes>) -> Self {
+        let body = content.into();
+        HttpRequestBuilder {
+            body: Ok(body),
+            ..self
+        }
     }
 }
 

--- a/crates/extensions/tedge_http_ext/src/test_helpers.rs
+++ b/crates/extensions/tedge_http_ext/src/test_helpers.rs
@@ -24,7 +24,7 @@ pub trait HttpRequestExt {
 #[async_trait]
 impl HttpRequestExt for HttpRequest {
     async fn json<T: DeserializeOwned>(self) -> Result<T, HttpError> {
-        let bytes = self.into_body().collect().await?.to_bytes();
+        let bytes = self.into_body().unwrap_or_default();
         Ok(serde_json::from_slice(&bytes)?)
     }
 }

--- a/crates/extensions/tedge_http_ext/src/test_helpers.rs
+++ b/crates/extensions/tedge_http_ext/src/test_helpers.rs
@@ -24,7 +24,7 @@ pub trait HttpRequestExt {
 #[async_trait]
 impl HttpRequestExt for HttpRequest {
     async fn json<T: DeserializeOwned>(self) -> Result<T, HttpError> {
-        let bytes = self.into_body().unwrap_or_default();
+        let bytes = self.request.into_body().unwrap_or_default();
         Ok(serde_json::from_slice(&bytes)?)
     }
 }

--- a/crates/extensions/tedge_http_ext/src/tests.rs
+++ b/crates/extensions/tedge_http_ext/src/tests.rs
@@ -1,4 +1,6 @@
 use crate::*;
+use backoff::exponential::ExponentialBackoff;
+use http::StatusCode;
 use rustls::ClientConfig;
 use rustls::RootCertStore;
 use tedge_actors::ClientMessageBox;
@@ -41,6 +43,33 @@ async fn requests_include_thin_edge_user_agent() {
     _mock.assert();
 }
 
+#[tokio::test]
+async fn retries_on_502() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/")
+        .with_status(502)
+        .expect(2)
+        .create_async()
+        .await;
+
+    let mut http = spawn_http_actor().await;
+
+    let request = HttpRequestBuilder::get(server.url())
+        .build()
+        .expect("A simple HTTPS GET request");
+
+    let response = http.await_response(request).await.unwrap();
+    assert!(matches!(
+        response.unwrap_err(),
+        HttpError::HttpStatusError {
+            code: StatusCode::BAD_GATEWAY,
+            ..
+        }
+    ));
+    _mock.assert();
+}
+
 async fn spawn_http_actor() -> ClientMessageBox<HttpRequest, HttpResult> {
     if rustls::crypto::CryptoProvider::get_default().is_none() {
         let _ = rustls::crypto::ring::default_provider().install_default();
@@ -48,7 +77,18 @@ async fn spawn_http_actor() -> ClientMessageBox<HttpRequest, HttpResult> {
     let config = ClientConfig::builder()
         .with_root_certificates(RootCertStore::empty())
         .with_no_client_auth();
-    let mut builder = HttpActor::new(config).builder();
+    let mut builder = HttpActor::new(config)
+        .with_backoff(
+            // for test: tweaked to exactly 1 retry
+            ExponentialBackoff {
+                initial_interval: Duration::from_millis(5),
+                multiplier: 10.0,
+                randomization_factor: f64::EPSILON,
+                max_elapsed_time: Some(Duration::from_millis(50)),
+                ..Default::default()
+            },
+        )
+        .builder();
     let handle = ClientMessageBox::new(&mut builder);
 
     tokio::spawn(builder.run());

--- a/crates/extensions/tedge_http_ext/src/tests.rs
+++ b/crates/extensions/tedge_http_ext/src/tests.rs
@@ -121,6 +121,64 @@ async fn retries_on_retry_status() {
     mock2.assert();
 }
 
+#[tokio::test]
+async fn retries_only_idempotent_methods() {
+    let mut server = mockito::Server::new_async().await;
+    let mut http = spawn_http_actor().await;
+
+    // also HEAD, OPTIONS, TRACE, but currently not supported by HttpActor
+    let idempotent = [http::Method::GET, http::Method::PUT, http::Method::DELETE];
+
+    for method in idempotent {
+        let m = method.as_str();
+        let mock = server
+            .mock(m, format!("/{m}").as_str())
+            .with_status(500)
+            .expect(2)
+            .create_async()
+            .await;
+
+        let request = match method {
+            http::Method::GET => HttpRequestBuilder::get(format!("{}/{m}", server.url())),
+            http::Method::PUT => HttpRequestBuilder::put(format!("{}/{m}", server.url())),
+            http::Method::DELETE => HttpRequestBuilder::delete(format!("{}/{m}", server.url())),
+            _ => unreachable!(),
+        };
+        let request = request.build().unwrap();
+        let response = http.await_response(request).await.unwrap();
+        assert!(matches!(
+            response.unwrap_err(),
+            HttpError::HttpStatusError {
+                code: StatusCode::INTERNAL_SERVER_ERROR,
+                ..
+            }
+        ));
+
+        mock.assert_async().await;
+    }
+
+    // only POST isn't idempotent
+    let mock = server
+        .mock("POST", "/POST")
+        .with_status(500)
+        .expect(1)
+        .create_async()
+        .await;
+    let request = HttpRequestBuilder::post(format!("{}/POST", server.url()))
+        .build()
+        .unwrap();
+    let response = http.await_response(request).await.unwrap();
+    assert!(matches!(
+        response.unwrap_err(),
+        HttpError::HttpStatusError {
+            code: StatusCode::INTERNAL_SERVER_ERROR,
+            ..
+        }
+    ));
+
+    mock.assert_async().await;
+}
+
 async fn spawn_http_actor() -> ClientMessageBox<HttpRequest, HttpResult> {
     if rustls::crypto::CryptoProvider::get_default().is_none() {
         let _ = rustls::crypto::ring::default_provider().install_default();

--- a/crates/extensions/tedge_http_ext/src/tests.rs
+++ b/crates/extensions/tedge_http_ext/src/tests.rs
@@ -70,6 +70,57 @@ async fn retries_on_502() {
     _mock.assert();
 }
 
+#[tokio::test]
+async fn retries_on_retry_status() {
+    let mut server = mockito::Server::new_async().await;
+
+    // first try without retry_statuses to confirm we don't retry without it
+    let mock = server
+        .mock("GET", "/non-retried")
+        .with_status(501)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let mut http = spawn_http_actor().await;
+
+    let request = HttpRequestBuilder::get(format!("{}/non-retried", server.url()))
+        .build()
+        .unwrap();
+    let response = http.await_response(request).await.unwrap();
+    assert!(matches!(
+        response.unwrap_err(),
+        HttpError::HttpStatusError {
+            code: StatusCode::NOT_IMPLEMENTED,
+            ..
+        }
+    ));
+    mock.assert();
+
+    // then use retry_statuses to retry on a usually non-retryable response status
+    let mock2 = server
+        .mock("GET", "/retried")
+        .with_status(501)
+        .expect(2)
+        .create_async()
+        .await;
+
+    let request = HttpRequestBuilder::get(format!("{}/retried", server.url()))
+        .retry_statuses([StatusCode::NOT_IMPLEMENTED])
+        .build()
+        .unwrap();
+
+    let response = http.await_response(request).await.unwrap();
+    assert!(matches!(
+        response.unwrap_err(),
+        HttpError::HttpStatusError {
+            code: StatusCode::NOT_IMPLEMENTED,
+            ..
+        }
+    ));
+    mock2.assert();
+}
+
 async fn spawn_http_actor() -> ClientMessageBox<HttpRequest, HttpResult> {
     if rustls::crypto::CryptoProvider::get_default().is_none() {
         let _ = rustls::crypto::ring::default_provider().install_default();


### PR DESCRIPTION
## Proposed changes

Adds retry to `HttpActor`.

This actor is used for regular (not download/upload) HTTP calls through c8y_auth_proxy to C8y REST API, etc. so it should now retry when some endpoints (e.g. fetching internal id) return 502.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #4288
- #2615

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

