### PR TITLE
refactor: Remove custom 404 retry for `c8y_http_proxy`

### DIFF
--- a/crates/extensions/c8y_http_proxy/src/actor.rs
+++ b/crates/extensions/c8y_http_proxy/src/actor.rs
@@ -10,30 +10,11 @@ use c8y_api::json_c8y::C8yManagedObject;
 use c8y_api::json_c8y::InternalIdResponse;
 use http::StatusCode;
 use serde_json::json;
-use std::time::Duration;
 use tedge_actors::ClientMessageBox;
-use tedge_http_ext::HttpError;
 use tedge_http_ext::HttpRequest;
 use tedge_http_ext::HttpRequestBuilder;
 use tedge_http_ext::HttpResponseExt;
 use tedge_http_ext::HttpResult;
-use tokio::time::sleep;
-use tracing::debug;
-
-/// Maximum number of attempts to fetch the Cumulocity internal id of an entity.
-///
-/// A freshly registered device (typically a child device) may not have been created yet in the
-/// Cumulocity inventory when the mapper first needs its internal id (e.g. to publish its software
-/// list). In that case the lookup transiently fails with `404 Not Found`. Retrying a few times
-/// with a growing delay lets the mapper recover from this race instead of silently dropping the
-/// request.
-const INTERNAL_ID_MAX_ATTEMPTS: u32 = 8;
-
-/// Delay before the first internal-id lookup retry (doubles after each attempt).
-const INTERNAL_ID_RETRY_INITIAL_INTERVAL: Duration = Duration::from_millis(1000);
-
-/// Upper bound for the delay between internal-id lookup retries.
-const INTERNAL_ID_RETRY_MAX_INTERVAL: Duration = Duration::from_secs(10);
 
 #[derive(Clone)]
 pub struct C8YHttpProxyActor {
@@ -53,31 +34,16 @@ impl C8YHttpProxyActor {
     pub async fn try_get_internal_id(&mut self, device_id: &str) -> Result<String, C8YRestError> {
         let url_get_id: String = self.end_point.proxy_url_for_internal_id(device_id);
 
-        let mut attempt = 0;
-        let mut interval = INTERNAL_ID_RETRY_INITIAL_INTERVAL;
-        loop {
-            attempt += 1;
-            let request = HttpRequestBuilder::get(&url_get_id).build()?;
-            match self.http.await_response(request).await?.error_for_status() {
-                Ok(response) => {
-                    let internal_id_response: InternalIdResponse = response.json().await?;
-                    return Ok(internal_id_response.id());
-                }
-                // The entity is registered locally but not created yet in the c8y inventory:
-                // retry the lookup a few times before giving up so the request is not lost.
-                Err(err)
-                    if is_entity_not_created_yet(&err) && attempt < INTERNAL_ID_MAX_ATTEMPTS =>
-                {
-                    debug!(
-                        "Internal id of {device_id} not available yet \
-                         (attempt {attempt}/{INTERNAL_ID_MAX_ATTEMPTS}), retrying in {interval:?}"
-                    );
-                    sleep(interval).await;
-                    interval = (interval * 2).min(INTERNAL_ID_RETRY_MAX_INTERVAL);
-                }
-                Err(err) => return Err(err.into()),
-            }
-        }
+        let request = HttpRequestBuilder::get(&url_get_id)
+            .retry_statuses([StatusCode::NOT_FOUND])
+            .build()?;
+        let response = self
+            .http
+            .await_response(request)
+            .await?
+            .error_for_status()?;
+        let internal_id_response: InternalIdResponse = response.json().await?;
+        Ok(internal_id_response.id())
     }
 
     pub(crate) async fn create_event(
@@ -191,15 +157,4 @@ impl C8YHttpProxyActor {
 
         Ok(())
     }
-}
-
-/// Whether an HTTP error indicates that a c8y entity has not been created yet.
-///
-/// The internal-id lookup of an entity that is registered locally but not created yet in the
-/// Cumulocity inventory returns `404 Not Found`. This is a transient condition worth retrying.
-fn is_entity_not_created_yet(err: &HttpError) -> bool {
-    matches!(
-        err,
-        HttpError::HttpStatusError { code, .. } if *code == StatusCode::NOT_FOUND
-    )
 }

--- a/crates/extensions/c8y_http_proxy/src/tests.rs
+++ b/crates/extensions/c8y_http_proxy/src/tests.rs
@@ -14,7 +14,7 @@ use tedge_actors::Builder;
 use tedge_actors::MessageReceiver;
 use tedge_actors::Sender;
 use tedge_config::TEdgeConfig;
-use tedge_http_ext::backoff::exponential::ExponentialBackoff;
+use tedge_http_ext::backoff::ExponentialBackoff;
 use tedge_http_ext::test_helpers::HttpResponseBuilder;
 use tedge_http_ext::HttpActor;
 use tedge_http_ext::HttpError;
@@ -149,46 +149,50 @@ async fn get_internal_id_before_posting_software_list() {
 // Time is paused so the retry back-off intervals elapse instantly.
 #[tokio::test(start_paused = true)]
 async fn get_internal_id_retry_fails_after_exceeding_attempts_threshold() {
-    let c8y_host = "c8y.tenant.io";
-    let main_device_id = "device-001";
+    let external_id = "device-001";
     let child_device_id = "child-101";
 
-    let (mut proxy, mut c8y) = spawn_c8y_http_proxy(c8y_host.into(), main_device_id.into()).await;
-
-    // Mock server definition
-    tokio::spawn(async move {
-        // Always fail the internal id lookup for the child device
-        loop {
-            let get_internal_id_url = format!(
-                "http://localhost:8001/c8y/identity/externalIds/c8y_Serial/{child_device_id}"
-            );
-            assert_recv(
-                &mut c8y,
-                Some(
-                    HttpRequestBuilder::get(&get_internal_id_url)
-                        .build()
-                        .unwrap(),
-                ),
-            )
-            .await;
-            let c8y_response = HttpResponseBuilder::new()
-                .status(StatusCode::NOT_FOUND)
-                .build()
-                .unwrap();
-            c8y.send(Ok(c8y_response)).await.unwrap();
-        }
-    });
-
-    // Fetch the software list so that it internally invokes get_internal_id
-    let res = proxy
-        .send_software_list_http(
-            C8yUpdateSoftwareListResponse::default(),
-            child_device_id.into(),
-        )
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/c8y/identity/externalIds/c8y_Serial/child-101")
+        .with_status(StatusCode::NOT_FOUND.as_u16().into())
+        .expect_at_least(2)
+        .create_async()
         .await;
+
+    let target_url = "remote.c8y.com".to_string();
+    let server_url = server.host_with_port();
+    let (proxy_host, proxy_port) = server_url.split_once(':').unwrap();
+    let proxy = ProxyUrlGenerator::new(
+        proxy_host.into(),
+        proxy_port.parse().unwrap(),
+        Protocol::Http,
+    );
+
+    let tedge_config = TEdgeConfig::load_toml_str("");
+    let tls_config = tedge_config.http.client_tls_config().unwrap();
+    let mut http_actor = HttpActor::new(tls_config)
+        .with_backoff(test_backoff())
+        .builder();
+
+    let config = C8YHttpConfig {
+        c8y_http_host: target_url.clone(),
+        c8y_mqtt_host: target_url,
+        device_id: external_id.into(),
+        proxy,
+    };
+    let mut proxy = C8YHttpProxy::new(config, &mut http_actor);
+
+    tokio::spawn(async move { http_actor.run().await });
+
+    let res = proxy.c8y_internal_id(child_device_id).await;
     assert!(
-        res.is_err(),
-        "Expected software list request to fail once the internal id lookup gives up"
+        matches!(
+            res,
+            Err(crate::messages::C8YRestError::FromHttpError(HttpError::HttpStatusError { code, .. }))
+                if code == StatusCode::NOT_FOUND
+        ),
+        "Expected the internal id lookup to fail after exhausting retries: {res:?}"
     );
 }
 
@@ -199,83 +203,53 @@ async fn get_internal_id_retry_fails_after_exceeding_attempts_threshold() {
 // Time is paused so the retry back-off intervals elapse instantly.
 #[tokio::test(start_paused = true)]
 async fn get_internal_id_retries_until_the_device_is_created() {
-    let c8y_host = "c8y.tenant.io";
-    let main_device_id = "device-001";
+    let external_id = "device-001";
     let child_device_id = "child-101";
 
-    let (mut proxy, mut c8y) = spawn_c8y_http_proxy(c8y_host.into(), main_device_id.into()).await;
-
-    // Mock server definition
-    tokio::spawn(async move {
-        let get_internal_id_url =
-            format!("http://localhost:8001/c8y/identity/externalIds/c8y_Serial/{child_device_id}");
-
-        // The child device is not created in the c8y inventory yet: fail the first lookups
-        for _ in 0..3 {
-            assert_recv(
-                &mut c8y,
-                Some(
-                    HttpRequestBuilder::get(&get_internal_id_url)
-                        .build()
-                        .unwrap(),
-                ),
-            )
-            .await;
-            let c8y_response = HttpResponseBuilder::new()
-                .status(StatusCode::NOT_FOUND)
-                .build()
-                .unwrap();
-            c8y.send(Ok(c8y_response)).await.unwrap();
-        }
-
-        // Once the child device has been created, the internal id lookup succeeds
-        assert_recv(
-            &mut c8y,
-            Some(
-                HttpRequestBuilder::get(&get_internal_id_url)
-                    .build()
-                    .unwrap(),
-            ),
-        )
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/c8y/identity/externalIds/c8y_Serial/child-101")
+        .with_status(StatusCode::NOT_FOUND.as_u16().into())
+        .expect(3)
+        .create_async()
         .await;
-        let c8y_response = HttpResponseBuilder::new()
-            .status(200)
-            .json(&InternalIdResponse::new("200", child_device_id))
-            .build()
-            .unwrap();
-        c8y.send(Ok(c8y_response)).await.unwrap();
-
-        // ... and the software list is finally posted against the resolved internal id
-        let c8y_software_list = C8yUpdateSoftwareListResponse::default();
-        assert_recv(
-            &mut c8y,
-            Some(
-                HttpRequestBuilder::put(
-                    "http://localhost:8001/c8y/inventory/managedObjects/200".to_string(),
-                )
-                .header("content-type", "application/json")
-                .header("accept", "application/json")
-                .json(&c8y_software_list)
-                .build()
-                .unwrap(),
-            ),
-        )
+    let _mock_success = server
+        .mock("GET", "/c8y/identity/externalIds/c8y_Serial/child-101")
+        .with_status(200)
+        .with_body(serde_json::to_string(&InternalIdResponse::new("200", child_device_id)).unwrap())
+        .expect(1)
+        .create_async()
         .await;
-        let c8y_response = HttpResponseBuilder::new().status(200).build().unwrap();
-        c8y.send(Ok(c8y_response)).await.unwrap();
-    });
 
-    // Fetch the software list so that it internally invokes get_internal_id
-    let res = proxy
-        .send_software_list_http(
-            C8yUpdateSoftwareListResponse::default(),
-            child_device_id.into(),
-        )
-        .await;
-    assert!(
-        res.is_ok(),
-        "Expected software list request to succeed once the device is created: {res:?}"
+    let target_url = "remote.c8y.com".to_string();
+    let server_url = server.host_with_port();
+    let (proxy_host, proxy_port) = server_url.split_once(':').unwrap();
+    let proxy = ProxyUrlGenerator::new(
+        proxy_host.into(),
+        proxy_port.parse().unwrap(),
+        Protocol::Http,
     );
+
+    let tedge_config = TEdgeConfig::load_toml_str("");
+    let tls_config = tedge_config.http.client_tls_config().unwrap();
+    let mut http_actor = HttpActor::new(tls_config)
+        .with_backoff(test_backoff())
+        .builder();
+
+    let config = C8YHttpConfig {
+        c8y_http_host: target_url.clone(),
+        c8y_mqtt_host: target_url,
+        device_id: external_id.into(),
+        proxy,
+    };
+    let mut proxy = C8YHttpProxy::new(config, &mut http_actor);
+
+    tokio::spawn(async move { http_actor.run().await });
+
+    let result = proxy.c8y_internal_id(child_device_id).await;
+    assert_eq!(result.unwrap(), "200");
+    _mock.assert();
+    _mock_success.assert();
 }
 
 #[tokio::test]
@@ -444,21 +418,23 @@ async fn request_internal_id_before_posting_software_list() {
     .await;
 }
 #[tokio::test(start_paused = true)]
-#[test_case::test_case(501, 1; "don't retry when header is non-retryable")]
-#[test_case::test_case(500, 2; "retry when header is retryable")]
-async fn get_internal_id_retries_depending_on_response_status(
-    status: usize,
-    expected_retries: usize,
-) {
+#[test_case::test_case(501, false; "don't retry when header is non-retryable")]
+#[test_case::test_case(404, true; "retry when external identity is not found")]
+#[test_case::test_case(500, true; "retry when header is retryable")]
+async fn get_internal_id_retries_depending_on_response_status(status: usize, retryable: bool) {
     let external_id = "device-001";
 
     let mut server = mockito::Server::new_async().await;
-    let _mock = server
+    let mock = server
         .mock("GET", "/c8y/identity/externalIds/c8y_Serial/device-001")
-        .with_status(status)
-        .expect(expected_retries)
-        .create_async()
-        .await;
+        .with_status(status);
+    // NOTE: The retries are only bounded by the back-off `max_elapsed_time`, not by a number of attempts
+    let _mock = match retryable {
+        true => mock.expect_at_least(2),
+        false => mock.expect(1),
+    }
+    .create_async()
+    .await;
     let target_url = "remote.c8y.com".to_string();
     let server_url = server.host_with_port();
     let (proxy_host, proxy_port) = server_url.split_once(':').unwrap();
@@ -471,16 +447,7 @@ async fn get_internal_id_retries_depending_on_response_status(
     let tedge_config = TEdgeConfig::load_toml_str("");
     let tls_config = tedge_config.http.client_tls_config().unwrap();
     let mut http_actor = HttpActor::new(tls_config)
-        .with_backoff(
-            // for test: tweaked to exactly 1 retry
-            ExponentialBackoff {
-                initial_interval: Duration::from_millis(5),
-                multiplier: 10.0,
-                randomization_factor: f64::EPSILON,
-                max_elapsed_time: Some(Duration::from_millis(50)),
-                ..Default::default()
-            },
-        )
+        .with_backoff(test_backoff())
         .builder();
 
     let config = C8YHttpConfig {
@@ -528,4 +495,14 @@ async fn assert_recv(
 ) {
     let actual = from.recv().await;
     tedge_http_ext::test_helpers::assert_request_eq(actual, expected)
+}
+
+fn test_backoff() -> ExponentialBackoff {
+    ExponentialBackoff {
+        initial_interval: Duration::from_millis(1),
+        multiplier: 2.0,
+        randomization_factor: f64::EPSILON,
+        max_elapsed_time: Some(Duration::from_secs(1)),
+        ..Default::default()
+    }
 }


### PR DESCRIPTION
## Proposed changes

c8y_http_proxy now uses a generic HttpActor retry that retries for other response statuses as well.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

