### PR TITLE
fix: align aws and az default mapper topics with c8y

### DIFF
--- a/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
+++ b/crates/common/tedge_config/src/tedge_toml/tedge_config.rs
@@ -701,7 +701,7 @@ define_tedge_config! {
 
         /// Set of MQTT topics the Cumulocity mapper should subscribe to
         #[tedge_config(example = "te/+/+/+/+/a/+,te/+/+/+/+/m/+,te/+/+/+/+/m/+/meta,te/+/+/+/+/e/+")]
-        #[tedge_config(default(value = "te/+/+/+/+,te/+/+/+/+/twin/+,te/+/+/+/+/m/+,te/+/+/+/+/m/+/meta,te/+/+/+/+/e/+,te/+/+/+/+/a/+,te/+/+/+/+/status/health"))]
+        #[tedge_config(default(function = "default_cloud_mapper_topics"))]
         #[tedge_config(exposable)]
         topics: TemplatesSet,
 
@@ -967,7 +967,7 @@ define_tedge_config! {
 
         /// Set of MQTT topics the Azure IoT mapper should subscribe to
         #[tedge_config(example = "te/+/+/+/+/a/+,te/+/+/+/+/m/+,te/+/+/+/+/e/+")]
-        #[tedge_config(default(value = "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+,te/+/+/+/+/status/health"))]
+        #[tedge_config(default(function = "default_cloud_mapper_topics"))]
         #[tedge_config(exposable)]
         topics: TemplatesSet,
     },
@@ -1073,7 +1073,7 @@ define_tedge_config! {
 
         /// Set of MQTT topics the AWS IoT mapper should subscribe to
         #[tedge_config(example = "te/+/+/+/+/a/+,te/+/+/+/+/m/+,te/+/+/+/+/e/+")]
-        #[tedge_config(default(value = "te/+/+/+/+/m/+,te/+/+/+/+/e/+,te/+/+/+/+/a/+,te/+/+/+/+/status/health"))]
+        #[tedge_config(default(function = "default_cloud_mapper_topics"))]
         #[tedge_config(exposable)]
         topics: TemplatesSet,
     },
@@ -1616,6 +1616,12 @@ fn aws_mqtt_payload_limit() -> MqttPayloadLimit {
     AWS_MQTT_PAYLOAD_LIMIT.try_into().unwrap()
 }
 
+fn default_cloud_mapper_topics() -> TemplatesSet {
+    TemplatesSet::from(
+        "te/+/+/+/+,te/+/+/+/+/twin/+,te/+/+/+/+/m/+,te/+/+/+/+/m/+/meta,te/+/+/+/+/e/+,te/+/+/+/+/a/+,te/+/+/+/+/status/health",
+    )
+}
+
 fn default_http_bind_address(dto: &TEdgeConfigDto) -> IpAddr {
     let external_address = dto.mqtt.external.bind.address;
     external_address
@@ -1907,6 +1913,23 @@ mod tests {
     use tedge_test_utils::fs::TempTedgeDir;
 
     use super::*;
+
+    #[test]
+    fn default_aws_and_az_topics_match_c8y() {
+        let config = TEdgeConfig::load_toml_str("");
+        let expected = [
+            "te/+/+/+/+",
+            "te/+/+/+/+/twin/+",
+            "te/+/+/+/+/m/+",
+            "te/+/+/+/+/m/+/meta",
+            "te/+/+/+/+/e/+",
+            "te/+/+/+/+/a/+",
+            "te/+/+/+/+/status/health",
+        ];
+        assert_eq!(config.c8y_reader(None).unwrap().topics, expected);
+        assert_eq!(config.az_reader(None).unwrap().topics, expected);
+        assert_eq!(config.aws_reader(None).unwrap().topics, expected);
+    }
 
     #[test_case::test_case("device.id")]
     #[test_case::test_case("device.type")]

--- a/docs/src/references/mappers/builtin-flows.md
+++ b/docs/src/references/mappers/builtin-flows.md
@@ -165,7 +165,7 @@ If the template file is removed, it will be recreated by the mapper on the next 
 The Azure mapper behavior is defined by a builtin flow located at `/etc/tedge/mappers/az/flows/mea.toml`:
 
 ```toml
-input.mqtt.topics = ["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
+input.mqtt.topics = ["te/+/+/+/+", "te/+/+/+/+/twin/+", "te/+/+/+/+/m/+", "te/+/+/+/+/m/+/meta", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
 
 steps = [
     { builtin = "skip-mosquitto-health-status" },
@@ -222,7 +222,7 @@ and keeping the associated `.toml.template` file as a witness.
 The AWS mapper behavior is defined by a builtin flow located at `/etc/tedge/mappers/aws/flows/mea.toml`:
 
 ```toml
-input.mqtt.topics = ["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
+input.mqtt.topics = ["te/+/+/+/+", "te/+/+/+/+/twin/+", "te/+/+/+/+/m/+", "te/+/+/+/+/m/+/meta", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
 
 steps = [
   { builtin = "skip-mosquitto-health-status" },

--- a/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
+++ b/tests/RobotFramework/tests/tedge/call_tedge_config_list.robot
@@ -205,7 +205,7 @@ set/unset az.topics
     ${unset}    Execute Command    tedge config list
     Should Contain
     ...    ${unset}
-    ...    az.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
+    ...    az.topics=["te/+/+/+/+", "te/+/+/+/+/twin/+", "te/+/+/+/+/m/+", "te/+/+/+/+/m/+/meta", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
 
 set/unset aws.topics
     Execute Command    sudo tedge config set aws.topics topic1,topic2    # Changing aws.topics
@@ -217,7 +217,7 @@ set/unset aws.topics
     ${unset}    Execute Command    tedge config list
     Should Contain
     ...    ${unset}
-    ...    aws.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
+    ...    aws.topics=["te/+/+/+/+", "te/+/+/+/+/twin/+", "te/+/+/+/+/m/+", "te/+/+/+/+/m/+/meta", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
 
 set/unset aws.url
     Execute Command    sudo tedge config set aws.url your-endpoint.amazonaws.com    # Changing aws.url

--- a/tests/RobotFramework/tests/tedge/tedge_config_add_remove.robot
+++ b/tests/RobotFramework/tests/tedge/tedge_config_add_remove.robot
@@ -73,18 +73,18 @@ tedge config append/remove default value
     ${initial}    Execute Command    tedge config list
     Should Contain
     ...    ${initial}
-    ...    az.topics=["te/+/+/+/+/m/+", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
+    ...    az.topics=["te/+/+/+/+", "te/+/+/+/+/twin/+", "te/+/+/+/+/m/+", "te/+/+/+/+/m/+/meta", "te/+/+/+/+/e/+", "te/+/+/+/+/a/+", "te/+/+/+/+/status/health"]
 
     # Add value to array with default values
     Execute Command    sudo tedge config add az.topics azure1,azure2
     ${add}    Execute Command    tedge config list
     Should Contain
     ...    ${add}
-    ...    az.topics=["azure1", "azure2", "te/+/+/+/+/a/+", "te/+/+/+/+/e/+", "te/+/+/+/+/m/+", "te/+/+/+/+/status/health"]
+    ...    az.topics=["azure1", "azure2", "te/+/+/+/+", "te/+/+/+/+/a/+", "te/+/+/+/+/e/+", "te/+/+/+/+/m/+", "te/+/+/+/+/m/+/meta", "te/+/+/+/+/status/health", "te/+/+/+/+/twin/+"]
 
     # Remove one of the default values and new value
     Execute Command    sudo tedge config remove az.topics azure2,te/+/+/+/+/status/health
     ${remove}    Execute Command    tedge config list
     Should Contain
     ...    ${remove}
-    ...    az.topics=["azure1", "te/+/+/+/+/a/+", "te/+/+/+/+/e/+", "te/+/+/+/+/m/+"]
+    ...    az.topics=["azure1", "te/+/+/+/+", "te/+/+/+/+/a/+", "te/+/+/+/+/e/+", "te/+/+/+/+/m/+", "te/+/+/+/+/m/+/meta", "te/+/+/+/+/twin/+"]


### PR DESCRIPTION
## Proposed changes

`tedge config list topics` showed `c8y.topics` subscribing to entity registration (`te/+/+/+/+`), twins, and measurement metadata, while `aws.topics` and `az.topics` only had measurements, events, alarms, and health.

Use one shared default so the three mappers subscribe to the same local topics.

Fixes #3377

The second bullet on that issue (`mqtt.topic_root` vs hardcoded `te/` in the default strings) is unchanged; c8y already used the same `te/` literals.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue

https://github.com/thin-edge/thin-edge.io/issues/3377

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Validation

```
CARGO_TARGET_DIR=... cargo test -p tedge_config --lib --offline
```

392 passed, including `default_aws_and_az_topics_match_c8y`.

Robot expected strings for `tedge config unset` / `add`/`remove` of `az.topics` and `aws.topics` were updated to the shared default.

## Further comments

AWS `set-aws-topic` still drops entity/twin/meta frames (match arms are m/e/a/health only). Azure forwards whatever it subscribes. Subscribing is what #3377 asked for; mapping those extra AWS frames would be a follow-up.

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.