### PR TITLE
feat: `tedge connect` change error format and show unpaired key diagnostic

### DIFF
--- a/crates/core/tedge/src/cli/connect/c8y.rs
+++ b/crates/core/tedge/src/cli/connect/c8y.rs
@@ -197,7 +197,19 @@ pub async fn create_device_with_direct_connection(
                     failure.explain(&connection, validity)
                 ));
             }
-            Err(err) => return Err(anyhow!("{err:#}\n\n{}", error_context(stage))),
+            Err(err) => {
+                let err: anyhow::Error = err.into();
+                if let Some(err2 @ std::io::Error { .. }) = err.root_cause().downcast_ref() {
+                    if let Some(Error::AlertReceived(AlertDescription::HandshakeFailure)) =
+                        err2.get_ref().and_then(|e| e.downcast_ref())
+                    {
+                        let failure = TlsFailure::UnpairedPrivateKey;
+                        return Err(anyhow!("{err:#}\n\n{}", failure.explain(&connection, None)));
+                    }
+                }
+
+                return Err(anyhow!("{err:#}\n\n{}", error_context(stage)));
+            }
             _ => {}
         }
     }

--- a/crates/core/tedge/src/cli/connect/c8y.rs
+++ b/crates/core/tedge/src/cli/connect/c8y.rs
@@ -8,7 +8,6 @@ use crate::cli::is_bridge_health_up_message;
 use crate::DeviceStatus;
 use anyhow::anyhow;
 use anyhow::bail;
-use anyhow::Context as _;
 use base64::prelude::*;
 use c8y_api::smartrest::message::get_smartrest_template_id;
 use c8y_api::smartrest::message_ids::GET_DEVICE_MANAGED_OBJECT_ID;
@@ -183,7 +182,7 @@ pub async fn create_device_with_direct_connection(
             }
             Err(ConnectionError::Io(err) | ConnectionError::Tls(TlsError::Io(err))) => {
                 let Some(failure) = classify_tls_error(&err, &connection, stage) else {
-                    return Err(err).context(error_context(stage));
+                    return Err(anyhow!("{err:#}\n\n{}", error_context(stage)));
                 };
 
                 let validity = match (failure, connection.certificate()) {
@@ -193,9 +192,12 @@ pub async fn create_device_with_direct_connection(
                     _ => None,
                 };
 
-                return Err(err).context(failure.explain(&connection, validity));
+                return Err(anyhow!(
+                    "{err:#}\n\n{}",
+                    failure.explain(&connection, validity)
+                ));
             }
-            Err(err) => return Err(err).context(error_context(stage)),
+            Err(err) => return Err(anyhow!("{err:#}\n\n{}", error_context(stage))),
             _ => {}
         }
     }


### PR DESCRIPTION
## Proposed changes

2 changes:

### Change error format

Print lower-level error chain messages on a separate line from higher-level diagnostics help.

before:
```
$ tedge connect c8y

...
Creating device in Cumulocity cloud... ✗
error: Cumulocity sent a TLS handshake larger than the 64 KB thin-edge.io can accept.

The likely cause is an unnecessarily large `certificate_authorities` list. This must be corrected on the Cumulocity side; changing this device's certificate or configuration will not fix it.

Contact Cumulocity support and quote the MQTT host `localhost`.: message buffer full
```

after:

```
...
Creating device in Cumulocity cloud... ✗
error: message buffer full

Cumulocity sent a TLS handshake larger than the 64 KB thin-edge.io can accept.

The likely cause is an unnecessarily large `certificate_authorities` list. This must be corrected on the Cumulocity side; changing this device's certificate or configuration will not fix it.

Contact Cumulocity support and quote the MQTT host `localhost`.
```

### Unpaired key diagnostic

Show a diagnostic when private key doesn't match public key, like so:

```
$ tedge connect c8y

...

Creating device in Cumulocity cloud... ✗
error: Mqtt state: Mqtt serialization/deserialization error: IO: received fatal alert: HandshakeFailure: Mqtt serialization/deserialization error: IO: received fatal alert: HandshakeFailure: IO: received fatal alert: HandshakeFailure: received fatal alert: HandshakeFailure

The configured private key does not belong to the device certificate.

This connection is configured to use:
  certificate: /etc/tedge/device-certs/tedge-certificate.pem (from 'c8y.device.cert_path')
  private key: an HSM private key (selected by 'c8y.device.key_uri')

These two have to be a matching pair: the certificate has to be the one issued for that exact key.

So check that 'c8y.device.cert_path' names the certificate that was issued for the key held in the HSM, and not another certificate.
```

This check was implemented in db002db8, but due to how rumqttc wraps its errors, we didn't detect it correctly, which is now fixed.

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

To make this check even more solid, we could verify a test message using the configured keypair to be absolutely sure that the keys don't match but it's probably good enough already.