### PR TITLE
fix: run c8y mapper with bare `tedge run all` if configured with separate http and mqtt hosts

### DIFF
--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -2265,6 +2265,26 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn all_mapper_configs_shows_c8y_if_configured_with_separate_http_and_mqtt() {
+        // Previously, if a c8y mapper was configured with separate HTTP and MQTT endpoints,
+        // it would not be included in the configured mappers, and thus would be excluded in
+        // a bare `tedge run all`. This test ensures that such a configuration is still included.
+        let ttd = TempTedgeDir::new();
+        ttd.dir("mappers")
+            .dir("c8y")
+            .file("mapper.toml")
+            .with_toml_content(toml::toml! {
+                mqtt = "t123.cumulocity.example.com"
+                http = "c8y.example.com"
+            });
+
+        let tedge_config = TEdgeConfig::load(ttd.path()).await.unwrap();
+        let configs = tedge_config.all_mapper_configs::<C8yMapperSpecificConfig>();
+
+        assert_eq!(configs.len(), 1);
+    }
+
     fn profile_name(input: Option<&str>) -> Option<ProfileName> {
         input
             .map(<_>::to_owned)

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config/mapper_config/compat.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config/mapper_config/compat.rs
@@ -273,7 +273,7 @@ where
 /// This trait provides a uniform interface for accessing common fields
 /// from different cloud configuration readers (C8y, Az, Aws).
 pub trait CloudConfigAccessor {
-    fn url(&self) -> &OptionalConfig<ConnectUrl>;
+    fn url(&self) -> OptionalConfig<ConnectUrl>;
     fn device_id(&self) -> Result<String, ReadError>;
     fn device_id_key(&self, profile: Option<&str>) -> ReadableKey;
     fn device_key_path(&self) -> &AbsolutePath;
@@ -289,8 +289,31 @@ pub trait CloudConfigAccessor {
 }
 
 impl CloudConfigAccessor for TEdgeConfigReaderC8y {
-    fn url(&self) -> &OptionalConfig<ConnectUrl> {
-        &self.url
+    fn url(&self) -> OptionalConfig<ConnectUrl> {
+        match self.url.clone() {
+            OptionalConfig::Present { value, key } => OptionalConfig::Present { value, key },
+            OptionalConfig::Empty(url_key) => {
+                let host = self
+                    .http
+                    .as_ref()
+                    .map(|h| h.host())
+                    .or(self.mqtt.as_ref().map(|h| h.host()));
+
+                match host {
+                    OptionalConfig::Present {
+                        value,
+                        key: http_key,
+                    } => OptionalConfig::Present {
+                        value: value
+                            .to_string()
+                            .parse()
+                            .expect("same validation for c8y.http/c8y.mqtt and c8y.url"),
+                        key: http_key.clone(),
+                    },
+                    OptionalConfig::Empty(_) => OptionalConfig::Empty(url_key),
+                }
+            }
+        }
     }
 
     fn device_id_key(&self, profile: Option<&str>) -> ReadableKey {
@@ -349,8 +372,8 @@ impl CloudConfigAccessor for TEdgeConfigReaderC8y {
 }
 
 impl CloudConfigAccessor for TEdgeConfigReaderAz {
-    fn url(&self) -> &OptionalConfig<ConnectUrl> {
-        &self.url
+    fn url(&self) -> OptionalConfig<ConnectUrl> {
+        self.url.clone()
     }
 
     fn device_id_key(&self, profile: Option<&str>) -> ReadableKey {
@@ -409,8 +432,8 @@ impl CloudConfigAccessor for TEdgeConfigReaderAz {
 }
 
 impl CloudConfigAccessor for TEdgeConfigReaderAws {
-    fn url(&self) -> &OptionalConfig<ConnectUrl> {
-        &self.url
+    fn url(&self) -> OptionalConfig<ConnectUrl> {
+        self.url.clone()
     }
 
     fn device_id_key(&self, profile: Option<&str>) -> ReadableKey {

--- a/crates/common/tedge_config_macros/src/option.rs
+++ b/crates/common/tedge_config_macros/src/option.rs
@@ -38,6 +38,13 @@ impl<T> OptionalConfig<T> {
     pub fn empty(key: impl Into<Cow<'static, str>>) -> Self {
         Self::Empty(key.into())
     }
+
+    pub fn or(self, optional: OptionalConfig<T>) -> Self {
+        match self {
+            Self::Present { .. } => self,
+            Self::Empty(_) => optional,
+        }
+    }
 }
 
 impl<T> From<OptionalConfig<T>> for Option<T> {

--- a/tests/RobotFramework/tests/tedge_run_all/run_all_c8y.robot
+++ b/tests/RobotFramework/tests/tedge_run_all/run_all_c8y.robot
@@ -8,8 +8,9 @@ Documentation       Smoke tests for the single-process supervisor (`tedge run al
 ...                 on every restart, while its pid stays put — only the supervised task
 ...                 is rebuilt, not the process), that an update requiring an agent
 ...                 restart exits the whole process for the service manager to restart it,
-...                 and that the supervisor can host multiple mappers (c8y + a custom
-...                 flows-only mapper) simultaneously.
+...                 that the supervisor can host multiple mappers (c8y + a custom
+...                 flows-only mapper) simultaneously, and that a bare `tedge run all`
+...                 discovers a c8y mapper configured with separate HTTP and MQTT urls.
 ...
 ...                 The device is registered once for the suite, but each test gets a
 ...                 freshly started supervisor and tears it down again afterwards, so the
@@ -89,6 +90,24 @@ A config update restarting the agent restarts the whole process
     Wait Until Keyword Succeeds
     ...    60s    2s    Service Health Status Should Be Up    tedge-mapper-c8y
     [Teardown]    Stop Supervisor And Remove Config Type
+
+Bare tedge run all starts a c8y mapper configured with separate HTTP and MQTT urls
+    [Documentation]    A c8y mapper may be configured without `c8y.url`, by giving its MQTT
+    ...    and HTTP endpoints separately. Such a mapper is still a configured mapper, so a
+    ...    bare `tedge run all` (with no mapper named on the command line) must run it.
+    [Setup]    Start Bare Supervisor With Separate Http And Mqtt Urls
+
+    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-agent
+    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-mapper-c8y
+
+    # And the mapper picked up from the split configuration still talks to Cumulocity.
+    Wait Until Keyword Succeeds
+    ...    60s    2s    Service Health Status Should Be Up    tedge-mapper-bridge-c8y
+    Cumulocity.Should Have Services    name=tedge-mapper-c8y    service_type=service    status=up
+
+    [Teardown]    Stop Supervisor And Restore Url
 
 SIGUSR1 restarts the mapper
     # The mapper publishes a health `up` message every time it (re)starts, stamped
@@ -201,6 +220,29 @@ Start Supervisor With Restart On Failure
     # service manager to start it again.
     Execute Command
     ...    cmd=systemd-run --unit=tedge-run-all --collect -p User=tedge -p Group=tedge -p Restart=on-failure /usr/bin/tedge run all c8y
+
+Start Bare Supervisor With Separate Http And Mqtt Urls
+    # Replace `c8y.url` with the equivalent pair of explicit endpoints, which is a
+    # supported way of configuring a mapper whose HTTP and MQTT endpoints differ. Both
+    # point at the tenant the suite is connected to, so the mapper stays functional.
+    ${domain}=    Cumulocity.Get Domain
+    Execute Command    tedge config set c8y.mqtt ${domain}
+    Execute Command    tedge config set c8y.http ${domain}
+    Execute Command    tedge config unset c8y.url
+
+    # No mapper is named here: the supervisor has to work out for itself which mappers
+    # are configured, which is exactly what used to miss this c8y mapper.
+    Execute Command
+    ...    cmd=systemd-run --unit=tedge-run-all --collect -p User=tedge -p Group=tedge /usr/bin/tedge run all
+
+Stop Supervisor And Restore Url
+    # Put `c8y.url` back and drop the split endpoints, so the rest of the suite sees the
+    # configuration exactly as the suite setup left it.
+    ${domain}=    Cumulocity.Get Domain
+    Execute Command    tedge config set c8y.url ${domain}
+    Execute Command    tedge config unset c8y.mqtt
+    Execute Command    tedge config unset c8y.http
+    Stop Supervisor
 
 Stop Supervisor And Remove Config Type
     # Drop the config type declaration (and the file its update created) so the other


### PR DESCRIPTION
## Proposed changes
In #4253, `tedge run all` was changed to run all the configured mappers. This detection was based on the `url` field of `MapperConfig`, and this was being set from the `url` field from the relevant mapper.toml. However, for Cumulocity, we have the `http` and `mqtt` configurations for the hosts which can be set as an alternative to `url`.

This PR changes the configured url for Cumulocity to fall back to the `http` field if the `url` field isn't set. It shouldn't matter whether the field is `http` or `mqtt`, we don't use this field for anything other than checking a url is set for the mapper in question, and if one of those is configured, both have to be.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
- #4302

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

