### PR TITLE
feat: used fixed width padding when logging the timestamp to improve log line readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5117,6 +5117,7 @@ dependencies = [
  "serde",
  "tedge-p11",
  "tempfile",
+ "time",
  "tokio",
  "toml 0.9.6",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5237,6 +5237,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 2.0.12",
+ "time",
  "tokio",
  "tokio-stream",
  "toml 0.9.6",

--- a/crates/common/tedge_config/Cargo.toml
+++ b/crates/common/tedge_config/Cargo.toml
@@ -37,6 +37,7 @@ tedge_api = { workspace = true }
 tedge_config_macros = { workspace = true }
 tedge_utils = { workspace = true, features = ["timestamp"] }
 thiserror = { workspace = true }
+time = { workspace = true, features = ["formatting", "macros"] }
 tokio = { workspace = true, features = ["fs"] }
 tokio-stream = { workspace = true }
 toml = { workspace = true }

--- a/crates/common/tedge_config/src/system_toml/log_level.rs
+++ b/crates/common/tedge_config/src/system_toml/log_level.rs
@@ -8,10 +8,13 @@ use std::fmt;
 use std::io::IsTerminal;
 use std::str::FromStr;
 use std::sync::Arc;
+use time::format_description::BorrowedFormatItem;
+use time::macros::format_description;
 use tracing::field::Visit;
 use tracing::Subscriber;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::fmt::time::FormatTime;
+use tracing_subscriber::fmt::time::UtcTime;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::LookupSpan;
@@ -29,8 +32,27 @@ macro_rules! subscriber_builder {
         tracing_subscriber::fmt()
             .with_writer(std::io::stderr)
             .with_ansi(std::io::stderr().is_terminal() && yansi::Condition::no_color())
-            .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339())
+            .with_timer($crate::utc_timer())
     };
+}
+
+/// The RFC 3339 timestamp format used by every thin-edge.io subscriber.
+///
+/// Identical to the `time` crate's `Rfc3339` well-known format, except that the
+/// fractional seconds are always 9 digits, zero-padded on the right.
+const TIMESTAMP_FORMAT: &[BorrowedFormatItem<'static>] =
+    format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z");
+
+/// The UTC timer used by every thin-edge.io subscriber.
+///
+/// [`UtcTime::rfc_3339`] formats the fractional seconds with the `time` crate's
+/// `Rfc3339` well-known format, which emits only as many subsecond digits as
+/// are needed and so produces a variable-width field (`.20652489Z` vs
+/// `.183284722Z`), shifting the rest of the log line horizontally.
+/// [`TIMESTAMP_FORMAT`] keeps the same layout and nanosecond precision, but pads
+/// the fractional part to a fixed 9 digits so the columns stay aligned.
+pub fn utc_timer() -> UtcTime<&'static [BorrowedFormatItem<'static>]> {
+    UtcTime::new(TIMESTAMP_FORMAT)
 }
 
 /// Configures and enables logging taking into account flags, env variables and file config.
@@ -484,7 +506,7 @@ pub fn set_log_level(log_level: tracing::Level) {
     let subscriber = tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_ansi(std::io::stderr().is_terminal() && yansi::Condition::no_color())
-        .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339());
+        .with_timer(utc_timer());
 
     if std::env::var("RUST_LOG").is_ok() {
         subscriber
@@ -503,7 +525,7 @@ enum TimeFormat {
 impl FormatTime for TimeFormat {
     fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> std::fmt::Result {
         match self {
-            Self::Enabled => tracing_subscriber::fmt::time::UtcTime::rfc_3339().format_time(w),
+            Self::Enabled => utc_timer().format_time(w),
             Self::Disabled => ().format_time(w),
         }
     }
@@ -516,7 +538,41 @@ mod tests {
     use std::io;
     use std::sync::Mutex;
     use tempfile::TempDir;
+    use time::macros::datetime;
+    use time::Duration;
     use tracing::Level;
+    use tracing_subscriber::fmt::format::Writer;
+
+    #[test_case::test_case(0, "2026-08-27T13:25:28.000000000Z"; "no fractional part")]
+    #[test_case::test_case(1, "2026-08-27T13:25:28.000000001Z"; "single significant digit")]
+    #[test_case::test_case(206_524_890, "2026-08-27T13:25:28.206524890Z"; "one trailing zero")]
+    #[test_case::test_case(183_284_722, "2026-08-27T13:25:28.183284722Z"; "all digits significant")]
+    #[test_case::test_case(500_000_000, "2026-08-27T13:25:28.500000000Z"; "eight trailing zeroes")]
+    #[test_case::test_case(999_999_999, "2026-08-27T13:25:28.999999999Z"; "maximum nanoseconds")]
+    fn timestamps_are_padded_to_nine_fractional_digits(nanos: i64, expected: &str) {
+        let timestamp = datetime!(2026-08-27 13:25:28 UTC) + Duration::nanoseconds(nanos);
+        assert_eq!(timestamp.format(&TIMESTAMP_FORMAT).unwrap(), expected);
+    }
+
+    /// The timer is fed the current time, so only its shape can be asserted.
+    #[test]
+    fn utc_timer_always_emits_nine_fractional_digits() {
+        for _ in 0..1_000 {
+            let mut formatted = String::new();
+            utc_timer()
+                .format_time(&mut Writer::new(&mut formatted))
+                .unwrap();
+
+            let (_, fraction) = formatted.split_once('.').expect("a fractional part");
+            let fraction = fraction.strip_suffix('Z').expect("a Z suffix");
+            assert_eq!(
+                fraction.len(),
+                9,
+                "expected 9 fractional digits in {formatted}"
+            );
+            assert!(fraction.chars().all(|c| c.is_ascii_digit()));
+        }
+    }
 
     #[test]
     fn valid_log_level() -> anyhow::Result<()> {

--- a/crates/extensions/tedge-p11-server/Cargo.toml
+++ b/crates/extensions/tedge-p11-server/Cargo.toml
@@ -19,6 +19,7 @@ rustls.workspace = true
 sd-listen-fds.workspace = true
 serde.workspace = true
 tedge-p11.workspace = true
+time = { workspace = true, features = ["formatting", "macros"] }
 tokio = { workspace = true, features = [
     "macros",
     "rt-multi-thread",

--- a/crates/extensions/tedge-p11-server/src/main.rs
+++ b/crates/extensions/tedge-p11-server/src/main.rs
@@ -25,13 +25,23 @@ use serde::Deserialize;
 use tedge_p11::CryptokiConfigDirect;
 use tedge_p11::TedgeP11Client;
 use tedge_p11::TedgeP11Server;
+use time::format_description::BorrowedFormatItem;
+use time::macros::format_description;
 use tokio::signal::unix::SignalKind;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
 use tracing::Level;
+use tracing_subscriber::fmt::time::UtcTime;
 use tracing_subscriber::EnvFilter;
+
+/// The RFC 3339 timestamp format shared with the other thin-edge.io services:
+/// fractional seconds always zero-padded to 9 digits, so the log columns stay
+/// aligned. Duplicated from `tedge_config` to keep this server's dependencies
+/// minimal.
+const TIMESTAMP_FORMAT: &[BorrowedFormatItem<'static>] =
+    format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z");
 
 /// thin-edge.io service for passing PKCS#11 cryptographic tokens.
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
@@ -244,6 +254,7 @@ async fn main() -> anyhow::Result<()> {
     let if_dev_logging = std::env::var("RUST_LOG").is_ok();
 
     tracing_subscriber::fmt()
+        .with_timer(UtcTime::new(TIMESTAMP_FORMAT))
         .with_file(if_dev_logging)
         .with_line_number(if_dev_logging)
         .with_env_filter(


### PR DESCRIPTION
## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the
maintainers why we should accept this pull request. If it fixes a bug or
resolves a feature request, be sure to link to that issue.
-->

Very minor improvement to make the log output slightly more readable by using fixed length encoding on the timestamps in the log output.

The change enforces a fixed length of 9 decimal places when displaying the timestamp, e.g.

```sh
# before
2026-08-27T13:25:28.11275288Z

# after
2026-08-27T13:25:28.112752880Z

```

In the context of the log output, the following shows a before and after, where the latter timestamps are fully aligned.

**Before**

```log
2026-08-27T13:25:28.107349674Z  INFO component{name=tedge-agent}:sm-agent: tedge_api::workflow::log::log_dir: Removed out-dated log file: /var/log/tedge/agent/workflow-software_list-c8y-mapper-2026-08-27T13-25-28.089555837Z.log
2026-08-27T13:25:28.108365223Z  INFO component{name=tedge-mapper-c8y}: MQTT bridge: [cloud] Received SUBACK (Subscription Acknowledged): SubAck { pkid: 1, return_codes: [Success(AtLeastOnce)] }
2026-08-27T13:25:28.108665184Z  INFO component{name=tedge-agent}:sm-agent: tedge_agent::operation_workflows::actor: Executing builtin:software_list operation scheduled step
2026-08-27T13:25:28.11275288Z  INFO component{name=tedge-mapper-c8y}: MQTT bridge: [cloud] Received SUBACK (Subscription Acknowledged): SubAck { pkid: 2, return_codes: [Success(AtLeastOnce)] }
2026-08-27T13:25:28.114422058Z  INFO component{name=tedge-agent}:sm-agent: tedge_api::workflow::log::command_log: => moving to software_list @ executing
2026-08-27T13:25:28.115965778Z  INFO component{name=tedge-agent}:sm-agent: tedge_api::workflow::log::log_dir: Removed out-dated log file: /var/log/tedge/agent/workflow-software_list-c8y-mapper-2026-08-27T13-25-28.095324587Z.log
2026-08-27T13:25:28.117046744Z  INFO component{name=tedge-agent}:sm-agent: tedge_agent::operation_workflows::actor: software_list operation executing: waiting for sub-operation completion
2026-08-27T13:25:28.117257121Z  INFO component{name=tedge-agent}:sm-agent: tedge_api::workflow::log::log_dir: Removed out-dated log file: /var/log/tedge/agent/workflow-software_list-c8y-mapper-2026-08-27T13-25-28.089555837Z.log
2026-08-27T13:25:28.119506428Z  INFO component{name=tedge-agent}:sm-agent: tedge_agent::operation_workflows::actor: software_list operation executing: waiting for sub-operation completion
2026-08-27T13:25:28.13148514Z  INFO component{name=tedge-mapper-c8y}: MQTT bridge: [cloud] Received SUBACK (Subscription Acknowledged): SubAck { pkid: 3, return_codes: [Success(AtLeastOnce)] }
2026-08-27T13:25:28.13151739Z  INFO component{name=tedge-mapper-c8y}: MQTT bridge: [cloud] Received SUBACK (Subscription Acknowledged): SubAck { pkid: 4, return_codes: [Success(AtLeastOnce)] }
2026-08-27T13:25:28.133328987Z  INFO component{name=tedge-agent}:sm-agent: tedge_agent::software_manager::actor: Checking if tedge got self updated
2026-08-27T13:25:28.133369862Z  INFO component{name=tedge-agent}:sm-agent: tedge_agent::software_manager::actor: Current running version: 2.0.2~285+gc6cc23d
```

**After**

```log
2026-08-27T13:25:28.107349674Z  INFO component{name=tedge-agent}:sm-agent: tedge_api::workflow::log::log_dir: Removed out-dated log file: /var/log/tedge/agent/workflow-software_list-c8y-mapper-2026-08-27T13-25-28.089555837Z.log
2026-08-27T13:25:28.108365223Z  INFO component{name=tedge-mapper-c8y}: MQTT bridge: [cloud] Received SUBACK (Subscription Acknowledged): SubAck { pkid: 1, return_codes: [Success(AtLeastOnce)] }
2026-08-27T13:25:28.108665184Z  INFO component{name=tedge-agent}:sm-agent: tedge_agent::operation_workflows::actor: Executing builtin:software_list operation scheduled step
2026-08-27T13:25:28.112752880Z  INFO component{name=tedge-mapper-c8y}: MQTT bridge: [cloud] Received SUBACK (Subscription Acknowledged): SubAck { pkid: 2, return_codes: [Success(AtLeastOnce)] }
2026-08-27T13:25:28.114422058Z  INFO component{name=tedge-agent}:sm-agent: tedge_api::workflow::log::command_log: => moving to software_list @ executing
2026-08-27T13:25:28.115965778Z  INFO component{name=tedge-agent}:sm-agent: tedge_api::workflow::log::log_dir: Removed out-dated log file: /var/log/tedge/agent/workflow-software_list-c8y-mapper-2026-08-27T13-25-28.095324587Z.log
2026-08-27T13:25:28.117046744Z  INFO component{name=tedge-agent}:sm-agent: tedge_agent::operation_workflows::actor: software_list operation executing: waiting for sub-operation completion
2026-08-27T13:25:28.117257121Z  INFO component{name=tedge-agent}:sm-agent: tedge_api::workflow::log::log_dir: Removed out-dated log file: /var/log/tedge/agent/workflow-software_list-c8y-mapper-2026-08-27T13-25-28.089555837Z.log
2026-08-27T13:25:28.119506428Z  INFO component{name=tedge-agent}:sm-agent: tedge_agent::operation_workflows::actor: software_list operation executing: waiting for sub-operation completion
2026-08-27T13:25:28.131485140Z  INFO component{name=tedge-mapper-c8y}: MQTT bridge: [cloud] Received SUBACK (Subscription Acknowledged): SubAck { pkid: 3, return_codes: [Success(AtLeastOnce)] }
2026-08-27T13:25:28.131517390Z  INFO component{name=tedge-mapper-c8y}: MQTT bridge: [cloud] Received SUBACK (Subscription Acknowledged): SubAck { pkid: 4, return_codes: [Success(AtLeastOnce)] }
2026-08-27T13:25:28.133328987Z  INFO component{name=tedge-agent}:sm-agent: tedge_agent::software_manager::actor: Checking if tedge got self updated
2026-08-27T13:25:28.133369862Z  INFO component{name=tedge-agent}:sm-agent: tedge_agent::software_manager::actor: Current running version: 2.0.2~285+gc6cc23d
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

