### PR TITLE
fix: trim SmartREST operation results on a character boundary

### DIFF
--- a/crates/core/c8y_api/src/smartrest/smartrest_serializer.rs
+++ b/crates/core/c8y_api/src/smartrest/smartrest_serializer.rs
@@ -48,7 +48,10 @@ fn fail_operation(template_id: usize, operation: &str, reason: &str) -> Smartres
             .expect("operation name shouldn't put payload over size limit")
     } else {
         warn!("Failure reason too long, message truncated to 500 bytes");
-        SmartrestPayload::serialize((template_id, operation, &reason[..500]))
+        // Truncating on a character boundary, as slicing a `str` inside a
+        // multi-byte character panics
+        let reason = &reason[..reason.floor_char_boundary(500)];
+        SmartrestPayload::serialize((template_id, operation, reason))
             .expect("operation name shouldn't put payload over size limit")
     }
 }
@@ -154,8 +157,19 @@ pub fn succeed_operation(
         let reason = reason.strip_prefix('"').unwrap_or(reason);
         let reason = reason.strip_suffix('"').unwrap_or(reason);
 
-        // if we'd cut across an escaped " character, move trim point 1 char back to omit it
-        if &reason[max_result_limit - 1..=max_result_limit] == r#""""# {
+        // Truncating on a character boundary, as slicing a `str` inside a
+        // multi-byte character panics
+        max_result_limit = reason.floor_char_boundary(max_result_limit);
+
+        // Every double quote is escaped as a pair in the CSV field. If the trim point falls
+        // in the middle of such a pair, i.e. right after an odd number of consecutive quotes,
+        // move it back by one so the field is not left with a dangling quote.
+        let quote_run = reason.as_bytes()[..max_result_limit]
+            .iter()
+            .rev()
+            .take_while(|byte| **byte == b'"')
+            .count();
+        if quote_run % 2 == 1 {
             max_result_limit -= 1;
         }
         let trimmed_reason = &reason[..max_result_limit];
@@ -669,5 +683,58 @@ mod tests {
         let num_quotes = reason.chars().filter(|c| *c == '"').count();
 
         assert_eq!(num_quotes, expected_num_quotes);
+    }
+
+    #[test]
+    fn succeed_operation_trims_reason_on_a_char_boundary() {
+        // Each 'é' is 2 bytes long and the trim point is at an even offset,
+        // so the leading one byte 'a' is what makes it fall inside a character
+        let reason = format!("a{}", "é".repeat(MAX_PAYLOAD_LIMIT_IN_BYTES));
+
+        let smartrest =
+            succeed_operation(SET_OPERATION_TO_SUCCESSFUL, "c8y_Command", reason).unwrap();
+
+        assert!(
+            smartrest.as_str().len() <= MAX_PAYLOAD_LIMIT_IN_BYTES,
+            "bigger than message size limit: {} > {}",
+            smartrest.as_str().len(),
+            MAX_PAYLOAD_LIMIT_IN_BYTES
+        );
+        assert!(smartrest.as_str().ends_with("...<trimmed>\""));
+    }
+
+    #[test]
+    fn succeed_operation_never_trims_inside_a_quote_run() {
+        // Two adjacent quotes in the reason are escaped into a run of four in the CSV field.
+        // Sweeping the position of that run makes the trim point fall at every offset within it.
+        for prefix_len in 15960..15985 {
+            let reason = format!("{}\"\"{}", "a".repeat(prefix_len), "b".repeat(200));
+
+            let smartrest =
+                succeed_operation(SET_OPERATION_TO_SUCCESSFUL, "c8y_Command", reason).unwrap();
+
+            let field = smartrest.as_str().splitn(3, ',').nth(2).unwrap();
+            let num_quotes = field.chars().filter(|c| *c == '"').count();
+            assert_eq!(
+                num_quotes % 2,
+                0,
+                "dangling quote for prefix_len {prefix_len}: ...{}",
+                &field[field.len().saturating_sub(30)..]
+            );
+        }
+    }
+
+    #[test]
+    fn fail_operation_truncates_reason_on_a_char_boundary() {
+        // Each 'é' is 2 bytes long and the 500 bytes limit is even,
+        // so the leading one byte 'a' is what makes it fall inside a character
+        let reason = format!("a{}", "é".repeat(500));
+
+        let smartrest = fail_operation(SET_OPERATION_TO_FAILED, "c8y_Command", &reason);
+
+        assert_eq!(
+            smartrest.as_str(),
+            format!("502,c8y_Command,a{}", "é".repeat(249))
+        );
     }
 }


### PR DESCRIPTION
## Proposed changes

`succeed_operation` truncates an over-sized operation result by slicing a `&str` at a raw byte offset, which panics when that offset falls inside a multi-byte character. `fail_operation` truncates a failure reason the same way.

A custom operation handler returning a large non-ASCII result is enough to trigger it — command output containing accented or CJK characters, for instance. The panic happens in the spawned operation task, which the Cumulocity mapper unwraps when clearing the command topic (`operations/handler.rs`), so it shuts `tedge-mapper-c8y` down and leaves the operation stuck in EXECUTING.

Reproduced against `main`:

```
thread 'main' panicked at crates/core/c8y_api/src/smartrest/smartrest_serializer.rs:158:37:
end byte index 15977 is not a char boundary; it is inside 'é' (bytes 15976..15978 of string)
```

While in there, a second defect in the same block: the heuristic that avoids splitting a CSV-escaped `""` pair only looked at the two bytes around the trim point, so it cut a longer run of quotes in half and emitted a field with a dangling quote:

```
503,c8y_Command,"aaaaaaaaaaaaaaaa"...<trimmed>"
```

The length of the quote run ending at the trim point is now used instead, which is the correct rule since CSV escaping always doubles quotes.

Both trim sites use `str::floor_char_boundary`, stable since 1.86 and so available on the 1.92 MSRV (verified with `rustc +1.92`).

This was found while implementing #4322, which makes the path reachable by default (the built-in shell operation reports arbitrary command output). Splitting it out as it stands on its own.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Paste Link to the issue

Found while working on #4322

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the CLA (in all commits with `git commit -s`)
- [x] I ran `just check` locally and all tests passed
- [x] I have added tests that prove my fix is effective
- [ ] I have added necessary documentation (not applicable)

## Testing performed

- `cargo test -p c8y_api` — 79 SmartREST tests pass
- `cargo clippy -p c8y_api --all-targets` — clean
- Three regression tests added, each verified to **fail** against the unfixed code:
  - `succeed_operation_trims_reason_on_a_char_boundary`
  - `succeed_operation_never_trims_inside_a_quote_run` (sweeps the trim point across a quote run)
  - `fail_operation_truncates_reason_on_a_char_boundary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
