### PR TITLE
fix: use URL-relative links on the service plugin guide

### DIFF
--- a/docs/src/references/init-system-configuration.md
+++ b/docs/src/references/init-system-configuration.md
@@ -60,7 +60,7 @@ will be interpreted as
 Every key is an **action** of this init system, except `name` and `is_available`,
 which describe the init system rather than a service.
 An action can be run with
-[`tedge service <action> <service-name>`](./cli/tedge-service).
+[`tedge service <action> <service-name>`](../cli/tedge-service).
 
 ## Custom actions
 

--- a/docs/src/references/service-plugin-api.md
+++ b/docs/src/references/service-plugin-api.md
@@ -9,7 +9,7 @@ description: Service Plugin API reference
 
 A **service plugin** runs the actions of services with a type other than the default type `service`.
 The service type is the `type` field of the
-[service registration message](./mqtt-api#register-a-service-of-the-main-device).
+[service registration message](../mqtt-api#register-a-service-of-the-main-device).
 
 For example, given a service `my_service` is registered as below:
 ```sh te2mqtt formats=v1
@@ -33,7 +33,7 @@ The service type selects the backend that runs the action.
 
 | Service type          | Backend                                                                            |
 |-----------------------|--------------------------------------------------------------------------------------|
-| `service` (default)   | The init system, as configured in [`system.toml`](./init-system-configuration)  |
+| `service` (default)   | The init system, as configured in [`system.toml`](../init-system-configuration)  |
 | any other type `<t>`  | The service plugin `<plugin-dir>/<t>`                                              |
 
 The plugin directories are the `tedge config` value `service.plugin_paths`,
@@ -118,7 +118,7 @@ A rejected argument fails the command without any backend being invoked.
 * The plugin can print anything on stdout and stderr.
   When the caller is `tedge-agent`, both end up in the operation log of the command.
   The only exception is the `:::begin-tedge:::` and `:::end-tedge:::` markers, which
-  [update the state of a command](./agent/operation-workflow#next-step-determined-by-script-output):
+  [update the state of a command](../agent/operation-workflow#next-step-determined-by-script-output):
   the runner drops the lines holding them,
   so that the output of a plugin is never read as a state update.
 


### PR DESCRIPTION
## Proposed changes

The links introduced by #4308,  to the tedge service CLI page, the MQTT API, system.toml and the operation workflow resolved one level too shallow, which broke [build of the GitHub pages](https://github.com/thin-edge/thin-edge.io/actions/runs/34352154437/job/102467810331).

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
#4308

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s. You can activate automatic signing by running `just prepare-dev` once)
- [ ] I ran `just format` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `just check` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

