### PR TITLE
docs: add product security section for vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues,
+pull requests or discussions.
+
+Report them privately using
+[GitHub's private vulnerability reporting](https://github.com/thin-edge/thin-edge.io/security/advisories/new),
+which is enabled on this repository.
+The report is only visible to you and the thin-edge.io maintainers,
+and the follow-up discussion happens in the comment thread of the resulting draft advisory.
+
+The [Reporting a Vulnerability](https://thin-edge.github.io/thin-edge.io/security/reporting-a-vulnerability/)
+documentation describes what to include in a report and what happens after you submit one.
+
+## Security advisories
+
+Advisories are published on the
+[security advisories page](https://github.com/thin-edge/thin-edge.io/security/advisories)
+of this repository, and announced in the
+[Tech Community](https://techcommunity.cumulocity.com/) under the
+[tedge-security](https://community.cumulocity.com/tag/tedge-security/1617) tag,
+together with emergency releases and safety guidance.
+
+See [Security Advisories](https://thin-edge.github.io/thin-edge.io/security/security-advisories/)
+for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ which is enabled on this repository.
 The report is only visible to you and the thin-edge.io maintainers,
 and the follow-up discussion happens in the comment thread of the resulting draft advisory.
 
-The [Reporting a Vulnerability](https://thin-edge.github.io/thin-edge.io/security/reporting-a-vulnerability/)
+The [Reporting a Vulnerability](docs/src/security/reporting-a-vulnerability.md)
 documentation describes what to include in a report and what happens after you submit one.
 
 ## Security advisories
@@ -23,5 +23,5 @@ of this repository, and announced in the
 [tedge-security](https://community.cumulocity.com/tag/tedge-security/1617) tag,
 together with emergency releases and safety guidance.
 
-See [Security Advisories](https://thin-edge.github.io/thin-edge.io/security/security-advisories/)
+See [Security Advisories](docs/src/security/security-advisories.md)
 for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,14 @@ and the follow-up discussion happens in the comment thread of the resulting draf
 The [Reporting a Vulnerability](docs/src/security/reporting-a-vulnerability.md)
 documentation describes what to include in a report and what happens after you submit one.
 
+## Scope
+
+This policy covers the software published from this repository.
+It does not cover community plugins and other community extensions,
+including those hosted under the [thin-edge organization](https://github.com/thin-edge),
+which are maintained independently.
+Report a vulnerability in a community project to the maintainers of that project.
+
 ## Security advisories
 
 Advisories are published on the

--- a/docs/src/operate/security/index.md
+++ b/docs/src/operate/security/index.md
@@ -25,4 +25,10 @@ It is therefore recommended to set things up step by step.
 - The second step is to enable TLS on the local MQTT and HTTP connections.
 - The final step is to enforce certificate-based client authentication on the local MQTT and HTTP connections.
 
+:::note
+To report a security vulnerability in %%te%% itself,
+or to learn how security advisories are published,
+see [Product Security](../../security/index.md).
+:::
+
 <DocCardList />

--- a/docs/src/security/index.md
+++ b/docs/src/security/index.md
@@ -1,0 +1,20 @@
+---
+title: Product Security
+tags: [Security]
+sidebar_position: 7
+description: Reporting security vulnerabilities in %%te%% and staying informed about security advisories
+---
+
+import DocCardList from '@theme/DocCardList';
+
+This section describes how the %%te%% project handles the security of the software that it publishes:
+how to report a vulnerability that you have found,
+and how the project informs users about vulnerabilities, fixes and mitigations.
+
+:::note
+If you are looking for guidance on how to *configure* %%te%% securely,
+for example certificates, TLS and access control,
+see [Security and Access Control](../operate/security/index.md) instead.
+:::
+
+<DocCardList />

--- a/docs/src/security/reporting-a-vulnerability.md
+++ b/docs/src/security/reporting-a-vulnerability.md
@@ -1,0 +1,102 @@
+---
+title: Reporting a Vulnerability
+tags: [Security]
+sidebar_position: 1
+description: How to privately report a security vulnerability in %%te%%
+---
+
+The %%te%% project welcomes reports about security vulnerabilities in any of its components,
+and asks that such reports are made privately so that a fix can be prepared
+before the problem becomes publicly known.
+
+:::caution
+Never report a suspected vulnerability through a public GitHub issue, pull request or discussion,
+and never post a proof of concept in a public forum.
+Use the private reporting channel described below.
+:::
+
+## How to report
+
+Vulnerabilities are reported using
+[GitHub's private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability),
+which is enabled on the %%te%% repository.
+A report creates a draft security advisory that is visible only to you and the %%te%% maintainers.
+
+1. Open the [new advisory report form](https://github.com/thin-edge/thin-edge.io/security/advisories/new).
+
+   You can also reach the same form from the repository itself,
+   by selecting **Security** &rarr; **Advisories** &rarr; **Report a vulnerability**.
+
+2. Fill in the form, using the guidance in [What to include in a report](#what-to-include-in-a-report).
+
+3. Submit the report.
+
+You need a GitHub account to submit a report, as the whole exchange with the maintainers happens
+in the comment thread of the draft advisory.
+You are notified there of any update, and you can keep adding information to the report at any time.
+
+If the vulnerability affects one of the other repositories of the
+[thin-edge organization](https://github.com/thin-edge), such as a community plugin,
+report it on that repository instead, using the same procedure.
+If the repository has no **Report a vulnerability** option,
+report it on the %%te%% repository and name the affected repository in the report.
+
+## What to include in a report
+
+A good report is one that lets a maintainer reproduce and assess the problem without a lengthy exchange.
+The [Cumulocity responsible disclosure policy](https://cumulocity.com/docs/legal-notices/responsible-disclosure-policy/#reporting-a-potential-security-vulnerability)
+describes what makes a good security report, and the same expectations apply here.
+
+Try to provide the following information:
+
+- **Affected versions**: the output of `tedge --version`, and whether older or newer versions are affected.
+- **Affected components**: which binaries, plugins or services are involved, for example `tedge-mapper`, `tedge-agent` or `tedge-p11-server`.
+- **Environment**: the operating system, architecture and how %%te%% was installed, for example a Debian package, a container image or a build from source.
+- **Configuration**: the settings which are relevant to the problem, for example how the MQTT and HTTP listeners are bound, or how the device certificate is stored.
+- **Reproduction steps**: a minimal, step-by-step description, including any commands, MQTT messages or HTTP requests needed to trigger the problem.
+- **Impact**: what an attacker can achieve, and what access is required to do so, for example local access to the device, access to the local network or access to the cloud tenant.
+- **Mitigation**: any workaround or configuration change which reduces the impact, if you know of one.
+- **Disclosure status**: whether the problem is already known publicly, and whether you intend to publish anything about it.
+
+:::caution
+Remove secrets from anything you attach to a report.
+Log files, configuration dumps and packet captures may contain private keys, device certificates,
+cloud credentials, tokens and tenant URLs.
+:::
+
+## What happens next
+
+1. A maintainer acknowledges the report and starts the assessment.
+   Questions and clarifications are exchanged in the comment thread of the draft advisory.
+
+2. If the report is accepted, the maintainers determine the affected versions and the severity,
+   and prepare a fix privately.
+   You are informed about the outcome of the assessment, including when a report is rejected
+   and why it is not considered to be a vulnerability.
+
+3. The fix is released and an advisory is published, as described in
+   [Security Advisories](security-advisories.md).
+
+4. Unless you ask otherwise, you are credited in the advisory as the reporter.
+
+Please keep the details of the report private until the advisory has been published.
+
+## Vulnerabilities in dependencies
+
+%%te%% is built from a number of third-party components,
+and vulnerabilities are regularly disclosed against them.
+
+- If a vulnerability in a dependency is exploitable through %%te%%,
+  report it privately as described above, even when the upstream problem is already public,
+  so that the impact on %%te%% can be assessed and a release prepared.
+- If you only want to point out that a dependency should be updated,
+  and the vulnerability is not exploitable through %%te%%,
+  then a normal [GitHub issue](https://github.com/thin-edge/thin-edge.io/issues) is enough.
+
+## Vulnerabilities in a cloud platform
+
+%%te%% connects to cloud platforms such as Cumulocity, AWS IoT and Azure IoT,
+but it is not part of them.
+A vulnerability in the cloud platform itself has to be reported to its vendor.
+For Cumulocity, follow the
+[Cumulocity responsible disclosure policy](https://cumulocity.com/docs/legal-notices/responsible-disclosure-policy/).

--- a/docs/src/security/reporting-a-vulnerability.md
+++ b/docs/src/security/reporting-a-vulnerability.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 description: How to privately report a security vulnerability in %%te%%
 ---
 
-The %%te%% project welcomes reports about security vulnerabilities in any of its components,
+The %%te%% project welcomes reports about security vulnerabilities,
 and asks that such reports are made privately so that a fix can be prepared
 before the problem becomes publicly known.
 
@@ -14,6 +14,22 @@ Never report a suspected vulnerability through a public GitHub issue, pull reque
 and never post a proof of concept in a public forum.
 Use the private reporting channel described below.
 :::
+
+## Scope
+
+This process covers the software which is published from the
+[thin-edge/thin-edge.io](https://github.com/thin-edge/thin-edge.io) repository:
+the `tedge` command line interface, the mapper, the agent
+and the plugins which are built and released from that repository.
+
+It does not cover community plugins and other community extensions,
+even when they are hosted under the [thin-edge organization](https://github.com/thin-edge).
+Those are maintained independently and are outside the responsibility of the %%te%% maintainers.
+Report a vulnerability in a community plugin to the maintainers of that project,
+following whatever process its own repository documents.
+
+If you are not sure whether a component is in scope, report it anyway.
+A report which turns out to be out of scope is redirected rather than ignored.
 
 ## How to report
 
@@ -34,12 +50,6 @@ A report creates a draft security advisory that is visible only to you and the %
 You need a GitHub account to submit a report, as the whole exchange with the maintainers happens
 in the comment thread of the draft advisory.
 You are notified there of any update, and you can keep adding information to the report at any time.
-
-If the vulnerability affects one of the other repositories of the
-[thin-edge organization](https://github.com/thin-edge), such as a community plugin,
-report it on that repository instead, using the same procedure.
-If the repository has no **Report a vulnerability** option,
-report it on the %%te%% repository and name the affected repository in the report.
 
 ## What to include in a report
 

--- a/docs/src/security/security-advisories.md
+++ b/docs/src/security/security-advisories.md
@@ -25,10 +25,13 @@ Each advisory states:
 - credit to the reporter, unless they asked to stay anonymous.
 
 Where appropriate, a CVE identifier is requested through GitHub when the advisory is published.
-Published advisories are added to the
-[GitHub Advisory Database](https://github.com/advisories),
-so that tools such as Dependabot and other vulnerability scanners
-can detect an affected version of %%te%%.
+
+:::note
+%%te%% is distributed as Linux packages and container images,
+and not through a package registry which vulnerability scanners index.
+Do not rely on a tool such as Dependabot to tell you that an advisory applies to your devices:
+subscribe to one of the channels described below instead.
+:::
 
 ## Announcements in the Tech Community
 
@@ -75,7 +78,7 @@ with a description of the problem, the affected versions and the upgrade path.
 You are recommended to use at least one of the following:
 
 - Watch the [tedge-security](https://community.cumulocity.com/tag/tedge-security/1617) tag in the Tech Community.
-- Watch the %%te%% repository on GitHub, selecting **Custom** &rarr; **Security alerts** and **Releases**,
-  to be notified of new advisories and releases.
+- Watch the %%te%% repository on GitHub, selecting **Custom** &rarr; **Releases**,
+  to be notified of every new release, including the ones which contain a security fix.
 - Track the versions of %%te%% which are deployed on your devices,
   so that you can determine quickly whether an advisory applies to your fleet.

--- a/docs/src/security/security-advisories.md
+++ b/docs/src/security/security-advisories.md
@@ -1,0 +1,81 @@
+---
+title: Security Advisories
+tags: [Security]
+sidebar_position: 2
+description: How %%te%% publishes security advisories, emergency releases and safety guidance
+---
+
+Once a vulnerability has been fixed, or once a mitigation is available,
+the %%te%% project informs its users through two complementary channels:
+a GitHub security advisory, which is the authoritative and machine-readable record,
+and an announcement in the Tech Community, which reaches users who do not follow the repository.
+
+## GitHub security advisories
+
+Advisories are published on the
+[security advisories page](https://github.com/thin-edge/thin-edge.io/security/advisories)
+of the %%te%% repository.
+
+Each advisory states:
+
+- a description of the vulnerability and of its impact,
+- the affected versions and the version in which the problem is fixed,
+- a severity rating,
+- any workaround which can be applied when upgrading is not immediately possible,
+- credit to the reporter, unless they asked to stay anonymous.
+
+Where appropriate, a CVE identifier is requested through GitHub when the advisory is published.
+Published advisories are added to the
+[GitHub Advisory Database](https://github.com/advisories),
+so that tools such as Dependabot and other vulnerability scanners
+can detect an affected version of %%te%%.
+
+## Announcements in the Tech Community
+
+Security announcements are published in the
+[Tech Community](https://techcommunity.cumulocity.com/)
+under the [tedge-security](https://community.cumulocity.com/tag/tedge-security/1617) tag.
+
+This tag is used for all the notifications which require the attention of an operator,
+and not only for advisories:
+
+- **Security advisories**, linking to the corresponding GitHub advisory and to the release containing the fix.
+- **Emergency releases**, when a release is published outside of the regular release cycle.
+- **Safety guidance**, such as a recommended configuration change, a workaround for an unfixed problem,
+  or a warning about an insecure usage pattern.
+
+To be notified, open the
+[tedge-security](https://community.cumulocity.com/tag/tedge-security/1617) tag
+while logged in to the Tech Community, and watch it.
+
+:::note
+A Tech Community announcement never replaces the advisory.
+When the two differ, the GitHub advisory is the reference.
+:::
+
+## Emergency releases
+
+A fix for a vulnerability is released as a patch release,
+published through the same channels as any other release:
+the [GitHub releases](https://github.com/thin-edge/thin-edge.io/releases) page,
+the Cloudsmith package repositories and the container images.
+See [Installation](../install/index.md) for the details of each channel.
+
+An emergency release is a patch release which is published outside of the regular release cycle,
+because the severity of the problem does not allow waiting for the next planned release.
+Such a release contains the security fix and as few unrelated changes as possible,
+so that it can be adopted quickly and with a low risk of regression.
+
+Emergency releases are announced under the
+[tedge-security](https://community.cumulocity.com/tag/tedge-security/1617) tag,
+with a description of the problem, the affected versions and the upgrade path.
+
+## Staying informed
+
+You are recommended to use at least one of the following:
+
+- Watch the [tedge-security](https://community.cumulocity.com/tag/tedge-security/1617) tag in the Tech Community.
+- Watch the %%te%% repository on GitHub, selecting **Custom** &rarr; **Security alerts** and **Releases**,
+  to be notified of new advisories and releases.
+- Track the versions of %%te%% which are deployed on your devices,
+  so that you can determine quickly whether an advisory applies to your fleet.


### PR DESCRIPTION
## Proposed changes

Adds a **Product Security** section to the documentation, covering the two things the issue asks for:

* **[Reporting a Vulnerability](https://github.com/reubenmiller/thin-edge.io/blob/claude/thin-edge-issue-4318-pr-91a1b9/docs/src/security/reporting-a-vulnerability.md)** — how to report privately through GitHub's private vulnerability reporting (already enabled on this repository), what to include in a report (referencing the [Cumulocity responsible disclosure policy](https://cumulocity.com/docs/legal-notices/responsible-disclosure-policy/#reporting-a-potential-security-vulnerability) for what makes a good report), what happens after a report is submitted, and how to handle vulnerabilities in dependencies or in a cloud platform.
* **[Security Advisories](https://github.com/reubenmiller/thin-edge.io/blob/claude/thin-edge-issue-4318-pr-91a1b9/docs/src/security/security-advisories.md)** — how advisories are published on the repository's advisories page, and how advisories, emergency releases and safety guidance are announced under the [`tedge-security`](https://community.cumulocity.com/tag/tedge-security/1617) tag in the [Tech Community](https://techcommunity.cumulocity.com/).

Also adds a top-level `SECURITY.md`, so that GitHub surfaces the policy from the repository's Security tab and from the "Report a vulnerability" form, and a cross-link from the existing *Security and Access Control* section (which is about configuring a device securely, a different topic).

The new section is placed at the top level with `sidebar_position: 7`, between *References* and *Legacy*.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [x] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/4318

<br/>

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

Documentation-only change, so no Rust formatting, linting or tests apply. Validated instead with:

* `npx docusaurus-mdx-checker` in `docs/` (the CI markdown job) — all 293 MDX files compiled.
* A full `tedge-docs` Docusaurus production build against this branch, with `onBrokenLinks: 'throw'` — succeeded, and the new section renders in the sidebar as *Overview → … → References → **Product Security** → Legacy*. The four broken-anchor warnings it reports are pre-existing (`extend/flows`, `references/mappers/user-defined-mappers`).
* All external URLs checked for HTTP 200.

## Further comments

The change went through an independent review pass, which caught three factual errors that are worth recording since they are easy to reintroduce:

1. `SECURITY.md` originally linked to `https://thin-edge.github.io/thin-edge.io/security/...`. The root path of the docs site serves the **last released snapshot**, so those pages would have 404'd until the next release — verified by inspecting the build output, which contained `build/next/security/` but no `build/security/`. `SECURITY.md` is outside the reach of Docusaurus' broken-link check, so nothing in CI would have caught it. It now links to the markdown sources in the repository.
2. The advisories page claimed that publishing a GitHub advisory lets "Dependabot and other vulnerability scanners" detect an affected version. Dependabot only acts on *reviewed* advisories mapped to a supported package ecosystem, and thin-edge.io is not published in one (`crates.io` has no `tedge`, `tedge_api`, `tedge_actors` or `tedge_config`); it ships as Linux packages and container images. The page now says so explicitly, so operators do not rely on coverage that does not exist.
3. It also advised watching the repository with **Custom → Security alerts**. That option delivers Dependabot alerts, which GitHub only sends to users with write, maintain or admin permissions — a silent no-op for the operators this page addresses. It now recommends watching releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
