### PR TITLE
fix: avoid two double quotes around mqtt topic when displayed in error messages

### DIFF
--- a/crates/core/tedge/src/cli/mqtt/subscribe.rs
+++ b/crates/core/tedge/src/cli/mqtt/subscribe.rs
@@ -34,7 +34,7 @@ pub struct SimpleTopicFilter(String);
 impl Command for MqttSubscribeCommand {
     fn description(&self) -> String {
         format!(
-            "subscribe to the topic \"{:?}\" with QoS \"{:?}\".",
+            "subscribe to the topic \"{}\" with QoS \"{:?}\".",
             self.topic.pattern(),
             self.qos
         )


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Avoid duplicating double quotes around the MQTT topic which is displayed in an error message.

Below shows an example before and after when an explicit error (invalid ca file) is triggered, look for the value after "topic" 

**Before**

```sh
TEDGE_MQTT_CLIENT_AUTH_CA_FILE=' ' tedge mqtt sub '#'    
Error: failed to subscribe to the topic ""#"" with QoS "AtMostOnce".

Caused by:
    Could not access /Users/johnsmith/dev/projects/thin-edge.io/code/thin-edge.io/ : No such file or directory (os error 2)
```

**After**

```sh
TEDGE_MQTT_CLIENT_AUTH_CA_FILE=' ' tedge mqtt sub '#'    
Error: failed to subscribe to the topic "#" with QoS "AtMostOnce".

Caused by:
    Could not access /Users/johnsmith/dev/projects/thin-edge.io/code/thin-edge.io/ : No such file or directory (os error 2)
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

