### PR TITLE
refactor(test-utils): make TempTedgeDir/TempTedgeFile return Utf8Path

### DIFF
--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -2138,7 +2138,7 @@ mod tests {
             format!("{error:#}"),
             format!(
                 "failed to read {}/mappers: Permission denied (os error 13)",
-                ttd.path().display()
+                ttd.path()
             )
         );
     }

--- a/crates/common/tedge_config/src/tedge_toml/tedge_config_location.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config_location.rs
@@ -918,7 +918,7 @@ type = "a-service-type""#;
         )
         .unwrap();
         let _env_lock = EnvSandbox::new().await;
-        let toml_path = dir.utf8_path().join("tedge.toml");
+        let toml_path = dir.path().join("tedge.toml");
         let (_config, warnings) = t
             .load_dto_with_warnings::<FileAndEnvironment>()
             .await
@@ -935,7 +935,7 @@ type = "a-service-type""#;
     async fn specifies_file_name_and_variable_path_in_relevant_warnings_before_migrations() {
         let (dir, t) = create_temp_tedge_config("c8y.smartrest.unknown = \"test.c8y.io\"").unwrap();
         let _env_lock = EnvSandbox::new().await;
-        let toml_path = dir.utf8_path().join("tedge.toml");
+        let toml_path = dir.path().join("tedge.toml");
         let (_config, warnings) = t
             .load_dto_with_warnings::<FileAndEnvironment>()
             .await

--- a/crates/common/tedge_utils/src/file.rs
+++ b/crates/common/tedge_utils/src/file.rs
@@ -527,7 +527,7 @@ mod tests {
         let ttd = TempTedgeDir::new();
         let file_path = ttd.path().join("file");
 
-        TedgePaths::from_root_with_defaults(ttd.utf8_path(), "", "")
+        TedgePaths::from_root_with_defaults(ttd.path(), "", "")
             .file("file")
             .unwrap()
             .with_mode(0o644)
@@ -587,7 +587,7 @@ mod tests {
         let src_dir = TempTedgeDir::new();
         let file_path = src_dir.path().join("file");
 
-        TedgePaths::from_root_with_defaults(src_dir.utf8_path(), "", "")
+        TedgePaths::from_root_with_defaults(src_dir.path(), "", "")
             .file("file")
             .unwrap()
             .with_mode(0o775)

--- a/crates/common/tedge_utils/src/notify.rs
+++ b/crates/common/tedge_utils/src/notify.rs
@@ -230,7 +230,7 @@ mod tests {
             String::from("file_b") => vec![FsEvent::FileCreated, FsEvent::Modified]
         };
 
-        let mut stream = fs_notify_stream(&[ttd.path(), ttd.path()]).unwrap();
+        let mut stream = fs_notify_stream(&[ttd.std_path(), ttd.std_path()]).unwrap();
 
         let fs_notify_handler = tokio::task::spawn(async move {
             assert_rx_stream(expected_events, &mut stream).await;
@@ -251,7 +251,7 @@ mod tests {
         let ttd = Arc::new(TempTedgeDir::new());
         let ttd_clone = ttd.clone();
         let mut fs_notify = NotifyStream::try_default().unwrap();
-        fs_notify.add_watcher(ttd.path()).unwrap();
+        fs_notify.add_watcher(ttd.std_path()).unwrap();
 
         let assert_file_events = tokio::spawn(async move {
             let expected_events = hashmap! {
@@ -292,7 +292,7 @@ mod tests {
             String::from("file_c") => vec![FsEvent::FileCreated, FsEvent::FileDeleted]
         };
 
-        let mut stream = fs_notify_stream(&[ttd.path()]).unwrap();
+        let mut stream = fs_notify_stream(&[ttd.std_path()]).unwrap();
 
         let fs_notify_handler = tokio::task::spawn(async move {
             assert_rx_stream(expected_events, &mut stream).await;
@@ -328,8 +328,13 @@ mod tests {
             String::from("dir_d") => vec![FsEvent::DirectoryCreated],
         };
 
-        let mut stream =
-            fs_notify_stream(&[ttd_a.path(), ttd_b.path(), ttd_c.path(), ttd_d.path()]).unwrap();
+        let mut stream = fs_notify_stream(&[
+            ttd_a.std_path(),
+            ttd_b.std_path(),
+            ttd_c.std_path(),
+            ttd_d.std_path(),
+        ])
+        .unwrap();
 
         let fs_notify_handler = tokio::task::spawn(async move {
             assert_rx_stream(expected_events, &mut stream).await;
@@ -360,13 +365,13 @@ mod tests {
         let dir = TempTedgeDir::new();
         let nested_dir = dir.dir("nested");
 
-        let mut stream = fs_notify_stream(&[nested_dir.path()]).unwrap();
+        let mut stream = fs_notify_stream(&[nested_dir.std_path()]).unwrap();
 
         // Test create
         let file = nested_dir.file("file");
         assert_rx_stream(
             [(
-                file.utf8_path().file_name().unwrap().to_string(),
+                file.path().file_name().unwrap().to_string(),
                 vec![FsEvent::Modified],
             )]
             .into(),
@@ -382,7 +387,7 @@ mod tests {
         .unwrap();
         assert_rx_stream(
             [(
-                file.utf8_path().file_name().unwrap().to_string(),
+                file.path().file_name().unwrap().to_string(),
                 vec![FsEvent::Modified],
             )]
             .into(),
@@ -398,7 +403,7 @@ mod tests {
         .unwrap();
         assert_rx_stream(
             [(
-                file.utf8_path().file_name().unwrap().to_string(),
+                file.path().file_name().unwrap().to_string(),
                 vec![FsEvent::Modified],
             )]
             .into(),
@@ -410,7 +415,7 @@ mod tests {
         std::fs::remove_file(file.path()).unwrap();
         assert_rx_stream(
             [(
-                file.utf8_path().file_name().unwrap().to_string(),
+                file.path().file_name().unwrap().to_string(),
                 vec![FsEvent::Modified],
             )]
             .into(),
@@ -426,7 +431,7 @@ mod tests {
         .unwrap();
         assert_rx_stream(
             [(
-                file.utf8_path().file_name().unwrap().to_string(),
+                file.path().file_name().unwrap().to_string(),
                 vec![FsEvent::Modified],
             )]
             .into(),

--- a/crates/common/tedge_utils/src/paths.rs
+++ b/crates/common/tedge_utils/src/paths.rs
@@ -658,7 +658,7 @@ mod tests {
     #[tokio::test]
     async fn ensure_creates_missing_managed_directories_with_default_mode() {
         let ttd = TempTedgeDir::new();
-        let root = ttd.utf8_path();
+        let root = ttd.path();
         let owner = current_owner();
         let config_root =
             TedgePaths::from_root_with_defaults(root, owner.user.clone(), owner.group.clone());
@@ -678,7 +678,7 @@ mod tests {
     #[tokio::test]
     async fn group_writable_sets_group_write_bit() {
         let ttd = TempTedgeDir::new();
-        let root = ttd.utf8_path();
+        let root = ttd.path();
         let owner = current_owner();
         let config_root =
             TedgePaths::from_root_with_defaults(root, owner.user.clone(), owner.group.clone());
@@ -699,7 +699,7 @@ mod tests {
         let ttd = TempTedgeDir::new();
         let owner = current_owner();
         let config_root = TedgePaths::from_root_with_defaults(
-            ttd.utf8_path(),
+            ttd.path(),
             owner.user.clone(),
             owner.group.clone(),
         );
@@ -724,7 +724,7 @@ mod tests {
 
         let owner = current_owner();
         let config_root = TedgePaths::from_root_with_defaults(
-            ttd.utf8_path(),
+            ttd.path(),
             owner.user.clone(),
             owner.group.clone(),
         );
@@ -743,7 +743,7 @@ mod tests {
     #[tokio::test]
     async fn explicit_owner_override_replaces_default_owner() {
         let ttd = TempTedgeDir::new();
-        let root = TedgePaths::from_root_with_defaults(ttd.utf8_path(), "tedge", "tedge");
+        let root = TedgePaths::from_root_with_defaults(ttd.path(), "tedge", "tedge");
 
         let file = root
             .file("mosquitto-conf/c8y-bridge.conf")
@@ -756,7 +756,7 @@ mod tests {
     #[test]
     fn file_parent_uses_file_owner() {
         let ttd = TempTedgeDir::new();
-        let root = TedgePaths::from_root_with_defaults(ttd.utf8_path(), "tedge", "tedge");
+        let root = TedgePaths::from_root_with_defaults(ttd.path(), "tedge", "tedge");
 
         let parent = root
             .file("operations/c8y/c8y_RemoteAccessConnect")
@@ -771,29 +771,22 @@ mod tests {
     #[test]
     fn managed_paths_can_be_displayed() {
         let ttd = TempTedgeDir::new();
-        let root = TedgePaths::from_root_with_defaults(ttd.utf8_path(), "tedge", "tedge");
+        let root = TedgePaths::from_root_with_defaults(ttd.path(), "tedge", "tedge");
         let file = root.file("operations/c8y/c8y_Restart").unwrap();
         let parent = file.parent();
 
         assert_eq!(
             file.to_string(),
-            ttd.path()
-                .join("operations/c8y/c8y_Restart")
-                .display()
-                .to_string()
+            ttd.path().join("operations/c8y/c8y_Restart")
         );
-        assert_eq!(
-            parent.to_string(),
-            ttd.path().join("operations/c8y").display().to_string()
-        );
+        assert_eq!(parent.to_string(), ttd.path().join("operations/c8y"));
     }
 
     #[tokio::test]
     async fn file_create_if_missing_writes_content_on_first_call() {
         let ttd = TempTedgeDir::new();
         let owner = current_owner();
-        let config_root =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path(), owner.user, owner.group);
+        let config_root = TedgePaths::from_root_with_defaults(ttd.path(), owner.user, owner.group);
 
         config_root
             .file("system.toml")
@@ -814,8 +807,7 @@ mod tests {
         ttd.file("system.toml")
             .with_raw_content("# existing config");
         let owner = current_owner();
-        let config_root =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path(), owner.user, owner.group);
+        let config_root = TedgePaths::from_root_with_defaults(ttd.path(), owner.user, owner.group);
 
         config_root
             .file("system.toml")
@@ -833,7 +825,7 @@ mod tests {
     #[tokio::test]
     async fn file_create_if_missing_sets_mode() {
         let ttd = TempTedgeDir::new();
-        let root = ttd.utf8_path();
+        let root = ttd.path();
         let owner = current_owner();
         let config_root = TedgePaths::from_root_with_defaults(root, owner.user, owner.group);
 
@@ -850,7 +842,7 @@ mod tests {
     #[tokio::test]
     async fn file_create_if_missing_fails_when_parent_missing() {
         let ttd = TempTedgeDir::new();
-        let root = ttd.utf8_path().join("root-not-created");
+        let root = ttd.path().join("root-not-created");
         // root is intentionally not created
         let owner = current_owner();
         let config_root = TedgePaths::from_root_with_defaults(&root, owner.user, owner.group);
@@ -869,8 +861,7 @@ mod tests {
     async fn file_create_if_missing_with_wrong_user() {
         let ttd = TempTedgeDir::new();
         let owner = current_owner();
-        let config_root =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path(), owner.user, owner.group);
+        let config_root = TedgePaths::from_root_with_defaults(ttd.path(), owner.user, owner.group);
 
         let err = config_root
             .file("system.toml")
@@ -887,8 +878,7 @@ mod tests {
     async fn ensure_with_wrong_user() {
         let ttd = TempTedgeDir::new();
         let owner = current_owner();
-        let config_root =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path(), owner.user, owner.group);
+        let config_root = TedgePaths::from_root_with_defaults(ttd.path(), owner.user, owner.group);
 
         let err = config_root
             .dir("operations")
@@ -909,8 +899,7 @@ mod tests {
 
         let ttd = TempTedgeDir::new();
 
-        let config_root =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path(), "root", root_group());
+        let config_root = TedgePaths::from_root_with_defaults(ttd.path(), "root", root_group());
         let failing_ancestor = ttd.path().join("operations");
         let requested = ttd.path().join("operations").join("c8y");
 
@@ -922,14 +911,14 @@ mod tests {
             .unwrap_err();
 
         let err = err.to_string();
-        assert!(err.contains(&failing_ancestor.display().to_string()));
-        assert!(!err.contains(&requested.display().to_string()));
+        assert!(err.contains(failing_ancestor.as_str()));
+        assert!(!err.contains(requested.as_str()));
     }
 
     #[tokio::test]
     async fn ensure_creates_directories_above_the_root_but_does_not_take_ownership() {
         let ttd = TempTedgeDir::new();
-        let root = ttd.utf8_path().join("missing-parent").join("managed-root");
+        let root = ttd.path().join("missing-parent").join("managed-root");
 
         let config_root = TedgePaths::from_root_with_defaults(&root, "root", root_group());
 
@@ -943,13 +932,13 @@ mod tests {
 
         assert!(err.contains("Failed to change owner"));
         assert!(err.contains("missing-parent/managed-root"));
-        assert!(ttd.utf8_path().join("missing-parent").is_dir());
+        assert!(ttd.path().join("missing-parent").is_dir());
     }
 
     #[tokio::test]
     async fn replace_atomic_preserves_symlink_following_behavior() {
         let ttd = TempTedgeDir::new();
-        let root = ttd.utf8_path();
+        let root = ttd.path();
         let bridge_conf = ttd
             .dir("mosquitto-conf")
             .file("c8y-bridge.conf")
@@ -980,8 +969,7 @@ mod tests {
     async fn template_persistence_creates_active_and_template_files() {
         let ttd = TempTedgeDir::new();
         let owner = current_owner();
-        let config_root =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path(), owner.user, owner.group);
+        let config_root = TedgePaths::from_root_with_defaults(ttd.path(), owner.user, owner.group);
 
         config_root
             .template_file("bridge/rules.toml")
@@ -1009,8 +997,7 @@ mod tests {
         let ttd = TempTedgeDir::new();
         ttd.dir("bridge");
         let owner = current_owner();
-        let config_root =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path(), owner.user, owner.group);
+        let config_root = TedgePaths::from_root_with_defaults(ttd.path(), owner.user, owner.group);
 
         config_root
             .template_file("bridge/rules.toml")
@@ -1044,8 +1031,7 @@ mod tests {
         let ttd = TempTedgeDir::new();
         ttd.dir("bridge");
         let owner = current_owner();
-        let config_root =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path(), owner.user, owner.group);
+        let config_root = TedgePaths::from_root_with_defaults(ttd.path(), owner.user, owner.group);
 
         config_root
             .template_file("bridge/rules.toml")
@@ -1082,8 +1068,7 @@ mod tests {
         let ttd = TempTedgeDir::new();
         ttd.dir("bridge");
         let owner = current_owner();
-        let config_root =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path(), owner.user, owner.group);
+        let config_root = TedgePaths::from_root_with_defaults(ttd.path(), owner.user, owner.group);
 
         config_root
             .template_file("bridge/rules.toml")
@@ -1124,8 +1109,7 @@ mod tests {
         let ttd = TempTedgeDir::new();
         ttd.dir("bridge");
         let owner = current_owner();
-        let config_root =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path(), owner.user, owner.group);
+        let config_root = TedgePaths::from_root_with_defaults(ttd.path(), owner.user, owner.group);
 
         let err = config_root
             .template_file("bridge/rules.toml")
@@ -1139,8 +1123,7 @@ mod tests {
         let ttd = TempTedgeDir::new();
         ttd.dir("bridge");
         let owner = current_owner();
-        let config_root =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path(), owner.user, owner.group);
+        let config_root = TedgePaths::from_root_with_defaults(ttd.path(), owner.user, owner.group);
 
         config_root
             .template_file("bridge/rules.toml")

--- a/crates/common/upload/src/upload.rs
+++ b/crates/common/upload/src/upload.rs
@@ -350,7 +350,7 @@ mod tests {
             .with_raw_content("Hello, world!");
 
         let mut uploader = Uploader::new(
-            ttd.utf8_path().join("file_upload.txt"),
+            ttd.path().join("file_upload.txt"),
             None,
             CloudHttpConfig::test_value(),
         );
@@ -381,7 +381,7 @@ mod tests {
             .with_raw_content("Hello, world!");
 
         let mut uploader = Uploader::new(
-            ttd.utf8_path().join("file_upload.txt"),
+            ttd.path().join("file_upload.txt"),
             None,
             CloudHttpConfig::test_value(),
         );
@@ -413,7 +413,7 @@ mod tests {
             .with_raw_content("Hello, world!");
 
         let mut uploader = Uploader::new(
-            ttd.utf8_path().join("file_upload.txt"),
+            ttd.path().join("file_upload.txt"),
             None,
             CloudHttpConfig::test_value(),
         );
@@ -447,7 +447,7 @@ mod tests {
             .with_raw_content("Hello, world!");
 
         let mut uploader = Uploader::new(
-            ttd.utf8_path().join("file_upload.txt"),
+            ttd.path().join("file_upload.txt"),
             None,
             CloudHttpConfig::test_value(),
         );
@@ -686,7 +686,7 @@ mod tests {
 
         let url = UploadInfo::new(&target_url).set_method(UploadMethod::PUT);
 
-        let mut uploader = Uploader::new(file.utf8_path_buf(), None, CloudHttpConfig::test_value());
+        let mut uploader = Uploader::new(file.path_buf(), None, CloudHttpConfig::test_value());
         // tweaked to exactly 1 retry
         uploader.set_backoff(ExponentialBackoff {
             initial_interval: Duration::from_millis(5),

--- a/crates/core/plugin_sm/src/plugin_manager.rs
+++ b/crates/core/plugin_sm/src/plugin_manager.rs
@@ -291,14 +291,14 @@ mod tests {
     #[tokio::test]
     async fn test_no_sm_plugin_dir() {
         let config_dir = TempTedgeDir::new();
-        let mut plugin_dir_path = config_dir.utf8_path_buf();
+        let mut plugin_dir_path = config_dir.path_buf();
         plugin_dir_path.push("sm-plugins");
 
         let actual = ExternalPlugins::open(
             plugin_dir_path,
             None,
             SudoCommandBuilder::enabled(false),
-            config_dir.utf8_path_buf(),
+            config_dir.path_buf(),
         )
         .await;
         assert!(actual.is_ok());

--- a/crates/core/plugin_sm/tests/plugin_manager.rs
+++ b/crates/core/plugin_sm/tests/plugin_manager.rs
@@ -17,7 +17,7 @@ mod tests {
             plugin_dir.path(),
             None,
             SudoCommandBuilder::enabled(false),
-            config_dir.utf8_path_buf(),
+            config_dir.path_buf(),
         )
         .await
         .unwrap();
@@ -42,7 +42,7 @@ mod tests {
             plugin_dir.path(),
             None,
             SudoCommandBuilder::enabled(false),
-            config_dir.utf8_path_buf(),
+            config_dir.path_buf(),
         )
         .await
         .unwrap();
@@ -65,7 +65,7 @@ mod tests {
             plugin_dir.path(),
             Some("dummy".into()),
             SudoCommandBuilder::enabled(false),
-            config_dir.utf8_path_buf(),
+            config_dir.path_buf(),
         )
         .await?;
         assert!(result.empty());

--- a/crates/core/tedge/src/cli/connect/command.rs
+++ b/crates/core/tedge/src/cli/connect/command.rs
@@ -1505,9 +1505,9 @@ Each cloud profile requires either a unique URL or unique device ID, so it corre
             let cloud = Cloud::c8y(Some("new".parse().unwrap()));
             let ttd = TempTedgeDir::new();
             let cert = rcgen::generate_simple_self_signed(["test-device".into()]).unwrap();
-            let mut cert_path = ttd.utf8_path().to_owned();
+            let mut cert_path = ttd.path().to_owned();
             cert_path.push("test.crt");
-            let mut key_path = ttd.utf8_path().to_owned();
+            let mut key_path = ttd.path().to_owned();
             key_path.push("test.key");
             std::fs::write(&cert_path, cert.cert.pem()).unwrap();
             std::fs::write(&key_path, cert.signing_key.serialize_pem()).unwrap();
@@ -1531,9 +1531,9 @@ Each cloud profile requires either a unique URL or unique device ID, so it corre
         async fn allows_combination_of_urls_and_device_ids() {
             let cloud = Cloud::c8y(Some("new".parse().unwrap()));
             let ttd = TempTedgeDir::new();
-            let mut cert_path = ttd.utf8_path().to_owned();
+            let mut cert_path = ttd.path().to_owned();
             cert_path.push("test.crt");
-            let mut key_path = ttd.utf8_path().to_owned();
+            let mut key_path = ttd.path().to_owned();
             key_path.push("test.key");
             let cert = rcgen::generate_simple_self_signed(["test-device".into()]).unwrap();
             std::fs::write(&cert_path, cert.cert.pem()).unwrap();
@@ -1681,7 +1681,7 @@ Each cloud profile requires either a unique URL or unique device ID, so it corre
 
         fn bridge_config_with_cn(cn: &str) -> (TempTedgeDir, BridgeConfig) {
             let ttd = TempTedgeDir::new();
-            let cert_path = ttd.utf8_path().join("device.crt");
+            let cert_path = ttd.path().join("device.crt");
             std::fs::write(&cert_path, self_signed_cert_pem(cn)).unwrap();
             (ttd, bridge_config_with_cert(cert_path))
         }

--- a/crates/core/tedge/src/cli/diag/collect.rs
+++ b/crates/core/tedge/src/cli/diag/collect.rs
@@ -274,14 +274,14 @@ mod tests {
         let second_plugin_dir = ttd.dir("plugins_2");
         let third_plugin_dir = ttd.dir("plugins_3");
         let mut command = DiagCollectCommand::new(&ttd);
-        command.add_plugin_dir(second_plugin_dir.utf8_path());
-        command.add_plugin_dir(third_plugin_dir.utf8_path());
+        command.add_plugin_dir(second_plugin_dir.path());
+        command.add_plugin_dir(third_plugin_dir.path());
         with_exec_permission(command.first_plugin_dir().join("plugin_1a"), "pwd");
         with_exec_permission(command.first_plugin_dir().join("plugin_1b"), "pwd");
-        with_exec_permission(second_plugin_dir.utf8_path().join("plugin_2a"), "pwd");
-        with_exec_permission(second_plugin_dir.utf8_path().join("plugin_2b"), "pwd");
-        with_exec_permission(third_plugin_dir.utf8_path().join("plugin_3a"), "pwd");
-        with_exec_permission(third_plugin_dir.utf8_path().join("plugin_3b"), "pwd");
+        with_exec_permission(second_plugin_dir.path().join("plugin_2a"), "pwd");
+        with_exec_permission(second_plugin_dir.path().join("plugin_2b"), "pwd");
+        with_exec_permission(third_plugin_dir.path().join("plugin_3a"), "pwd");
+        with_exec_permission(third_plugin_dir.path().join("plugin_3b"), "pwd");
 
         let mut logger = DualLogger::new(command.diag_dir.join("summary.log")).unwrap();
         let plugins = command.read_diag_plugins(&mut logger).await.unwrap();
@@ -291,7 +291,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_diag_plugins_ignores_not_existing_plugin_dirs() {
         let ttd = TempTedgeDir::new();
-        let second_plugin_dir = ttd.utf8_path().join("plugins_2");
+        let second_plugin_dir = ttd.path().join("plugins_2");
         assert!(!second_plugin_dir.exists());
 
         let mut command = DiagCollectCommand::new(&ttd);
@@ -411,11 +411,11 @@ mod tests {
             let diag_dir = ttd.dir("tmp").dir("tarball");
             Self {
                 plugin_dir: BTreeSet::from([
-                    AbsolutePath::from_path(plugin_dir.utf8_path_buf()).unwrap()
+                    AbsolutePath::from_path(plugin_dir.path_buf()).unwrap()
                 ]),
-                config_dir: AbsolutePath::from_path(config_dir.utf8_path_buf()).unwrap(),
-                working_dir: AbsolutePath::from_path(working_dir.utf8_path_buf()).unwrap(),
-                diag_dir: AbsolutePath::from_path(diag_dir.utf8_path_buf()).unwrap(),
+                config_dir: AbsolutePath::from_path(config_dir.path_buf()).unwrap(),
+                working_dir: AbsolutePath::from_path(working_dir.path_buf()).unwrap(),
+                diag_dir: AbsolutePath::from_path(diag_dir.path_buf()).unwrap(),
                 tarball_name: "tarball".to_string(),
                 keep_dir: false,
                 graceful_timeout: Duration::from_secs(60),

--- a/crates/core/tedge/src/cli/init.rs
+++ b/crates/core/tedge/src/cli/init.rs
@@ -411,8 +411,8 @@ mod tests {
         async fn initializes_directories() {
             let ttd = TempTedgeDir::new();
             let tedge_dir = ttd.dir("tedge");
-            let logs_dir = tedge_dir.utf8_path().join("logs");
-            let data_dir = tedge_dir.utf8_path().join("data");
+            let logs_dir = tedge_dir.path().join("logs");
+            let data_dir = tedge_dir.path().join("data");
             tedge_dir.file("tedge.toml").with_raw_content(&format!(
                 "logs.path = \"{logs_dir}\"\ndata.path = \"{data_dir}\"\n",
             ));

--- a/crates/core/tedge/src/cli/mapper/cli.rs
+++ b/crates/core/tedge/src/cli/mapper/cli.rs
@@ -417,7 +417,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn empty_mappers_dir_returns_empty() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(&mappers_root).await.unwrap();
 
             assert!(scan_mappers_shallow(&mappers_root).await.is_empty());
@@ -426,7 +426,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn dir_without_mapper_toml_or_flows_is_included() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_root.join("mymapper"))
                 .await
                 .unwrap();
@@ -439,7 +439,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn flows_only_mapper_is_included() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let flows_dir = mappers_root.join("thingsboard/flows");
             tokio::fs::create_dir_all(&flows_dir).await.unwrap();
 
@@ -451,7 +451,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn lists_mapper_with_cloud_type_in_table() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let c8y_dir = mappers_root.join("c8y");
             tokio::fs::create_dir_all(&c8y_dir).await.unwrap();
             tokio::fs::write(c8y_dir.join("mapper.toml"), "cloud_type = \"c8y\"\n")
@@ -471,7 +471,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn lists_mapper_without_cloud_type() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let tb_dir = mappers_root.join("thingsboard");
             tokio::fs::create_dir_all(&tb_dir).await.unwrap();
             tokio::fs::write(
@@ -489,7 +489,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn lists_mixed_mappers_sorted() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             for name in ["zz-mapper", "aa-mapper", "mm-mapper"] {
                 tokio::fs::create_dir_all(mappers_root.join(name))
                     .await
@@ -503,7 +503,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn cert_cn_shown_with_tag_in_device_id_column() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             let cert = mapper_dir.join("cert.pem");
@@ -534,10 +534,10 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn tedge_toml_device_id_shown_with_tag() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-            let creds = ttd.utf8_path().join("creds.toml");
+            let creds = ttd.path().join("creds.toml");
             tokio::fs::write(
                 &creds,
                 "[credentials]\nusername = \"u\"\npassword = \"p\"\n",
@@ -566,7 +566,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn unreadable_cert_leaves_device_id_blank() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(
@@ -594,7 +594,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn flows_only_mapper_has_blank_url_and_identity() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_root.join("thingsboard/flows"))
                 .await
                 .unwrap();
@@ -622,7 +622,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn cloud_type_shown_for_mappers_that_set_it() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             // c8y and production have cloud_type; thingsboard does not
             for (name, content) in [
                 ("c8y", "cloud_type = \"c8y\"\n"),
@@ -693,7 +693,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn url_prints_value_and_source() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(
@@ -713,10 +713,10 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn device_id_inferred_from_cert_cn() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-            let (cert, key) = write_cert(ttd.utf8_path()).await;
+            let (cert, key) = write_cert(ttd.path()).await;
             tokio::fs::write(
                 mapper_dir.join("mapper.toml"),
                 "url = \"mqtt.example.com:8883\"\n",
@@ -740,10 +740,10 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn device_id_falls_back_to_tedge_toml() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-            let creds = ttd.utf8_path().join("creds.toml");
+            let creds = ttd.path().join("creds.toml");
             tokio::fs::write(
                 &creds,
                 "[credentials]\nusername = \"u\"\npassword = \"p\"\n",
@@ -771,7 +771,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn device_id_errors_when_cert_unreadable() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(
@@ -800,7 +800,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn relative_cert_path_resolves_to_absolute_with_source() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(mapper_dir.join("cert.pem"), TEST_CERT_PEM)
@@ -839,7 +839,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn url_not_set_errors() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             // mapper.toml exists but has no url
@@ -862,10 +862,10 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn device_id_not_set_with_password_auth_errors() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-            let creds = ttd.utf8_path().join("creds.toml");
+            let creds = ttd.path().join("creds.toml");
             tokio::fs::write(
                 &creds,
                 "[credentials]\nusername = \"u\"\npassword = \"p\"\n",
@@ -895,7 +895,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn missing_mapper_lists_multiple_available() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             for name in ["alpha", "beta", "gamma"] {
                 tokio::fs::create_dir_all(mappers_root.join(name))
                     .await
@@ -921,7 +921,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn missing_mapper_no_mappers_configured() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(&mappers_root).await.unwrap();
 
             let result = run_get(
@@ -942,7 +942,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn missing_mapper_errors_with_available_list() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_root.join("existing"))
                 .await
                 .unwrap();
@@ -963,7 +963,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn custom_key_returns_raw_toml_value() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(
@@ -988,7 +988,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn mapper_without_toml_errors() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             // No mapper.toml written
@@ -1004,7 +1004,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn schema_key_not_set_errors() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(
@@ -1028,7 +1028,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn unknown_key_errors() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             let mapper_dir = mappers_root.join("tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(
@@ -1051,7 +1051,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn aws_config_get_reads_from_tedge_toml() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_root.join("aws"))
                 .await
                 .unwrap();
@@ -1069,7 +1069,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn aws_config_get_without_mapper_toml_succeeds() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_root.join("aws"))
                 .await
                 .unwrap();
@@ -1086,7 +1086,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn az_config_get_reads_from_tedge_toml() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_root.join("az"))
                 .await
                 .unwrap();
@@ -1104,7 +1104,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn az_config_get_without_mapper_toml_succeeds() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_root.join("az"))
                 .await
                 .unwrap();
@@ -1122,7 +1122,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn profiled_c8y_config_get_reads_from_tedge_toml() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_root.join("c8y.prod"))
                 .await
                 .unwrap();
@@ -1139,7 +1139,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn profiled_c8y_works_when_default_c8y_also_exists() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             // Both c8y and c8y.new exist — this is the realistic scenario.
             tokio::fs::create_dir_all(mappers_root.join("c8y"))
                 .await
@@ -1162,7 +1162,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn profiled_aws_config_get_reads_from_tedge_toml() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_root.join("aws.staging"))
                 .await
                 .unwrap();
@@ -1180,7 +1180,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn profiled_az_config_get_reads_from_tedge_toml() {
             let ttd = TempTedgeDir::new();
-            let mappers_root = ttd.utf8_path().join("mappers");
+            let mappers_root = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_root.join("az.staging"))
                 .await
                 .unwrap();

--- a/crates/core/tedge/src/cli/upload/c8y.rs
+++ b/crates/core/tedge/src/cli/upload/c8y.rs
@@ -156,7 +156,12 @@ mod tests {
         };
 
         let c8y = mock_auth_proxy("test-device", "event-123", &c8y_event).await;
-        let upload = upload_cmd(&c8y, file.to_path_buf(), "test-device", c8y_event);
+        let upload = upload_cmd(
+            &c8y,
+            file.std_path().to_path_buf(),
+            "test-device",
+            c8y_event,
+        );
 
         // Step by step
         assert_eq!(

--- a/crates/core/tedge_agent/src/http_server/actor.rs
+++ b/crates/core/tedge_agent/src/http_server/actor.rs
@@ -351,7 +351,7 @@ mod tests {
 
     impl<Cert> TestFileTransferService<Cert> {
         fn temp_path_for(&self, file: &str) -> Utf8PathBuf {
-            self.temp_dir.utf8_path().join("file-transfer").join(file)
+            self.temp_dir.path().join("file-transfer").join(file)
         }
 
         async fn spawn(
@@ -384,7 +384,7 @@ mod tests {
     }
 
     fn http_config(ttd: &TempTedgeDir, bind_port: u16) -> TestConfig {
-        let data_dir: DataDir = TedgePaths::from_root_with_defaults(ttd.utf8_path(), "", "").into();
+        let data_dir: DataDir = TedgePaths::from_root_with_defaults(ttd.path(), "", "").into();
         TestConfig {
             file_transfer_dir: data_dir.file_transfer_dir(),
             data_dir,
@@ -411,7 +411,7 @@ mod tests {
             None
         };
 
-        let data_dir = DataDir::from(TedgePaths::from_root_with_defaults(ttd.utf8_path(), "", ""));
+        let data_dir = DataDir::from(TedgePaths::from_root_with_defaults(ttd.path(), "", ""));
 
         Ok(TestConfig {
             file_transfer_dir: data_dir.file_transfer_dir(),

--- a/crates/core/tedge_agent/src/http_server/entity_store.rs
+++ b/crates/core/tedge_agent/src/http_server/entity_store.rs
@@ -2019,8 +2019,7 @@ mod tests {
 
     fn setup() -> TestHandle {
         let ttd: TempTedgeDir = TempTedgeDir::new();
-        let data_dir: DataDir =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path_buf(), "", "").into();
+        let data_dir: DataDir = TedgePaths::from_root_with_defaults(ttd.path_buf(), "", "").into();
         let file_transfer_dir = data_dir.file_transfer_dir();
 
         let mut entity_store_box = ServerMessageBoxBuilder::new("EntityStoreBox", 16);

--- a/crates/core/tedge_agent/src/http_server/file_transfer.rs
+++ b/crates/core/tedge_agent/src/http_server/file_transfer.rs
@@ -196,7 +196,7 @@ mod tests {
     async fn file_is_uploaded_to_provided_data_dir() {
         let path = "some/dir/file";
         let (ttd, mut app) = app();
-        let expected_output_file = ttd.utf8_path().join("file-transfer").join(path);
+        let expected_output_file = ttd.path().join("file-transfer").join(path);
 
         upload_file(&mut app, path, "some content").await;
 
@@ -249,7 +249,7 @@ mod tests {
         dir_path.push("test-dir");
         assert!(err_is_is_a_directory(
             &std::fs::read_to_string(&dir_path).unwrap_err(),
-            Utf8Path::from_path(dir_path.as_path()).unwrap()
+            &dir_path
         ))
     }
 
@@ -264,7 +264,7 @@ mod tests {
 
         assert!(!err_is_is_a_directory(
             &std::fs::read_to_string(&unknown_path).unwrap_err(),
-            Utf8Path::from_path(unknown_path.as_path()).unwrap()
+            &unknown_path
         ))
     }
 
@@ -406,8 +406,7 @@ mod tests {
 
     fn app() -> (TempTedgeDir, Router) {
         let ttd = TempTedgeDir::new();
-        let data_dir: DataDir =
-            TedgePaths::from_root_with_defaults(ttd.utf8_path_buf(), "", "").into();
+        let data_dir: DataDir = TedgePaths::from_root_with_defaults(ttd.path_buf(), "", "").into();
         let file_transfer_dir = data_dir.file_transfer_dir();
         let router = file_transfer_router(file_transfer_dir, data_dir);
         (ttd, router)

--- a/crates/core/tedge_agent/src/operation_workflows/tests.rs
+++ b/crates/core/tedge_agent/src/operation_workflows/tests.rs
@@ -6,7 +6,6 @@ use crate::operation_workflows::builder::WorkflowActorBuilder;
 use crate::operation_workflows::config::OperationConfig;
 use crate::software_manager::actor::SoftwareCommand;
 use crate::Capabilities;
-use camino::Utf8Path;
 use serde_json::json;
 use std::process::Output;
 use std::sync::Arc;
@@ -93,9 +92,7 @@ async fn convert_incoming_software_list_request() -> Result<(), DynError> {
                 log_path: Some(
                     tmp_dir
                         .path()
-                        .join("workflow-software_list-some-cmd-id.log")
-                        .try_into()
-                        .unwrap(),
+                        .join("workflow-software_list-some-cmd-id.log"),
                 ),
             },
         }])
@@ -143,13 +140,7 @@ async fn convert_incoming_software_update_request() -> Result<(), DynError> {
                 status: CommandStatus::Scheduled,
                 update_list: vec![debian_list],
                 failures: vec![],
-                log_path: Some(
-                    tmp_dir
-                        .path()
-                        .join("workflow-software_update-1234.log")
-                        .try_into()
-                        .unwrap(),
-                ),
+                log_path: Some(tmp_dir.path().join("workflow-software_update-1234.log")),
             },
         }])
         .await;
@@ -183,13 +174,7 @@ async fn convert_incoming_restart_request() -> Result<(), DynError> {
             cmd_id: "random".to_string(),
             payload: RestartCommandPayload {
                 status: CommandStatus::Scheduled,
-                log_path: Some(
-                    tmp_dir
-                        .path()
-                        .join("workflow-restart-random.log")
-                        .try_into()
-                        .unwrap(),
-                ),
+                log_path: Some(tmp_dir.path().join("workflow-restart-random.log")),
             },
         }])
         .await;
@@ -1134,7 +1119,7 @@ async fn spawn_mqtt_operation_converter(
     > = SimpleMessageBoxBuilder::new("Uploader", 5);
 
     let tmp_dir = Arc::new(TempTedgeDir::new());
-    let tmp_path = Utf8Path::from_path(tmp_dir.path()).unwrap();
+    let tmp_path = tmp_dir.path();
     let config_root = TedgePaths::from_root_with_defaults(tmp_path, "", "");
     let operations_dir = tmp_dir.dir("operations");
     for (file_name, content) in workflows {

--- a/crates/core/tedge_agent/src/restart_manager/tests.rs
+++ b/crates/core/tedge_agent/src/restart_manager/tests.rs
@@ -115,8 +115,8 @@ async fn spawn_restart_manager(
 
     let config = RestartManagerConfig {
         device_topic_id: EntityTopicId::default_main_device(),
-        tmp_dir: tmp_dir.utf8_path_buf(),
-        config_dir: TedgePaths::from_root_with_defaults(tmp_dir.utf8_path(), "", ""),
+        tmp_dir: tmp_dir.path_buf(),
+        config_dir: TedgePaths::from_root_with_defaults(tmp_dir.path(), "", ""),
         state_dir: TedgePaths::from_root_with_defaults("/some/unknown/dir", "", ""),
         sudo: SudoCommandBuilder::enabled(true),
     };

--- a/crates/core/tedge_agent/src/software_manager/tests.rs
+++ b/crates/core/tedge_agent/src/software_manager/tests.rs
@@ -181,15 +181,15 @@ async fn spawn_software_manager(
     let mut converter_builder: SimpleMessageBoxBuilder<SoftwareCommand, SoftwareCommand> =
         SimpleMessageBoxBuilder::new("Converter", 5);
 
-    let config_root = TedgePaths::from_root_with_defaults(tmp_dir.utf8_path(), "", "");
+    let config_root = TedgePaths::from_root_with_defaults(tmp_dir.path(), "", "");
 
     let config = SoftwareManagerConfig {
         device: EntityTopicId::default_main_device(),
-        tmp_dir: TedgePaths::from_root_with_defaults(tmp_dir.utf8_path(), "", ""),
+        tmp_dir: TedgePaths::from_root_with_defaults(tmp_dir.path(), "", ""),
         config_dir: config_root.clone(),
         state_dir: TedgePaths::from_root_with_defaults("/some/unknown/dir", "", ""),
         sm_plugins_dir: config_root.dir("sm-plugins").unwrap(),
-        log_dir: TedgePaths::from_root_with_defaults(tmp_dir.utf8_path(), "", "").root_dir(),
+        log_dir: TedgePaths::from_root_with_defaults(tmp_dir.path(), "", "").root_dir(),
         default_plugin_type: None,
         sudo: SudoCommandBuilder::with_program(SUDO),
     };

--- a/crates/core/tedge_agent/src/state_repository/state.rs
+++ b/crates/core/tedge_agent/src/state_repository/state.rs
@@ -112,7 +112,7 @@ mod tests {
     fn new_test_state_repository(temp_dir: &TempTedgeDir) -> AgentStateRepository<State> {
         AgentStateRepository::new(
             TedgePaths::from_root_with_defaults("/some/unknown/dir", "", ""),
-            TedgePaths::from_root_with_defaults(temp_dir.utf8_path(), "", ""),
+            TedgePaths::from_root_with_defaults(temp_dir.path(), "", ""),
             "current-operation",
         )
     }
@@ -124,7 +124,7 @@ mod tests {
             .file("current-operation")
             .with_raw_content(r#"{"operation_id":"1234","operation":"list"}"#);
         let repo: AgentStateRepository<State> = AgentStateRepository::new(
-            TedgePaths::from_root_with_defaults(temp_dir.utf8_path(), "", ""),
+            TedgePaths::from_root_with_defaults(temp_dir.path(), "", ""),
             TedgePaths::from_root_with_defaults("/some/unknown/dir", "", ""),
             "current-operation",
         );
@@ -144,7 +144,7 @@ mod tests {
         temp_dir.dir(".agent").file("current-operation");
         let repo: AgentStateRepository<State> = AgentStateRepository::new(
             TedgePaths::from_root_with_defaults("/some/unknown/dir", "", ""),
-            TedgePaths::from_root_with_defaults(temp_dir.utf8_path(), "", ""),
+            TedgePaths::from_root_with_defaults(temp_dir.path(), "", ""),
             "current-operation",
         );
 
@@ -156,7 +156,7 @@ mod tests {
         let temp_dir = TempTedgeDir::new();
         let repo: AgentStateRepository<State> = AgentStateRepository::new(
             TedgePaths::from_root_with_defaults("/some/unknown/dir", "", ""),
-            TedgePaths::from_root_with_defaults(temp_dir.utf8_path(), "", ""),
+            TedgePaths::from_root_with_defaults(temp_dir.path(), "", ""),
             "current-operation",
         );
 

--- a/crates/core/tedge_agent/src/twin_manager/tests.rs
+++ b/crates/core/tedge_agent/src/twin_manager/tests.rs
@@ -98,7 +98,7 @@ pub(crate) struct TestHandle {
 pub fn setup(inventory_json: Value) -> TestHandle {
     let mqtt_schema = MqttSchema::default();
     let tmp_dir = TempTedgeDir::default();
-    let config_dir = tmp_dir.utf8_path_buf();
+    let config_dir = tmp_dir.path_buf();
     create_inventory_json_file_with_content(&tmp_dir, &inventory_json.to_string());
 
     let main_device_id = EntityTopicId::default_main_device();

--- a/crates/core/tedge_api/src/workflow/log/command_log.rs
+++ b/crates/core/tedge_api/src/workflow/log/command_log.rs
@@ -225,11 +225,8 @@ mod tests {
         let tmp_dir = TempTedgeDir::new();
         let workflow_log = tmp_dir.file("workflow.log");
         let log_file_path = workflow_log.path();
-        let mut command_log = CommandLog::from_log_path(
-            workflow_log.utf8_path(),
-            "software_update".into(),
-            "123".into(),
-        );
+        let mut command_log =
+            CommandLog::from_log_path(workflow_log.path(), "software_update".into(), "123".into());
 
         // Prepare a command
         let mut command = LoggedCommand::new("echo", "/tmp").unwrap();
@@ -260,11 +257,8 @@ EOF
         let tmp_dir = TempTedgeDir::new();
         let workflow_log = tmp_dir.file("workflow.log");
         let log_file_path = workflow_log.path();
-        let mut command_log = CommandLog::from_log_path(
-            workflow_log.utf8_path(),
-            "software_update".into(),
-            "123".into(),
-        );
+        let mut command_log =
+            CommandLog::from_log_path(workflow_log.path(), "software_update".into(), "123".into());
 
         // Prepare a command that triggers some content on stderr
         let mut command = LoggedCommand::new("ls", "/tmp").unwrap();
@@ -310,11 +304,8 @@ stdout (EMPTY)
         let tmp_dir = TempTedgeDir::new();
         let workflow_log = tmp_dir.file("workflow.log");
         let log_file_path = workflow_log.path();
-        let mut command_log = CommandLog::from_log_path(
-            workflow_log.utf8_path(),
-            "software_update".into(),
-            "123".into(),
-        );
+        let mut command_log =
+            CommandLog::from_log_path(workflow_log.path(), "software_update".into(), "123".into());
 
         // Prepare a command that cannot be executed
         let command = LoggedCommand::new("dummy-command", "/tmp").unwrap();

--- a/crates/core/tedge_mapper/src/aws/mapper.rs
+++ b/crates/core/tedge_mapper/src/aws/mapper.rs
@@ -205,7 +205,7 @@ mod tests {
     async fn bridge_rules_load_from_toml_with_correct_topics() {
         let ttd = create_test_dir("aws.url = \"test.test.io\"").await;
         let (certificate, key) = make_self_signed_cert("test-device-id");
-        let mapper_dir: camino::Utf8PathBuf = ttd.path().join("mappers/aws").try_into().unwrap();
+        let mapper_dir = ttd.path().join("mappers/aws");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
         tokio::fs::write(mapper_dir.join("cert.pem"), certificate.pem())
             .await
@@ -253,7 +253,7 @@ mod tests {
             create_test_dir("aws.url = \"test.test.io\"\naws.bridge.topic_prefix = \"custom-aws\"")
                 .await;
         let (certificate, key) = make_self_signed_cert("test-device-id");
-        let mapper_dir: camino::Utf8PathBuf = ttd.path().join("mappers/aws").try_into().unwrap();
+        let mapper_dir = ttd.path().join("mappers/aws");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
         tokio::fs::write(mapper_dir.join("cert.pem"), certificate.pem())
             .await

--- a/crates/core/tedge_mapper/src/az/mapper.rs
+++ b/crates/core/tedge_mapper/src/az/mapper.rs
@@ -210,7 +210,7 @@ mod tests {
     async fn bridge_rules_load_from_toml_with_correct_topics() {
         let ttd = create_test_dir("az.url = \"test.test.io\"").await;
         let (certificate, key) = make_self_signed_cert("test-device-id");
-        let mapper_dir: camino::Utf8PathBuf = ttd.path().join("mappers/az").try_into().unwrap();
+        let mapper_dir = ttd.path().join("mappers/az");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
         tokio::fs::write(mapper_dir.join("cert.pem"), certificate.pem())
             .await
@@ -255,7 +255,7 @@ mod tests {
             create_test_dir("az.url = \"test.test.io\"\naz.bridge.topic_prefix = \"custom-az\"")
                 .await;
         let (certificate, key) = make_self_signed_cert("test-device-id");
-        let mapper_dir: camino::Utf8PathBuf = ttd.path().join("mappers/az").try_into().unwrap();
+        let mapper_dir = ttd.path().join("mappers/az");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
         tokio::fs::write(mapper_dir.join("cert.pem"), certificate.pem())
             .await

--- a/crates/core/tedge_mapper/src/c8y/mapper.rs
+++ b/crates/core/tedge_mapper/src/c8y/mapper.rs
@@ -468,8 +468,6 @@ mod tests {
     }
 
     mod template_rules {
-        use camino::Utf8PathBuf;
-
         use super::*;
 
         fn has_local_subscription(config: &BridgeConfig, topic: &str) -> bool {
@@ -665,7 +663,7 @@ mqtt_service.topics = ["custom/topic"]
         async fn mapper_namespace_can_read_lazy_values() {
             let (ttd, _config) = load_config("").await;
             // Create a mapper.toml with a value ${mapper.*} can reference
-            let mapper_dir: Utf8PathBuf = ttd.path().join("mappers/c8y").try_into().unwrap();
+            let mapper_dir = ttd.path().join("mappers/c8y");
             let certificate = rcgen::generate_simple_self_signed(vec!["my-device".into()]).unwrap();
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(mapper_dir.join("cert.pem"), certificate.cert.pem())

--- a/crates/core/tedge_mapper/src/core/mappers_dir.rs
+++ b/crates/core/tedge_mapper/src/core/mappers_dir.rs
@@ -86,7 +86,7 @@ mod tests {
         #[tokio::test]
         async fn bridge_dir_without_mapper_toml_is_flagged() {
             let ttd = TempTedgeDir::new();
-            let mappers_dir = ttd.utf8_path().join("mappers");
+            let mappers_dir = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_dir.join("thingsboard/bridge"))
                 .await
                 .unwrap();
@@ -101,7 +101,7 @@ mod tests {
         #[tokio::test]
         async fn bridge_dir_with_mapper_toml_is_not_flagged() {
             let ttd = TempTedgeDir::new();
-            let mappers_dir = ttd.utf8_path().join("mappers");
+            let mappers_dir = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_dir.join("thingsboard/bridge"))
                 .await
                 .unwrap();
@@ -119,7 +119,7 @@ mod tests {
         #[tokio::test]
         async fn dir_without_bridge_subdir_is_not_flagged() {
             let ttd = TempTedgeDir::new();
-            let mappers_dir = ttd.utf8_path().join("mappers");
+            let mappers_dir = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_dir.join("thingsboard"))
                 .await
                 .unwrap();
@@ -134,7 +134,7 @@ mod tests {
         #[tokio::test]
         async fn empty_mapper_dir_is_not_flagged() {
             let ttd = TempTedgeDir::new();
-            let mappers_dir = ttd.utf8_path().join("mappers");
+            let mappers_dir = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_dir.join("thingsboard"))
                 .await
                 .unwrap();
@@ -149,7 +149,7 @@ mod tests {
         #[tokio::test]
         async fn empty_flows_dir_is_not_flagged() {
             let ttd = TempTedgeDir::new();
-            let mappers_dir = ttd.utf8_path().join("mappers");
+            let mappers_dir = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_dir.join("thingsboard/flows"))
                 .await
                 .unwrap();
@@ -164,7 +164,7 @@ mod tests {
         #[tokio::test]
         async fn builtin_mapper_dir_with_bridge_but_no_toml_is_not_flagged() {
             let ttd = TempTedgeDir::new();
-            let mappers_dir = ttd.utf8_path().join("mappers");
+            let mappers_dir = ttd.path().join("mappers");
             for name in ["aws", "az", "c8y", "aws.prod", "az.staging"] {
                 tokio::fs::create_dir_all(mappers_dir.join(format!("{name}/bridge")))
                     .await
@@ -180,7 +180,7 @@ mod tests {
         #[tokio::test]
         async fn handles_nonexistent_mappers_dir_gracefully() {
             let ttd = TempTedgeDir::new();
-            let mappers_dir = ttd.utf8_path().join("nonexistent/mappers");
+            let mappers_dir = ttd.path().join("nonexistent/mappers");
             assert!(collect_bridge_without_mapper_dirs(&mappers_dir)
                 .await
                 .is_empty());
@@ -191,7 +191,7 @@ mod tests {
             let warnings = CapturedWarnings::install();
 
             let ttd = TempTedgeDir::new();
-            let mappers_dir = ttd.utf8_path().join("mappers");
+            let mappers_dir = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_dir.join("thingsboard/bridge"))
                 .await
                 .unwrap();
@@ -214,7 +214,7 @@ mod tests {
             let warnings = CapturedWarnings::install();
 
             let ttd = TempTedgeDir::new();
-            let mappers_dir = ttd.utf8_path().join("mappers");
+            let mappers_dir = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_dir.join("stale-dir"))
                 .await
                 .unwrap();
@@ -233,7 +233,7 @@ mod tests {
             let warnings = CapturedWarnings::install();
 
             let ttd = TempTedgeDir::new();
-            let mappers_dir = ttd.utf8_path().join("mappers");
+            let mappers_dir = ttd.path().join("mappers");
             tokio::fs::create_dir_all(mappers_dir.join("thingsboard/flows"))
                 .await
                 .unwrap();

--- a/crates/core/tedge_mapper/src/custom/config.rs
+++ b/crates/core/tedge_mapper/src/custom/config.rs
@@ -309,7 +309,7 @@ mod tests {
     #[tokio::test]
     async fn cloud_type_parses_known_values() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
 
         for (toml_val, expected) in [
@@ -331,7 +331,7 @@ mod tests {
     #[tokio::test]
     async fn cloud_type_rejects_unknown_value() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
         tokio::fs::write(
             mapper_dir.join("mapper.toml"),
@@ -350,7 +350,7 @@ mod tests {
     #[tokio::test]
     async fn cloud_type_absent_gives_none() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
         tokio::fs::write(
             mapper_dir.join("mapper.toml"),
@@ -366,7 +366,7 @@ mod tests {
     #[tokio::test]
     async fn returns_none_when_file_not_found() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
+        let mapper_dir = ttd.path().join("mappers/testmapper");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
 
         let result = load_mapper_config(&mapper_dir).await.unwrap();
@@ -376,7 +376,7 @@ mod tests {
     #[tokio::test]
     async fn parses_valid_toml() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
+        let mapper_dir = ttd.path().join("mappers/thingsboard");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
 
         tokio::fs::write(
@@ -414,7 +414,7 @@ topic_prefix = "tb"
     #[tokio::test]
     async fn returns_error_with_path_for_invalid_toml() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/broken");
+        let mapper_dir = ttd.path().join("mappers/broken");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
 
         tokio::fs::write(mapper_dir.join("mapper.toml"), "this is not = valid [ toml")
@@ -432,7 +432,7 @@ topic_prefix = "tb"
     #[tokio::test]
     async fn default_port_is_8883_when_not_specified() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/noport");
+        let mapper_dir = ttd.path().join("mappers/noport");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
 
         tokio::fs::write(
@@ -451,7 +451,7 @@ url = "mqtt.example.com"
     #[tokio::test]
     async fn parses_full_schema() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/full");
+        let mapper_dir = ttd.path().join("mappers/full");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
 
         tokio::fs::write(
@@ -490,7 +490,7 @@ keepalive_interval = "60s"
     #[tokio::test]
     async fn parses_configured_max_payload_size() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/limited");
+        let mapper_dir = ttd.path().join("mappers/limited");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
 
         tokio::fs::write(
@@ -507,7 +507,7 @@ keepalive_interval = "60s"
     #[tokio::test]
     async fn max_payload_size_defaults_to_mqtt_maximum() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/unlimited");
+        let mapper_dir = ttd.path().join("mappers/unlimited");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
 
         tokio::fs::write(
@@ -528,7 +528,7 @@ keepalive_interval = "60s"
     #[tokio::test]
     async fn parses_password_auth_method() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/pw");
+        let mapper_dir = ttd.path().join("mappers/pw");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
 
         tokio::fs::write(
@@ -548,7 +548,7 @@ credentials_path = "/etc/tedge/mappers/pw/creds.toml"
     #[tokio::test]
     async fn reads_credentials_from_toml_file() {
         let ttd = TempTedgeDir::new();
-        let creds_path = ttd.utf8_path().join("credentials.toml");
+        let creds_path = ttd.path().join("credentials.toml");
         tokio::fs::write(
             &creds_path,
             "[credentials]\nusername = \"alice\"\npassword = \"s3cr3t\"\n",
@@ -564,7 +564,7 @@ credentials_path = "/etc/tedge/mappers/pw/creds.toml"
     #[tokio::test]
     async fn credentials_error_on_missing_file() {
         let ttd = TempTedgeDir::new();
-        let creds_path = ttd.utf8_path().join("missing.toml");
+        let creds_path = ttd.path().join("missing.toml");
         let err = read_mapper_credentials(&creds_path).await.unwrap_err();
         assert!(
             format!("{err}").contains("credentials"),
@@ -611,7 +611,7 @@ credentials_path = "/etc/tedge/mappers/pw/creds.toml"
         #[tokio::test]
         async fn relative_cert_path_is_resolved_to_mapper_dir() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
+            let mapper_dir = ttd.path().join("mappers/thingsboard");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(
                 mapper_dir.join("mapper.toml"),
@@ -637,7 +637,7 @@ credentials_path = "/etc/tedge/mappers/pw/creds.toml"
         #[tokio::test]
         async fn absolute_cert_path_is_unchanged() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
+            let mapper_dir = ttd.path().join("mappers/thingsboard");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(
                 mapper_dir.join("mapper.toml"),
@@ -658,7 +658,7 @@ credentials_path = "/etc/tedge/mappers/pw/creds.toml"
         #[tokio::test]
         async fn nested_relative_path_resolves_correctly() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
+            let mapper_dir = ttd.path().join("mappers/thingsboard");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(
                 mapper_dir.join("mapper.toml"),
@@ -678,7 +678,7 @@ credentials_path = "/etc/tedge/mappers/pw/creds.toml"
         #[tokio::test]
         async fn dot_dot_in_relative_path_is_normalized() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
+            let mapper_dir = ttd.path().join("mappers/thingsboard");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(
                 mapper_dir.join("mapper.toml"),
@@ -691,7 +691,7 @@ credentials_path = "/etc/tedge/mappers/pw/creds.toml"
             let device = config.device.unwrap();
             assert_eq!(
                 device.cert_path.unwrap(),
-                ttd.utf8_path().join("certs/device.pem"),
+                ttd.path().join("certs/device.pem"),
                 "../../ should be resolved and normalized away"
             );
         }
@@ -699,7 +699,7 @@ credentials_path = "/etc/tedge/mappers/pw/creds.toml"
         #[tokio::test]
         async fn relative_credentials_path_is_resolved() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
+            let mapper_dir = ttd.path().join("mappers/thingsboard");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(
                 mapper_dir.join("mapper.toml"),

--- a/crates/core/tedge_mapper/src/custom/mapper.rs
+++ b/crates/core/tedge_mapper/src/custom/mapper.rs
@@ -466,7 +466,7 @@ mod tests {
         #[tokio::test]
         async fn errors_when_directory_missing() {
             let ttd = TempTedgeDir::new();
-            let config_dir = ttd.utf8_path();
+            let config_dir = ttd.path();
             let mapper_dir = config_dir.join("mappers/nonexistent");
 
             let err = validate_and_load(&mapper_dir, config_dir)
@@ -483,7 +483,7 @@ mod tests {
         #[tokio::test]
         async fn error_lists_available_mappers() {
             let ttd = TempTedgeDir::new();
-            let config_dir = ttd.utf8_path();
+            let config_dir = ttd.path();
 
             for name in ["thingsboard", "mycloud"] {
                 let dir = config_dir.join(format!("mappers/{name}"));
@@ -506,7 +506,7 @@ mod tests {
         #[tokio::test]
         async fn error_lists_flows_only_mappers_without_mapper_toml() {
             let ttd = TempTedgeDir::new();
-            let config_dir = ttd.utf8_path();
+            let config_dir = ttd.path();
             // A flows-only mapper: just a directory, no mapper.toml
             tokio::fs::create_dir_all(config_dir.join("mappers/myflows"))
                 .await
@@ -527,7 +527,7 @@ mod tests {
         #[tokio::test]
         async fn error_when_no_mappers_exist() {
             let ttd = TempTedgeDir::new();
-            let config_dir = ttd.utf8_path();
+            let config_dir = ttd.path();
             tokio::fs::create_dir_all(config_dir.join("mappers"))
                 .await
                 .unwrap();
@@ -547,7 +547,7 @@ mod tests {
         #[tokio::test]
         async fn starts_in_flows_only_mode_even_if_flows_directory_does_not_exist() {
             let ttd = TempTedgeDir::new();
-            let config_dir = ttd.utf8_path();
+            let config_dir = ttd.path();
             let mapper_dir = config_dir.join("mappers/testmapper");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             tokio::fs::write(mapper_dir.join("mapper.toml"), "url = \"host:8883\"\n")
@@ -565,7 +565,7 @@ mod tests {
         #[tokio::test]
         async fn flows_only_when_no_bridge_dir() {
             let ttd = TempTedgeDir::new();
-            let config_dir = ttd.utf8_path();
+            let config_dir = ttd.path();
             let mapper_dir = config_dir.join("mappers/myflows");
             tokio::fs::create_dir_all(mapper_dir.join("flows"))
                 .await
@@ -582,7 +582,7 @@ mod tests {
         #[tokio::test]
         async fn errors_when_bridge_without_mapper_toml() {
             let ttd = TempTedgeDir::new();
-            let config_dir = ttd.utf8_path();
+            let config_dir = ttd.path();
             let mapper_dir = config_dir.join("mappers/testmapper");
             tokio::fs::create_dir_all(mapper_dir.join("bridge"))
                 .await
@@ -602,7 +602,7 @@ mod tests {
         #[tokio::test]
         async fn with_bridge_only_when_no_flows_dir() {
             let ttd = TempTedgeDir::new();
-            let config_dir = ttd.utf8_path();
+            let config_dir = ttd.path();
             let mapper_dir = config_dir.join("mappers/testmapper");
             tokio::fs::create_dir_all(mapper_dir.join("bridge"))
                 .await
@@ -625,7 +625,7 @@ mod tests {
         #[tokio::test]
         async fn with_bridge_and_flows_when_both_present() {
             let ttd = TempTedgeDir::new();
-            let config_dir = ttd.utf8_path();
+            let config_dir = ttd.path();
             let mapper_dir = config_dir.join("mappers/testmapper");
             tokio::fs::create_dir_all(mapper_dir.join("bridge"))
                 .await
@@ -651,7 +651,7 @@ mod tests {
         #[tokio::test]
         async fn errors_when_bridge_mapper_toml_is_malformed() {
             let ttd = TempTedgeDir::new();
-            let config_dir = ttd.utf8_path();
+            let config_dir = ttd.path();
             let mapper_dir = config_dir.join("mappers/testmapper");
             tokio::fs::create_dir_all(mapper_dir.join("bridge"))
                 .await
@@ -680,7 +680,7 @@ mod tests {
         #[tokio::test]
         async fn creates_flows_directory_if_absent() {
             let ttd = TempTedgeDir::new();
-            let config_root = TedgePaths::from_root_with_defaults(ttd.utf8_path(), "", "");
+            let config_root = TedgePaths::from_root_with_defaults(ttd.path(), "", "");
             let mapper_dir = config_root.dir("mappers/testmapper").unwrap();
             tokio::fs::create_dir_all(&mapper_dir.path()).await.unwrap();
             let tedge_config = TEdgeConfig::load_toml_str("");
@@ -740,7 +740,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn missing_url_returns_error_with_file_path_hint() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
+            let mapper_dir = ttd.path().join("mappers/testmapper");
             let tedge_config = TEdgeConfig::load_toml_str("");
             let config = make_config(None);
             let effective = resolve(&config, &tedge_config).await;
@@ -759,8 +759,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn auto_without_credentials_resolves_to_certificate() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
-            let (cert, key) = write_cert(ttd.utf8_path()).await;
+            let mapper_dir = ttd.path().join("mappers/testmapper");
+            let (cert, key) = write_cert(ttd.path()).await;
             let tedge_config = TEdgeConfig::load_toml_str(&format!(
                 "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
             ));
@@ -776,8 +776,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn explicit_certificate_method_resolves_to_certificate() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
-            let (cert, key) = write_cert(ttd.utf8_path()).await;
+            let mapper_dir = ttd.path().join("mappers/testmapper");
+            let (cert, key) = write_cert(ttd.path()).await;
             let tedge_config = TEdgeConfig::load_toml_str(&format!(
                 "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
             ));
@@ -794,7 +794,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn password_method_without_credentials_path_errors() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
+            let mapper_dir = ttd.path().join("mappers/testmapper");
             let tedge_config = TEdgeConfig::load_toml_str("");
             let mut config = make_config(Some("mqtt.example.com:1883"));
             config.auth_method = AuthMethodConfig::Password;
@@ -813,8 +813,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn auto_with_credentials_path_resolves_to_password() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
-            let creds_path = ttd.utf8_path().join("creds.toml");
+            let mapper_dir = ttd.path().join("mappers/testmapper");
+            let creds_path = ttd.path().join("creds.toml");
             tokio::fs::write(
                 &creds_path,
                 "[credentials]\nusername = \"alice\"\npassword = \"secret\"\n",
@@ -835,8 +835,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn explicit_password_method_with_credentials_path_resolves_to_password() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
-            let creds_path = ttd.utf8_path().join("creds.toml");
+            let mapper_dir = ttd.path().join("mappers/testmapper");
+            let creds_path = ttd.path().join("creds.toml");
             tokio::fs::write(
                 &creds_path,
                 "[credentials]\nusername = \"bob\"\npassword = \"pass\"\n",
@@ -858,12 +858,12 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn mapper_toml_cert_takes_precedence_over_tedge_config() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
+            let mapper_dir = ttd.path().join("mappers/thingsboard");
             let tedge_config = TEdgeConfig::load_toml_str(
                 "device.cert_path = \"/nonexistent/tedge-cert.pem\"\n\
                  device.key_path = \"/nonexistent/tedge-key.pem\"\n",
             );
-            let (mapper_cert, mapper_key) = write_cert(ttd.utf8_path()).await;
+            let (mapper_cert, mapper_key) = write_cert(ttd.path()).await;
             let mut config = make_config(Some("mqtt.example.com:8883"));
             config.device = Some(DeviceConfig {
                 id: None,
@@ -881,8 +881,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn absent_mapper_cert_falls_back_to_tedge_config() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
-            let (cert, key) = write_cert(ttd.utf8_path()).await;
+            let mapper_dir = ttd.path().join("mappers/thingsboard");
+            let (cert, key) = write_cert(ttd.path()).await;
             let tedge_config = TEdgeConfig::load_toml_str(&format!(
                 "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
             ));
@@ -897,8 +897,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn cert_cn_used_as_mqtt_client_id() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
-            let (cert, key) = write_cert(ttd.utf8_path()).await;
+            let mapper_dir = ttd.path().join("mappers/thingsboard");
+            let (cert, key) = write_cert(ttd.path()).await;
             let tedge_config = TEdgeConfig::load_toml_str(&format!(
                 "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
             ));
@@ -915,8 +915,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn password_auth_uses_device_id_as_client_id() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
-            let creds_path = ttd.utf8_path().join("creds.toml");
+            let mapper_dir = ttd.path().join("mappers/thingsboard");
+            let creds_path = ttd.path().join("creds.toml");
             write_creds(&creds_path).await;
             let tedge_config = TEdgeConfig::load_toml_str("");
             let mut config = make_config(Some("mqtt.example.com:1883"));
@@ -939,8 +939,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn password_auth_without_device_id_returns_error() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
-            let creds_path = ttd.utf8_path().join("creds.toml");
+            let mapper_dir = ttd.path().join("mappers/thingsboard");
+            let creds_path = ttd.path().join("creds.toml");
             write_creds(&creds_path).await;
             let tedge_config = TEdgeConfig::load_toml_str("");
             let mut config = make_config(Some("mqtt.example.com:1883"));
@@ -960,8 +960,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn cert_auth_without_device_id_returns_error() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/thingsboard");
-            let (cert, key) = write_cert_no_cn(ttd.utf8_path()).await;
+            let mapper_dir = ttd.path().join("mappers/thingsboard");
+            let (cert, key) = write_cert_no_cn(ttd.path()).await;
             let tedge_config = TEdgeConfig::load_toml_str(&format!(
                 "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
             ));
@@ -1028,8 +1028,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
             #[tokio::test]
             async fn tls_off_with_password_auth_connects_without_tls() {
                 let ttd = TempTedgeDir::new();
-                let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
-                let creds_path = ttd.utf8_path().join("creds.toml");
+                let mapper_dir = ttd.path().join("mappers/testmapper");
+                let creds_path = ttd.path().join("creds.toml");
                 write_creds(&creds_path).await;
                 let tedge_config = TEdgeConfig::load_toml_str("device.id = \"test-device\"");
                 let mut config = make_config(Some("mqtt.example.com:1883"));
@@ -1054,8 +1054,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
             #[tokio::test]
             async fn tls_on_with_cert_auth_connects_with_tls() {
                 let ttd = TempTedgeDir::new();
-                let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
-                let (cert, key) = write_cert(ttd.utf8_path()).await;
+                let mapper_dir = ttd.path().join("mappers/testmapper");
+                let (cert, key) = write_cert(ttd.path()).await;
                 let tedge_config = TEdgeConfig::load_toml_str(&format!(
                     "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
                 ));
@@ -1080,8 +1080,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
             #[tokio::test]
             async fn auto_port_8883_infers_tls_on() {
                 let ttd = TempTedgeDir::new();
-                let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
-                let (cert, key) = write_cert(ttd.utf8_path()).await;
+                let mapper_dir = ttd.path().join("mappers/testmapper");
+                let (cert, key) = write_cert(ttd.path()).await;
                 let tedge_config = TEdgeConfig::load_toml_str(&format!(
                     "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
                 ));
@@ -1106,8 +1106,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
             #[tokio::test]
             async fn auto_port_1883_infers_tls_off() {
                 let ttd = TempTedgeDir::new();
-                let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
-                let creds_path = ttd.utf8_path().join("creds.toml");
+                let mapper_dir = ttd.path().join("mappers/testmapper");
+                let creds_path = ttd.path().join("creds.toml");
                 write_creds(&creds_path).await;
                 let tedge_config = TEdgeConfig::load_toml_str("device.id = \"test-device\"");
                 let mut config = make_config(Some("mqtt.example.com:1883"));
@@ -1132,8 +1132,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
             #[tokio::test]
             async fn other_port_defaults_to_tls_on() {
                 let ttd = TempTedgeDir::new();
-                let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
-                let (cert, key) = write_cert(ttd.utf8_path()).await;
+                let mapper_dir = ttd.path().join("mappers/testmapper");
+                let (cert, key) = write_cert(ttd.path()).await;
                 let tedge_config = TEdgeConfig::load_toml_str(&format!(
                     "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
                 ));
@@ -1158,8 +1158,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
             #[tokio::test]
             async fn tls_off_with_cert_auth_fails() {
                 let ttd = TempTedgeDir::new();
-                let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
-                let (cert, key) = write_cert(ttd.utf8_path()).await;
+                let mapper_dir = ttd.path().join("mappers/testmapper");
+                let (cert, key) = write_cert(ttd.path()).await;
                 let tedge_config = TEdgeConfig::load_toml_str(&format!(
                     "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
                 ));
@@ -1181,8 +1181,8 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
             #[tokio::test]
             async fn auto_tls_inferred_off_with_cert_auth_fails() {
                 let ttd = TempTedgeDir::new();
-                let mapper_dir = ttd.utf8_path().join("mappers/testmapper");
-                let (cert, key) = write_cert(ttd.utf8_path()).await;
+                let mapper_dir = ttd.path().join("mappers/testmapper");
+                let (cert, key) = write_cert(ttd.path()).await;
                 let tedge_config = TEdgeConfig::load_toml_str(&format!(
                     "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
                 ));

--- a/crates/core/tedge_mapper/src/custom/resolve.rs
+++ b/crates/core/tedge_mapper/src/custom/resolve.rs
@@ -915,9 +915,9 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn cert_cn_used_as_device_id() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-        let (cert, key) = write_cert(ttd.utf8_path()).await;
+        let (cert, key) = write_cert(ttd.path()).await;
         let tedge_config = TEdgeConfig::load_toml_str(&format!(
             "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
         ));
@@ -935,7 +935,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn max_payload_size_surfaces_through_effective_config() {
         let ttd = TempTedgeDir::new();
-        let (cert, key) = write_cert(ttd.utf8_path()).await;
+        let (cert, key) = write_cert(ttd.path()).await;
         let tedge_config = TEdgeConfig::load_toml_str(&format!(
             "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
         ));
@@ -953,7 +953,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn max_payload_size_defaults_to_mqtt_maximum() {
         let ttd = TempTedgeDir::new();
-        let (cert, key) = write_cert(ttd.utf8_path()).await;
+        let (cert, key) = write_cert(ttd.path()).await;
         let tedge_config = TEdgeConfig::load_toml_str(&format!(
             "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
         ));
@@ -973,9 +973,9 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn explicit_device_id_overridden_by_cert_cn() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-        let (cert, key) = write_cert(ttd.utf8_path()).await;
+        let (cert, key) = write_cert(ttd.path()).await;
         let tedge_config = TEdgeConfig::load_toml_str(&format!(
             "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
         ));
@@ -998,9 +998,9 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn cert_with_no_cn_falls_back_to_explicit_device_id() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-        let (cert, key) = write_cert_no_cn(ttd.utf8_path()).await;
+        let (cert, key) = write_cert_no_cn(ttd.path()).await;
         let tedge_config = TEdgeConfig::load_toml_str(&format!(
             "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
         ));
@@ -1024,7 +1024,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn unreadable_cert_yields_none_device_id() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
         let tedge_config = TEdgeConfig::load_toml_str(
             "device.cert_path = \"/nonexistent/cert.pem\"\n\
@@ -1045,9 +1045,9 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn password_auth_uses_explicit_device_id() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-        let creds_path = ttd.utf8_path().join("creds.toml");
+        let creds_path = ttd.path().join("creds.toml");
         tokio::fs::write(
             &creds_path,
             "[credentials]\nusername = \"u\"\npassword = \"p\"\n",
@@ -1076,9 +1076,9 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn password_auth_falls_back_to_tedge_device_id() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-        let creds_path = ttd.utf8_path().join("creds.toml");
+        let creds_path = ttd.path().join("creds.toml");
         tokio::fs::write(
             &creds_path,
             "[credentials]\nusername = \"u\"\npassword = \"p\"\n",
@@ -1101,9 +1101,9 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn cert_path_from_mapper_toml_is_sourced_correctly() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-        let (cert, key) = write_cert(ttd.utf8_path()).await;
+        let (cert, key) = write_cert(ttd.path()).await;
         let toml = format!("[device]\ncert_path = \"{cert}\"\nkey_path = \"{key}\"\n");
         tokio::fs::write(mapper_dir.join("mapper.toml"), &toml)
             .await
@@ -1124,7 +1124,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn relative_cert_path_annotated_as_resolved() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
         // write actual cert files so load_mapper_config doesn't fail on validation
         let (_, _) = write_cert(&mapper_dir).await;
@@ -1155,9 +1155,9 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn cert_path_falls_back_to_tedge_toml() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-        let (cert, key) = write_cert(ttd.utf8_path()).await;
+        let (cert, key) = write_cert(ttd.path()).await;
         let tedge_config = TEdgeConfig::load_toml_str(&format!(
             "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
         ));
@@ -1177,7 +1177,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
     #[tokio::test]
     async fn root_cert_path_defaults_to_etc_ssl_certs() {
         let ttd = TempTedgeDir::new();
-        let mapper_dir = ttd.utf8_path().join("mappers/tb");
+        let mapper_dir = ttd.path().join("mappers/tb");
         tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
         let tedge_config = TEdgeConfig::load_toml_str("");
         let config = make_config(None);
@@ -1239,7 +1239,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn schema_key_device_id_from_cert_cn() {
             let ttd = TempTedgeDir::new();
-            let (cert, key) = write_cert(ttd.utf8_path()).await;
+            let (cert, key) = write_cert(ttd.path()).await;
             let tedge_config = TEdgeConfig::load_toml_str(&format!(
                 "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
             ));
@@ -1257,7 +1257,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn schema_key_cert_path_from_tedge_toml_fallback() {
             let ttd = TempTedgeDir::new();
-            let (cert, key) = write_cert(ttd.utf8_path()).await;
+            let (cert, key) = write_cert(ttd.path()).await;
             let tedge_config = TEdgeConfig::load_toml_str(&format!(
                 "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
             ));
@@ -1358,7 +1358,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn schema_key_shadows_raw_table_value() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/tb");
+            let mapper_dir = ttd.path().join("mappers/tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             write_cert(&mapper_dir).await;
             tokio::fs::write(
@@ -1445,7 +1445,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn absolute_cert_path_in_mapper_toml() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/tb");
+            let mapper_dir = ttd.path().join("mappers/tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             let (cert, key) = write_cert(&mapper_dir).await;
             tokio::fs::write(
@@ -1470,7 +1470,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn relative_cert_path_in_mapper_toml() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/tb");
+            let mapper_dir = ttd.path().join("mappers/tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
             write_cert(&mapper_dir).await;
             tokio::fs::write(
@@ -1495,7 +1495,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn cert_path_inherited_from_tedge_toml() {
             let ttd = TempTedgeDir::new();
-            let (cert, key) = write_cert(ttd.utf8_path()).await;
+            let (cert, key) = write_cert(ttd.path()).await;
             let tedge_config = TEdgeConfig::load_toml_str(&format!(
                 "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
             ));
@@ -1514,7 +1514,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn device_id_inferred_from_cert_cn() {
             let ttd = TempTedgeDir::new();
-            let (cert, key) = write_cert(ttd.utf8_path()).await;
+            let (cert, key) = write_cert(ttd.path()).await;
             let tedge_config = TEdgeConfig::load_toml_str(&format!(
                 "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
             ));
@@ -1548,7 +1548,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn device_id_falls_back_to_tedge_toml() {
             let ttd = TempTedgeDir::new();
-            let creds = ttd.utf8_path().join("creds.toml");
+            let creds = ttd.path().join("creds.toml");
             tokio::fs::write(
                 &creds,
                 "[credentials]\nusername = \"u\"\npassword = \"p\"\n",
@@ -1572,9 +1572,9 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
         #[tokio::test]
         async fn short_tags_match_expected_labels() {
             let ttd = TempTedgeDir::new();
-            let mapper_dir = ttd.utf8_path().join("mappers/tb");
+            let mapper_dir = ttd.path().join("mappers/tb");
             tokio::fs::create_dir_all(&mapper_dir).await.unwrap();
-            let (cert, key) = write_cert(ttd.utf8_path()).await;
+            let (cert, key) = write_cert(ttd.path()).await;
             let tedge_config = TEdgeConfig::load_toml_str(&format!(
                 "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
             ));
@@ -1625,7 +1625,7 @@ AwEHoUQDQgAEdklRDw9+AAMRbpNMWJutKe4QO/tUlvrBR2swUYN9onxXdKNjJ/k3\n\
             // The overlay (e.g. from the c8y config) may contain a device.id, but the
             // cert CN — computed during resolve — must take precedence.
             let ttd = TempTedgeDir::new();
-            let (cert, key) = write_cert(ttd.utf8_path()).await;
+            let (cert, key) = write_cert(ttd.path()).await;
             let tedge_config = TEdgeConfig::load_toml_str(&format!(
                 "device.cert_path = \"{cert}\"\ndevice.key_path = \"{key}\"\n"
             ));

--- a/crates/extensions/c8y_firmware_manager/src/tests.rs
+++ b/crates/extensions/c8y_firmware_manager/src/tests.rs
@@ -635,9 +635,9 @@ async fn spawn_firmware_manager(
         device_id.to_string(),
         tedge_host,
         TEDGE_HTTP_PORT,
-        tmp_dir.utf8_path_buf(),
+        tmp_dir.path_buf(),
         DataDir::from(TedgePaths::from_root_with_defaults(
-            tmp_dir.utf8_path_buf(),
+            tmp_dir.path_buf(),
             "",
             "",
         )),

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -3118,12 +3118,12 @@ pub(crate) mod tests {
         let mut topics =
             C8yMapperConfig::default_internal_topic_filter(&"c8y".try_into().unwrap()).unwrap();
         let custom_operation_topics =
-            C8yMapperConfig::get_topics_from_custom_operations(tmp_dir.utf8_path(), &bridge_config)
+            C8yMapperConfig::get_topics_from_custom_operations(tmp_dir.path(), &bridge_config)
                 .unwrap();
         topics.add_all(custom_operation_topics);
         topics.remove_overlapping_patterns();
 
-        let root_dir = TedgePaths::from_root_with_defaults(tmp_dir.utf8_path(), "", "");
+        let root_dir = TedgePaths::from_root_with_defaults(tmp_dir.path(), "", "");
 
         C8yMapperConfig::new(
             root_dir.clone().into(),

--- a/crates/extensions/c8y_mapper_ext/src/operations/handlers/config_snapshot.rs
+++ b/crates/extensions/c8y_mapper_ext/src/operations/handlers/config_snapshot.rs
@@ -696,7 +696,7 @@ mod tests {
         // Uploader gets the upload request for the log path
         let request = ul.recv().await.expect("timeout");
         assert_eq!(request.0, "c8y-mapper-1234"); // Command ID
-        assert_eq!(request.1.file_path, test_log.utf8_path());
+        assert_eq!(request.1.file_path, test_log.path());
 
         // Simulate Uploader returns a result
         ul.send((
@@ -751,7 +751,7 @@ mod tests {
         // Uploader gets the upload request for the log path
         let request = ul.recv().await.expect("timeout");
         assert_eq!(request.0, "c8y-mapper-1234"); // Command ID
-        assert_eq!(request.1.file_path, test_log.utf8_path());
+        assert_eq!(request.1.file_path, test_log.path());
 
         // Simulate Uploader returns a result
         ul.send((

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -13,12 +13,12 @@ use c8y_api::json_c8y::InternalIdResponse;
 use c8y_api::json_c8y_deserializer::C8yDeviceControlTopic;
 use c8y_api::proxy_url::Protocol;
 use c8y_api::smartrest::topic::C8yTopic;
+use camino::Utf8Path;
 use serde_json::json;
 use std::collections::HashMap;
 use std::fs;
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use tedge_actors::futures::channel::mpsc;
@@ -1175,6 +1175,7 @@ async fn mapper_dynamically_updates_supported_operations_for_tedge_device() {
         ttd.dir("operations")
             .dir("c8y")
             .file("c8y_TestOp3")
+            .std_path()
             .to_path_buf(),
     ))
     .await
@@ -1259,6 +1260,7 @@ async fn mapper_dynamically_updates_supported_operations_for_child_device() {
             .dir("c8y")
             .dir("test-device:device:child1")
             .file("c8y_ChildTestOp3")
+            .std_path()
             .to_path_buf(),
     ))
     .await
@@ -1356,6 +1358,7 @@ async fn mapper_dynamically_updates_supported_operations_for_nested_child_device
             .dir("c8y")
             .dir("child11")
             .file("c8y_ChildTestOp3")
+            .std_path()
             .to_path_buf(),
     ))
     .await
@@ -3081,7 +3084,7 @@ async fn mapper_publishes_all_supported_operations_on_signal() {
 }
 
 fn assert_command_exec_log_content(cfg_dir: TempTedgeDir, expected_contents: &str) {
-    let paths = fs::read_dir(cfg_dir.to_path_buf().join("agent")).unwrap();
+    let paths = fs::read_dir(cfg_dir.path().join("agent")).unwrap();
     for path in paths {
         let mut file =
             File::open(path.unwrap().path()).expect("Unable to open the command exec log file");
@@ -3097,7 +3100,7 @@ fn assert_command_exec_log_content(cfg_dir: TempTedgeDir, expected_contents: &st
 
 fn create_custom_op_file(
     ttd: &TempTedgeDir,
-    cmd_file: &Path,
+    cmd_file: &Utf8Path,
     graceful_timeout: Option<i64>,
     forceful_timeout: Option<i64>,
 ) {
@@ -3112,17 +3115,14 @@ fn create_custom_op_file(
     if let Some(timeout) = forceful_timeout {
         custom_content.insert("forceful_timeout".into(), toml::Value::Integer(timeout));
     }
-    custom_content.insert(
-        "command".into(),
-        toml::Value::String(cmd_file.display().to_string()),
-    );
+    custom_content.insert("command".into(), toml::Value::String(cmd_file.to_string()));
 
     let mut map = toml::map::Map::new();
     map.insert("exec".into(), toml::Value::Table(custom_content));
     custom_op_file.with_toml_content(map);
 }
 
-fn create_custom_cmd(custom_cmd: &Path, content: &str) {
+fn create_custom_cmd(custom_cmd: &Utf8Path, content: &str) {
     with_exec_permission(custom_cmd, content);
 }
 
@@ -3227,7 +3227,7 @@ pub(crate) async fn c8y_mapper_builder(
         .connect_source(AvailabilityBuilder::channels(), &mut c8y_mapper_builder);
     c8y_mapper_builder.connect_source(NoConfig, &mut availability_box_builder);
 
-    let mapper_dir = tmp_dir.utf8_path().join("mappers").join("c8y");
+    let mapper_dir = tmp_dir.path().join("mappers").join("c8y");
     let managed_dir = TedgePaths::from_root_with_defaults(&mapper_dir, "", "").root_dir();
     let flows_dir = tedge_flows::managed_flows_dir(&managed_dir);
     flows_dir.ensure().await.unwrap();
@@ -3283,8 +3283,7 @@ pub(crate) fn test_mapper_config(tmp_dir: &TempTedgeDir) -> C8yMapperConfig {
     let mut topics =
         C8yMapperConfig::default_internal_topic_filter(&"c8y".try_into().unwrap()).unwrap();
     let custom_operation_topics =
-        C8yMapperConfig::get_topics_from_custom_operations(tmp_dir.utf8_path(), &bridge_config)
-            .unwrap();
+        C8yMapperConfig::get_topics_from_custom_operations(tmp_dir.path(), &bridge_config).unwrap();
     topics.add_all(custom_operation_topics);
     topics.add_unchecked("te/+/+/+/+/cmd/software_update");
     topics.add_unchecked("te/+/+/+/+/cmd/software_update/+");
@@ -3304,7 +3303,7 @@ pub(crate) fn test_mapper_config(tmp_dir: &TempTedgeDir) -> C8yMapperConfig {
 
     topics.remove_overlapping_patterns();
 
-    let root_dir = TedgePaths::from_root_with_defaults(tmp_dir.utf8_path(), "", "");
+    let root_dir = TedgePaths::from_root_with_defaults(tmp_dir.path(), "", "");
     let _agent_log_dir = tmp_dir.dir("agent");
 
     C8yMapperConfig::new(

--- a/crates/extensions/tedge_config_manager/src/tests.rs
+++ b/crates/extensions/tedge_config_manager/src/tests.rs
@@ -59,10 +59,7 @@ struct TestHandle {
 
 fn prepare() -> Result<TempTedgeDir, anyhow::Error> {
     let tempdir = TempTedgeDir::new();
-    let tempdir_path = tempdir
-        .path()
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("temp dir not created"))?;
+    let tempdir_path = tempdir.path().as_str();
 
     // Test files
     tempdir.file("file_a");
@@ -110,7 +107,7 @@ async fn new_config_manager_builder(
     DownloaderMessageBox,
     UploaderMessageBox,
 ) {
-    let config_root = TedgePaths::from_root_with_defaults(temp_dir.utf8_path(), "", "");
+    let config_root = TedgePaths::from_root_with_defaults(temp_dir.path(), "", "");
     let tmp_root = TedgePaths::from_root_with_defaults(
         Utf8Path::from_path(&std::env::temp_dir()).unwrap(),
         "",
@@ -118,11 +115,7 @@ async fn new_config_manager_builder(
     );
     let config = ConfigManagerConfig {
         config_dir: config_root.clone(),
-        plugin_dirs: vec![temp_dir
-            .to_path_buf()
-            .join("config-plugins")
-            .try_into()
-            .unwrap()],
+        plugin_dirs: vec![temp_dir.path().join("config-plugins")],
         plugin_config_dir: config_root.root_dir(),
         plugin_config_path: config_root.file("tedge-configuration-plugin.toml").unwrap(),
         config_snapshot_meta_topic: Topic::new_unchecked("te/device/main///cmd/config_snapshot"),
@@ -190,11 +183,8 @@ async fn default_plugin_config() {
         read_to_string(tempdir.path().join("tedge-configuration-plugin.toml")).unwrap();
     let plugin_config_toml: Table = from_str(&plugin_config_content).unwrap();
 
-    let tedge_config_path = format!("{}/tedge.toml", tempdir.path().to_string_lossy());
-    let tedge_log_plugin_config_path = format!(
-        "{}/plugins/tedge-log-plugin.toml",
-        tempdir.path().to_string_lossy()
-    );
+    let tedge_config_path = format!("{}/tedge.toml", tempdir.path());
+    let tedge_log_plugin_config_path = format!("{}/plugins/tedge-log-plugin.toml", tempdir.path());
     let expected_config = toml::toml! {
         [[files]]
         path = tedge_config_path
@@ -794,7 +784,7 @@ async fn execute_config_set_operation_step() -> Result<(), anyhow::Error> {
         json!({
             "type": "type_two",
             "setFrom": downloaded_path.path(),
-            "workDir": work_dir.utf8_path(),
+            "workDir": work_dir.path(),
         }),
     );
 
@@ -916,7 +906,7 @@ async fn execute_config_set_operation_step_file_not_found() -> Result<(), anyhow
         json!({
             "type": "type_two",
             "setFrom": missing_path,
-            "workDir": work_dir.utf8_path(),
+            "workDir": work_dir.path(),
         }),
     );
 
@@ -935,7 +925,7 @@ async fn execute_config_set_operation_step_file_not_found() -> Result<(), anyhow
 }
 
 fn test_config(tempdir: &TempTedgeDir) -> ConfigManagerConfig {
-    let config_root = TedgePaths::from_root_with_defaults(tempdir.utf8_path(), "", "");
+    let config_root = TedgePaths::from_root_with_defaults(tempdir.path(), "", "");
     let tmp_root = TedgePaths::from_root_with_defaults(
         Utf8Path::from_path(&std::env::temp_dir()).unwrap(),
         "",

--- a/crates/extensions/tedge_downloader_ext/src/tests.rs
+++ b/crates/extensions/tedge_downloader_ext/src/tests.rs
@@ -23,7 +23,7 @@ async fn download_without_auth() {
 
     let target_path = ttd.path().join("downloaded_file");
     let server_url = server.url();
-    let download_request = DownloadRequest::new(&server_url, &target_path);
+    let download_request = DownloadRequest::new(&server_url, target_path.as_std_path());
 
     let mut requester = spawn_downloader_actor().await;
 
@@ -58,7 +58,8 @@ async fn download_with_auth() {
 
     let mut headers = HeaderMap::new();
     headers.append(AUTHORIZATION, "Bearer token".parse().unwrap());
-    let download_request = DownloadRequest::new(&server_url, &target_path).with_headers(headers);
+    let download_request =
+        DownloadRequest::new(&server_url, target_path.as_std_path()).with_headers(headers);
 
     let mut requester = spawn_downloader_actor().await;
 
@@ -100,7 +101,7 @@ async fn download_if_download_key_is_struct() {
 
     let target_path = ttd.path().join("downloaded_file");
     let server_url = server.url();
-    let download_request = DownloadRequest::new(&server_url, &target_path);
+    let download_request = DownloadRequest::new(&server_url, target_path.as_std_path());
     let request_key = TestDownloadKey {
         text: "I am test".to_string(),
         some: true,

--- a/crates/extensions/tedge_file_system_ext/src/lib.rs
+++ b/crates/extensions/tedge_file_system_ext/src/lib.rs
@@ -185,12 +185,12 @@ mod tests {
         let temp = TempTedgeDir::new();
         let ttd = temp.dir("watched-dir");
         let ttd_link = temp.link_dir(&ttd, "watched-symlink");
-        let ttd_full = ttd.to_path_buf().canonicalize().unwrap().to_path_buf();
+        let ttd_full = ttd.path().canonicalize().unwrap();
         let mut fs_actor_builder = FsWatchActorBuilder::new();
         let client_builder: SimpleMessageBoxBuilder<FsWatchEvent, NoMessage> =
             SimpleMessageBoxBuilder::new("FS Client", 5);
 
-        fs_actor_builder.connect_sink(ttd_link.to_path_buf(), &client_builder);
+        fs_actor_builder.connect_sink(ttd_link.std_path().to_path_buf(), &client_builder);
 
         let actor = fs_actor_builder.build();
         let client_box = client_builder.build();

--- a/crates/extensions/tedge_log_manager/src/tests.rs
+++ b/crates/extensions/tedge_log_manager/src/tests.rs
@@ -168,15 +168,12 @@ async fn spawn_log_manager_actor(
 #[tokio::test]
 async fn default_plugin_config() {
     let tempdir = TempTedgeDir::new();
-    let (_mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (_mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
     let plugin_config_content =
         read_to_string(tempdir.path().join("tedge-log-plugin.toml")).unwrap();
     let plugin_config_toml: Table = from_str(&plugin_config_content).unwrap();
 
-    let agent_logs_path = format!(
-        "{}/agent/workflow-software_*",
-        tempdir.path().to_string_lossy()
-    );
+    let agent_logs_path = format!("{}/agent/workflow-software_*", tempdir.path());
     let expected_config = toml! {
         [[files]]
         type = "software-management"
@@ -189,7 +186,7 @@ async fn default_plugin_config() {
 #[tokio::test]
 async fn log_manager_reloads_log_types() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let log_reload_topic = Topic::new_unchecked("te/device/main///cmd/log_upload");
 
@@ -207,7 +204,7 @@ async fn log_manager_reloads_log_types() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn log_manager_reloads_log_types_on_plugin_dir_removal() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let log_reload_topic = Topic::new_unchecked("te/device/main///cmd/log_upload");
 
@@ -223,7 +220,7 @@ async fn log_manager_reloads_log_types_on_plugin_dir_removal() -> Result<(), any
     // Events that must NOT trigger a reload: a nested sub-directory removal and a change to a
     // file nested in a sub-directory.
     // Plugins live directly under the plugin dir root, so neither is a plugin.
-    let nested_dir = tempdir.utf8_path().join("log-plugins").join("nested");
+    let nested_dir = tempdir.path().join("log-plugins").join("nested");
     fs.send(FsWatchEvent::DirectoryDeleted(nested_dir.clone().into()))
         .await?;
     fs.send(FsWatchEvent::Modified(nested_dir.join("plugin").into()))
@@ -232,7 +229,7 @@ async fn log_manager_reloads_log_types_on_plugin_dir_removal() -> Result<(), any
     // Removing the whole plugin directory (e.g. `rm -rf`) emits a single `DirectoryDeleted`
     // for the directory itself, with no per-file `FileDeleted` events. The actor must still
     // reload and publish the now-empty set of supported log types.
-    let plugin_dir = tempdir.utf8_path().join("log-plugins");
+    let plugin_dir = tempdir.path().join("log-plugins");
     std::fs::remove_dir_all(&plugin_dir)?;
     fs.send(FsWatchEvent::DirectoryDeleted(plugin_dir.into()))
         .await?;
@@ -248,7 +245,7 @@ async fn log_manager_reloads_log_types_on_plugin_dir_removal() -> Result<(), any
 #[tokio::test]
 async fn log_manager_reloads_log_types_on_new_plugin_file() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let log_reload_topic = Topic::new_unchecked("te/device/main///cmd/log_upload");
 
@@ -256,7 +253,7 @@ async fn log_manager_reloads_log_types_on_new_plugin_file() -> Result<(), anyhow
     mqtt.skip(1).await;
 
     // A new executable plugin dropped directly into the plugin dir must be picked up.
-    let plugin_path = tempdir.utf8_path().join("log-plugins").join("custom");
+    let plugin_path = tempdir.path().join("log-plugins").join("custom");
     with_exec_permission(
         &plugin_path,
         "#!/bin/bash\ncase \"$1\" in\n    \"list\") echo \"app_log\" ;;\n    *) exit 1 ;;\nesac\n",
@@ -281,7 +278,7 @@ async fn log_manager_reloads_log_types_on_new_plugin_file() -> Result<(), anyhow
 #[tokio::test]
 async fn log_manager_reloads_log_types_on_plugin_file_deletion() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let log_reload_topic = Topic::new_unchecked("te/device/main///cmd/log_upload");
 
@@ -289,7 +286,7 @@ async fn log_manager_reloads_log_types_on_plugin_file_deletion() -> Result<(), a
     mqtt.skip(1).await;
 
     // Deleting the only plugin file (a direct child of the plugin dir) drops its types.
-    let plugin_path = tempdir.utf8_path().join("log-plugins").join("file");
+    let plugin_path = tempdir.path().join("log-plugins").join("file");
     std::fs::remove_file(&plugin_path)?;
     fs.send(FsWatchEvent::FileDeleted(plugin_path.into()))
         .await?;
@@ -305,7 +302,7 @@ async fn log_manager_reloads_log_types_on_plugin_file_deletion() -> Result<(), a
 #[tokio::test]
 async fn log_manager_reloads_log_types_on_plugin_config_change() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, mut fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let log_reload_topic = Topic::new_unchecked("te/device/main///cmd/log_upload");
 
@@ -319,7 +316,7 @@ async fn log_manager_reloads_log_types_on_plugin_config_change() -> Result<(), a
 
     // Editing the plugin config file must be re-read on reload: exclude one of the file plugin's
     // types and confirm the published set shrinks accordingly.
-    let config_path = tempdir.utf8_path().join("tedge-log-plugin.toml");
+    let config_path = tempdir.path().join("tedge-log-plugin.toml");
     std::fs::write(
         &config_path,
         "[[plugins.file.filters]]\nexclude = \"type_two\"\n",
@@ -337,7 +334,7 @@ async fn log_manager_reloads_log_types_on_plugin_config_change() -> Result<(), a
 #[tokio::test]
 async fn log_manager_upload_log_files_on_request() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _fs, mut uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _fs, mut uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let logfile_topic = Topic::new_unchecked("te/device/main///cmd/log_upload/1234");
 
@@ -412,7 +409,7 @@ async fn log_manager_upload_log_files_on_request() -> Result<(), anyhow::Error> 
 #[tokio::test]
 async fn filter_logs_by_line_count() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _fs, mut uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _fs, mut uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let logfile_topic = Topic::new_unchecked("te/device/main///cmd/log_upload/5678");
 
@@ -476,7 +473,7 @@ async fn filter_logs_by_line_count() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn filter_logs_by_search_text() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _fs, mut uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _fs, mut uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let logfile_topic = Topic::new_unchecked("te/device/main///cmd/log_upload/9012");
 
@@ -539,7 +536,7 @@ async fn filter_logs_by_search_text() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn filter_logs_by_search_text_and_line_count() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _fs, mut uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _fs, mut uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let logfile_topic = Topic::new_unchecked("te/device/main///cmd/log_upload/3456");
 
@@ -603,7 +600,7 @@ async fn filter_logs_by_search_text_and_line_count() -> Result<(), anyhow::Error
 #[tokio::test]
 async fn request_logtype_that_does_not_exist() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let logfile_topic = Topic::new_unchecked("te/device/main///cmd/log_upload/1234");
 
@@ -650,7 +647,7 @@ async fn request_logtype_that_does_not_exist() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn ignore_topic_for_another_device() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _http, _fs) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _http, _fs) = spawn_log_manager_actor(tempdir.path()).await;
 
     // Check for child device topic
     let another_device_topic = Topic::new_unchecked("te/device/child01///cmd/log_upload/1234");
@@ -680,7 +677,7 @@ async fn ignore_topic_for_another_device() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn send_incorrect_payload() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let logfile_topic = Topic::new_unchecked("te/device/main///cmd/log_upload/1234");
 
@@ -709,7 +706,7 @@ async fn send_incorrect_payload() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn read_log_from_file_that_does_not_exist() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let logfile_topic = Topic::new_unchecked("te/device/main///cmd/log_upload/1234");
 
@@ -756,7 +753,7 @@ async fn read_log_from_file_that_does_not_exist() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn log_types_published_on_software_update_message() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let log_reload_topic = Topic::new_unchecked("te/device/main///cmd/log_upload");
     let software_update_topic = Topic::new_unchecked("te/device/main///cmd/software_update/1234");
@@ -814,7 +811,7 @@ async fn log_types_published_on_software_update_message() -> Result<(), anyhow::
 #[tokio::test]
 async fn log_types_published_on_config_update_message() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let log_reload_topic = Topic::new_unchecked("te/device/main///cmd/log_upload");
     let config_update_topic = Topic::new_unchecked("te/device/main///cmd/config_update/1234");
@@ -890,7 +887,7 @@ async fn log_types_published_on_config_update_message() -> Result<(), anyhow::Er
 #[tokio::test]
 async fn log_types_not_published_on_random_command_update() -> Result<(), anyhow::Error> {
     let tempdir = prepare()?;
-    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.utf8_path()).await;
+    let (mut mqtt, _fs, _uploader) = spawn_log_manager_actor(tempdir.path()).await;
 
     let restart_topic = Topic::new_unchecked("te/device/main///cmd/restart/1234");
 

--- a/crates/extensions/tedge_mqtt_bridge/src/persist.rs
+++ b/crates/extensions/tedge_mqtt_bridge/src/persist.rs
@@ -186,7 +186,7 @@ mod tests {
                 "user = '{}'\ngroup = '{}'\n",
                 owner.user, owner.group
             ));
-            TEdgeConfig::load(ttd.utf8_path()).await.unwrap()
+            TEdgeConfig::load(ttd.path()).await.unwrap()
         }
 
         async fn load_config(ttd: &TempTedgeDir) -> TEdgeConfig {
@@ -196,7 +196,7 @@ mod tests {
         #[tokio::test]
         async fn creates_both_config_and_template_when_neither_exists() {
             let ttd = TempTedgeDir::new();
-            let dir = ttd.utf8_path().join("bridge");
+            let dir = ttd.path().join("bridge");
             tokio::fs::create_dir_all(&dir).await.unwrap();
             let config = load_config(&ttd).await;
             let content = "test content";
@@ -222,7 +222,7 @@ mod tests {
         #[tokio::test]
         async fn creates_directory_using_the_system_toml_user() {
             let ttd = TempTedgeDir::new();
-            let dir = ttd.utf8_path().join("bridge");
+            let dir = ttd.path().join("bridge");
 
             #[cfg(target_os = "linux")]
             let target_group = "root";
@@ -250,7 +250,7 @@ mod tests {
         #[tokio::test]
         async fn creates_missing_directory_using_the_current_system_toml_user() {
             let ttd = TempTedgeDir::new();
-            let dir = ttd.utf8_path().join("bridge");
+            let dir = ttd.path().join("bridge");
             let config = load_config(&ttd).await;
 
             persist_bridge_config_file(&dir, "test", "test content", &config)
@@ -275,7 +275,7 @@ mod tests {
         #[tokio::test]
         async fn updates_both_when_config_matches_template() {
             let ttd = TempTedgeDir::new();
-            let dir = ttd.utf8_path().join("bridge");
+            let dir = ttd.path().join("bridge");
             tokio::fs::create_dir_all(&dir).await.unwrap();
             let config = load_config(&ttd).await;
 
@@ -310,7 +310,7 @@ mod tests {
         #[tokio::test]
         async fn only_updates_template_when_config_is_overridden() {
             let ttd = TempTedgeDir::new();
-            let dir = ttd.utf8_path().join("bridge");
+            let dir = ttd.path().join("bridge");
             tokio::fs::create_dir_all(&dir).await.unwrap();
             let config = load_config(&ttd).await;
 
@@ -348,7 +348,7 @@ mod tests {
         #[tokio::test]
         async fn only_updates_template_when_disabled_marker_exists() {
             let ttd = TempTedgeDir::new();
-            let dir = ttd.utf8_path().join("bridge");
+            let dir = ttd.path().join("bridge");
             tokio::fs::create_dir_all(&dir).await.unwrap();
             let config = load_config(&ttd).await;
 
@@ -393,7 +393,7 @@ mod tests {
         async fn skips_disabled_config_files() {
             let ttd = TempTedgeDir::new();
             let bridge_dir = ttd.dir("mappers").dir("c8y").dir("bridge");
-            let bridge_dir = bridge_dir.utf8_path();
+            let bridge_dir = bridge_dir.path();
 
             // Create valid bridge configs
             let config_content = r#"
@@ -415,7 +415,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let tedge_config = TEdgeConfig::load(ttd.utf8_path()).await.unwrap();
+            let tedge_config = TEdgeConfig::load(ttd.path()).await.unwrap();
 
             let bridge_config = load_bridge_rules_from_directory(
                 bridge_dir,
@@ -435,7 +435,7 @@ mod tests {
         async fn ignores_template_files() {
             let ttd = TempTedgeDir::new();
             let bridge_dir = ttd.dir("mappers").dir("c8y").dir("bridge");
-            let bridge_dir = bridge_dir.utf8_path();
+            let bridge_dir = bridge_dir.path();
 
             // Create a valid bridge config and its template
             let config_content = r#"
@@ -453,7 +453,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let tedge_config = TEdgeConfig::load(ttd.utf8_path()).await.unwrap();
+            let tedge_config = TEdgeConfig::load(ttd.path()).await.unwrap();
 
             let bridge_config = load_bridge_rules_from_directory(
                 bridge_dir,

--- a/crates/extensions/tedge_uploader_ext/src/tests.rs
+++ b/crates/extensions/tedge_uploader_ext/src/tests.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use camino::Utf8Path;
 use certificate::CloudHttpConfig;
 use tedge_actors::ClientMessageBox;
 use tedge_actors::DynError;
@@ -36,9 +35,7 @@ async fn upload_without_auth() -> Result<(), DynError> {
         .create_async()
         .await;
 
-    let target_path = Utf8Path::from_path(ttd.path())
-        .unwrap()
-        .join("file_to_upload.txt");
+    let target_path = ttd.path().join("file_to_upload.txt");
 
     std::fs::write(&target_path, "Hello, world!").unwrap();
 
@@ -73,9 +70,7 @@ async fn upload_with_auth() -> Result<(), DynError> {
         .create_async()
         .await;
 
-    let target_path = Utf8Path::from_path(ttd.path())
-        .unwrap()
-        .join("file_to_upload.txt");
+    let target_path = ttd.path().join("file_to_upload.txt");
 
     std::fs::write(&target_path, "Hello, world!").unwrap();
 

--- a/crates/tests/tedge_test_utils/src/fs.rs
+++ b/crates/tests/tedge_test_utils/src/fs.rs
@@ -7,7 +7,6 @@ use std::io::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::prelude::OpenOptionsExt;
 use std::path::Path;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
 #[derive(Debug, Clone)]
@@ -18,7 +17,7 @@ pub struct TempTedgeDir {
 
 #[derive(Debug, Clone)]
 pub struct TempTedgeFile {
-    pub file_path: PathBuf,
+    pub file_path: Utf8PathBuf,
 }
 
 impl Default for TempTedgeDir {
@@ -56,8 +55,7 @@ impl TempTedgeDir {
     }
 
     pub fn file(&self, file_name: &str) -> TempTedgeFile {
-        let root = self.temp_dir.path().to_path_buf();
-        let path = root.join(&self.current_file_path).join(file_name);
+        let path = self.current_file_path.join(file_name);
 
         if !path.exists() {
             let file = fs::File::create(&path).unwrap();
@@ -82,20 +80,16 @@ impl TempTedgeDir {
         }
     }
 
-    pub fn path(&self) -> &Path {
-        self.current_file_path.as_std_path()
-    }
-
-    pub fn utf8_path(&self) -> &Utf8Path {
+    pub fn path(&self) -> &Utf8Path {
         self.current_file_path.as_path()
     }
 
-    pub fn utf8_path_buf(&self) -> Utf8PathBuf {
+    pub fn path_buf(&self) -> Utf8PathBuf {
         self.current_file_path.clone()
     }
 
-    pub fn to_path_buf(&self) -> PathBuf {
-        self.current_file_path.clone().into_std_path_buf()
+    pub fn std_path(&self) -> &Path {
+        self.current_file_path.as_std_path()
     }
 
     pub fn set_mode(&self, mode: u32) {
@@ -107,8 +101,9 @@ impl TempTedgeFile {
     pub fn with_raw_content(self, content: &str) -> Self {
         let mut file = OpenOptions::new()
             .write(true)
+            .truncate(true)
             .create(false)
-            .open(self.file_path.clone())
+            .open(&self.file_path)
             .unwrap();
         file.write_all(content.as_bytes()).unwrap();
         file.flush().unwrap();
@@ -120,7 +115,7 @@ impl TempTedgeFile {
         let mut file = OpenOptions::new()
             .write(true)
             .create(false)
-            .open(self.file_path)
+            .open(&self.file_path)
             .unwrap();
         let file_content = content.to_string();
         file.write_all(file_content.as_bytes()).unwrap();
@@ -132,20 +127,16 @@ impl TempTedgeFile {
         std::fs::remove_file(self.path()).unwrap();
     }
 
-    pub fn path(&self) -> &Path {
-        Path::new(&self.file_path)
+    pub fn path(&self) -> &Utf8Path {
+        &self.file_path
     }
 
-    pub fn utf8_path(&self) -> &Utf8Path {
-        Utf8Path::from_path(self.path()).unwrap()
+    pub fn path_buf(&self) -> Utf8PathBuf {
+        self.file_path.clone()
     }
 
-    pub fn to_path_buf(&self) -> PathBuf {
-        PathBuf::from(self.path())
-    }
-
-    pub fn utf8_path_buf(&self) -> Utf8PathBuf {
-        Utf8PathBuf::from_path_buf(self.to_path_buf()).unwrap()
+    pub fn std_path(&self) -> &Path {
+        self.file_path.as_std_path()
     }
 }
 

--- a/plugins/tedge_file_config_plugin/src/config.rs
+++ b/plugins/tedge_file_config_plugin/src/config.rs
@@ -254,7 +254,7 @@ type = "nginx.conf"
         let config_file = ttd
             .file("plugin_config.toml")
             .with_raw_content(toml_content);
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         let types = config.get_all_file_types();
 
@@ -272,7 +272,7 @@ type = "nginx.conf"
         let config_file = ttd
             .file("plugin_config.toml")
             .with_raw_content(toml_content);
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         let types = config.get_all_file_types();
 
@@ -291,7 +291,7 @@ type = "single.conf"
         let config_file = ttd
             .file("plugin_config.toml")
             .with_raw_content(toml_content);
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         let types = config.get_all_file_types();
 
@@ -314,7 +314,7 @@ type = "other.conf"
         let config_file = ttd
             .file("plugin_config.toml")
             .with_raw_content(toml_content);
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         let types = config.get_all_file_types();
 
@@ -399,7 +399,7 @@ type = "service.toml"
         let config_file = ttd
             .file("plugin_config.toml")
             .with_raw_content(toml_content);
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         assert!(config.get_file_entry("app.conf").is_some());
         assert!(config.get_file_entry("service.toml").is_some());
@@ -420,7 +420,7 @@ type = "test+config"
 "#;
         let config_file = ttd.file("forbidden.toml").with_raw_content(toml_content);
 
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         // Should only contain the plugin config itself, not the invalid entry
         assert_eq!(config.files.len(), 1);
@@ -441,7 +441,7 @@ type = "test#config"
             .file("forbidden_hash.toml")
             .with_raw_content(toml_content);
 
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         // Should only contain the plugin config itself, not the invalid entry
         assert_eq!(config.files.len(), 1);
@@ -463,7 +463,7 @@ type = "duplicate.conf"
 "#;
         let config_file = ttd.file("duplicate.toml").with_raw_content(toml_content);
 
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         // Should only contain the plugin config itself, duplicates rejected
         assert_eq!(config.files.len(), 1);
@@ -481,7 +481,7 @@ path = "/etc/myapp.conf"
 "#;
         let config_file = ttd.file("no_type.toml").with_raw_content(toml_content);
 
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         // Should use path as config_type when type is not specified
         assert!(config.get_file_entry("/etc/myapp.conf").is_some());
@@ -504,7 +504,7 @@ service_action = "restart"
             .file("valid_action_restart.toml")
             .with_raw_content(toml_content);
 
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         assert_eq!(config.files.len(), 2);
         let entry = config.get_file_entry("test.conf").unwrap();
@@ -527,7 +527,7 @@ service_action = "start"
             .file("invalid_action.toml")
             .with_raw_content(toml_content);
 
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         // Should only contain the plugin config itself, invalid service_action rejected
         assert_eq!(config.files.len(), 1);
@@ -549,7 +549,7 @@ service_action = "restart"
             .file("action_without_service.toml")
             .with_raw_content(toml_content);
 
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         assert_eq!(config.files.len(), 1);
         assert!(config.get_file_entry(DEFAULT_PLUGIN_CONFIG_TYPE).is_some());
@@ -570,7 +570,7 @@ service = "testservice"
             .file("service_without_action.toml")
             .with_raw_content(toml_content);
 
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
         assert_eq!(config.files.len(), 2);
         let entry = config.get_file_entry("test.conf").unwrap();

--- a/plugins/tedge_file_config_plugin/src/lib.rs
+++ b/plugins/tedge_file_config_plugin/src/lib.rs
@@ -314,9 +314,9 @@ type = "service"
         let config_file = ttd
             .file("plugin_config.toml")
             .with_raw_content(toml_content);
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
-        let service_manager = GeneralServiceManager::try_new(ttd.utf8_path()).unwrap();
+        let service_manager = GeneralServiceManager::try_new(ttd.path()).unwrap();
         let plugin = FileConfigPlugin::new(config, TedgeWriteStatus::Disabled, service_manager);
         let types = plugin.list().unwrap();
 
@@ -330,9 +330,9 @@ type = "service"
     fn test_list_returns_default_type_for_empty_file() {
         let ttd = TempTedgeDir::new();
         let config_file = ttd.file("plugin_config.toml").with_raw_content("");
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
-        let service_manager = GeneralServiceManager::try_new(ttd.utf8_path()).unwrap();
+        let service_manager = GeneralServiceManager::try_new(ttd.path()).unwrap();
         let plugin = FileConfigPlugin::new(config, TedgeWriteStatus::Disabled, service_manager);
         let types = plugin.list().unwrap();
 
@@ -343,9 +343,9 @@ type = "service"
     #[test]
     fn test_list_returns_default_type_for_non_existent_file() {
         let ttd = TempTedgeDir::new();
-        let config = PluginConfig::new(&ttd.utf8_path().join("no_file.toml"));
+        let config = PluginConfig::new(&ttd.path().join("no_file.toml"));
 
-        let service_manager = GeneralServiceManager::try_new(ttd.utf8_path()).unwrap();
+        let service_manager = GeneralServiceManager::try_new(ttd.path()).unwrap();
         let plugin = FileConfigPlugin::new(config, TedgeWriteStatus::Disabled, service_manager);
         let types = plugin.list().unwrap();
 
@@ -364,9 +364,9 @@ type = "app.conf"
         let config_file = ttd
             .file("plugin_config.toml")
             .with_raw_content(toml_content);
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
-        let service_manager = GeneralServiceManager::try_new(ttd.utf8_path()).unwrap();
+        let service_manager = GeneralServiceManager::try_new(ttd.path()).unwrap();
         let plugin = FileConfigPlugin::new(config, TedgeWriteStatus::Disabled, service_manager);
         let result = plugin.get("unknown`");
 
@@ -384,14 +384,14 @@ type = "app.conf"
 path = "{}"
 type = "missing.conf"
 "#,
-            non_existent_path.to_str().unwrap()
+            non_existent_path.as_str()
         );
         let config_file = ttd
             .file("plugin_config.toml")
             .with_raw_content(&toml_content);
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
-        let service_manager = GeneralServiceManager::try_new(ttd.utf8_path()).unwrap();
+        let service_manager = GeneralServiceManager::try_new(ttd.path()).unwrap();
         let plugin = FileConfigPlugin::new(config, TedgeWriteStatus::Disabled, service_manager);
         let result = plugin.get("missing.conf");
 
@@ -411,13 +411,11 @@ type = "app.conf"
         let config_file = ttd
             .file("plugin_config.toml")
             .with_raw_content(toml_content);
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
-        let service_manager = GeneralServiceManager::try_new(ttd.utf8_path()).unwrap();
+        let service_manager = GeneralServiceManager::try_new(ttd.path()).unwrap();
         let plugin = FileConfigPlugin::new(config, TedgeWriteStatus::Disabled, service_manager);
-        let result = plugin
-            .set("unknown.conf", source_file.path().try_into().unwrap())
-            .await;
+        let result = plugin.set("unknown.conf", source_file.path()).await;
 
         assert!(matches!(result, Err(PluginError::InvalidConfigType(_))));
     }
@@ -440,18 +438,16 @@ type = "app.conf"
 path = "{}"
 type = "test.conf"
 "#,
-            dest_file_path.to_str().unwrap()
+            dest_file_path.as_str()
         );
         let config_file = ttd
             .file("plugin_config.toml")
             .with_raw_content(&toml_content);
-        let config = PluginConfig::new(config_file.utf8_path());
+        let config = PluginConfig::new(config_file.path());
 
-        let service_manager = GeneralServiceManager::try_new(ttd.utf8_path()).unwrap();
+        let service_manager = GeneralServiceManager::try_new(ttd.path()).unwrap();
         let plugin = FileConfigPlugin::new(config, TedgeWriteStatus::Disabled, service_manager);
-        let result = plugin
-            .set("test.conf", source_file.path().try_into().unwrap())
-            .await;
+        let result = plugin.set("test.conf", source_file.path()).await;
 
         assert!(result.is_ok());
 

--- a/plugins/tedge_file_config_plugin/tests/cli.rs
+++ b/plugins/tedge_file_config_plugin/tests/cli.rs
@@ -20,9 +20,7 @@ type = "app-config"
         .with_raw_content(config_content);
 
     let mut cmd = Command::cargo_bin("tedge-file-config-plugin").unwrap();
-    cmd.arg("--config-dir")
-        .arg(ttd.path().to_str().unwrap())
-        .arg("list");
+    cmd.arg("--config-dir").arg(ttd.path().as_str()).arg("list");
 
     cmd.assert()
         .success()
@@ -45,7 +43,7 @@ type = "tedge.toml"
 
     let mut cmd = Command::cargo_bin("tedge-file-config-plugin").unwrap();
     cmd.arg("--config-dir")
-        .arg(ttd.path().to_str().unwrap())
+        .arg(ttd.path().as_str())
         .arg("get")
         .arg("unknown-type");
 
@@ -68,7 +66,7 @@ fn test_get_command_existing_file() {
 path = "{}"
 type = "test.conf"
 "#,
-        test_config_file.path().display()
+        test_config_file.path()
     );
     ttd.dir("plugins")
         .file("tedge-configuration-plugin.toml")
@@ -76,7 +74,7 @@ type = "test.conf"
 
     let mut cmd = Command::cargo_bin("tedge-file-config-plugin").unwrap();
     cmd.arg("--config-dir")
-        .arg(ttd.path().to_str().unwrap())
+        .arg(ttd.path().as_str())
         .arg("get")
         .arg("test.conf");
 
@@ -104,7 +102,7 @@ fn test_set_command() {
 path = "{}"
 type = "dest.conf"
 "#,
-        dest_file.utf8_path()
+        dest_file.path()
     );
     ttd.dir("plugins")
         .file("tedge-configuration-plugin.toml")
@@ -112,12 +110,12 @@ type = "dest.conf"
 
     let mut cmd = Command::cargo_bin("tedge-file-config-plugin").unwrap();
     cmd.arg("--config-dir")
-        .arg(ttd.path().to_str().unwrap())
+        .arg(ttd.path().as_str())
         .arg("set")
         .arg("dest.conf")
-        .arg(source_file.path().to_str().unwrap())
+        .arg(source_file.path().as_str())
         .arg("--work-dir")
-        .arg(ttd.path().join("workdir").to_str().unwrap());
+        .arg(ttd.path().join("workdir").as_str());
 
     cmd.assert().success();
 
@@ -145,7 +143,7 @@ enable =  ["true"]
 disable =  ["true"]
 is_active = ["true"]
 "#,
-        witness_file.utf8_path()
+        witness_file.path()
     );
     ttd.file("system.toml")
         .with_raw_content(&system_toml_content);
@@ -160,7 +158,7 @@ path = "{}"
 type = "test.conf"
 service = "dummy-service"
 "###,
-        dest_file.utf8_path()
+        dest_file.path()
     );
     ttd.dir("plugins")
         .file("tedge-configuration-plugin.toml")
@@ -173,12 +171,12 @@ service = "dummy-service"
     // Set the configuration (which also triggers service restart)
     let mut cmd = Command::cargo_bin("tedge-file-config-plugin").unwrap();
     cmd.arg("--config-dir")
-        .arg(ttd.path().to_str().unwrap())
+        .arg(ttd.path().as_str())
         .arg("set")
         .arg("test.conf")
-        .arg(target_file.path().to_str().unwrap())
+        .arg(target_file.path().as_str())
         .arg("--work-dir")
-        .arg(ttd.path().join("workdir").to_str().unwrap());
+        .arg(ttd.path().join("workdir").as_str());
 
     cmd.assert().success();
 
@@ -205,7 +203,7 @@ path = "{}"
 type = "tedge.conf"
 service = "tedge-agent"
 "###,
-        dest_file.utf8_path()
+        dest_file.path()
     );
     ttd.dir("plugins")
         .file("tedge-configuration-plugin.toml")
@@ -217,12 +215,12 @@ service = "tedge-agent"
 
     let mut cmd = Command::cargo_bin("tedge-file-config-plugin").unwrap();
     cmd.arg("--config-dir")
-        .arg(ttd.path().to_str().unwrap())
+        .arg(ttd.path().as_str())
         .arg("set")
         .arg("tedge.conf")
-        .arg(target_file.path().to_str().unwrap())
+        .arg(target_file.path().as_str())
         .arg("--work-dir")
-        .arg(ttd.path().join("workdir").to_str().unwrap());
+        .arg(ttd.path().join("workdir").as_str());
 
     let output = cmd.output().unwrap();
     assert!(output.status.success());
@@ -263,7 +261,7 @@ path = "{}"
 type = "tedge.conf"
 service = "tedge-agent"
 "###,
-        dest_file.utf8_path()
+        dest_file.path()
     );
     ttd.dir("plugins")
         .file("tedge-configuration-plugin.toml")
@@ -271,11 +269,11 @@ service = "tedge-agent"
 
     let mut cmd = Command::cargo_bin("tedge-file-config-plugin").unwrap();
     cmd.arg("--config-dir")
-        .arg(ttd.path().to_str().unwrap())
+        .arg(ttd.path().as_str())
         .arg("verify")
         .arg("tedge.conf")
         .arg("--work-dir")
-        .arg(ttd.path().join("workdir").to_str().unwrap());
+        .arg(ttd.path().join("workdir").as_str());
 
     // The agent spawns this plugin, so it is running by definition; there may not
     // even be a tedge-agent service to probe (e.g. under `tedge run all`).
@@ -291,9 +289,7 @@ fn test_empty_config_file() {
         .with_raw_content("");
 
     let mut cmd = Command::cargo_bin("tedge-file-config-plugin").unwrap();
-    cmd.arg("--config-dir")
-        .arg(ttd.path().to_str().unwrap())
-        .arg("list");
+    cmd.arg("--config-dir").arg(ttd.path().as_str()).arg("list");
 
     // The default tedge-configuration-plugin type must still be listed
     cmd.assert()
@@ -310,9 +306,7 @@ fn test_invalid_config_file() {
         .with_raw_content("not#toml");
 
     let mut cmd = Command::cargo_bin("tedge-file-config-plugin").unwrap();
-    cmd.arg("--config-dir")
-        .arg(ttd.path().to_str().unwrap())
-        .arg("list");
+    cmd.arg("--config-dir").arg(ttd.path().as_str()).arg("list");
 
     // The default tedge-configuration-plugin type must still be listed
     cmd.assert()

--- a/plugins/tedge_file_log_plugin/src/log_utils.rs
+++ b/plugins/tedge_file_log_plugin/src/log_utils.rs
@@ -159,7 +159,7 @@ mod tests {
 
     fn prepare() -> (TempTedgeDir, Vec<FileEntry>) {
         let tempdir = TempTedgeDir::new();
-        let tempdir_path = tempdir.path().to_str().unwrap();
+        let tempdir_path = tempdir.path().as_str();
 
         tempdir.file("file_a_one");
         tempdir.file("file_b_one");
@@ -210,7 +210,7 @@ mod tests {
     /// most recent to oldest
     fn test_filter_logs_path_containing_wildcard_on_type_and_metadata() {
         let (tempdir, files) = prepare();
-        let tempdir_path = tempdir.path().to_str().unwrap();
+        let tempdir_path = tempdir.path().as_str();
 
         let logs = filter_logs(&files, "type_one", datetime!(1970-01-01 00:00:03 +00:00)).unwrap();
 
@@ -239,7 +239,7 @@ mod tests {
     /// most recent to oldest
     fn test_filter_logs_with_static_path_on_type_and_metadata() {
         let (tempdir, _) = prepare();
-        let tempdir_path = tempdir.path().to_str().unwrap();
+        let tempdir_path = tempdir.path().as_str();
 
         // provide vector of files with static paths
         let files: Vec<FileEntry> = vec![
@@ -286,7 +286,7 @@ mod tests {
     /// Now returns all lines since filtering is done by the agent.
     fn test_read_log_content() {
         let (tempdir, _) = prepare();
-        let tempdir_path = tempdir.path().to_str().unwrap();
+        let tempdir_path = tempdir.path().as_str();
         let file_path = &format!("{tempdir_path}/file_a_one");
         let mut log_file = std::fs::OpenOptions::new()
             .append(true)
@@ -321,7 +321,7 @@ mod tests {
     /// Now returns all lines since filtering is done by the agent.
     fn test_read_log_content_multiple_files() {
         let (tempdir, files) = prepare();
-        let tempdir_path = tempdir.path().to_str().unwrap();
+        let tempdir_path = tempdir.path().as_str();
 
         for (file_name, m_time) in [
             ("file_a_one", 2),
@@ -349,7 +349,7 @@ mod tests {
             &files,
             "type_one",
             datetime!(1970-01-01 00:00:03 +00:00),
-            tempdir.utf8_path(),
+            tempdir.path(),
         )
         .unwrap();
 

--- a/plugins/tedge_file_log_plugin/tests/cli.rs
+++ b/plugins/tedge_file_log_plugin/tests/cli.rs
@@ -10,7 +10,7 @@ const BINARY_NAME: &str = "tedge-file-log-plugin";
 
 fn setup() -> (TempTedgeDir, String) {
     let temp_dir = TempTedgeDir::new();
-    let temp_path = temp_dir.path().to_str().unwrap().to_string();
+    let temp_path = temp_dir.path().as_str().to_string();
 
     // Create config directory structure
     let config_dir = temp_dir.dir("config");
@@ -57,7 +57,7 @@ type = "service"
     let plugin_config_file = plugins_dir.file("tedge-log-plugin.toml");
     fs::write(plugin_config_file.path(), config_content).unwrap();
 
-    (temp_dir, config_dir.utf8_path().to_string())
+    (temp_dir, config_dir.path().to_string())
 }
 
 #[test]

--- a/plugins/tedge_flows_plugin/src/install.rs
+++ b/plugins/tedge_flows_plugin/src/install.rs
@@ -158,11 +158,11 @@ mod tests {
         mappers_dir.dir("local").dir("flows");
         let tarball_path = create_test_tarball(&ttd, "tar.gz");
         let flow_record = FlowRecord::new("local/hello").unwrap();
-        let flow_dir = flow_record.flow_dir(mappers_dir.utf8_path());
+        let flow_dir = flow_record.flow_dir(mappers_dir.path());
 
         install_flow(
-            ttd.utf8_path(),
-            mappers_dir.utf8_path(),
+            ttd.path(),
+            mappers_dir.path(),
             &flow_record,
             None,
             tarball_path.as_str(),
@@ -182,11 +182,11 @@ mod tests {
         mappers_dir.dir("local").dir("flows");
         let tarball_path = create_test_tarball(&ttd, "tar.gz");
         let flow_record = FlowRecord::new("local/hello/world").unwrap();
-        let flow_dir = flow_record.flow_dir(mappers_dir.utf8_path());
+        let flow_dir = flow_record.flow_dir(mappers_dir.path());
 
         install_flow(
-            ttd.utf8_path(),
-            mappers_dir.utf8_path(),
+            ttd.path(),
+            mappers_dir.path(),
             &flow_record,
             None,
             tarball_path.as_str(),
@@ -205,11 +205,11 @@ mod tests {
         let mappers_dir = ttd.dir("mappers");
         mappers_dir.dir("local").dir("flows");
         let flow_record = FlowRecord::new("local/hello").unwrap();
-        let flow_dir = flow_record.flow_dir(mappers_dir.utf8_path());
+        let flow_dir = flow_record.flow_dir(mappers_dir.path());
 
         install_flow(
-            ttd.utf8_path(),
-            mappers_dir.utf8_path(),
+            ttd.path(),
+            mappers_dir.path(),
             &flow_record,
             None,
             create_test_tarball(&ttd, "tar").as_str(),
@@ -227,7 +227,7 @@ mod tests {
         let ttd = TempTedgeDir::new();
         let mappers_dir = ttd.dir("mappers");
         let flow_record = FlowRecord::new("local/hello").unwrap();
-        let flow_dir = flow_record.flow_dir(mappers_dir.utf8_path());
+        let flow_dir = flow_record.flow_dir(mappers_dir.path());
         let tarball_path = create_test_tarball(&ttd, "tar.gz");
 
         // Pre-existing flow at version 0.1.0
@@ -240,8 +240,8 @@ mod tests {
         assert_eq!(get_flow_version(flow_dir.join("flow.toml")), "0.1.0");
 
         install_flow(
-            ttd.utf8_path(),
-            mappers_dir.utf8_path(),
+            ttd.path(),
+            mappers_dir.path(),
             &flow_record,
             None,
             tarball_path.as_str(),
@@ -259,7 +259,7 @@ mod tests {
         let ttd = TempTedgeDir::new();
         let mappers_dir = ttd.dir("mappers");
         let flow_record = FlowRecord::new("local/hello").unwrap();
-        let flow_dir = flow_record.flow_dir(mappers_dir.utf8_path());
+        let flow_dir = flow_record.flow_dir(mappers_dir.path());
         let tarball_path = create_test_tarball(&ttd, "tar.gz");
 
         // Pre-existing flow with a custom params.toml
@@ -270,8 +270,8 @@ mod tests {
             .with_toml_content(toml::toml! { param1 = "value1" });
 
         install_flow(
-            ttd.utf8_path(),
-            mappers_dir.utf8_path(),
+            ttd.path(),
+            mappers_dir.path(),
             &flow_record,
             None,
             tarball_path.as_str(),
@@ -301,7 +301,7 @@ mod tests {
             .with_toml_content(toml::toml! { version = "1.0.0" });
         work_dir.file("params.toml.template");
 
-        let tarball_path = ttd.utf8_path().join(format!("hello.{format}"));
+        let tarball_path = ttd.path().join(format!("hello.{format}"));
         let tar_file = fs::File::create(&tarball_path).unwrap();
 
         match format {
@@ -322,7 +322,7 @@ mod tests {
     }
 
     fn append_work_dir<W: std::io::Write>(work_dir: &TempTedgeDir, archive: &mut tar::Builder<W>) {
-        for entry in fs::read_dir(work_dir.utf8_path()).unwrap() {
+        for entry in fs::read_dir(work_dir.path()).unwrap() {
             let entry = entry.unwrap();
             let path = entry.path();
             if path.is_file() {

--- a/plugins/tedge_flows_plugin/src/list.rs
+++ b/plugins/tedge_flows_plugin/src/list.rs
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn missing_mappers_dir_returns_empty() {
         let ttd = TempTedgeDir::new();
-        let non_existent = ttd.utf8_path().join("no-such-dir");
+        let non_existent = ttd.path().join("no-such-dir");
         let flows = retrieve_flows(non_existent);
         assert!(flows.is_empty());
     }
@@ -158,7 +158,7 @@ mod tests {
             .file("hello.toml")
             .with_toml_content(toml::toml! { version = "1.0" });
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         assert_eq!(entries(&flows), [("local", "hello", "1.0")]);
     }
 
@@ -172,7 +172,7 @@ mod tests {
             .file("flow.toml")
             .with_toml_content(toml::toml! { version = "1.0" });
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         assert_eq!(entries(&flows), [("local", "hello", "1.0")]);
     }
 
@@ -186,7 +186,7 @@ mod tests {
             .file("world.toml")
             .with_toml_content(toml::toml! { version = "1.0" });
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         assert_eq!(entries(&flows), [("local", "hello/world", "1.0")]);
     }
 
@@ -201,7 +201,7 @@ mod tests {
             .file("flow.toml")
             .with_toml_content(toml::toml! { version = "1.0" });
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         assert_eq!(entries(&flows), [("local", "hello/world", "1.0")]);
     }
 
@@ -216,7 +216,7 @@ mod tests {
             .file("world.toml")
             .with_toml_content(toml::toml! { version = "1.0" });
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         assert_eq!(entries(&flows), [("local", "world", "1.0")]);
     }
 
@@ -230,7 +230,7 @@ mod tests {
             .file("world.toml")
             .with_toml_content(toml::toml! { version = "1.0" });
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         assert_eq!(entries(&flows), [("local", "world", "1.0")]);
     }
 
@@ -246,7 +246,7 @@ mod tests {
             .file("hello.toml")
             .with_toml_content(toml::toml! { version = "2.0" });
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         assert_eq!(
             entries(&flows),
             [("local", "flow", "1.0"), ("local", "hello", "2.0")]
@@ -263,7 +263,7 @@ mod tests {
             .file(".toml")
             .with_toml_content(toml::toml! { version = "1.0" });
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         assert!(flows.is_empty());
     }
 
@@ -277,7 +277,7 @@ mod tests {
             .file("world.toml")
             .with_toml_content(toml::toml! { version = "1.0" });
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         assert_eq!(entries(&flows), [("local", "world", "1.0")]);
     }
 
@@ -293,7 +293,7 @@ mod tests {
             .file("hello.toml")
             .with_toml_content(toml::toml! { version = "1.0" });
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         assert_eq!(entries(&flows), [("local", "hello", "1.0")]);
     }
 
@@ -310,7 +310,7 @@ mod tests {
             .file("flow.toml")
             .with_toml_content(toml::toml! { version = "2.0" });
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         // Sorted by (mapper, name, version): 1.0 < 2.0
         assert_eq!(
             entries(&flows),
@@ -339,7 +339,7 @@ mod tests {
             .with_toml_content(toml::toml! { version = "3.0" });
         local_flows.file("params.toml");
 
-        let flows = retrieve_flows(ttd.utf8_path());
+        let flows = retrieve_flows(ttd.path());
         assert_eq!(
             entries(&flows),
             [

--- a/plugins/tedge_flows_plugin/src/remove.rs
+++ b/plugins/tedge_flows_plugin/src/remove.rs
@@ -86,8 +86,8 @@ mod tests {
         hello.file("main.js");
         let flow_record = FlowRecord::new("local/hello").unwrap();
 
-        remove_flow(mappers_dir.utf8_path(), &flow_record, None, false).unwrap();
-        assert!(!flow_record.flow_dir(mappers_dir.utf8_path()).exists());
+        remove_flow(mappers_dir.path(), &flow_record, None, false).unwrap();
+        assert!(!flow_record.flow_dir(mappers_dir.path()).exists());
     }
 
     #[test]
@@ -103,8 +103,8 @@ mod tests {
         world.file("main.js");
         let flow_record = FlowRecord::new("local/hello/world").unwrap();
 
-        remove_flow(mappers_dir.utf8_path(), &flow_record, None, false).unwrap();
-        assert!(!flow_record.flow_dir(mappers_dir.utf8_path()).exists());
+        remove_flow(mappers_dir.path(), &flow_record, None, false).unwrap();
+        assert!(!flow_record.flow_dir(mappers_dir.path()).exists());
     }
 
     #[test]
@@ -119,8 +119,8 @@ mod tests {
             .with_toml_content(toml::toml! { version = "1.0" });
         let flow_record = FlowRecord::new("local/hello").unwrap();
 
-        remove_flow(mappers_dir.utf8_path(), &flow_record, None, false).unwrap();
-        assert!(!flow_record.flow_toml(mappers_dir.utf8_path()).exists());
+        remove_flow(mappers_dir.path(), &flow_record, None, false).unwrap();
+        assert!(!flow_record.flow_toml(mappers_dir.path()).exists());
     }
 
     #[test]
@@ -138,14 +138,14 @@ mod tests {
             .with_toml_content(toml::toml! { version = "1.0" });
         let flow_record = FlowRecord::new("local/hello").unwrap();
 
-        remove_flow(mappers_dir.utf8_path(), &flow_record, None, false).unwrap();
+        remove_flow(mappers_dir.path(), &flow_record, None, false).unwrap();
 
         assert!(
-            !flow_record.flow_dir(mappers_dir.utf8_path()).exists(),
+            !flow_record.flow_dir(mappers_dir.path()).exists(),
             "directory should be removed"
         );
         assert!(
-            flow_record.flow_toml(mappers_dir.utf8_path()).exists(),
+            flow_record.flow_toml(mappers_dir.path()).exists(),
             "hello.toml should be untouched"
         );
     }
@@ -157,7 +157,7 @@ mod tests {
 
         // Neither a directory nor a .toml file — should succeed silently.
         let flow_record = FlowRecord::new("local/hello").unwrap();
-        remove_flow(mappers_dir.utf8_path(), &flow_record, None, false).unwrap();
+        remove_flow(mappers_dir.path(), &flow_record, None, false).unwrap();
     }
 
     #[test]
@@ -173,9 +173,9 @@ mod tests {
         hello.file("params.toml.template");
         let flow_record = FlowRecord::new("local/hello").unwrap();
 
-        remove_flow(mappers_dir.utf8_path(), &flow_record, None, true).unwrap();
+        remove_flow(mappers_dir.path(), &flow_record, None, true).unwrap();
 
-        let dir = flow_record.flow_dir(mappers_dir.utf8_path());
+        let dir = flow_record.flow_dir(mappers_dir.path());
         assert!(dir.exists(), "directory should be kept");
         assert!(
             dir.join("params.toml").exists(),


### PR DESCRIPTION
## Proposed changes
The first step in adopting `camino::Utf8Path` across the thin-edge codebase. This makes a few change to the test APIs we use for generating files:

- `path()` now returns `&Utf8Path` (was `&Path`)
- `path_buf()` returns `Utf8PathBuf` (renamed from `utf8_path_buf()`)
- `utf8_path()` renamed to `path()` across all callers
- Add `std_path()` as stopgap for call sites still needing `&Path`
- Add `truncate(true)` to `with_raw_content` for safe overwrites
- `TempTedgeFile::file_path` changed from `PathBuf` to `Utf8PathBuf`

Call sites that still need `&Path` (e.g. for `fs_notify_stream`, `FsWatchEvent`, `DownloadRequest`) use the new `std_path()` method. Once we have finished migrating the production code to use `Utf8Path` across the board, this method will be removed.

If you check out the code locally, you can see all the changes that aren't the `utf8_path` to `path` rename by doing the following (which means "exclude any hunks which match the regex `\.(utf8_)path` on every line"):

```bash
git diff -I'\.(utf8_)?path' HEAD~1..HEAD
```

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [x] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

