### PR TITLE
fix: Don't check mosquitto bridge config if using built-in bridge

### DIFF
--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -196,40 +196,39 @@ impl ConnectCommand {
         tedge_config: &TEdgeConfig,
         bridge_config: &BridgeConfig,
     ) -> Result<(), Fancy<ConnectError>> {
-        // If the bridge is part of the mapper, the bridge config file won't exist
-        // TODO tidy me up once mosquitto is no longer required for bridge
-        if self
-            .check_if_bridge_exists(tedge_config, bridge_config)
-            .await
-        {
-            match self.check_connection(tedge_config).await {
-                Ok(DeviceStatus::AlreadyExists) => {
-                    match self
-                        .tenant_matches_configured_url(tedge_config, bridge_config)
-                        .await?
-                    {
-                        // Check failed, warning has been printed already
-                        // Don't tell them the connection test succeeded because that's not true
-                        Some(false) => {}
-                        // Either the check succeeded or it wasn't relevant (e.g. non-Cumulocity connection)
-                        Some(true) | None => {
-                            eprintln!(
-                                "Connection check to {} cloud is successful.",
-                                bridge_config.cloud_name
-                            )
-                        }
-                    }
-
-                    Ok(())
-                }
-                Ok(DeviceStatus::Unknown) => Err(ConnectError::UnknownDeviceStatus.into()),
-                Err(err) => Err(err),
+        if !tedge_config.mqtt.bridge.built_in {
+            let is_bridge_config_valid = self
+                .check_if_bridge_exists(tedge_config, bridge_config)
+                .await;
+            if !is_bridge_config_valid {
+                warning!(
+                    r#"The bridge is not currently configured; run "tedge reconnect" to establish a new connection"#
+                );
             }
-        } else {
-            Err((ConnectError::DeviceNotConnected {
-                cloud: self.cloud.to_string(),
-            })
-            .into())
+        }
+
+        match self.check_connection(tedge_config).await {
+            Ok(DeviceStatus::AlreadyExists) => {
+                match self
+                    .tenant_matches_configured_url(tedge_config, bridge_config)
+                    .await?
+                {
+                    // Check failed, warning has been printed already
+                    // Don't tell them the connection test succeeded because that's not true
+                    Some(false) => {}
+                    // Either the check succeeded or it wasn't relevant (e.g. non-Cumulocity connection)
+                    Some(true) | None => {
+                        eprintln!(
+                            "Connection check to {} cloud is successful.",
+                            bridge_config.cloud_name
+                        )
+                    }
+                }
+
+                Ok(())
+            }
+            Ok(DeviceStatus::Unknown) => Err(ConnectError::UnknownDeviceStatus.into()),
+            Err(err) => Err(err),
         }
     }
 

--- a/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
+++ b/tests/RobotFramework/tests/tedge_connect/tedge_connect_test.robot
@@ -127,6 +127,29 @@ tedge connect does not create tedge-mosquitto.conf when mqtt.bind.enabled is fal
     Execute Command    sudo tedge reconnect c8y
     File Should Not Exist    /etc/tedge/mosquitto-conf/tedge-mosquitto.conf
 
+tedge connect --test keeps working if c8y-bridge.conf is missing and built-in bridge is used
+    [Tags]    \#4309
+    Execute Command    sudo tedge config set mqtt.bridge.built_in true
+    Execute Command    sudo tedge reconnect c8y
+    Execute Command    sudo rm /etc/tedge/mosquitto-conf/c8y-bridge.conf
+    ${output}=    Execute Command    sudo tedge connect c8y --test    stdout=${False}    stderr=${True}
+    Should Contain    ${output}    Connection check to c8y cloud is successful.
+
+tedge connect --test fails if c8y-bridge.conf is missing and mosquitto bridge is used
+    [Tags]    \#4309
+    Execute Command    sudo tedge config set mqtt.bridge.built_in false
+    Execute Command    sudo tedge reconnect c8y
+    Execute Command    sudo rm /etc/tedge/mosquitto-conf/c8y-bridge.conf
+
+    # at this point test should still work because mosquitto is still running and configuration is in memory
+    Execute Command    sudo tedge connect c8y --test
+
+    # but after a restart it should fail
+    Execute Command    sudo systemctl restart mosquitto
+    ${output}=    Execute Command    sudo tedge connect c8y --test    stdout=${False}    stderr=${True}    exp_exit_code=1
+    Should Contain    ${output}    warning: The bridge is not currently configured; run "tedge reconnect" to establish a new connection
+    Should Contain    ${output}    error: Failed to verify device is connected to Cumulocity: Connection to Cumulocity is not healthy
+
 
 *** Keywords ***
 Should Have File Permissions


### PR DESCRIPTION
## Proposed changes

When running `tedge connect --test`, we no longer check the bridge configuration files before testing the connection. Instead, we immediately check the health of the bridge and then verify the bridge is working by sending data to Cumulocity cloud through it and waiting for the response. If after checking the connection is unhealthy, we check mosquitto bridge configuration file only if we're using the mosquitto bridge (i.e. we aren't using the built-in bridge).
    
This change was made because it is possible that the file doesn't exist yet the bridge connection is working (if some earlier reconnect/disconnect command didn't exit cleanly). With the previous check, if the file didn't exist we treated the connection as disconnected even though the connection was working and we could test it by sending data. Now we start by checking the connection first, and if it's unhealthy, we check mosquitto bridge config only if we're actually using it.

### `tedge connect c8y --test`

Also improved reporting if config file is missing.

before:
```
Testing connection to Cumulocity:
        mapper configuration file: /etc/tedge/mappers/c8y/mapper.toml
        device id: TST_copy_direct_limo
        cloud profile: <none>
        cloud host: thin-edge-io.eu-latest.cumulocity.com:8883
        auth type: Certificate
        certificate file: /etc/tedge/device-certs/tedge-certificate.pem
        cryptoki: off
        bridge: mosquitto
        service manager: systemd
        mosquitto version: 2.1.2
        proxy: Not configured
error: Device is not connected to Cumulocity cloud
```

after:
```
Testing connection to Cumulocity:
        mapper configuration file: /etc/tedge/mappers/c8y/mapper.toml
        device id: TST_copy_direct_limo
        cloud profile: <none>
        cloud host: thin-edge-io.eu-latest.cumulocity.com:8883
        auth type: Certificate
        certificate file: /etc/tedge/device-certs/tedge-certificate.pem
        cryptoki: off
        bridge: mosquitto
        service manager: systemd
        mosquitto version: 2.1.2
        proxy: Not configured
Verifying device is connected to cloud... ✗
warning: The bridge is not currently configured; run "tedge connect" to establish a new connection
error: Failed to verify device is connected to Cumulocity: Connection to Cumulocity is not healthy
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

#4309

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

