### PR TITLE
feat: improve mqtt client auth errors by showing source settings

### DIFF
--- a/crates/common/certificate/src/lib.rs
+++ b/crates/common/certificate/src/lib.rs
@@ -366,7 +366,9 @@ pub fn translate_rustls_error(err: &(dyn std::error::Error + 'static)) -> Option
 
 #[derive(thiserror::Error, Debug)]
 pub enum CertificateError {
-    #[error("Could not access {path}: {error}")]
+    // The path is quoted, as otherwise leading/trailing whitespace in a
+    // misconfigured path is invisible in the error message.
+    #[error("Could not access {path:?}: {error}")]
     IoError {
         path: PathBuf,
         error: std::io::Error,
@@ -387,7 +389,7 @@ pub enum CertificateError {
     #[error("Fail to parse the private key")]
     UnknownPrivateKeyFormat,
 
-    #[error("Could not parse certificate {path}")]
+    #[error("Could not parse certificate {path:?}")]
     CertificateParseFailed {
         path: PathBuf,
         source: anyhow::Error,

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config/mqtt_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config/mqtt_config.rs
@@ -101,21 +101,25 @@ impl TryFrom<TEdgeMqttClientAuthConfig> for mqtt_channel::AuthenticationConfig {
         if let Some(ca_file) = config.ca_file {
             debug!(target: "MQTT", "Using CA certificate file: {}", ca_file);
             let cert_store = &mut authentication_config.get_cert_store_mut();
-            parse_root_certificate::add_certs_from_file(cert_store, ca_file)?;
+            parse_root_certificate::add_certs_from_file(cert_store, ca_file)
+                .context("Invalid 'mqtt.client.auth.ca_file'")?;
         }
 
         // Adds all certificate from all files in the directory `ca_dir` to the trust store.
         if let Some(ca_dir) = config.ca_dir {
             debug!(target: "MQTT", "Using CA certificate directory: {}", ca_dir);
             let cert_store = &mut authentication_config.get_cert_store_mut();
-            parse_root_certificate::add_certs_from_directory(cert_store, ca_dir)?;
+            parse_root_certificate::add_certs_from_directory(cert_store, ca_dir)
+                .context("Invalid 'mqtt.client.auth.ca_dir'")?;
         }
 
         // Provides client certificate and private key for authentication.
         if let Some(client_cert) = config.client_cert {
             debug!(target: "MQTT", "Using client certificate file: {}", client_cert.cert_file);
             debug!(target: "MQTT", "Using client private key file: {}", client_cert.key_file);
-            authentication_config.set_cert_config(client_cert.cert_file, client_cert.key_file)?;
+            authentication_config
+                .set_cert_config(client_cert.cert_file, client_cert.key_file)
+                .context("Invalid 'mqtt.client.auth.cert_file' or 'mqtt.client.auth.key_file'")?;
         }
 
         // Provides client username/password for authentication.


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Minor improvements around the errors messages displayed to users when the mqtt client auth settings aren't invalid (e.g. the file doesn't exist).

* Use double quotes around the paths so that any whitespace related errors are more obvious to users
* Include the tedge setting source related to the error so it is easier to debug and fix

**Example**

Below shows the error message when an invalid client auth ca file is give (just a blank space).

```
TEDGE_MQTT_CLIENT_AUTH_CA_FILE=' ' tedge mqtt sub '#'
Error: failed to subscribe to the topic ""#"" with QoS "AtMostOnce".

Caused by:
    0: Invalid 'mqtt.client.auth.ca_file'
    1: Could not access "/Users/johnsmith/dev/projects/thin-edge.io/code/thin-edge.io/ ": No such file or directory (os error 2)
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

