### PR TITLE
feat: publish the sbom with every official release

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -258,6 +258,40 @@ jobs:
           || contains(needs.*.result, 'skipped')
         }}
 
+  # Generate the Software Bill Of Materials (sbom) so that it can be attached
+  # to the github release. It is generated on every run (and not only when tagging)
+  # so that any breakage is detected before a release is made.
+  sbom:
+    name: Generate sbom
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          # Fetch the tags as just detects the version from git when it is parsed
+          fetch-depth: 0
+          allow-unsafe-pr-checkout: true
+
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: taiki-e/install-action@just
+      - name: Install cargo-cyclonedx
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-cyclonedx@0.5.9
+
+      - name: Generate sbom
+        run: just generate-sbom
+
+      - name: Upload sbom
+        uses: actions/upload-artifact@v7
+        with:
+          name: sbom
+          path: target/sbom/*.cdx.json
+          if-no-files-found: error
+
   approve:
     # Note: Use approval as a job so that the downstream jobs are only prompted once (if more than 1 matrix job is defined)
     name: Approve
@@ -443,6 +477,8 @@ jobs:
       - name: Download release artifacts
         uses: actions/download-artifact@v8
         with:
+          # Only the packages are needed, in particular not the sbom or the test reports
+          pattern: packages-*
           path: containers/tedge/packages/
 
       - name: Set up QEMU
@@ -521,6 +557,8 @@ jobs:
       - name: Download release artifacts
         uses: actions/download-artifact@v8
         with:
+          # Only the packages are needed, in particular not the sbom or the test reports
+          pattern: packages-*
           path: containers/tedge-p11-server/packages/
 
       - name: Set up QEMU
@@ -604,13 +642,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [publish-virtual-packages, publish-containers, publish-p11-server-containers]
+    needs: [publish-virtual-packages, publish-containers, publish-p11-server-containers, sbom]
     if: |
       always() &&
       startsWith(github.ref, 'refs/tags/') &&
       needs.publish-virtual-packages.result == 'success' &&
       needs.publish-containers.result == 'success' &&
-      needs.publish-p11-server-containers.result == 'success'
+      needs.publish-p11-server-containers.result == 'success' &&
+      needs.sbom.result == 'success'
+    # Note: if the sbom job fails on a tag, this job is skipped and neither the cloudsmith
+    # packages are promoted nor the docs snapshot is created. Use "Re-run failed jobs" to
+    # complete the release once the sbom job succeeds.
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -626,12 +668,23 @@ jobs:
           if ! just generate-changelog --from-tags; then
             echo "Warning: Failed to generate changelog, but it should not block a release" > _CHANGELOG.md
           fi
+      # Note: the sbom job is already a pre-condition of this job, so the sbom does exist.
+      # Downloading/attaching it is nevertheless best-effort, as it must not prevent the
+      # cloudsmith packages from being promoted by the last step of this job
+      - name: Download sbom
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: sbom
+          path: target/sbom/
+
       - name: Release
         uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           body_path: _CHANGELOG.md
+          files: target/sbom/*.cdx.json
           generate_release_notes: false
           draft: true
 

--- a/docs/src/contribute/package-hosting.md
+++ b/docs/src/contribute/package-hosting.md
@@ -266,6 +266,29 @@ The version is automatically generated from the source code management tool, git
 |`distance`|Number of commits on the `main` branch since last official release|
 |`git_sha`|Git commit sha which the package was built from. This makes it easier to trace the version back to the exact commit|
 
+## Software Bill of Materials (SBOM) {#sbom}
+
+Every official release publishes [CycloneDX](https://cyclonedx.org) Software Bill of Materials (SBOM) documents
+as assets on the [GitHub release page](https://github.com/thin-edge/thin-edge.io/releases).
+
+%%te%% is distributed as two executables, and each one is described by its own SBOM.
+
+|File|Describes|
+|----|---------|
+|`tedge.cdx.json`|The `tedge` multicall binary, which also provides `tedge-mapper`, `tedge-agent`, `tedge-watchdog`, `tedge-apt-plugin`, `tedge-flows-plugin`, `c8y-firmware-plugin`, `c8y-remote-access-plugin`, `tedge-write`, `tedge-file-config-plugin` and `tedge-file-log-plugin`|
+|`tedge-p11-server.cdx.json`|The `tedge-p11-server` executable|
+
+The SBOMs cover all of the platforms that %%te%% is released for,
+and are generated from the resolved dependency graph rather than from the graph of an individual build.
+They are therefore a superset of what is linked into any single release artifact:
+dependencies which only apply to another platform, optional dependencies, and dev-dependencies are all listed.
+
+The SBOM of any commit can also be generated locally using:
+
+```sh
+just generate-sbom
+```
+
 # How is this made possible?
 
 Package repository hosting is graciously provided by [Cloudsmith](https://cloudsmith.com).

--- a/justfile
+++ b/justfile
@@ -245,10 +245,55 @@ publish-linux-target TARGET=DEFAULT_TARGET *ARGS='':
 generate-changelog *ARGS:
     ./ci/changelog/changelog.sh {{ARGS}}
 
-# Generate Software Bill Of Materials (sbom)
+# Generate Software Bill Of Materials (sbom), one per released binary, under target/sbom
 generate-sbom:
-    cargo install cargo-cyclonedx
-    cargo cyclonedx --describe binaries --all-features --all --no-build-deps --format json -v
+    #!/usr/bin/env bash
+    set -e
+    OUTPUT_DIR="target/sbom"
+
+    # Note: keep the version in sync with the sbom job of .github/workflows/build-workflow.yml
+    # so that a locally generated sbom matches the released one
+    CYCLONEDX_VERSION="0.5.9"
+    if ! cargo cyclonedx --version 2>/dev/null | grep -qw "$CYCLONEDX_VERSION"; then
+        cargo install --locked --version "$CYCLONEDX_VERSION" cargo-cyclonedx
+    fi
+
+    # Remove any sbom left behind by a previous (interrupted) run so that a stale sbom
+    # is never collected below
+    find crates plugins -name '*.cdx.json' -delete
+
+    # Note: '--target all' is used as the binaries are released for several platforms
+    # (e.g. musl, darwin) whose dependencies differ. Without it the sbom would only
+    # describe the host platform and silently omit, say, the macOS specific dependencies.
+    #
+    # Note: cargo-cyclonedx describes the resolved dependency graph rather than the graph
+    # which is actually built, so the sbom is a superset of what is linked into the
+    # binaries. This is not affected by the feature flags: the output is identical with
+    # and without --all-features.
+    cargo cyclonedx --describe binaries --all-features --all --no-build-deps --format json --target all -v
+
+    # cargo-cyclonedx emits an sbom for every crate with a binary target, writes it next
+    # to that crate and suffixes it with '_bin', so keep only the sboms of the released
+    # binaries and collect them under their binary name to make publishing them easier.
+    # Note: `tedge` is a multicall binary, so its sbom already covers the components
+    # which are not built as a standalone binary (e.g. tedge-mapper, tedge-write)
+    source ./ci/package_list.sh
+
+    mkdir -p "$OUTPUT_DIR"
+    rm -f "$OUTPUT_DIR"/*.cdx.json
+    for name in "${BINARIES[@]}"; do
+        sbom=$(find crates plugins -name "${name}_bin.cdx.json")
+        if [ -z "$sbom" ]; then
+            echo "No sbom was generated for the '$name' binary" >&2
+            exit 1
+        fi
+        mv -f "$sbom" "$OUTPUT_DIR/${name}.cdx.json"
+    done
+
+    # Discard the sboms of the components which are covered by a multicall binary
+    find crates plugins -name '*.cdx.json' -delete
+
+    ls -l "$OUTPUT_DIR"
 
 # Remove unused/unreferenced images
 clean-unused-images *ARGS:


### PR DESCRIPTION
## Proposed changes

Relates to thin-edge/thin-edge.io#4319.

The CycloneDX SBOM is now generated in CI and attached to the GitHub release, so that users can integrate it into their product workflows.

* A new `sbom` job generates the SBOMs and uploads them as a workflow artifact.
  It runs on **every** workflow trigger, not only when tagging, so that breakage is detected in a PR rather than during a release.
* The `release` job downloads that artifact and attaches the `*.cdx.json` files to the GitHub release.
* `just generate-sbom` now collects the per-binary SBOMs (which `cargo-cyclonedx` writes next to each crate) into `target/sbom`, pins the `cargo-cyclonedx` version, and generates for all target platforms.
* The release assets are documented in the package hosting page.

Hosting the SBOM in Cloudsmith is explicitly out of scope, as stated in the issue.

### Release assets

Two SBOMs are published, one per released binary:

| File | Describes |
|------|-----------|
| `tedge.cdx.json` | the `tedge` multicall binary (also provides `tedge-mapper`, `tedge-agent`, `tedge-watchdog`, `tedge-apt-plugin`, `tedge-flows-plugin`, `c8y-firmware-plugin`, `c8y-remote-access-plugin`, `tedge-write`, `tedge-file-config-plugin`, `tedge-file-log-plugin`) |
| `tedge-p11-server.cdx.json` | the `tedge-p11-server` executable |

`cargo-cyclonedx` also emits an SBOM for the crates behind `tedge-write`, `tedge-file-config-plugin` and `tedge-file-log-plugin`, but those are not built as standalone binaries and are already covered by `tedge.cdx.json`, so they are discarded. The list of binaries to keep is read from `ci/package_list.sh` — the same list used to build them — and generation fails if one of them is not described. Each file is renamed on collection to drop `cargo-cyclonedx`'s `_bin` suffix.

### Notes for reviewers

**`--target all` was added to the recipe.** Without it, `cargo-cyclonedx` describes the host platform only, which in CI is `x86_64-unknown-linux-gnu` — a target thin-edge.io does not release. The resulting SBOM silently omitted dependencies that *are* linked into released artifacts:

* macOS artifacts: `core-foundation`, `core-foundation-sys`, `fsevent-sys`, `security-framework`, `security-framework-sys`
* armv7 artifacts: `atomic`, `bytemuck`

Those are false negatives, which is the dangerous direction for an SBOM. `--target all` was verified to be a true superset of the graphs of all 10 released targets, at the cost of ~75 Windows/wasm components that ship nowhere (over-reporting, the safe direction). Per-target SBOMs via `--target-in-filename` would be more precise if that trade is not wanted.

**Known limitation (pre-existing, not introduced here).** `cargo-cyclonedx` describes the *resolved* dependency graph rather than the graph that is actually built, so the SBOM also lists optional and dev-dependencies which are not linked into the binaries — e.g. `aws-lc-rs` and `quinn` appear even though `cargo tree -p tedge -e normal -i aws-lc-rs` reports "nothing to print". This is not affected by the feature flags: the output is byte-identical with and without `--all-features`. It is disclosed in the docs, and would need its own change (likely upstream).

**Failure handling.** If the `sbom` job fails on a tag, the `release` job is skipped, so neither the Cloudsmith promotion nor the docs snapshot runs; "Re-run failed jobs" completes the release. Inside the `release` job the download/attach is best-effort (`continue-on-error`, no `fail_on_unmatched_files`) so it can never abort the job before the Cloudsmith promotion.

**Unrelated-looking change.** `pattern: packages-*` was added to the two container publish jobs, which download *all* workflow artifacts with no `name`. Without it the new `sbom` artifact would end up in the docker build context. It also excludes the `report-*` test artifacts, which were previously being pulled in.

### Optional follow-ups (not done here)

* `--spec-version 1.5` — the output is currently CycloneDX 1.3.
* SBOM `bom-ref`/`purl` values embed the absolute checkout path; no fix available in cargo-cyclonedx 0.5.9.
* Include the version in the asset filenames.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md) — not run, no Rust or Robot Framework code is changed
- [ ] I used `just check` to verify my changes — not run, no Rust code is changed; see the validation listed below instead
- [x] I have added tests that prove my fix is effective or that my feature works (N/A — release packaging change; the `sbom` job exercises it on every CI run)
- [x] I have added necessary documentation

## Further comments

Validation performed:

* `just generate-sbom` run repeatedly — produces exactly the 2 released binaries' SBOMs in `target/sbom` (530 and 196 components), is idempotent, sweeps SBOMs left behind by an interrupted run, and leaves `git status` clean (`*.cdx.json` is gitignored).
* Verified that generation fails loudly when a released binary has no SBOM.
* Verified `--target all` is a superset of all 10 released targets, and that the host default is not.
* Workflow YAML parses and the `release` job's `if` expression is unaffected by the added comments.
* `just --summary`, `just --list`, `typos`, `git diff --check`.
* `npx docusaurus-mdx-checker` in `docs/`: 287/287 MDX files compile.

The CI-only parts (artifact upload/download and the release asset attachment) cannot be exercised locally and will first run in this PR's own build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


